### PR TITLE
Add transaction entry dialog with inline account/asset creation

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionRepositoryImpl.kt
@@ -71,6 +71,7 @@ class TransactionRepositoryImpl(
                 sourceAccountId = transaction.sourceAccountId,
                 targetAccountId = transaction.targetAccountId,
                 assetId = transaction.assetId,
+                amount = transaction.amount,
                 timestamp = transaction.timestamp.toEpochMilliseconds(),
             )
             queries.lastInsertRowId().executeAsOne()
@@ -82,6 +83,7 @@ class TransactionRepositoryImpl(
                 sourceAccountId = transaction.sourceAccountId,
                 targetAccountId = transaction.targetAccountId,
                 assetId = transaction.assetId,
+                amount = transaction.amount,
                 timestamp = transaction.timestamp.toEpochMilliseconds(),
                 id = transaction.id,
             )

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Transaction.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Transaction.sq
@@ -3,6 +3,7 @@ CREATE TABLE `Transaction` (
     sourceAccountId INTEGER NOT NULL,
     targetAccountId INTEGER NOT NULL,
     assetId INTEGER NOT NULL,
+    amount REAL NOT NULL,
     timestamp INTEGER NOT NULL,
     FOREIGN KEY (sourceAccountId) REFERENCES Account(id) ON DELETE CASCADE,
     FOREIGN KEY (targetAccountId) REFERENCES Account(id) ON DELETE CASCADE,
@@ -30,12 +31,12 @@ AND timestamp >= ? AND timestamp <= ?
 ORDER BY timestamp DESC;
 
 insert:
-INSERT INTO `Transaction`(sourceAccountId, targetAccountId, assetId, timestamp)
-VALUES (?, ?, ?, ?);
+INSERT INTO `Transaction`(sourceAccountId, targetAccountId, assetId, amount, timestamp)
+VALUES (?, ?, ?, ?, ?);
 
 update:
 UPDATE `Transaction`
-SET sourceAccountId = ?, targetAccountId = ?, assetId = ?, timestamp = ?
+SET sourceAccountId = ?, targetAccountId = ?, assetId = ?, amount = ?, timestamp = ?
 WHERE id = ?;
 
 delete:

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Transaction.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Transaction.kt
@@ -9,5 +9,6 @@ data class Transaction(
     val sourceAccountId: Long,
     val targetAccountId: Long,
     val assetId: Long,
+    val amount: Double,
     val timestamp: Instant,
 )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -82,7 +82,12 @@ fun MoneyManagerApp(
                     is Screen.Accounts -> AccountsScreen(repositorySet.accountRepository)
                     is Screen.Assets -> AssetsScreen(repositorySet.assetRepository)
                     is Screen.Categories -> CategoriesScreen(repositorySet.categoryRepository)
-                    is Screen.Transactions -> TransactionsScreen(repositorySet.transactionRepository)
+                    is Screen.Transactions ->
+                        TransactionsScreen(
+                            transactionRepository = repositorySet.transactionRepository,
+                            accountRepository = repositorySet.accountRepository,
+                            assetRepository = repositorySet.assetRepository,
+                        )
                 }
             }
         }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/TransactionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/TransactionsScreen.kt
@@ -5,57 +5,106 @@ package com.moneymanager.ui.screens
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.Asset
 import com.moneymanager.domain.model.Transaction
+import com.moneymanager.domain.repository.AccountRepository
+import com.moneymanager.domain.repository.AssetRepository
 import com.moneymanager.domain.repository.TransactionRepository
+import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import org.lighthousegames.logging.logging
+import kotlin.time.Clock
+
+private val logger = logging()
 
 @Composable
-fun TransactionsScreen(transactionRepository: TransactionRepository) {
+fun TransactionsScreen(
+    transactionRepository: TransactionRepository,
+    accountRepository: AccountRepository,
+    assetRepository: AssetRepository,
+) {
     val transactions by transactionRepository.getAllTransactions().collectAsState(initial = emptyList())
+    val accounts by accountRepository.getAllAccounts().collectAsState(initial = emptyList())
+    val assets by assetRepository.getAllAssets().collectAsState(initial = emptyList())
+    var showCreateDialog by remember { mutableStateOf(false) }
 
-    Column(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .padding(16.dp),
-    ) {
-        Text(
-            text = "Your Transactions",
-            style = MaterialTheme.typography.headlineMedium,
-            modifier = Modifier.padding(bottom = 16.dp),
-        )
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+        ) {
+            Text(
+                text = "Your Transactions",
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.padding(bottom = 16.dp),
+            )
 
-        if (transactions.isEmpty()) {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = "No transactions yet. Add your first transaction!",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        } else {
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(transactions) { transaction ->
-                    TransactionCard(transaction)
+            if (transactions.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "No transactions yet. Add your first transaction!",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(transactions) { transaction ->
+                        TransactionCard(transaction, accounts, assets)
+                    }
                 }
             }
+        }
+
+        FloatingActionButton(
+            onClick = { showCreateDialog = true },
+            modifier =
+                Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp),
+        ) {
+            Text("+", style = MaterialTheme.typography.headlineLarge)
+        }
+
+        if (showCreateDialog) {
+            TransactionEntryDialog(
+                transactionRepository = transactionRepository,
+                accountRepository = accountRepository,
+                assetRepository = assetRepository,
+                accounts = accounts,
+                assets = assets,
+                onDismiss = { showCreateDialog = false },
+            )
         }
     }
 }
 
 @Composable
