### PR TITLE
feat(csv): add time column support for CSV import strategies

### DIFF
--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ImportMonzoCsvE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ImportMonzoCsvE2ETest.kt
@@ -190,6 +190,7 @@ class ImportMonzoCsvE2ETest {
             // Step 6: Verify column auto-detection selected the correct columns
             // The ColumnDetector should have selected:
             // - Date Column: "Date" (not "Transaction ID" which was the bug)
+            // - Time Column: "Time" (optional, auto-detected from Monzo format)
             // - Amount Column: "Amount"
             // - Description Column: "Description"
             // - Target Account Column: "Name"
@@ -204,6 +205,9 @@ class ImportMonzoCsvE2ETest {
             // The Date column dropdown should show "Date" (not "Transaction ID")
             waitUntilAtLeastOneExists(hasText("Date", substring = false), timeoutMillis = 10000)
 
+            // The Time column section should be visible and auto-detected as "Time"
+            waitUntilAtLeastOneExists(hasText("Time Column (Optional)", substring = true), timeoutMillis = 10000)
+
             // The Amount column dropdown should show "Amount"
             waitUntilAtLeastOneExists(hasText("Amount", substring = false), timeoutMillis = 10000)
 
@@ -217,6 +221,12 @@ class ImportMonzoCsvE2ETest {
             // Date column sample: "24/02/2022" (from "Date" column, not "tx_..." from "Transaction ID")
             // These may be truncated in supportingText, so just check for part of the date format
             waitUntilAtLeastOneExists(hasText("24/02/2022", substring = true), timeoutMillis = 10000)
+
+            // Time column sample: "17:44:34" (from "Time" column in Monzo format)
+            waitUntilAtLeastOneExists(hasText("17:44:34", substring = true), timeoutMillis = 10000)
+
+            // The Time Format field should be visible since a time column was auto-detected
+            waitUntilAtLeastOneExists(hasText("Time Format", substring = true), timeoutMillis = 10000)
 
             // Cancel the dialog to return to CSV detail screen
             onNodeWithText("Cancel").performClick()


### PR DESCRIPTION
## Summary
- Add support for separate time columns in CSV import strategies
- Useful for bank exports like Monzo that have date and time in separate columns
- Time column is auto-detected and optional (can be set to "None")

## Changes
- Add time column auto-detection to `ColumnDetector` (pattern: "time")
- Add time value pattern matching (HH:mm or HH:mm:ss format)
- Add optional time column dropdown with "None" option in strategy dialog
- Show time format field when a time column is selected
- Wire `timeColumnName` and `timeFormat` to `DateTimeParsingMapping`
- Update E2E test to verify time column auto-detection

## Test plan
- [x] Build passes locally
- [x] E2E test verifies time column auto-detection for Monzo CSV format
- [ ] Manual test: Create import strategy with time column for Monzo export

🤖 Generated with [Claude Code](https://claude.com/claude-code)