### PR TITLE
build(kover): exclude test modules from coverage aggregation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,9 +58,11 @@ dependencyAnalysis {
 
 // Aggregate Kover coverage from all subprojects
 // Only include projects that have actual source code (not intermediate directories)
+// Exclude test modules (under :test:) from coverage aggregation
 dependencies {
     subprojects
         .filter { it.buildFile.exists() && it.file("src").exists() }
+        .filter { !it.path.startsWith(":test:") }
         .forEach { subproject ->
             kover(subproject)
         }


### PR DESCRIPTION
## Summary
- Exclude modules under `:test:` directory from Kover coverage aggregation
- Test modules contain test fixtures and utilities, not production code that should be measured for coverage

## Test plan
- [x] Verified `./gradlew koverXmlReport` completes successfully
- [ ] Verify coverage reports no longer include test module classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)