### PR TITLE
feat(csv): add fallback column support for description field

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/csv/CsvTransferMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/csv/CsvTransferMapper.kt
@@ -350,9 +350,23 @@ class CsvTransferMapper(
         values: List<String>,
     ): String {
         return when (mapping) {
-            is DirectColumnMapping -> getColumnValue(mapping.columnName, values)
+            is DirectColumnMapping -> getDirectColumnValue(mapping, values)
             else -> throw IllegalArgumentException("Invalid description mapping type: ${mapping::class}")
         }
+    }
+
+    /**
+     * Gets the effective value from a DirectColumnMapping,
+     * trying the primary column first, then fallbacks in order.
+     */
+    private fun getDirectColumnValue(
+        mapping: DirectColumnMapping,
+        values: List<String>,
+    ): String {
+        return mapping.allColumns
+            .map { getColumnValue(it, values) }
+            .firstOrNull { it.isNotBlank() }
+            ?: ""
     }
 
     private fun parseCurrency(

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
@@ -81,13 +81,23 @@ data class DateTimeParsingMapping(
 /**
  * Directly copies a string value from a CSV column.
  * Used for the description field.
+ *
+ * When [fallbackColumns] is specified, if the primary [columnName] is empty,
+ * each fallback column is tried in order until a non-empty value is found.
  */
 @Serializable
 data class DirectColumnMapping(
     override val id: FieldMappingId,
     override val fieldType: TransferField,
     val columnName: String,
-) : FieldMapping
+    val fallbackColumns: List<String> = emptyList(),
+) : FieldMapping {
+    /**
+     * Returns all columns to check in priority order (primary first, then fallbacks).
+     */
+    val allColumns: List<String>
+        get() = listOf(columnName) + fallbackColumns
+}
 
 /**
  * Parses a numeric amount from CSV columns.


### PR DESCRIPTION
## Summary
- Add `fallbackColumns` to `DirectColumnMapping` model for description field
- Add `getDirectColumnValue()` helper in CsvTransferMapper that tries primary column first, then fallbacks in order
- Add UI dropdown for selecting description fallback column with auto-detection

This mirrors the fallback column support already available for the target account field, allowing description values to fall back to another column when the primary column is empty.

## Test plan
- [ ] Create a new import strategy with a description column that has some empty values
- [ ] Verify fallback column is auto-detected and shown in dropdown
- [ ] Import CSV and verify description uses fallback value when primary is empty
- [ ] Verify existing strategies without fallback continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)