### PR TITLE
Improve transaction UI with account-specific views

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
@@ -7,5 +7,6 @@ sealed class Screen(val route: String, val title: String) {
 
     data object Categories : Screen("categories", "Categories")
 
-    data object Transactions : Screen("transactions", "Transactions")
+    data class AccountTransactions(val accountId: Long, val accountName: String) :
+        Screen("account-transactions", accountName)
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
@@ -35,6 +35,7 @@ class AccountsScreenTest {
                     accountRepository = repository,
                     transactionRepository = FakeTransactionRepository(),
                     assetRepository = FakeAssetRepository(),
+                    onAccountClick = {},
                 )
             }
 
@@ -69,6 +70,7 @@ class AccountsScreenTest {
                     accountRepository = repository,
                     transactionRepository = FakeTransactionRepository(),
                     assetRepository = FakeAssetRepository(),
+                    onAccountClick = {},
                 )
             }
 
@@ -78,7 +80,7 @@ class AccountsScreenTest {
         }
 
     @Test
-    fun accountsScreen_displaysFloatingActionButton() =
+    fun accountsScreen_displaysAddAccountButton() =
         runComposeUiTest {
             // Given
             val repository = FakeAccountRepository(emptyList())
@@ -89,15 +91,16 @@ class AccountsScreenTest {
                     accountRepository = repository,
                     transactionRepository = FakeTransactionRepository(),
                     assetRepository = FakeAssetRepository(),
+                    onAccountClick = {},
                 )
             }
 
             // Then
-            onNodeWithText("+").assertIsDisplayed()
+            onNodeWithText("+ Add Account").assertIsDisplayed()
         }
 
     @Test
-    fun accountsScreen_opensCreateDialog_whenFabClicked() =
+    fun accountsScreen_opensCreateDialog_whenAddAccountClicked() =
         runComposeUiTest {
             // Given
             val repository = FakeAccountRepository(emptyList())
@@ -108,10 +111,11 @@ class AccountsScreenTest {
                     accountRepository = repository,
                     transactionRepository = FakeTransactionRepository(),
                     assetRepository = FakeAssetRepository(),
+                    onAccountClick = {},
                 )
             }
 
-            onNodeWithText("+").performClick()
+            onNodeWithText("+ Add Account").performClick()
 
             // Then
             onNodeWithText("Create New Account").assertIsDisplayed()
@@ -137,6 +141,7 @@ class AccountsScreenTest {
                     accountRepository = repository,
                     transactionRepository = FakeTransactionRepository(),
                     assetRepository = FakeAssetRepository(),
+                    onAccountClick = {},
                 )
             }
 
@@ -163,6 +168,7 @@ class AccountsScreenTest {
                     accountRepository = repository,
                     transactionRepository = FakeTransactionRepository(),
                     assetRepository = FakeAssetRepository(),
+                    onAccountClick = {},
                 )
             }
 
@@ -186,11 +192,12 @@ class AccountsScreenTest {
                     accountRepository = repository,
                     transactionRepository = FakeTransactionRepository(),
                     assetRepository = FakeAssetRepository(),
+                    onAccountClick = {},
                 )
             }
 
             // Open dialog
-            onNodeWithText("+").performClick()
+            onNodeWithText("+ Add Account").performClick()
 
             // Try to create without filling fields
             onNodeWithText("Create").performClick()
@@ -211,11 +218,12 @@ class AccountsScreenTest {
                     accountRepository = repository,
                     transactionRepository = FakeTransactionRepository(),
                     assetRepository = FakeAssetRepository(),
+                    onAccountClick = {},
                 )
             }
 
             // Open dialog
-            onNodeWithText("+").performClick()
+            onNodeWithText("+ Add Account").performClick()
             onNodeWithText("Create New Account").assertIsDisplayed()
 
             // Click cancel
@@ -244,6 +252,7 @@ class AccountsScreenTest {
                     accountRepository = repository,
                     transactionRepository = FakeTransactionRepository(),
                     assetRepository = FakeAssetRepository(),
+                    onAccountClick = {},
                 )
             }
 
@@ -289,6 +298,7 @@ class AccountsScreenTest {
                     accountRepository = repository,
                     transactionRepository = FakeTransactionRepository(),
                     assetRepository = FakeAssetRepository(),
+                    onAccountClick = {},
                 )
             }
 


### PR DESCRIPTION
## Summary
- Replace standalone Transactions screen with account-specific transaction views
- Clicking an account now navigates to its transactions showing only relevant transactions
- Display signed amounts: negative (red) for outgoing, positive (green) for incoming
- Add global FAB for creating transactions from any screen
- Pre-populate source account when creating transaction from account view
- Remove Transactions from bottom navigation (now 3 tabs: Accounts, Assets, Categories)
- Replace account creation FAB with header button to avoid FAB conflict

## Test plan
- [ ] Click on an account to verify navigation to account transactions screen
- [ ] Verify transactions show correct sign (negative for outgoing, positive for incoming)
- [ ] Verify back button returns to accounts list
- [ ] Test global FAB opens transaction dialog from all screens
- [ ] When on account transactions, verify source account is pre-populated in transaction dialog
- [ ] Verify bottom navigation has 3 tabs (Accounts, Assets, Categories)
- [ ] Verify "+ Add Account" button in header creates new accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)