### PR TITLE
Require successful build before creating releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,68 @@ on:
 
 permissions:
   contents: write # Required to create releases and upload assets
+  actions: read # Required to check workflow status
 
 jobs:
+  check-build:
+    name: Verify Build Passed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get commit SHA for tag
+        id: get-sha
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # For tag pushes, get the commit the tag points to
+            COMMIT_SHA="${{ github.sha }}"
+          else
+            # For workflow_dispatch, get the SHA from the ref
+            COMMIT_SHA=$(git rev-parse HEAD)
+          fi
+          echo "sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+          echo "Checking build status for commit: $COMMIT_SHA"
+
+      - name: Check if build workflow passed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          COMMIT_SHA="${{ steps.get-sha.outputs.sha }}"
+          echo "Waiting for build workflow to complete for commit $COMMIT_SHA..."
+
+          # Wait up to 10 minutes for build to complete
+          for i in {1..60}; do
+            # Get the latest build workflow run for this commit
+            BUILD_STATUS=$(gh run list \
+              --workflow=build.yml \
+              --commit="$COMMIT_SHA" \
+              --json conclusion \
+              --jq '.[0].conclusion // "pending"')
+
+            echo "Build status: $BUILD_STATUS"
+
+            if [ "$BUILD_STATUS" = "success" ]; then
+              echo "✓ Build workflow passed for commit $COMMIT_SHA"
+              exit 0
+            elif [ "$BUILD_STATUS" = "failure" ] || [ "$BUILD_STATUS" = "cancelled" ]; then
+              echo "✗ Build workflow failed or was cancelled for commit $COMMIT_SHA"
+              echo "Release cannot proceed without a successful build"
+              exit 1
+            fi
+
+            # Still pending, wait and retry
+            sleep 10
+          done
+
+          echo "✗ Timeout waiting for build workflow to complete"
+          exit 1
+
   build-all:
     name: Build ${{ matrix.platform }}
+    needs: [check-build]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
Adds a safety check to the release workflow to ensure the build workflow has passed before creating releases.

## Changes
- Add `check-build` job that runs before the release builds
- Verifies that the build workflow passed on the commit being released
- Waits up to 10 minutes for the build to complete if it's still running
- Fails the release if the build failed, was cancelled, or times out
- The `build-all` job now depends on `check-build` passing
- Add `actions: read` permission to query workflow status

## How it works
1. When a tag triggers the release workflow (or it's manually triggered)
2. The `check-build` job identifies the commit SHA
3. It queries the build workflow status for that commit using `gh run list`
4. If the build is still running, it waits (checking every 10 seconds)
5. Only if the build is successful does it proceed to `build-all`
6. If the build failed or times out, the release is aborted

## Benefits
- Prevents releasing broken code
- Ensures all tests and checks passed before distribution
- Provides clear feedback if a release is blocked due to build failure
- No manual intervention needed - fully automated safety check

## Test plan
- [ ] Merge this PR
- [ ] Trigger a release (e.g., by merging a version bump)
- [ ] Verify the check-build job waits for and verifies the build workflow
- [ ] Verify the release only proceeds if the build is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)