### PR TITLE
feat(csv): add timezone support to CSV import strategy

### DIFF
--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/json/FieldMappingJsonCodecTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/json/FieldMappingJsonCodecTest.kt
@@ -14,6 +14,8 @@ import com.moneymanager.domain.model.csvstrategy.DirectColumnMapping
 import com.moneymanager.domain.model.csvstrategy.FieldMappingId
 import com.moneymanager.domain.model.csvstrategy.HardCodedAccountMapping
 import com.moneymanager.domain.model.csvstrategy.HardCodedCurrencyMapping
+import com.moneymanager.domain.model.csvstrategy.HardCodedTimezoneMapping
+import com.moneymanager.domain.model.csvstrategy.TimezoneLookupMapping
 import com.moneymanager.domain.model.csvstrategy.TransferField
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -282,5 +284,43 @@ class FieldMappingJsonCodecTest {
         assertTrue(json.contains("SOURCE_ACCOUNT"))
         assertTrue(json.contains("HardCodedAccountMapping"))
         assertTrue(json.contains("42"))
+    }
+
+    @Test
+    fun `encode and decode HardCodedTimezoneMapping`() {
+        val mapping =
+            HardCodedTimezoneMapping(
+                id = FieldMappingId(Uuid.random()),
+                fieldType = TransferField.TIMEZONE,
+                timezoneId = "Europe/London",
+            )
+        val mappings = mapOf(TransferField.TIMEZONE to mapping)
+
+        val json = FieldMappingJsonCodec.encode(mappings)
+        val decoded = FieldMappingJsonCodec.decode(json)
+
+        val decodedMapping = decoded[TransferField.TIMEZONE]
+        assertIs<HardCodedTimezoneMapping>(decodedMapping)
+        assertEquals("Europe/London", decodedMapping.timezoneId)
+        assertEquals(TransferField.TIMEZONE, decodedMapping.fieldType)
+    }
+
+    @Test
+    fun `encode and decode TimezoneLookupMapping`() {
+        val mapping =
+            TimezoneLookupMapping(
+                id = FieldMappingId(Uuid.random()),
+                fieldType = TransferField.TIMEZONE,
+                columnName = "Timezone",
+            )
+        val mappings = mapOf(TransferField.TIMEZONE to mapping)
+
+        val json = FieldMappingJsonCodec.encode(mappings)
+        val decoded = FieldMappingJsonCodec.decode(json)
+
+        val decodedMapping = decoded[TransferField.TIMEZONE]
+        assertIs<TimezoneLookupMapping>(decodedMapping)
+        assertEquals("Timezone", decodedMapping.columnName)
+        assertEquals(TransferField.TIMEZONE, decodedMapping.fieldType)
     }
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
@@ -131,3 +131,25 @@ data class CurrencyLookupMapping(
     override val fieldType: TransferField,
     val columnName: String,
 ) : FieldMapping
+
+/**
+ * Always uses a specific timezone, regardless of CSV data.
+ * The timezoneId should be a valid IANA timezone ID (e.g., "Europe/London", "UTC").
+ */
+@Serializable
+data class HardCodedTimezoneMapping(
+    override val id: FieldMappingId,
+    override val fieldType: TransferField,
+    val timezoneId: String,
+) : FieldMapping
+
+/**
+ * Looks up a timezone by IANA timezone ID from a CSV column.
+ * The column should contain valid timezone IDs (e.g., "Europe/London", "America/New_York").
+ */
+@Serializable
+data class TimezoneLookupMapping(
+    override val id: FieldMappingId,
+    override val fieldType: TransferField,
+    val columnName: String,
+) : FieldMapping

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/TransferField.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/TransferField.kt
@@ -13,4 +13,5 @@ enum class TransferField {
     DESCRIPTION,
     AMOUNT,
     CURRENCY,
+    TIMEZONE,
 }


### PR DESCRIPTION
## Summary

- Add timezone as a configurable field in CSV import strategy, following the same pattern as currency mapping
- Support both hardcoded timezone (e.g., "Europe/London", "UTC") and column-based timezone lookup
- Default to system timezone (`TimeZone.currentSystemDefault()`)
- Use kotlinx-datetime's `TimeZone.availableZoneIds` for multiplatform timezone list
- Add searchable timezone dropdown in the UI

## Changes

### Domain Model
- Added `TIMEZONE` to `TransferField` enum
- Added `HardCodedTimezoneMapping` class for fixed timezone
- Added `TimezoneLookupMapping` class for reading timezone from CSV column

### CSV Parsing
- Updated `CsvTransferMapper` to parse and apply timezone to timestamps
- Timezone is optional - defaults to system timezone if not configured

### UI
- Added timezone configuration section with radio buttons for mode selection
- Added searchable timezone picker dropdown with all IANA timezone IDs

### Tests
- Added JSON serialization tests for timezone mapping classes
- Added `CsvTransferMapper` tests verifying correct timezone application
- Added test demonstrating different timestamps for UTC vs Europe/London during BST

## Test plan
- [x] Build passes locally
- [x] Unit tests pass for new timezone functionality
- [x] JSON serialization/deserialization tests pass
- [ ] Manual testing of timezone UI in CSV import dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)