### PR TITLE
feat(csv): add CurrencyLookupMapping and form validation for import strategy

### DIFF
--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/json/FieldMappingJsonCodecTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/json/FieldMappingJsonCodecTest.kt
@@ -8,6 +8,7 @@ import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
 import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
+import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
 import com.moneymanager.domain.model.csvstrategy.DateTimeParsingMapping
 import com.moneymanager.domain.model.csvstrategy.DirectColumnMapping
 import com.moneymanager.domain.model.csvstrategy.FieldMappingId
@@ -169,6 +170,24 @@ class FieldMappingJsonCodecTest {
         val decodedMapping = decoded[TransferField.CURRENCY]
         assertIs<HardCodedCurrencyMapping>(decodedMapping)
         assertEquals(currencyId, decodedMapping.currencyId)
+    }
+
+    @Test
+    fun `encode and decode CurrencyLookupMapping`() {
+        val mapping =
+            CurrencyLookupMapping(
+                id = FieldMappingId(Uuid.random()),
+                fieldType = TransferField.CURRENCY,
+                columnName = "Currency",
+            )
+        val mappings = mapOf(TransferField.CURRENCY to mapping)
+
+        val json = FieldMappingJsonCodec.encode(mappings)
+        val decoded = FieldMappingJsonCodec.decode(json)
+
+        val decodedMapping = decoded[TransferField.CURRENCY]
+        assertIs<CurrencyLookupMapping>(decodedMapping)
+        assertEquals("Currency", decodedMapping.columnName)
     }
 
     @Test

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
@@ -120,3 +120,14 @@ data class HardCodedCurrencyMapping(
     override val fieldType: TransferField,
     val currencyId: CurrencyId,
 ) : FieldMapping
+
+/**
+ * Looks up a currency by code from a CSV column.
+ * The column should contain ISO 4217 currency codes (e.g., "GBP", "USD", "EUR").
+ */
+@Serializable
+data class CurrencyLookupMapping(
+    override val id: FieldMappingId,
+    override val fieldType: TransferField,
+    val columnName: String,
+) : FieldMapping

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/AccountPicker.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/AccountPicker.kt
@@ -39,6 +39,7 @@ import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
  * @param enabled Whether the picker is enabled
  * @param excludeAccountId Optional account ID to exclude from the list (e.g., the other account in a transfer)
  * @param placeholder Placeholder text shown when dropdown is expanded
