### PR TITLE
Add actions:write permission to auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write # Required to create tags
+  actions: write # Required to trigger workflows
 
 jobs:
   create-tag:


### PR DESCRIPTION
## Problem
The auto-tag workflow was failing with error:
```
HTTP 403: Resource not accessible by integration
```

This occurred when trying to trigger the release workflow using `gh workflow run`.

## Root Cause
The default `GITHUB_TOKEN` needs explicit `actions: write` permission to trigger other workflows via `workflow_dispatch`.

## Solution
Added `actions: write` to the permissions section of the auto-tag workflow.

## Testing
After merging:
- The auto-tag workflow should successfully trigger the release workflow
- Tag v0.1.3 already exists, so we can test by bumping to v0.1.4
- Or manually re-run the failed workflow after this is merged

## Related
- Failed run: https://github.com/NikolayMetchev/money-manager/actions/runs/19706052228
- PR #46 (version bump to 0.1.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)