### PR TITLE
Refactor CategoriesScreen to matrix-style balance layout

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java temurin-25.0.1+8.0.LTS

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CategoriesScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CategoriesScreenTest.kt
@@ -135,9 +135,8 @@ class CategoriesScreenTest {
                 )
             }
 
-            // Then
-            onNodeWithText("Food").assertIsDisplayed()
-            onNodeWithText("2").assertIsDisplayed() // Child count badge
+            // Then - child count is shown in brackets after category name
+            onNodeWithText("Food (2)").assertIsDisplayed()
         }
 
     @Test
@@ -791,13 +790,13 @@ class CategoriesScreenTest {
                 )
             }
 
-            // Initially only top-level visible
-            onNodeWithText("Food").assertIsDisplayed()
-            onNodeWithText("Groceries").assertDoesNotExist()
+            // Initially only top-level visible - child count shown in brackets
+            onNodeWithText("Food (1)").assertIsDisplayed()
+            onNodeWithText("Groceries (1)").assertDoesNotExist()
 
             // Expand Food by clicking the expand icon
             onAllNodesWithContentDescription("Expand")[0].performClick()
-            onNodeWithText("Groceries").assertIsDisplayed()
+            onNodeWithText("Groceries (1)").assertIsDisplayed()
             onNodeWithText("Organic").assertDoesNotExist()
 
             // Expand Groceries by clicking its expand icon (now there are 2 expand icons - Food is collapsed)


### PR DESCRIPTION
## Summary
- Redesign category balance display from inline badges to a spreadsheet-like matrix with fixed hierarchy column and horizontally scrollable currency balance columns
- Display currency codes as column headers with synchronized scrolling between header and all rows
- Show child count in brackets after category name (e.g., "Food (2)") instead of separate badge
- Add `.tool-versions` file for asdf Java version management (temurin-25.0.1)

## Test plan
- [ ] Verify categories with balances display correctly in matrix format
- [ ] Verify horizontal scrolling works when there are multiple currencies
- [ ] Verify header scrolls in sync with balance rows
- [ ] Verify child count displays correctly in category names
- [ ] Verify drag-and-drop still works with the new layout
- [ ] Run `./gradlew build` to ensure tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)