+ * @param isError Whether to show error state (red outline)
  */
 @Composable
 fun AccountPicker(
@@ -51,6 +52,7 @@ fun AccountPicker(
     enabled: Boolean = true,
     excludeAccountId: AccountId? = null,
     placeholder: String = "Type to search...",
+    isError: Boolean = false,
 ) {
     val accounts by accountRepository.getAllAccounts()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
@@ -96,6 +98,7 @@ fun AccountPicker(
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
             enabled = enabled,
             singleLine = true,
+            isError = isError,
         )
         ExposedDropdownMenu(
             expanded = expanded,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CurrencyPicker.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CurrencyPicker.kt
@@ -35,6 +35,7 @@ import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
  * @param modifier Optional modifier for the component
  * @param enabled Whether the picker is enabled
  * @param placeholder Placeholder text shown when dropdown is expanded
+ * @param isError Whether to show error state (red outline)
  */
 @Composable
 fun CurrencyPicker(
@@ -45,6 +46,7 @@ fun CurrencyPicker(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     placeholder: String = "Type to search...",
+    isError: Boolean = false,
 ) {
     val currencies by currencyRepository.getAllCurrencies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
@@ -89,6 +91,7 @@ fun CurrencyPicker(
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable),
             enabled = enabled,
             singleLine = true,
+            isError = isError,
         )
         ExposedDropdownMenu(
             expanded = expanded,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -123,12 +123,14 @@ fun ApplyStrategyDialog(
                 try {
                     val accountsByName = accounts.associateBy { it.name }
                     val currenciesById = currencies.associateBy { it.id }
+                    val currenciesByCode = currencies.associateBy { it.code.uppercase() }
                     val mapper =
                         CsvTransferMapper(
                             strategy = strategy,
                             columns = csvImport.columns,
                             existingAccounts = accountsByName,
                             existingCurrencies = currenciesById,
+                            existingCurrenciesByCode = currenciesByCode,
                         )
                     importPreparation = mapper.prepareImport(rows)
                     errorMessage = null
@@ -211,6 +213,7 @@ fun ApplyStrategyDialog(
                             val updatedAccounts = accountRepository.getAllAccounts().first()
                             val accountsByName = updatedAccounts.associateBy { it.name }
                             val currenciesById = currencies.associateBy { it.id }
+                            val currenciesByCode = currencies.associateBy { it.code.uppercase() }
 
                             val mapper =
                                 CsvTransferMapper(
@@ -218,6 +221,7 @@ fun ApplyStrategyDialog(
                                     columns = csvImport.columns,
                                     existingAccounts = accountsByName,
                                     existingCurrencies = currenciesById,
+                                    existingCurrenciesByCode = currenciesByCode,
                                 )
 
                             val finalPrep = mapper.prepareImport(rows)

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ImportMonzoCsvE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ImportMonzoCsvE2ETest.kt
@@ -189,12 +189,13 @@ class ImportMonzoCsvE2ETest {
             // - Amount Column: "Amount"
             // - Description Column: "Description"
             // - Target Account Column: "Name"
+            // - Currency Column: "Currency" (auto-detected, mode set to FROM_COLUMN)
 
             // Wait for the dialog to fully load with auto-detected values
             waitForIdle()
 
-            // Verify the currency dropdown is ready (account is already selected)
-            waitUntilExactlyOneExists(hasText("Select Currency"), timeoutMillis = 10000)
+            // Verify currency mode is set to FROM_COLUMN because "Currency" column was auto-detected
+            waitUntilAtLeastOneExists(hasText("From CSV Column"), timeoutMillis = 10000)
 
             // Verify the auto-detected column names are shown in the dropdown fields
             // The Date column dropdown should show "Date" (not "Transaction ID")
@@ -222,6 +223,16 @@ class ImportMonzoCsvE2ETest {
 
             // The Time Format field should be visible since a time column was auto-detected
             waitUntilAtLeastOneExists(hasText("Time Format", substring = true), timeoutMillis = 10000)
+
+            // Step 7: Verify currency column auto-detection
+            // The currency column dropdown label should show "Column containing currency code"
+            waitUntilAtLeastOneExists(
+                hasText("Column containing currency code", substring = true),
+                timeoutMillis = 10000,
+            )
+
+            // The currency column sample should show "GBP" (from "Currency" column in Monzo format)
+            waitUntilAtLeastOneExists(hasText("GBP", substring = true), timeoutMillis = 10000)
 
             // Cancel the dialog to return to CSV detail screen
             onNodeWithText("Cancel").performClick()


### PR DESCRIPTION
## Summary
- Add `CurrencyLookupMapping` to read currency codes from CSV columns (ISO 4217 codes like GBP, USD, EUR)
- Add currency column auto-detection in `ColumnDetector` (patterns: currency, ccy, curr, fx)
- Add UI toggle between hardcoded currency and CSV column mode with radio buttons
- Add form validation: Create button disabled until all required fields populated, empty fields highlighted in red
- Update `CsvTransferMapper` to handle new currency mapping type with `existingCurrenciesByCode` parameter

Fixes #202

## Test plan
- [x] CurrencyLookupMapping serialization/deserialization test added
- [x] CsvTransferMapper tests updated with new parameter
- [x] New tests for currency column parsing (success and error cases)
- [x] E2E test updated to verify currency column auto-detection
- [x] Build passes with all tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)