### PR TITLE
Fix database dialog dismissal and KMP hierarchy warning

### DIFF
--- a/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/DatabaseSelectionDialog.kt
+++ b/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/DatabaseSelectionDialog.kt
@@ -40,7 +40,9 @@ fun DatabaseSelectionDialog(
     require(defaultPath.path != null) { "Database selection dialog requires a non-null path" }
     var selectedPath by remember { mutableStateOf<Path?>(defaultPath.path) }
 
-    Dialog(onDismissRequest = onCancel) {
+    Dialog(
+        onDismissRequest = { /* Prevent dismissal by clicking outside */ },
+    ) {
         Surface(
             modifier =
                 Modifier

--- a/utils/currency/gradle.properties
+++ b/utils/currency/gradle.properties
@@ -1,0 +1,4 @@
+# Disable default Kotlin hierarchy template to allow custom jvmAndroidMain source set
+# This module shares JVM/Android-specific code (java.text.NumberFormat, java.util.Currency)
+# between JVM and Android targets via the jvmAndroidMain source set.
+kotlin.mpp.applyDefaultHierarchyTemplate=false


### PR DESCRIPTION
## Summary
This PR fixes two issues:

1. **Database dialog dismissal bug**: Prevents the database selection dialog from being dismissed by clicking outside, which previously caused a white screen
2. **Kotlin Multiplatform hierarchy warning**: Fixes the "Default Kotlin Hierarchy Template Not Applied Correctly" warning in the `:utils:currency` module

## Changes

### Database Dialog Fix
- Modified `DatabaseSelectionDialog.kt` to prevent dismissal via `onDismissRequest`
- Dialog now only closes when user explicitly clicks "Cancel" or "Create Database" buttons
- Fixes white screen issue that occurred when accidentally clicking outside the dialog

### KMP Hierarchy Fix
- Added module-specific `gradle.properties` in `utils/currency/`
- Disables default hierarchy template only for this module
- Allows custom `jvmAndroidMain` source set for sharing JVM/Android-specific code
- Does not affect other multiplatform modules in the project

## Test plan
- [x] Build succeeds: `./gradlew build`
- [x] Currency module builds without warnings
- [x] Other multiplatform modules unaffected
- [ ] Manual test: Run JVM app and verify database dialog cannot be dismissed by clicking outside
- [ ] Manual test: Verify dialog closes properly when clicking Cancel or Create Database

🤖 Generated with [Claude Code](https://claude.com/claude-code)