### PR TITLE
Add dependabot group for AndroidX dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,11 @@ updates:
       - dependency-name: "org.jetbrains.kotlinx:kotlinx-datetime"
         update-types: ["version-update:semver-patch"]
     groups:
+      # Group AndroidX dependencies together
+      androidx:
+        patterns:
+          - "androidx*"
+          - "androidx.*"
       # Group Kotlin-related updates together
       kotlin:
         patterns:

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -35,6 +35,9 @@
             <option value="$PROJECT_DIR$/app/ui" />
             <option value="$PROJECT_DIR$/app/ui/core" />
             <option value="$PROJECT_DIR$/gradle/build-logic" />
+            <option value="$PROJECT_DIR$/test" />
+            <option value="$PROJECT_DIR$/test/app" />
+            <option value="$PROJECT_DIR$/test/app/db" />
             <option value="$PROJECT_DIR$/utils" />
             <option value="$PROJECT_DIR$/utils/currency" />
           </set>


### PR DESCRIPTION
## Summary
- Add `androidx` group to dependabot configuration to bundle AndroidX-related updates
- Patterns: `androidx*` and `androidx.*` to capture all AndroidX dependencies
- Include updated `.idea/gradle.xml`

## Test plan
- [ ] Verify dependabot config is valid
- [ ] Next dependabot run should group AndroidX PRs together

🤖 Generated with [Claude Code](https://claude.com/claude-code)