### PR TITLE
Replace fully qualified type names with explicit imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -689,6 +689,28 @@ allCurrencies.forEach { currency ->
 createIncrementalRefreshTriggers(driver)
 ```
 
+### Type Imports
+
+**ALWAYS** import types explicitly. **NEVER** use fully qualified type names in code.
+
+❌ **Bad** - Fully qualified type name:
+```kotlin
+fun example(columnWidths: Map<CurrencyId, androidx.compose.ui.unit.Dp>) {
+    // ...
+}
+```
+
+✅ **Good** - Import the type:
+```kotlin
+import androidx.compose.ui.unit.Dp
+
+fun example(columnWidths: Map<CurrencyId, Dp>) {
+    // ...
+}
+```
+
+This improves code readability and is automatically enforced by ktlint which will expand wildcard imports into explicit imports.
+
 ### Platform Support Status
 
 The project currently supports:

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
@@ -11,7 +11,17 @@ import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -20,8 +30,29 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -31,6 +62,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.moneymanager.domain.model.Category
@@ -314,7 +346,7 @@ fun CategoriesScreen(
 @Composable
 private fun CurrencyHeaderRow(
     currencies: List<Currency>,
-    columnWidths: Map<CurrencyId, androidx.compose.ui.unit.Dp>,
+    columnWidths: Map<CurrencyId, Dp>,
     scrollState: ScrollState,
 ) {
     Row(
@@ -358,7 +390,7 @@ fun CategoryTreeItem(
     node: CategoryNode,
     balances: List<CategoryBalance>,
     currenciesWithBalances: List<Currency>,
-    columnWidths: Map<CurrencyId, androidx.compose.ui.unit.Dp>,
+    columnWidths: Map<CurrencyId, Dp>,
     balancesScrollState: ScrollState,
     isExpanded: Boolean,
     onToggleExpand: () -> Unit,


### PR DESCRIPTION
## Summary

Replace fully qualified type names with explicit imports in CategoriesScreen.kt and add a guideline to CLAUDE.md about always importing types.

## Changes

### CategoriesScreen.kt
- Add `import androidx.compose.ui.unit.Dp`
- Replace `androidx.compose.ui.unit.Dp` with `Dp` in function signatures for:
  - `CurrencyHeaderRow` parameter `columnWidths`
  - `CategoryTreeItem` parameter `columnWidths`

### CLAUDE.md
- Add new "Type Imports" section under Development Notes
- Provide clear examples of bad (fully qualified) vs good (imported) type usage
- Note that ktlint enforces this pattern by expanding wildcard imports

## Benefits

- Improves code readability by reducing visual noise
- Follows Kotlin best practices and community standards
- Aligns with ktlint formatting rules
- Makes code more maintainable

## Test plan

- [x] Build succeeds: `./gradlew :app:ui:core:compileKotlinJvm`
- [ ] Verify all type references are properly imported
- [ ] Check that ktlint doesn't complain about imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)