### PR TITLE
fix(gradle): increase metaspace to 1GB for daemon stability

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 
 # Configuration cache for faster builds
 org.gradle.configuration-cache=true


### PR DESCRIPTION
## Summary
- Increases JVM MaxMetaspaceSize from 512MB to 1GB in gradle.properties
- Fixes daemon metaspace exhaustion causing restarts between builds
- Required due to multiple code generation tools (Metro DI, Mappie, SQLDelight, Compose compiler) loading many classes

## Test plan
- [ ] Verify build completes without metaspace warning
- [ ] Confirm daemon remains stable across multiple builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)