### PR TITLE
Fix Android database seeding race condition

### DIFF
--- a/app/db/core/src/androidMain/kotlin/com/moneymanager/database/AndroidDatabaseManager.kt
+++ b/app/db/core/src/androidMain/kotlin/com/moneymanager/database/AndroidDatabaseManager.kt
@@ -16,8 +16,8 @@ private val DEFAULT_DB_LOCATION = DbLocation(DEFAULT_DATABASE_NAME)
 class AndroidDatabaseManager(private val context: Context) : DatabaseManager {
     override suspend fun openDatabase(location: DbLocation): MoneyManagerDatabase =
         withContext(Dispatchers.IO) {
-            // Track if this is a new database for seeding
-            var isNewDatabase = false
+            // Check if this is a new database before opening
+            val isNewDatabase = !context.getDatabasePath(location.name).exists()
 
             // AndroidSqliteDriver automatically handles schema creation
             val driver =
@@ -27,11 +27,6 @@ class AndroidDatabaseManager(private val context: Context) : DatabaseManager {
                     name = location.name,
                     callback =
                         object : AndroidSqliteDriver.Callback(MoneyManagerDatabase.Schema) {
-                            override fun onCreate(db: androidx.sqlite.db.SupportSQLiteDatabase) {
-                                super.onCreate(db)
-                                isNewDatabase = true
-                            }
-
                             override fun onOpen(db: androidx.sqlite.db.SupportSQLiteDatabase) {
                                 super.onOpen(db)
                                 // Apply connection-level PRAGMA settings


### PR DESCRIPTION
## Summary
- Fix race condition in Android database seeding where `onCreate` callback might not set `isNewDatabase` flag before we check it
- Now check if database file exists before opening, which is more reliable

## Test plan
- [x] `./gradlew :app:db:core:pixel6api34AndroidDeviceTest` passes (21 tests)
- [x] Full project build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)