### PR TITLE
Fix transaction dialog to default to currently viewed account

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/TransactionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/TransactionsScreen.kt
@@ -34,6 +34,7 @@ fun AccountTransactionsScreen(
     transactionRepository: TransactionRepository,
     accountRepository: AccountRepository,
     assetRepository: AssetRepository,
+    onAccountIdChange: (Long) -> Unit = {},
 ) {
     val allAccounts by accountRepository.getAllAccounts().collectAsState(initial = emptyList())
     val allTransactions by transactionRepository.getAllTransactions().collectAsState(initial = emptyList())
@@ -41,6 +42,11 @@ fun AccountTransactionsScreen(
 
     // Selected account state - default to the provided accountId
     var selectedAccountId by remember { mutableStateOf(accountId) }
+
+    // Notify parent when selected account changes
+    LaunchedEffect(selectedAccountId) {
+        onAccountIdChange(selectedAccountId)
+    }
 
     // Highlighted transaction state
     var highlightedTransactionId by remember { mutableStateOf<Long?>(null) }


### PR DESCRIPTION
## Summary
Fixes the issue where the transaction creation dialog would pre-select the original account instead of the currently viewed account when using account filter chips.

## Problem
When viewing account transactions and switching between accounts using the filter chips, clicking the "+" FAB would still pre-select the original account that was opened, not the currently selected account being viewed.

## Solution
- Hoisted the selected account state to the parent `MoneyManagerApp` component
- Updated FAB onClick to use the currently viewed account ID
- Added `onAccountIdChange` callback to `AccountTransactionsScreen` to notify parent when account selection changes
- The parent now tracks `currentlyViewedAccountId` and passes it to the transaction dialog

## Testing
1. Open an account's transactions
2. Switch to a different account using the filter chips
3. Click the "+" FAB to create a transaction
4. Verify that the "From Account" field defaults to the currently viewed account (not the originally opened account)

## Changes
- `MoneyManagerApp.kt`: Add `currentlyViewedAccountId` state and update FAB logic
- `TransactionsScreen.kt`: Add `onAccountIdChange` callback parameter and notify parent on account changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)