### PR TITLE
Refactor: Remove assetId and initialBalance from Account

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountMapper.kt
@@ -3,14 +3,12 @@
 package com.moneymanager.database.mapper
 
 import com.moneymanager.domain.model.Account
-import com.moneymanager.domain.model.Asset
 import tech.mappie.api.ObjectMappie
 import kotlin.time.Instant
 
-object AccountMapper : ObjectMappie<com.moneymanager.database.sql.AccountView, Account>() {
-    override fun map(from: com.moneymanager.database.sql.AccountView) =
+object AccountMapper : ObjectMappie<com.moneymanager.database.sql.Account, Account>() {
+    override fun map(from: com.moneymanager.database.sql.Account) =
         mapping {
             Account::openingDate fromValue Instant.fromEpochMilliseconds(from.openingDate)
-            Account::asset fromValue Asset(id = from.assetId, name = from.assetName)
         }
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/AccountRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/AccountRepositoryImpl.kt
@@ -36,8 +36,6 @@ class AccountRepositoryImpl(
             queries.transactionWithResult {
                 queries.insert(
                     name = account.name,
-                    assetId = account.asset.id,
-                    initialBalance = account.initialBalance,
                     openingDate = account.openingDate.toEpochMilliseconds(),
                 )
                 queries.lastInsertRowId().executeAsOne()
@@ -48,8 +46,6 @@ class AccountRepositoryImpl(
         withContext(Dispatchers.Default) {
             queries.update(
                 name = account.name,
-                assetId = account.asset.id,
-                initialBalance = account.initialBalance,
                 id = account.id,
             )
         }

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Account.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Account.sq
@@ -1,36 +1,22 @@
 CREATE TABLE Account (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL,
-    assetId INTEGER NOT NULL,
-    initialBalance REAL NOT NULL DEFAULT 0.0,
-    openingDate INTEGER NOT NULL,
-    FOREIGN KEY (assetId) REFERENCES Asset(id)
+    openingDate INTEGER NOT NULL
 );
 
-CREATE VIEW AccountView AS
-SELECT
-    Account.id AS id,
-    Account.name AS name,
-    Account.initialBalance AS initialBalance,
-    Account.openingDate AS openingDate,
-    Asset.id AS assetId,
-    Asset.name AS assetName
-FROM Account
-INNER JOIN Asset ON Account.assetId = Asset.id;
-
 selectAll:
-SELECT * FROM AccountView;
+SELECT * FROM Account;
 
 selectById:
-SELECT * FROM AccountView WHERE id = ?;
+SELECT * FROM Account WHERE id = ?;
 
 insert:
-INSERT INTO Account(name, assetId, initialBalance, openingDate)
-VALUES (?, ?, ?, ?);
+INSERT INTO Account(name, openingDate)
+VALUES (?, ?);
 
 update:
 UPDATE Account
-SET name = ?, assetId = ?, initialBalance = ?
+SET name = ?
 WHERE id = ?;
 
 delete:

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Account.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Account.kt
@@ -7,7 +7,5 @@ import kotlin.time.Instant
 data class Account(
     val id: Long = 0,
     val name: String,
-    val asset: Asset,
-    val initialBalance: Double = 0.0,
     val openingDate: Instant,
 )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -72,7 +72,7 @@ fun MoneyManagerApp(
         ) { paddingValues ->
             Box(modifier = Modifier.padding(paddingValues)) {
                 when (currentScreen) {
-                    is Screen.Accounts -> AccountsScreen(repositorySet.accountRepository, repositorySet.assetRepository)
+                    is Screen.Accounts -> AccountsScreen(repositorySet.accountRepository)
                     is Screen.Categories -> CategoriesScreen(repositorySet.categoryRepository)
                     is Screen.Transactions -> TransactionsScreen(repositorySet.transactionRepository)
                 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
@@ -8,9 +8,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import com.moneymanager.domain.model.Account
-import com.moneymanager.domain.model.Asset
 import com.moneymanager.domain.repository.AccountRepository
-import com.moneymanager.domain.repository.AssetRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -19,12 +17,6 @@ import kotlin.time.Clock
 
 @OptIn(ExperimentalTestApi::class)
 class AccountsScreenTest {
-    // Test assets
-    private val testUSD = Asset(id = 1L, name = "USD")
-    private val testEUR = Asset(id = 2L, name = "EUR")
-    private val testGBP = Asset(id = 3L, name = "GBP")
-    private val fakeAssetRepository = FakeAssetRepository()
-
     @Test
     fun accountsScreen_displaysEmptyState_whenNoAccounts() =
         runComposeUiTest {
@@ -33,7 +25,7 @@ class AccountsScreenTest {
 
             // When
             setContent {
-                AccountsScreen(accountRepository = repository, assetRepository = fakeAssetRepository)
+                AccountsScreen(accountRepository = repository)
             }
 
             // Then
@@ -51,15 +43,11 @@ class AccountsScreenTest {
                     Account(
                         id = 1L,
                         name = "Checking Account",
-                        asset = testUSD,
-                        initialBalance = 1000.0,
                         openingDate = now,
                     ),
                     Account(
                         id = 2L,
                         name = "Savings Account",
-                        asset = testUSD,
-                        initialBalance = 5000.0,
                         openingDate = now,
                     ),
                 )
@@ -67,14 +55,12 @@ class AccountsScreenTest {
 
             // When
             setContent {
-                AccountsScreen(accountRepository = repository, assetRepository = fakeAssetRepository)
+                AccountsScreen(accountRepository = repository)
             }
 
             // Then
             onNodeWithText("Checking Account").assertIsDisplayed()
             onNodeWithText("Savings Account").assertIsDisplayed()
-            onNodeWithText("USD 1000.00").assertIsDisplayed()
-            onNodeWithText("USD 5000.00").assertIsDisplayed()
         }
 
     @Test
@@ -85,7 +71,7 @@ class AccountsScreenTest {
 
             // When
             setContent {
-                AccountsScreen(accountRepository = repository, assetRepository = fakeAssetRepository)
+                AccountsScreen(accountRepository = repository)
             }
 
             // Then
@@ -100,7 +86,7 @@ class AccountsScreenTest {
 
             // When
             setContent {
-                AccountsScreen(accountRepository = repository, assetRepository = fakeAssetRepository)
+                AccountsScreen(accountRepository = repository)
             }
 
             onNodeWithText("+").performClick()
@@ -108,7 +94,6 @@ class AccountsScreenTest {
             // Then
             onNodeWithText("Create New Account").assertIsDisplayed()
             onNodeWithText("Account Name").assertIsDisplayed()
-            onNodeWithText("Asset").assertIsDisplayed()
         }
 
     @Test
@@ -120,44 +105,17 @@ class AccountsScreenTest {
                 Account(
                     id = 1L,
                     name = "My Checking",
-                    asset = testEUR,
-                    initialBalance = 2500.50,
                     openingDate = now,
                 )
             val repository = FakeAccountRepository(listOf(account))
 
             // When
             setContent {
-                AccountsScreen(accountRepository = repository, assetRepository = fakeAssetRepository)
+                AccountsScreen(accountRepository = repository)
             }
 
             // Then
             onNodeWithText("My Checking").assertIsDisplayed()
-            onNodeWithText("EUR 2500.50").assertIsDisplayed()
-        }
-
-    @Test
-    fun accountCard_displaysNegativeBalance_inErrorColor() =
-        runComposeUiTest {
-            // Given
-            val now = Clock.System.now()
-            val account =
-                Account(
-                    id = 1L,
-                    name = "Credit Card",
-                    asset = testUSD,
-                    initialBalance = -500.0,
-                    openingDate = now,
-                )
-            val repository = FakeAccountRepository(listOf(account))
-
-            // When
-            setContent {
-                AccountsScreen(accountRepository = repository, assetRepository = fakeAssetRepository)
-            }
-
-            // Then
-            onNodeWithText("USD -500.00").assertIsDisplayed()
         }
 
     @Test
@@ -169,15 +127,13 @@ class AccountsScreenTest {
                 Account(
                     id = 1L,
                     name = "Test Account",
-                    asset = testUSD,
-                    initialBalance = 100.0,
                     openingDate = now,
                 )
             val repository = FakeAccountRepository(listOf(account))
 
             // When
             setContent {
-                AccountsScreen(accountRepository = repository, assetRepository = fakeAssetRepository)
+                AccountsScreen(accountRepository = repository)
             }
 
             // Click the delete button (trash icon)
@@ -196,7 +152,7 @@ class AccountsScreenTest {
 
             // When
             setContent {
-                AccountsScreen(accountRepository = repository, assetRepository = fakeAssetRepository)
+                AccountsScreen(accountRepository = repository)
             }
 
             // Open dialog
@@ -217,7 +173,7 @@ class AccountsScreenTest {
 
             // When
             setContent {
-                AccountsScreen(accountRepository = repository, assetRepository = fakeAssetRepository)
+                AccountsScreen(accountRepository = repository)
             }
 
             // Open dialog
@@ -240,15 +196,13 @@ class AccountsScreenTest {
                 Account(
                     id = 1L,
                     name = "Test Account",
-                    asset = testUSD,
-                    initialBalance = 100.0,
                     openingDate = now,
                 )
             val repository = FakeAccountRepository(listOf(account))
 
             // When
             setContent {
-                AccountsScreen(accountRepository = repository, assetRepository = fakeAssetRepository)
+                AccountsScreen(accountRepository = repository)
             }
 
             // Open delete dialog
@@ -272,22 +226,16 @@ class AccountsScreenTest {
                     Account(
                         id = 1L,
                         name = "Account 1",
-                        asset = testUSD,
-                        initialBalance = 100.0,
                         openingDate = now,
                     ),
                     Account(
                         id = 2L,
                         name = "Account 2",
-                        asset = testEUR,
-                        initialBalance = 200.0,
                         openingDate = now,
                     ),
                     Account(
                         id = 3L,
                         name = "Account 3",
-                        asset = testGBP,
-                        initialBalance = 300.0,
                         openingDate = now,
                     ),
                 )
@@ -295,7 +243,7 @@ class AccountsScreenTest {
 
             // When
             setContent {
-                AccountsScreen(accountRepository = repository, assetRepository = fakeAssetRepository)
+                AccountsScreen(accountRepository = repository)
             }
 
             // Then - all accounts should be visible
@@ -304,7 +252,7 @@ class AccountsScreenTest {
             onNodeWithText("Account 3").assertIsDisplayed()
         }
 
-    // Fake repositories for testing
+    // Fake repository for testing
     private class FakeAccountRepository(
         private val accounts: List<Account>,
     ) : AccountRepository {
@@ -332,30 +280,6 @@ class AccountsScreenTest {
         override suspend fun deleteAccount(id: Long) {
             deletedAccounts.add(id)
             accountsFlow.value = accountsFlow.value.filter { it.id != id }
-        }
-    }
-
-    private class FakeAssetRepository : AssetRepository {
-        private val assets = mutableMapOf<String, Long>()
-        private var nextId = 1L
-
-        override fun getAllAssets(): Flow<List<Asset>> = flowOf(assets.map { (name, id) -> Asset(id = id, name = name) })
-
-        override fun getAssetById(id: Long): Flow<Asset?> =
-            flowOf(assets.entries.find { it.value == id }?.let { Asset(id = it.value, name = it.key) })
-
-        override suspend fun upsertAssetByName(name: String): Long {
-            return assets.getOrPut(name) {
-                nextId++
-            }
-        }
-
-        override suspend fun updateAsset(asset: Asset) {
-            assets[asset.name] = asset.id
-        }
-
-        override suspend fun deleteAsset(id: Long) {
-            assets.entries.find { it.value == id }?.let { assets.remove(it.key) }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove `assetId` foreign key and `initialBalance` columns from Account table
- Remove `AccountView` that was joining with Asset table
- Simplify `AccountMapper`, `AccountRepositoryImpl`, and `AccountsScreen` UI
- Update all related tests to reflect simplified Account model

This simplifies the Account model - asset/currency and initial balance will be determined through transactions in a future PR.

## Test plan
- [x] Build passes locally (`./gradlew build`)
- [x] All unit tests pass
- [x] UI tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)