### PR TITLE
Fix auto-tag workflow to trigger release builds

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -38,7 +38,7 @@ jobs:
             echo "Tag ${{ steps.version.outputs.tag }} does not exist"
           fi
 
-      - name: Create tag
+      - name: Create and push tag
         if: steps.check-tag.outputs.exists == 'false'
         run: |
           git config user.name "github-actions[bot]"
@@ -46,3 +46,11 @@ jobs:
           git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.version }}"
           git push origin "${{ steps.version.outputs.tag }}"
           echo "Created and pushed tag ${{ steps.version.outputs.tag }}"
+
+      - name: Trigger release workflow
+        if: steps.check-tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Triggering release workflow for tag ${{ steps.version.outputs.tag }}"
+          gh workflow run release.yml --ref "${{ steps.version.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*' # Triggers on version tags like v1.0.0, v2.1.3, etc.
+  workflow_dispatch: # Allow manual triggering from auto-tag workflow
 
 permissions:
   contents: write # Required to create releases and upload assets


### PR DESCRIPTION
## Problem
The auto-tag workflow was successfully creating tags (e.g., v0.1.2), but the release workflow wasn't triggering. This is because GitHub doesn't trigger workflows for tags created by the default GITHUB_TOKEN to prevent recursive workflow runs.

## Solution
- Added `workflow_dispatch` trigger to `release.yml` to allow manual workflow triggering
- Added a step in `auto-tag.yml` to manually trigger the release workflow using `gh workflow run` after creating a tag
- This ensures the release workflow runs immediately after a new version tag is created

## How it works now
1. VERSION file is updated and pushed to main
2. Auto-tag workflow detects the new version
3. Creates the git tag (e.g., v0.1.2)
4. Manually triggers the release workflow using GitHub CLI
5. Release workflow builds all platform installers and creates a GitHub release

## Testing
After merging this PR:
- The existing v0.1.2 tag can be used to manually test: `gh workflow run release.yml --ref v0.1.2`
- For the next version bump, the auto-tag workflow should automatically trigger the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)