### PR TITLE
Fix dropdown not selecting newly created items in TransactionEntryDialog

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -328,8 +328,6 @@ private fun MoneyManagerAppContent(
                 categoryRepository = repositorySet.categoryRepository,
                 currencyRepository = repositorySet.currencyRepository,
                 maintenanceService = repositorySet.maintenanceService,
-                accounts = accounts,
-                currencies = currencies,
                 preSelectedSourceAccountId = preSelectedAccountId,
                 preSelectedCurrencyId = preSelectedCurrencyId,
                 onDismiss = {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/TransactionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/TransactionsScreen.kt
@@ -823,12 +823,16 @@ fun TransactionEntryDialog(
     categoryRepository: CategoryRepository,
     currencyRepository: CurrencyRepository,
     maintenanceService: DatabaseMaintenanceService,
-    accounts: List<Account>,
-    currencies: List<Currency>,
     preSelectedSourceAccountId: AccountId? = null,
     preSelectedCurrencyId: CurrencyId? = null,
     onDismiss: () -> Unit,
 ) {
+    // Collect accounts and currencies from Flows so newly created items appear immediately
+    val accounts by accountRepository.getAllAccounts()
+        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val currencies by currencyRepository.getAllCurrencies()
+        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+
     var sourceAccountId by remember { mutableStateOf(preSelectedSourceAccountId) }
     var targetAccountId by remember { mutableStateOf<AccountId?>(null) }
     var currencyId by remember { mutableStateOf<CurrencyId?>(preSelectedCurrencyId) }


### PR DESCRIPTION
## Summary
- Fixed dropdowns in TransactionEntryDialog not selecting newly created accounts/currencies
- Changed from passing static lists as parameters to collecting from repository Flows
- Newly created items now appear immediately and are auto-selected in the dropdown

## Problem
When creating a new account or currency from within the Transaction Entry Dialog dropdowns (via "+ Create New Account" or "+ Create New Currency"), the newly created item wasn't being automatically selected. The dropdown stayed unfilled even though the item was created successfully.

## Root Cause
The `accounts` and `currencies` lists were passed as **static parameters** from the parent component (`MoneyManagerApp`). When a new item was created:
1. The callback correctly set the ID of the newly created item (e.g., `currencyId = newCurrencyId`)
2. But the `currencies` list used to display the dropdown wasn't reactive - it was a snapshot passed when the dialog was opened
3. The `currencies.find { it.id == currencyId }` lookup failed because the new item wasn't in the stale list

## Solution
Changed `TransactionEntryDialog` to collect `accounts` and `currencies` directly from the repository Flows instead of receiving them as parameters. This ensures the lists update reactively when new items are created.

## Test plan
- [ ] Open Transaction Entry Dialog
- [ ] Click on Account dropdown and select "+ Create New Account"
- [ ] Create a new account and verify it's automatically selected in the dropdown
- [ ] Click on Currency dropdown and select "+ Create New Currency"
- [ ] Create a new currency and verify it's automatically selected in the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)