-fun TransactionCard(transaction: Transaction) {
+fun TransactionCard(
+    transaction: Transaction,
+    accounts: List<Account>,
+    assets: List<Asset>,
+) {
+    val sourceAccount = accounts.find { it.id == transaction.sourceAccountId }
+    val targetAccount = accounts.find { it.id == transaction.targetAccountId }
+    val asset = assets.find { it.id == transaction.assetId }
+
     Card(
         modifier = Modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
@@ -71,27 +120,12 @@ fun TransactionCard(transaction: Transaction) {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Column {
+                Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = "Transaction",
+                        text = "${sourceAccount?.name ?: "Unknown"} → ${targetAccount?.name ?: "Unknown"}",
                         style = MaterialTheme.typography.titleMedium,
                     )
                     Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text = "Source Account: ${transaction.sourceAccountId}",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text = "Target Account: ${transaction.targetAccountId}",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        text = "Asset: ${transaction.assetId}",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
                     val dateTime = transaction.timestamp.toLocalDateTime(TimeZone.currentSystemDefault())
                     Text(
                         text = "${dateTime.date} ${dateTime.time}",
@@ -99,7 +133,458 @@ fun TransactionCard(transaction: Transaction) {
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        text = String.format("%.2f", transaction.amount),
+                        style = MaterialTheme.typography.titleLarge,
+                    )
+                    Text(
+                        text = asset?.name ?: "Unknown",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TransactionEntryDialog(
+    transactionRepository: TransactionRepository,
+    accountRepository: AccountRepository,
+    assetRepository: AssetRepository,
+    accounts: List<Account>,
+    assets: List<Asset>,
+    onDismiss: () -> Unit,
+) {
+    var sourceAccountId by remember { mutableStateOf<Long?>(null) }
+    var targetAccountId by remember { mutableStateOf<Long?>(null) }
+    var assetId by remember { mutableStateOf<Long?>(null) }
+    var amount by remember { mutableStateOf("") }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var isSaving by remember { mutableStateOf(false) }
+
+    var showCreateAccountDialog by remember { mutableStateOf(false) }
+    var showCreateAssetDialog by remember { mutableStateOf(false) }
+    var creatingForSource by remember { mutableStateOf(true) }
+
+    var sourceAccountExpanded by remember { mutableStateOf(false) }
+    var targetAccountExpanded by remember { mutableStateOf(false) }
+    var assetExpanded by remember { mutableStateOf(false) }
+
+    val scope = rememberCoroutineScope()
+
+    AlertDialog(
+        onDismissRequest = { if (!isSaving) onDismiss() },
+        title = { Text("Create New Transaction") },
+        text = {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                // Source Account Dropdown
+                ExposedDropdownMenuBox(
+                    expanded = sourceAccountExpanded,
+                    onExpandedChange = { sourceAccountExpanded = it },
+                ) {
+                    OutlinedTextField(
+                        value = accounts.find { it.id == sourceAccountId }?.name ?: "",
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("From Account") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = sourceAccountExpanded) },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(),
+                        enabled = !isSaving,
+                    )
+                    ExposedDropdownMenu(
+                        expanded = sourceAccountExpanded,
+                        onDismissRequest = { sourceAccountExpanded = false },
+                    ) {
+                        accounts.forEach { account ->
+                            DropdownMenuItem(
+                                text = { Text(account.name) },
+                                onClick = {
+                                    sourceAccountId = account.id
+                                    sourceAccountExpanded = false
+                                },
+                            )
+                        }
+                        DropdownMenuItem(
+                            text = { Text("+ Create New Account") },
+                            onClick = {
+                                creatingForSource = true
+                                showCreateAccountDialog = true
+                                sourceAccountExpanded = false
+                            },
+                        )
+                    }
+                }
+
+                // Target Account Dropdown
+                ExposedDropdownMenuBox(
+                    expanded = targetAccountExpanded,
+                    onExpandedChange = { targetAccountExpanded = it },
+                ) {
+                    OutlinedTextField(
+                        value = accounts.find { it.id == targetAccountId }?.name ?: "",
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("To Account") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = targetAccountExpanded) },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(),
+                        enabled = !isSaving,
+                    )
+                    ExposedDropdownMenu(
+                        expanded = targetAccountExpanded,
+                        onDismissRequest = { targetAccountExpanded = false },
+                    ) {
+                        accounts.forEach { account ->
+                            DropdownMenuItem(
+                                text = { Text(account.name) },
+                                onClick = {
+                                    targetAccountId = account.id
+                                    targetAccountExpanded = false
+                                },
+                            )
+                        }
+                        DropdownMenuItem(
+                            text = { Text("+ Create New Account") },
+                            onClick = {
+                                creatingForSource = false
+                                showCreateAccountDialog = true
+                                targetAccountExpanded = false
+                            },
+                        )
+                    }
+                }
+
+                // Asset Dropdown
+                ExposedDropdownMenuBox(
+                    expanded = assetExpanded,
+                    onExpandedChange = { assetExpanded = it },
+                ) {
+                    OutlinedTextField(
+                        value = assets.find { it.id == assetId }?.name ?: "",
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Asset/Currency") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = assetExpanded) },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(),
+                        enabled = !isSaving,
+                    )
+                    ExposedDropdownMenu(
+                        expanded = assetExpanded,
+                        onDismissRequest = { assetExpanded = false },
+                    ) {
+                        assets.forEach { asset ->
+                            DropdownMenuItem(
+                                text = { Text(asset.name) },
+                                onClick = {
+                                    assetId = asset.id
+                                    assetExpanded = false
+                                },
+                            )
+                        }
+                        DropdownMenuItem(
+                            text = { Text("+ Create New Asset") },
+                            onClick = {
+                                showCreateAssetDialog = true
+                                assetExpanded = false
+                            },
+                        )
+                    }
+                }
+
+                // Amount Input
+                OutlinedTextField(
+                    value = amount,
+                    onValueChange = { amount = it },
+                    label = { Text("Amount") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    enabled = !isSaving,
+                )
+
+                errorMessage?.let { error ->
+                    Text(
+                        text = error,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    when {
+                        sourceAccountId == null -> errorMessage = "Please select a source account"
+                        targetAccountId == null -> errorMessage = "Please select a target account"
+                        assetId == null -> errorMessage = "Please select an asset"
+                        amount.isBlank() -> errorMessage = "Amount is required"
+                        amount.toDoubleOrNull() == null -> errorMessage = "Invalid amount"
+                        amount.toDouble() <= 0 -> errorMessage = "Amount must be greater than 0"
+                        else -> {
+                            isSaving = true
+                            errorMessage = null
+                            scope.launch {
+                                try {
+                                    val now = Clock.System.now()
+                                    val newTransaction =
+                                        Transaction(
+                                            sourceAccountId = sourceAccountId!!,
+                                            targetAccountId = targetAccountId!!,
+                                            assetId = assetId!!,
+                                            amount = amount.toDouble(),
+                                            timestamp = now,
+                                        )
+                                    transactionRepository.createTransaction(newTransaction)
+                                    onDismiss()
+                                } catch (e: Exception) {
+                                    logger.error(e) { "Failed to create transaction: ${e.message}" }
+                                    errorMessage = "Failed to create transaction: ${e.message}"
+                                    isSaving = false
+                                }
+                            }
+                        }
+                    }
+                },
+                enabled = !isSaving,
+            ) {
+                if (isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Text("Create")
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                enabled = !isSaving,
+            ) {
+                Text("Cancel")
+            }
+        },
+    )
+
+    // Account Creation Dialog
+    if (showCreateAccountDialog) {
+        CreateAccountDialogInline(
+            accountRepository = accountRepository,
+            onAccountCreated = { accountId ->
+                if (creatingForSource) {
+                    sourceAccountId = accountId
+                } else {
+                    targetAccountId = accountId
+                }
+                showCreateAccountDialog = false
+            },
+            onDismiss = { showCreateAccountDialog = false },
+        )
+    }
+
+    // Asset Creation Dialog
+    if (showCreateAssetDialog) {
+        CreateAssetDialogInline(
+            assetRepository = assetRepository,
+            onAssetCreated = { newAssetId ->
+                assetId = newAssetId
+                showCreateAssetDialog = false
+            },
+            onDismiss = { showCreateAssetDialog = false },
+        )
+    }
+}
+
+@Composable
+fun CreateAccountDialogInline(
+    accountRepository: AccountRepository,
+    onAccountCreated: (Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var isSaving by remember { mutableStateOf(false) }
+
+    val scope = rememberCoroutineScope()
+
+    AlertDialog(
+        onDismissRequest = { if (!isSaving) onDismiss() },
+        title = { Text("Create New Account") },
+        text = {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Account Name") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    enabled = !isSaving,
+                )
+
+                errorMessage?.let { error ->
+                    Text(
+                        text = error,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (name.isBlank()) {
+                        errorMessage = "Account name is required"
+                    } else {
+                        isSaving = true
+                        errorMessage = null
+                        scope.launch {
+                            try {
+                                val now = Clock.System.now()
+                                val newAccount =
+                                    Account(
+                                        name = name.trim(),
+                                        openingDate = now,
+                                    )
+                                val accountId = accountRepository.createAccount(newAccount)
+                                onAccountCreated(accountId)
+                            } catch (e: Exception) {
+                                logger.error(e) { "Failed to create account: ${e.message}" }
+                                errorMessage = "Failed to create account: ${e.message}"
+                                isSaving = false
+                            }
+                        }
+                    }
+                },
+                enabled = !isSaving,
+            ) {
+                if (isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Text("Create")
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                enabled = !isSaving,
+            ) {
+                Text("Cancel")
+            }
+        },
+    )
+}
+
+@Composable
+fun CreateAssetDialogInline(
+    assetRepository: AssetRepository,
+    onAssetCreated: (Long) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var isSaving by remember { mutableStateOf(false) }
+
+    val scope = rememberCoroutineScope()
+
+    AlertDialog(
+        onDismissRequest = { if (!isSaving) onDismiss() },
+        title = { Text("Create New Asset") },
+        text = {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Asset Name (e.g., USD, EUR)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    enabled = !isSaving,
+                )
+
+                errorMessage?.let { error ->
+                    Text(
+                        text = error,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    if (name.isBlank()) {
+                        errorMessage = "Asset name is required"
+                    } else {
+                        isSaving = true
+                        errorMessage = null
+                        scope.launch {
+                            try {
+                                val assetId = assetRepository.upsertAssetByName(name.trim())
+                                onAssetCreated(assetId)
+                            } catch (e: Exception) {
+                                logger.error(e) { "Failed to create asset: ${e.message}" }
+                                errorMessage = "Failed to create asset: ${e.message}"
+                                isSaving = false
+                            }
+                        }
+                    }
+                },
+                enabled = !isSaving,
+            ) {
+                if (isSaving) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                    )
+                } else {
+                    Text("Create")
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                enabled = !isSaving,
+            ) {
+                Text("Cancel")
+            }
+        },
+    )
 }


### PR DESCRIPTION
## Summary

Implemented a comprehensive transaction entry dialog that enables users to create transactions with full inline creation capabilities:

- ✅ **Transaction Entry Dialog**: Material 3 dialog with dropdown selectors for source account, target account, and asset/currency
- ✅ **Inline Account Creation**: Create new accounts on-the-fly from within the transaction dialog
- ✅ **Inline Asset Creation**: Create new assets/currencies without leaving the transaction dialog
- ✅ **Amount Field**: Extended Transaction model with amount tracking (Double type)
- ✅ **Enhanced UI**: Updated transaction cards to display transfer format (Source → Target) with amounts
- ✅ **Input Validation**: Comprehensive validation for required fields and amount > 0
- ✅ **Error Handling**: User-friendly error messages with loading states

## Technical Details

**Database Changes:**
- Added `amount REAL NOT NULL` field to Transaction table
- Updated insert/update queries to handle amount

**Domain Model:**
- Extended `Transaction` data class with `amount: Double` field

**Repository:**
- Updated `TransactionRepositoryImpl` to include amount in create/update operations

**UI Components:**
- `TransactionEntryDialog`: Main dialog with ExposedDropdownMenuBox components
- `CreateAccountDialogInline`: Inline account creation dialog
- `CreateAssetDialogInline`: Inline asset creation dialog
- Enhanced `TransactionCard` to show meaningful transaction details
- Added FAB to TransactionsScreen for creating transactions

## Test Plan

- [x] Build passes successfully with all code quality checks
- [ ] Manual testing: Create a transaction with existing accounts/assets
- [ ] Manual testing: Create a transaction with inline account creation
- [ ] Manual testing: Create a transaction with inline asset creation
- [ ] Manual testing: Verify validation works (empty fields, invalid amounts)
- [ ] Manual testing: Verify transaction cards display correctly with amounts
- [ ] Manual testing: Verify transfer format shows account names correctly
- [ ] Manual testing: Test error handling when creation fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)