### PR TITLE
Apply dependency-analysis plugin as recommended in docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,21 +1,3 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath(libs.android.gradle.plugin)
-    }
-}
-
-plugins {
-    alias(libs.plugins.dependency.analysis)
-    alias(libs.plugins.kotlin.multiplatform) apply false
-    alias(libs.plugins.kotlin.jvm) apply false
-    alias(libs.plugins.android.kotlin.multiplatform.library) apply false
-    alias(libs.plugins.android.application) apply false
-}
-
 allprojects {
     repositories {
         google()
@@ -24,8 +6,6 @@ allprojects {
 }
 
 subprojects {
-    apply(plugin = "com.autonomousapps.dependency-analysis")
-
     // Make check task depend on detekt to run it as part of the build
     tasks.matching { it.name == "check" }.configureEach {
         dependsOn(tasks.matching { it.name == "detekt" })
@@ -50,9 +30,3 @@ dependencyAnalysis {
     }
 }
 
-// Run buildHealth as part of the build task
-subprojects {
-    tasks.matching { it.name == "build" }.configureEach {
-        finalizedBy(rootProject.tasks.named("buildHealth"))
-    }
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,6 +78,7 @@ mappie = { id = "tech.mappie.plugin", version.ref = "mappie" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
+build-health = { id = "com.autonomousapps.build-health", version.ref = "dependency-analysis" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }
 android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "android-gradle-plugin" }
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,9 +9,24 @@ pluginManagement {
     }
 }
 
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.13.1")
+    }
+}
+
 plugins {
     id("com.pablisco.gradle.auto.include") version "1.3"
     id("com.gradle.develocity") version "4.2.2"
+    id("com.autonomousapps.build-health") version "3.5.0"
+
+    // Kotlin plugins declared here for classloader compatibility with DAGP
+    id("org.jetbrains.kotlin.multiplatform") version "2.2.21" apply false
+    id("org.jetbrains.kotlin.jvm") version "2.2.21" apply false
 }
 
 develocity {


### PR DESCRIPTION
## Summary
- Use the build-health settings plugin (recommended since v2.0) instead of manually applying the dependency-analysis plugin
- Move AGP and Kotlin plugins to settings for classloader compatibility with DAGP
- Simplify build.gradle.kts by removing manual plugin application and task wiring

## Test plan
- [x] `./gradlew build` passes
- [x] `./gradlew buildHealth` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)