### PR TITLE
Fix Codecov not showing coverage for utils subdirectory

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,13 @@
 # https://docs.codecov.com/docs/codecovyml-reference
 
 # Wait for both unit and instrumented uploads before sending notifications
+# Disable default path fixes to let Codecov search the entire repo for files
+# This is needed for multi-module Kotlin projects where files can be in various
+# subdirectories (app/*, utils/*, test/*, etc.)
 codecov:
   notify:
     after_n_builds: 2
+  disable_default_path_fixes: true
 
 # Define flags for unit and instrumented tests
 flags:


### PR DESCRIPTION
## Summary
- Disable default path fixes in Codecov to allow searching the entire repo for source files
- Fixes issue where coverage for `utils/` subdirectory was not showing up in Codecov reports
- This is needed for multi-module Kotlin projects where files can be in various subdirectories (`app/*`, `utils/*`, `test/*`, etc.)

## Background
Codecov's default path fixes for Kotlin/JaCoCo projects were interfering with file path resolution. The JaCoCo XML report only contains package names (e.g., `com/moneymanager/currency`), and Codecov constructs file paths from these. The default fixes were causing Codecov to find files in `app/*` but miss files in `utils/*`.

## Test plan
- [ ] Verify CI build passes
- [ ] Check Codecov report after merge to confirm `utils/currency` coverage appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)