### PR TITLE
Remove debug log window and custom log wrapper

### DIFF
--- a/compose-ui/src/commonMain/kotlin/com/moneymanager/ui/ErrorScreen.kt
+++ b/compose-ui/src/commonMain/kotlin/com/moneymanager/ui/ErrorScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.moneymanager.ui.debug.DebugLogScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -26,61 +25,44 @@ fun ErrorScreen(
                 )
             },
         ) { paddingValues ->
-            Column(
+            Surface(
                 modifier =
                     Modifier
                         .fillMaxSize()
                         .padding(paddingValues),
+                color = MaterialTheme.colorScheme.errorContainer,
+                tonalElevation = 2.dp,
             ) {
-                // Error message section
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    color = MaterialTheme.colorScheme.errorContainer,
-                    tonalElevation = 2.dp,
+                Column(
+                    modifier = Modifier.padding(16.dp),
                 ) {
-                    Column(
-                        modifier = Modifier.padding(16.dp),
-                    ) {
-                        Text(
-                            text = "The application failed to initialize:",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.onErrorContainer,
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = errorMessage,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onErrorContainer,
-                        )
+                    Text(
+                        text = "The application failed to initialize:",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = errorMessage,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
 
-                        fullException?.let { exception ->
-                            Spacer(modifier = Modifier.height(16.dp))
-                            Text(
-                                text = "Exception Details:",
-                                style = MaterialTheme.typography.titleSmall,
-                                color = MaterialTheme.colorScheme.onErrorContainer,
-                            )
-                            Spacer(modifier = Modifier.height(4.dp))
-                            Text(
-                                text = exception.take(500) + if (exception.length > 500) "..." else "",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onErrorContainer,
-                            )
-                        }
-
+                    fullException?.let { exception ->
                         Spacer(modifier = Modifier.height(16.dp))
-                        HorizontalDivider()
-                        Spacer(modifier = Modifier.height(8.dp))
                         Text(
-                            text = "See full debug logs below ↓",
+                            text = "Exception Details:",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = exception.take(500) + if (exception.length > 500) "..." else "",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onErrorContainer,
                         )
                     }
                 }
-
-                // Debug logs section
-                DebugLogScreen()
             }
         }
     }

--- a/compose-ui/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/compose-ui/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -8,7 +8,6 @@ import com.moneymanager.domain.model.AppVersion
 import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.TransactionRepository
-import com.moneymanager.ui.debug.DebugLogScreen
 import com.moneymanager.ui.navigation.Screen
 import com.moneymanager.ui.screens.AccountsScreen
 import com.moneymanager.ui.screens.CategoriesScreen
@@ -73,12 +72,6 @@ fun MoneyManagerApp(
                         selected = currentScreen is Screen.Transactions,
                         onClick = { currentScreen = Screen.Transactions },
                     )
-                    NavigationBarItem(
-                        icon = { Text("🐛") },
-                        label = { Text("Debug") },
-                        selected = currentScreen is Screen.Debug,
-                        onClick = { currentScreen = Screen.Debug },
-                    )
                 }
             },
         ) { paddingValues ->
@@ -87,7 +80,6 @@ fun MoneyManagerApp(
                     is Screen.Accounts -> AccountsScreen(accountRepository)
                     is Screen.Categories -> CategoriesScreen(categoryRepository)
                     is Screen.Transactions -> TransactionsScreen(transactionRepository)
-                    is Screen.Debug -> DebugLogScreen()
                 }
             }
         }

--- a/compose-ui/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
+++ b/compose-ui/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
@@ -6,6 +6,4 @@ sealed class Screen(val route: String, val title: String) {
     data object Categories : Screen("categories", "Categories")
 
     data object Transactions : Screen("transactions", "Transactions")
-
-    data object Debug : Screen("debug", "Debug Logs")
 }

--- a/jvm-app/src/main/kotlin/com/moneymanager/Main.kt
+++ b/jvm-app/src/main/kotlin/com/moneymanager/Main.kt
@@ -20,8 +20,6 @@ import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.TransactionRepository
 import com.moneymanager.ui.DatabaseSelectionDialog
 import com.moneymanager.ui.MoneyManagerApp
-import com.moneymanager.ui.debug.LogCollector
-import com.moneymanager.ui.debug.LogLevel
 import org.lighthousegames.logging.logging
 import java.awt.FileDialog
 import java.awt.Frame
@@ -29,27 +27,8 @@ import java.nio.file.Paths
 
 private val logger = logging()
 
