### PR TITLE
Display categories as hierarchical tree view

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
@@ -1,19 +1,31 @@
 package com.moneymanager.ui.screens
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.Category
 import com.moneymanager.domain.repository.CategoryRepository
+import com.moneymanager.ui.util.CategoryNode
+import com.moneymanager.ui.util.buildCategoryForest
+import com.moneymanager.ui.util.flattenCategoryForest
 
 @Composable
 fun CategoriesScreen(categoryRepository: CategoryRepository) {
     val categories by categoryRepository.getAllCategories().collectAsState(initial = emptyList())
+    var expandedIds by remember { mutableStateOf(emptySet<Long>()) }
+
+    val forest = remember(categories) { buildCategoryForest(categories) }
+    val flattenedNodes = remember(forest, expandedIds) { flattenCategoryForest(forest, expandedIds) }
 
     Column(
         modifier =
@@ -40,11 +52,100 @@ fun CategoriesScreen(categoryRepository: CategoryRepository) {
             }
         } else {
             LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                items(categories) { category ->
-                    CategoryCard(category)
+                items(flattenedNodes, key = { it.category.id }) { node ->
+                    CategoryTreeItem(
+                        node = node,
+                        isExpanded = node.category.id in expandedIds,
+                        onToggleExpand = {
+                            expandedIds =
+                                if (node.category.id in expandedIds) {
+                                    expandedIds - node.category.id
+                                } else {
+                                    expandedIds + node.category.id
+                                }
+                        },
+                    )
                 }
+            }
+        }
+    }
+}
+
+@Composable
+fun CategoryTreeItem(
+    node: CategoryNode,
+    isExpanded: Boolean,
+    onToggleExpand: () -> Unit,
+) {
+    val hasChildren = node.children.isNotEmpty()
+    val rotationAngle by animateFloatAsState(
+        targetValue = if (isExpanded) 90f else 0f,
+        label = "expandIconRotation",
+    )
+
+    Card(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(start = (node.depth * 24).dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = if (node.depth == 0) 2.dp else 1.dp),
+        colors =
+            CardDefaults.cardColors(
+                containerColor =
+                    if (node.depth == 0) {
+                        MaterialTheme.colorScheme.surface
+                    } else {
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                    },
+            ),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable(enabled = hasChildren) { onToggleExpand() }
+                    .padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (hasChildren) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = if (isExpanded) "Collapse" else "Expand",
+                        modifier =
+                            Modifier
+                                .size(24.dp)
+                                .rotate(rotationAngle),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                } else {
+                    Spacer(modifier = Modifier.width(24.dp))
+                }
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                Text(
+                    text = node.category.name,
+                    style =
+                        if (node.depth == 0) {
+                            MaterialTheme.typography.titleMedium
+                        } else {
+                            MaterialTheme.typography.bodyMedium
+                        },
+                )
+            }
+
+            if (hasChildren) {
+                Text(
+                    text = "${node.children.size}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
         }
     }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/CategoryNode.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/CategoryNode.kt
@@ -1,0 +1,66 @@
+package com.moneymanager.ui.util
+
+import com.moneymanager.domain.model.Category
+
+/**
+ * Represents a node in the category tree hierarchy.
+ *
+ * @property category The category data for this node
+ * @property children The child nodes of this category
+ * @property depth The depth level in the tree (0 for root nodes)
+ */
+data class CategoryNode(
+    val category: Category,
+    val children: List<CategoryNode> = emptyList(),
+    val depth: Int = 0,
+)
+
+/**
+ * Builds a forest (list of trees) from a flat list of categories.
+ * Each root node represents a top-level category (parentId = null),
+ * with its descendants nested as children.
+ *
+ * @param categories The flat list of all categories
+ * @return List of root CategoryNode objects forming the forest
+ */
+fun buildCategoryForest(categories: List<Category>): List<CategoryNode> {
+    val childrenByParentId = categories.groupBy { it.parentId }
+
+    fun buildSubtree(
+        category: Category,
+        depth: Int,
+    ): CategoryNode {
+        val children =
+            childrenByParentId[category.id].orEmpty()
+                .map { buildSubtree(it, depth + 1) }
+        return CategoryNode(category = category, children = children, depth = depth)
+    }
+
+    return childrenByParentId[null].orEmpty()
+        .map { buildSubtree(it, depth = 0) }
+}
+
+/**
+ * Flattens a category forest into a list suitable for display in a LazyColumn.
+ * Each node includes its depth for indentation purposes.
+ *
+ * @param forest The list of root CategoryNode objects
+ * @param expandedIds Set of category IDs that are currently expanded
+ * @return Flattened list of CategoryNode objects in display order
+ */
+fun flattenCategoryForest(
+    forest: List<CategoryNode>,
+    expandedIds: Set<Long>,
+): List<CategoryNode> {
+    val result = mutableListOf<CategoryNode>()
+
+    fun traverse(node: CategoryNode) {
+        result.add(node)
+        if (node.category.id in expandedIds) {
+            node.children.forEach { traverse(it) }
+        }
+    }
+
+    forest.forEach { traverse(it) }
+    return result
+}


### PR DESCRIPTION
## Summary
- Replace flat list display with expandable tree/forest view for categories
- Add `CategoryNode` data class and tree-building utilities
- Parent categories show expand/collapse arrow with animated rotation
- Child categories are visually indented with lighter background styling
- Display child count badge for parent categories

## Test plan
- [ ] Verify categories with no children display without expand arrow
- [ ] Verify categories with children show expand arrow and child count
- [ ] Verify clicking parent category expands/collapses children
- [ ] Verify child categories are indented correctly at each depth level
- [ ] Verify animation on expand/collapse icon rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)