### PR TITLE
Add default Uncategorized category with ID -1

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -160,6 +160,13 @@ object DatabaseConfig {
         // Create triggers for incremental materialized view refresh
         createIncrementalRefreshTriggers(driver)
 
+        // Seed default "Uncategorized" category
+        database.categoryQueries.insertWithId(
+            id = -1,
+            name = "Uncategorized",
+            parentId = null,
+        )
+
         // Seed currencies
         val currencyRepository = RepositorySet(database).currencyRepository
         allCurrencies.forEach { currency ->

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Category.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Category.sq
@@ -23,6 +23,10 @@ insert:
 INSERT INTO Category(name, parentId)
 VALUES (?, ?);
 
+insertWithId:
+INSERT INTO Category(id, name, parentId)
+VALUES (?, ?, ?);
+
 update:
 UPDATE Category
 SET name = ?, parentId = ?

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Category.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Category.kt
@@ -4,4 +4,16 @@ data class Category(
     val id: Long = 0,
     val name: String,
     val parentId: Long? = null,
-)
+) {
+    companion object {
+        const val UNCATEGORIZED_ID = -1L
+        const val UNCATEGORIZED_NAME = "Uncategorized"
+
+        val UNCATEGORIZED =
+            Category(
+                id = UNCATEGORIZED_ID,
+                name = UNCATEGORIZED_NAME,
+                parentId = null,
+            )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a default "Uncategorized" category (ID: -1) that is automatically seeded into new databases
- Provides companion object constants in Category model for easy reference throughout the codebase (`Category.UNCATEGORIZED_ID`, `Category.UNCATEGORIZED_NAME`, `Category.UNCATEGORIZED`)
- Uses fixed ID -1 to avoid conflicts with auto-incrementing IDs (which start at 1)

## Implementation Details
- **Category.kt**: Added companion object with `UNCATEGORIZED_ID = -1L`, `UNCATEGORIZED_NAME = "Uncategorized"`, and a pre-built `UNCATEGORIZED` instance
- **Category.sq**: Added `insertWithId` query to support inserting categories with explicit IDs
- **DatabaseConfig.kt**: Updated `seedDatabase()` to create the default category using the new query

## Test plan
- [x] Build passes locally (`./gradlew build`)
- [ ] Verify default category is created in new databases with ID -1
- [ ] Verify existing databases are not affected (migration not required)
- [ ] Verify `Category.UNCATEGORIZED` constants are accessible from other modules
- [ ] Verify auto-increment still works for user-created categories (IDs start at 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)