### PR TITLE
fix(ui): dynamic column widths for balance matrix headings

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
@@ -129,18 +129,16 @@ fun CategoriesScreen(
     val columnWidths =
         remember(categoryBalances, currenciesWithBalances) {
             currenciesWithBalances.associate { currency ->
-                val maxBalance =
-                    categoryBalances
-                        .filter { it.balance.currency.id == currency.id }
-                        .maxOfOrNull { kotlin.math.abs(it.balance.amount) } ?: 0L
                 val maxMoney =
                     categoryBalances
                         .filter { it.balance.currency.id == currency.id }
                         .maxByOrNull { kotlin.math.abs(it.balance.amount) }?.balance
                 val formattedMax = maxMoney?.let { formatAmount(it) } ?: formatAmount(0.0, currency)
                 // Estimate width: ~8dp per character + 16dp padding
-                val estimatedWidth = (formattedMax.length * 8 + 16).dp
-                currency.id to maxOf(estimatedWidth, BALANCE_COLUMN_WIDTH)
+                val balanceWidth = (formattedMax.length * 8 + 16).dp
+                // Also consider header text width (currency code)
+                val headerWidth = (currency.code.length * 8 + 16).dp
+                currency.id to maxOf(balanceWidth, headerWidth, BALANCE_COLUMN_WIDTH)
             }
         }
 


### PR DESCRIPTION
## Summary
- Fix balance matrix headings getting truncated by dynamically sizing columns
- CategoriesScreen: Include currency code header width in column width calculations
- TransactionsScreen: Calculate column widths based on account names and balance amounts
- Fix auto-scroll bug that was scrolling to the wrong account (was using `accountId` parameter instead of `clickedAccountId`)

## Test plan
- [ ] Verify currency code headers in CategoriesScreen are not truncated
- [ ] Verify account name headers in TransactionsScreen are not truncated
- [ ] Verify clicking on a transaction's account scrolls to the correct account column in the matrix
- [ ] Verify balance values still display correctly in all columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)