### PR TITLE
ci: Group GitHub Actions updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,3 +59,8 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    groups:
+      # Group GitHub Actions together
+      github-actions:
+        patterns:
+          - "actions/*"


### PR DESCRIPTION
## Summary
- Add `groups` configuration to the `github-actions` package ecosystem in dependabot.yml
- Groups all `actions/*` dependencies (cache, upload-artifact, download-artifact, etc.) into a single PR
- Reduces PR noise from separate dependabot updates for related GitHub Actions

## Context
Currently dependabot creates separate PRs for each GitHub Action update:
- #165 - actions/cache from 4 to 5
- #166 - actions/download-artifact from 6 to 7
- #167 - actions/upload-artifact from 5 to 6

With this change, future updates will be grouped together.

## Test plan
- [ ] Verify dependabot.yml syntax is valid
- [ ] After merge, close existing PRs and wait for dependabot to create a grouped PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)