### PR TITLE
Update Android convention plugin to target Java 24

### DIFF
--- a/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
+++ b/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
         minSdk = libs.findVersion("android-minSdk").get().toString().toInt()
 
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
+            jvmTarget.set(JvmTarget.JVM_24)
         }
     }
 
@@ -35,6 +35,6 @@ kotlin {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
+        jvmTarget.set(JvmTarget.JVM_24)
     }
 }


### PR DESCRIPTION
## Summary
- Updated Android convention plugin to target Java 24 instead of Java 17
- Changed `JvmTarget.JVM_17` to `JvmTarget.JVM_24` in both androidLibrary compilerOptions and KotlinCompile tasks
- Build passes successfully with no errors

## Test plan
- [x] Verified local build completes successfully with `./gradlew.bat build`
- [x] All existing tests pass
- [x] No compilation errors or new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)