### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*' # Triggers on version tags like v1.0.0, v2.1.3, etc.
+
+permissions:
+  contents: write # Required to create releases and upload assets
+
+jobs:
+  build-all:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - platform: Windows
+            os: windows-latest
+            task: :jvm-app:packageMsi
+            artifact-name: windows-installer
+            artifact-path: jvm-app/build/compose/binaries/main/msi/*.msi
+          - platform: macOS
+            os: macos-latest
+            task: :jvm-app:packageDmg
+            artifact-name: macos-installer
+            artifact-path: jvm-app/build/compose/binaries/main/dmg/*.dmg
+          - platform: Linux
+            os: ubuntu-latest
+            task: :jvm-app:packageDeb
+            artifact-name: linux-installer
+            artifact-path: jvm-app/build/compose/binaries/main/deb/*.deb
+          - platform: Android
+            os: ubuntu-latest
+            task: :android-app:assembleRelease
+            artifact-name: android-apk
+            artifact-path: android-app/build/outputs/apk/release/*.apk
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build ${{ matrix.platform }}
+        uses: ./.github/actions/gradle-run
+        with:
+          command: ${{ matrix.task }} --stacktrace
+
+      - name: Upload ${{ matrix.platform }} artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: ${{ matrix.artifact-path }}
+          retention-days: 7
+
+  create-release:
+    name: Create GitHub Release
+    needs: [build-all]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+
+      - name: Display artifact structure
+        run: ls -R release-artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            release-artifacts/windows-installer/*.msi
+            release-artifacts/macos-installer/*.dmg
+            release-artifacts/linux-installer/*.deb
+            release-artifacts/android-apk/*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# Notes for production releases:
+#
+# Android Signing:
+# - Add secrets: ANDROID_KEYSTORE (base64), KEYSTORE_PASSWORD, KEY_ALIAS, KEY_PASSWORD
+# - Configure signing in android-app/build.gradle.kts
+# - Update workflow to decode keystore before building
+#
+# macOS Code Signing (optional but recommended):
+# - Add Apple Developer certificate secrets
+# - Configure signing to avoid security warnings for users


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically creates releases with native installers for all platforms when version tags are pushed.

## What's included

- **Windows MSI installer** (built on Windows runner)
- **macOS DMG installer** (built on macOS runner)  
- **Linux DEB package** (built on Ubuntu runner)
- **Android APK** (built on Ubuntu runner)

## Implementation details

- Uses matrix strategy with 4 platform variations for parallel builds
- Reuses existing `gradle-run` composite action for consistency
- Triggers on version tags matching `v*` pattern (e.g., `v1.0.0`, `v2.1.3`)
- Automatically creates GitHub release with all binaries attached
- Includes auto-generated release notes

## How to use

Push a version tag to trigger the workflow:

```bash
git tag v1.0.0
git push origin v1.0.0
```

The workflow will:
1. Build all 4 platform binaries in parallel
2. Create a GitHub release with the tag version
3. Attach all installers and APK to the release

## Future improvements

For production releases, consider adding:
- Android APK signing configuration
- macOS code signing to avoid security warnings

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test by pushing a test tag (e.g., `v0.1.0-test`)
- [ ] Confirm all 4 builds complete successfully
- [ ] Verify GitHub release is created with all artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)