### PR TITLE
refactor(db): use Mappie local conversion methods for type mappings

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountBalanceMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountBalanceMapper.kt
@@ -4,17 +4,15 @@ package com.moneymanager.database.mapper
 
 import com.moneymanager.database.sql.SelectAllBalances
 import com.moneymanager.domain.model.AccountBalance
-import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Money
 import tech.mappie.api.ObjectMappie
 import kotlin.uuid.Uuid
 
-object AccountBalanceMapper : ObjectMappie<SelectAllBalances, AccountBalance>() {
+object AccountBalanceMapper : ObjectMappie<SelectAllBalances, AccountBalance>(), IdConversions {
     override fun map(from: SelectAllBalances): AccountBalance =
         mapping {
-            AccountBalance::accountId fromValue AccountId(from.accountId)
             AccountBalance::balance fromValue Money(from.balance, from.toCurrency())
         }
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountMapper.kt
@@ -3,14 +3,9 @@
 package com.moneymanager.database.mapper
 
 import com.moneymanager.domain.model.Account
-import com.moneymanager.domain.model.AccountId
 import tech.mappie.api.ObjectMappie
-import kotlin.time.Instant
 
-object AccountMapper : ObjectMappie<com.moneymanager.database.sql.Account, Account>() {
-    override fun map(from: com.moneymanager.database.sql.Account) =
-        mapping {
-            Account::id fromValue AccountId(from.id)
-            Account::openingDate fromValue Instant.fromEpochMilliseconds(from.openingDate)
-        }
-}
+object AccountMapper :
+    ObjectMappie<com.moneymanager.database.sql.Account, Account>(),
+    IdConversions,
+    InstantConversions

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/CurrencyMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/CurrencyMapper.kt
@@ -1,16 +1,7 @@
-@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
-
 package com.moneymanager.database.mapper
 
 import com.moneymanager.domain.model.Currency
-import com.moneymanager.domain.model.CurrencyId
 import tech.mappie.api.ObjectMappie
-import kotlin.uuid.Uuid
 import com.moneymanager.database.sql.Currency as DbCurrency
 
-object CurrencyMapper : ObjectMappie<DbCurrency, Currency>() {
-    override fun map(from: DbCurrency) =
-        mapping {
-            Currency::id fromValue CurrencyId(Uuid.parse(from.id))
-        }
-}
+object CurrencyMapper : ObjectMappie<DbCurrency, Currency>(), IdConversions

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/IdConversions.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/IdConversions.kt
@@ -1,0 +1,16 @@
+@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.database.mapper
+
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.TransferId
+import kotlin.uuid.Uuid
+
+interface IdConversions {
+    fun toAccountId(id: Long): AccountId = AccountId(id)
+
+    fun toCurrencyId(id: String): CurrencyId = CurrencyId(Uuid.parse(id))
+
+    fun toTransferId(id: String): TransferId = TransferId(Uuid.parse(id))
+}

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/InstantConversions.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/InstantConversions.kt
@@ -1,0 +1,9 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.database.mapper
+
+import kotlin.time.Instant
+
+interface InstantConversions {
+    fun toInstant(epochMillis: Long): Instant = Instant.fromEpochMilliseconds(epochMillis)
+}

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/TransferMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/TransferMapper.kt
@@ -4,23 +4,19 @@ package com.moneymanager.database.mapper
 
 import com.moneymanager.database.sql.SelectAll
 import com.moneymanager.database.sql.SelectByDateRange
-import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.Transfer
-import com.moneymanager.domain.model.TransferId
 import tech.mappie.api.ObjectMappie
-import kotlin.time.Instant.Companion.fromEpochMilliseconds
 import kotlin.uuid.Uuid
 
-object TransferMapper : ObjectMappie<SelectAll, Transfer>() {
+object TransferMapper :
+    ObjectMappie<SelectAll, Transfer>(),
+    IdConversions,
+    InstantConversions {
     override fun map(from: SelectAll): Transfer =
         mapping {
-            Transfer::id fromValue TransferId(Uuid.parse(from.id))
-            Transfer::timestamp fromValue fromEpochMilliseconds(from.timestamp)
-            Transfer::sourceAccountId fromValue AccountId(from.sourceAccountId)
-            Transfer::targetAccountId fromValue AccountId(from.targetAccountId)
             Transfer::amount fromValue Money(from.amount, from.toCurrency())
         }
 


### PR DESCRIPTION
## Summary
- Add `InstantConversions` interface for automatic `Long → Instant` conversion using Mappie's local conversion methods feature
- Add `IdConversions` interface for automatic ID wrapper conversions (`Long → AccountId`, `String → CurrencyId`, `String → TransferId`)
- Simplify `AccountMapper`, `CurrencyMapper`, `TransferMapper`, and `AccountBalanceMapper` by removing explicit `fromValue` mappings

## Test plan
- [x] Build passes (`./gradlew build`)
- [x] All existing tests pass
- [ ] Manual testing of account/transfer/currency operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)