### PR TITLE
feat(android): enable R8 minification for release builds

### DIFF
--- a/app/main/android/proguard-rules.pro
+++ b/app/main/android/proguard-rules.pro
@@ -1,0 +1,7 @@
+# ProGuard rules for MoneyManager Android application
+
+# Keep Android entry point
+-keep class com.moneymanager.android.MainActivity { *; }
+
+# Suppress warnings for Android platform internals referenced by libres plurals
+-dontwarn libcore.icu.NativePluralRules

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    alias(libs.plugins.gradle.doctor)
     alias(libs.plugins.kover)
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m
 
 # Configuration cache for faster builds
 org.gradle.configuration-cache=true

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.api.dsl.ApplicationExtension
+import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -30,7 +31,12 @@ configure<ApplicationExtension> {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
     }
 
@@ -38,6 +44,12 @@ configure<ApplicationExtension> {
         sourceCompatibility = JavaVersion.toVersion(jvmTargetVersion)
         targetCompatibility = JavaVersion.toVersion(jvmTargetVersion)
     }
+}
+
+// Disable Compose mapping file generation to work around Java 25 compatibility issue
+// (ASM version used by the task doesn't support class file major version 69)
+configure<ComposeCompilerGradlePluginExtension> {
+    includeComposeMappingFile.set(false)
 }
 
 // Override ktlint android setting for Android modules

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ compose-plugin = "1.9.3"
 compose-ui-test = "1.9.3"
 dependency-analysis = "3.5.1"
 detekt = "2.0.0-alpha.1"
+gradle-doctor = "0.12.0"
 human-readable = "1.12.2"
 jvm-target = "25"
 jvm-toolchain = "25"
@@ -93,6 +94,7 @@ compose = { id = "org.jetbrains.compose", version.ref = "compose-plugin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }
+gradle-doctor = { id = "com.osacky.doctor", version.ref = "gradle-doctor" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- Enable R8 minification (`isMinifyEnabled`) and resource shrinking (`isShrinkResources`) for Android release builds
- Add ProGuard rules file with keep rules for MainActivity and dontwarn for libres plurals
- Disable Compose mapping file generation to work around Java 25/ASM compatibility issue (class file major version 69)
- Increase Gradle JVM heap from 2GB to 4GB to handle R8 processing
- Add Gradle Doctor plugin (0.12.0) for build health monitoring and optimization suggestions

## Test plan
- [ ] Run `./gradlew :app:main:android:assembleRelease` to verify R8 minification works
- [ ] Run `./gradlew build` to verify full build passes
- [ ] Check that Gradle Doctor doesn't report any build health issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)