### PR TITLE
Add concurrency controls to GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write # Required to create tags
   actions: write # Required to trigger workflows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and Test

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - 'v*' # Triggers on version tags like v1.0.0, v2.1.3, etc.
   workflow_dispatch: # Allow manual triggering from auto-tag workflow
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write # Required to create releases and upload assets
   actions: read # Required to check workflow status


### PR DESCRIPTION
## Summary

- Add concurrency configuration to all GitHub Actions workflows to automatically cancel old builds when new commits are pushed
- Prevents wasted CI resources during busy periods with multiple merges (e.g., batch Dependabot PRs)
- Ensures only the latest build runs to completion for each branch/PR

## Changes

**Workflows Updated:**
- `.github/workflows/build.yml` - Cancel old main/PR builds
- `.github/workflows/auto-tag.yml` - Cancel old tag creation runs  
- `.github/workflows/lint-format.yml` - Cancel old formatting runs
- `.github/workflows/release.yml` - Cancel old release builds

**Concurrency Configuration:**
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## Benefits

- **Saves CI minutes**: During multiple rapid merges, old builds are automatically cancelled
- **Faster feedback**: Reduces queue times by canceling unnecessary builds
- **Resource efficiency**: Only the latest build runs to completion
- **Better for PRs**: When pushing new commits during development, old builds are cancelled automatically

## Test Plan

- [ ] Verify workflows still trigger correctly on push to main
- [ ] Verify workflows still trigger correctly on pull requests
- [ ] Confirm old builds are cancelled when new commits are pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)