-private fun log(
-    level: LogLevel,
-    message: String,
-    throwable: Throwable? = null,
-) {
-    LogCollector.log(level, message, throwable)
-    val logMessage = if (throwable != null) "$message: ${throwable.message}" else message
-    when (level) {
-        LogLevel.DEBUG -> logger.debug { logMessage }
-        LogLevel.INFO -> logger.info { logMessage }
-        LogLevel.WARN -> logger.warn { logMessage }
-        LogLevel.ERROR -> logger.error { logMessage }
-    }
-    throwable?.let {
-        logger.error(it) { "Stack trace" }
-        it.printStackTrace()
-    }
-}
-
 fun main() {
-    log(LogLevel.INFO, "Starting Money Manager application")
+    logger.info { "Starting Money Manager application" }
 
     application {
         MainWindow(onExit = ::exitApplication)
@@ -65,18 +44,18 @@ private fun MainWindow(onExit: () -> Unit) {
 
     // Initialize on startup
     LaunchedEffect(Unit) {
-        log(LogLevel.INFO, "LaunchedEffect: Starting initialization")
+        logger.info { "LaunchedEffect: Starting initialization" }
         val defaultDbPath = DEFAULT_DATABASE_PATH
         val dbExists = defaultDbPath.exists()
-        log(LogLevel.DEBUG, "Default database path: $defaultDbPath, exists: $dbExists")
+        logger.debug { "Default database path: $defaultDbPath, exists: $dbExists" }
 
         if (dbExists) {
             databasePath = defaultDbPath
-            log(LogLevel.INFO, "Existing database found, initializing...")
+            logger.info { "Existing database found, initializing..." }
             appState = initializeApplication(defaultDbPath)
-            log(LogLevel.INFO, "Initialization complete")
+            logger.info { "Initialization complete" }
         } else {
-            log(LogLevel.INFO, "No existing database, showing dialog")
+            logger.info { "No existing database, showing dialog" }
             showDatabaseDialog = true
         }
     }
@@ -97,14 +76,14 @@ private fun MainWindow(onExit: () -> Unit) {
             DatabaseSelectionDialog(
                 defaultPath = DEFAULT_DATABASE_PATH,
                 onDatabaseSelected = { selectedPath ->
-                    log(LogLevel.INFO, "User selected database path: $selectedPath")
+                    logger.info { "User selected database path: $selectedPath" }
                     databasePath = DbLocation(selectedPath)
                     showDatabaseDialog = false
-                    log(LogLevel.INFO, "Database path set successfully")
+                    logger.info { "Database path set successfully" }
                     appState = initializeApplication(DbLocation(selectedPath))
                 },
                 onCancel = {
-                    log(LogLevel.INFO, "User cancelled database selection - exiting application")
+                    logger.info { "User cancelled database selection - exiting application" }
                     onExit()
                 },
                 onShowFileChooser = {
@@ -146,21 +125,21 @@ private data class AppState(
 )
 
 private fun initializeApplication(dbLocation: DbLocation): AppState {
-    log(LogLevel.INFO, "=== Starting Application Initialization ===")
-    log(LogLevel.INFO, "Database path: $dbLocation")
+    logger.info { "=== Starting Application Initialization ===" }
+    logger.info { "Database path: $dbLocation" }
 
-    log(LogLevel.INFO, "Creating DI component...")
+    logger.info { "Creating DI component..." }
     val params = AppComponentParams()
     val component: AppComponent = AppComponent.create(params)
-    log(LogLevel.INFO, "DI component created successfully")
+    logger.info { "DI component created successfully" }
 
     val accountRepository = component.repositoryFactory.createAccountRepository({ DEFAULT_DATABASE_PATH })
     val categoryRepository = component.repositoryFactory.createCategoryRepository({ DEFAULT_DATABASE_PATH })
     val transactionRepository = component.repositoryFactory.createTransactionRepository({ DEFAULT_DATABASE_PATH })
     val appVersion = component.appVersion
-    log(LogLevel.INFO, "App version: ${appVersion.value}")
-    log(LogLevel.INFO, "All repositories initialized successfully")
-    log(LogLevel.INFO, "=== Initialization Complete ===")
+    logger.info { "App version: ${appVersion.value}" }
+    logger.info { "All repositories initialized successfully" }
+    logger.info { "=== Initialization Complete ===" }
 
     return AppState(accountRepository, categoryRepository, transactionRepository, appVersion)
 }


### PR DESCRIPTION
## Summary

This PR removes the in-memory debug log window and simplifies logging by using the KMLogging library directly instead of wrapping it through a custom method.

## Changes

### Main.kt
- **Removed custom `log()` wrapper function** that called both `LogCollector` and the logger
- **Replaced all `log(LogLevel.INFO, ...)` calls** with direct `logger.info { ... }` calls
- **Removed imports**: `LogCollector`, `LogLevel`
- Logging now goes directly through KMLogging to file instead of also being collected in memory

### Navigation Changes
- **Removed Debug screen** from `Screen.kt` sealed class
- **Removed Debug tab** from `MoneyManagerApp.kt` bottom navigation bar (4 tabs → 3 tabs)
- Now only shows: Accounts, Categories, Transactions

### ErrorScreen.kt
- **Removed `DebugLogScreen` import and usage**
- **Simplified layout** by removing the debug logs section
- Error screen now only shows error message and exception details (no embedded log viewer)

## Impact

- **Code reduction**: 49 fewer lines across 4 files
- **Simpler logging**: Direct use of KMLogging instead of dual logging (file + in-memory)
- **Cleaner UI**: Removed debug-focused navigation tab
- **Files kept**: `LogCollector.kt` and `DebugLogWindow.kt` remain in the codebase but are unused (can be removed in future PR if needed)

## Benefits

1. **Simpler code**: No need for custom wrapper around the logging library
2. **Better performance**: No in-memory log collection overhead
3. **Cleaner UX**: Users don't see debug-focused UI elements
4. **Standard logging**: All logs go through the configured KMLogging backend (file-based)

## Test Plan

- [x] Build succeeds (`./gradlew :jvm-app:compileKotlin`)
- [ ] Run JVM app and verify logging works (check log files)
- [ ] Verify Debug tab is no longer visible in bottom navigation
- [ ] Verify app shows only 3 tabs: Accounts, Categories, Transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)