### PR TITLE
refactor(repository): simplify transfer method names

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionRepositoryImpl.kt
@@ -294,7 +294,7 @@ class TransactionRepositoryImpl(
             )
         }
 
-    override suspend fun createTransfersWithAttributesAndSources(
+    override suspend fun createTransfers(
         transfersWithAttributes: List<TransferWithAttributes>,
         sourceRecorder: SourceRecorder,
         onProgress: (suspend (created: Int, total: Int) -> Unit)?,
@@ -353,7 +353,7 @@ class TransactionRepositoryImpl(
             }
         }
 
-    override suspend fun updateTransferAndAttributes(
+    override suspend fun updateTransfer(
         transfer: Transfer?,
         deletedAttributeIds: Set<Long>,
         updatedAttributes: Map<Long, NewAttribute>,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/IncrementalMaterializedViewRefreshTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/IncrementalMaterializedViewRefreshTest.kt
@@ -272,7 +272,7 @@ class IncrementalMaterializedViewRefreshTest : DbTest() {
             repositories.maintenanceService.fullRefreshMaterializedViews()
 
             // UPDATE first transfer to have timestamp AFTER second
-            repositories.transactionRepository.updateTransferAndAttributes(
+            repositories.transactionRepository.updateTransfer(
                 transfer =
                     Transfer(
                         id = transfer1Id,
@@ -335,7 +335,7 @@ class IncrementalMaterializedViewRefreshTest : DbTest() {
             repositories.maintenanceService.fullRefreshMaterializedViews()
 
             // UPDATE to change BOTH source and target accounts (account1→account2 becomes account3→account4)
-            repositories.transactionRepository.updateTransferAndAttributes(
+            repositories.transactionRepository.updateTransfer(
                 transfer =
                     Transfer(
                         id = transferId,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/audit/AuditFunctionalTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/audit/AuditFunctionalTest.kt
@@ -307,7 +307,7 @@ class AuditFunctionalTest : DbTest() {
                 ),
             )
 
-            repositories.transactionRepository.updateTransferAndAttributes(
+            repositories.transactionRepository.updateTransfer(
                 transfer =
                     Transfer(
                         id = transferId,
@@ -381,7 +381,7 @@ class AuditFunctionalTest : DbTest() {
             )
 
             // Update transfer (revisionId should be 2)
-            repositories.transactionRepository.updateTransferAndAttributes(
+            repositories.transactionRepository.updateTransfer(
                 transfer =
                     Transfer(
                         id = transferId,
@@ -435,7 +435,7 @@ class AuditFunctionalTest : DbTest() {
             )
 
             // First update (revisionId = 2)
-            repositories.transactionRepository.updateTransferAndAttributes(
+            repositories.transactionRepository.updateTransfer(
                 transfer =
                     Transfer(
                         id = transferId,
@@ -452,7 +452,7 @@ class AuditFunctionalTest : DbTest() {
             )
 
             // Second update (revisionId = 3)
-            repositories.transactionRepository.updateTransferAndAttributes(
+            repositories.transactionRepository.updateTransfer(
                 transfer =
                     Transfer(
                         id = transferId,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/TransactionRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/TransactionRepositoryImplTest.kt
@@ -137,7 +137,7 @@ class TransactionRepositoryImplTest : DbTest() {
                         targetAccountId = sourceAccountId,
                         amount = Money.fromDisplayValue(100.0, currency),
                     )
-                repositories.transactionRepository.updateTransferAndAttributes(
+                repositories.transactionRepository.updateTransfer(
                     transfer = invalidTransfer,
                     deletedAttributeIds = emptySet(),
                     updatedAttributes = emptyMap(),

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionRepository.kt
@@ -83,7 +83,7 @@ interface TransactionRepository {
      * @param sourceRecorder Strategy for recording source information (includes device info)
      * @param onProgress Optional callback for batch progress (called after each batch of ~1000)
      */
-    suspend fun createTransfersWithAttributesAndSources(
+    suspend fun createTransfers(
         transfersWithAttributes: List<TransferWithAttributes>,
         sourceRecorder: SourceRecorder,
         onProgress: (suspend (created: Int, total: Int) -> Unit)? = null,
@@ -107,7 +107,7 @@ interface TransactionRepository {
      * @param newAttributes List of (typeId, value) pairs for new attributes
      * @param transactionId The transaction ID (needed when transfer is null)
      */
-    suspend fun updateTransferAndAttributes(
+    suspend fun updateTransfer(
         transfer: Transfer?,
         deletedAttributeIds: Set<Long>,
         updatedAttributes: Map<Long, NewAttribute>,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/TransactionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/TransactionsScreen.kt
@@ -1470,7 +1470,7 @@ fun TransactionEntryDialog(
 
                                 // Create transfer with attributes and source in one transaction
                                 val deviceId = deviceRepository.getOrCreateDevice(getDeviceInfo())
-                                transactionRepository.createTransfersWithAttributesAndSources(
+                                transactionRepository.createTransfers(
                                     transfersWithAttributes = listOf(TransferWithAttributes(transfer, attributesToSave)),
                                     sourceRecorder = ManualSourceRecorder(transferSourceQueries, deviceId),
                                 )
@@ -1979,7 +1979,7 @@ fun TransactionEditDialog(
 
                                     // Use the atomic method to update transfer and attributes together
                                     // This ensures only ONE revision bump even if both change
-                                    transactionRepository.updateTransferAndAttributes(
+                                    transactionRepository.updateTransfer(
                                         transfer = updatedTransfer,
                                         deletedAttributeIds = deletedAttributeIds,
                                         updatedAttributes = updatedAttributes,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -270,7 +270,7 @@ fun ApplyStrategyDialog(
                                         }
 
                                     // Create transfer with attributes and source in one operation
-                                    transactionRepository.createTransfersWithAttributesAndSources(
+                                    transactionRepository.createTransfers(
                                         transfersWithAttributes = listOf(TransferWithAttributes(transfer, attributes)),
                                         sourceRecorder =
                                             CsvImportSourceRecorder(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/SampleDataGenerator.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/SampleDataGenerator.kt
@@ -286,7 +286,7 @@ suspend fun generateSampleData(
     val deviceId = repositorySet.deviceRepository.getOrCreateDevice(getDeviceInfo())
     var transactionsCreated = 0
 
-    repositorySet.transactionRepository.createTransfersWithAttributesAndSources(
+    repositorySet.transactionRepository.createTransfers(
         transfersWithAttributes = allTransfersWithAttributes,
         sourceRecorder = SampleGeneratorSourceRecorder(repositorySet.transferSourceQueries, deviceId),
         onProgress = { created, total ->

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -310,7 +310,7 @@ class AccountTransactionsScreenTest {
                         amount = Money.fromDisplayValue(50.0, usdCurrency),
                     )
                 val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
-                repositories.transactionRepository.createTransfersWithAttributesAndSources(
+                repositories.transactionRepository.createTransfers(
                     transfersWithAttributes = listOf(com.moneymanager.domain.model.TransferWithAttributes(transfer, emptyList())),
                     sourceRecorder = SampleGeneratorSourceRecorder(repositories.transferSourceQueries, deviceId),
                 )
@@ -507,14 +507,14 @@ class AccountTransactionsScreenTest {
                         amount = Money.fromDisplayValue(100.0, usdCurrency),
                     )
                 val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
-                repositories.transactionRepository.createTransfersWithAttributesAndSources(
+                repositories.transactionRepository.createTransfers(
                     transfersWithAttributes = listOf(com.moneymanager.domain.model.TransferWithAttributes(transfer, emptyList())),
                     sourceRecorder = ManualSourceRecorder(repositories.transferSourceQueries, deviceId),
                 )
 
                 // Verify initial revision is 1
                 val initialTransfer =
-                    repositories.transactionRepository.getTransactionById(transferId!!.id).first()!!
+                    repositories.transactionRepository.getTransactionById(transferId.id).first()!!
                 assertEquals(1L, initialTransfer.revisionId, "Initial revision should be 1")
 
                 // Refresh materialized views so the transaction appears
@@ -674,14 +674,14 @@ class AccountTransactionsScreenTest {
                         amount = Money.fromDisplayValue(100.0, usdCurrency),
                     )
                 val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
-                repositories.transactionRepository.createTransfersWithAttributesAndSources(
+                repositories.transactionRepository.createTransfers(
                     transfersWithAttributes = listOf(com.moneymanager.domain.model.TransferWithAttributes(transfer, emptyList())),
                     sourceRecorder = ManualSourceRecorder(repositories.transferSourceQueries, deviceId),
                 )
 
                 // Verify initial revision is 1
                 val initialTransfer =
-                    repositories.transactionRepository.getTransactionById(transferId!!.id).first()!!
+                    repositories.transactionRepository.getTransactionById(transferId.id).first()!!
                 assertEquals(1L, initialTransfer.revisionId, "Initial revision should be 1")
 
                 // Refresh materialized views so the transaction appears
@@ -961,13 +961,13 @@ class AccountTransactionsScreenTest {
             )
         }
 
-        override suspend fun createTransfersWithAttributesAndSources(
+        override suspend fun createTransfers(
             transfersWithAttributes: List<com.moneymanager.domain.model.TransferWithAttributes>,
             sourceRecorder: com.moneymanager.domain.model.SourceRecorder,
             onProgress: (suspend (Int, Int) -> Unit)?,
         ) {}
 
-        override suspend fun updateTransferAndAttributes(
+        override suspend fun updateTransfer(
             transfer: Transfer?,
             deletedAttributeIds: Set<Long>,
             updatedAttributes: Map<Long, com.moneymanager.domain.model.NewAttribute>,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
@@ -448,13 +448,13 @@ class AccountsScreenTest {
                 hasPrevious = false,
             )
 
-        override suspend fun createTransfersWithAttributesAndSources(
+        override suspend fun createTransfers(
             transfersWithAttributes: List<com.moneymanager.domain.model.TransferWithAttributes>,
             sourceRecorder: com.moneymanager.domain.model.SourceRecorder,
             onProgress: (suspend (Int, Int) -> Unit)?,
         ) {}
 
-        override suspend fun updateTransferAndAttributes(
+        override suspend fun updateTransfer(
             transfer: Transfer?,
             deletedAttributeIds: Set<Long>,
             updatedAttributes: Map<Long, com.moneymanager.domain.model.NewAttribute>,

--- a/test/app/db/src/commonMain/kotlin/com/moneymanager/test/database/DbTest.kt
+++ b/test/app/db/src/commonMain/kotlin/com/moneymanager/test/database/DbTest.kt
@@ -40,7 +40,7 @@ abstract class DbTest {
      */
     protected suspend fun createTransfer(transfer: Transfer) {
         val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
-        repositories.transactionRepository.createTransfersWithAttributesAndSources(
+        repositories.transactionRepository.createTransfers(
             transfersWithAttributes = listOf(TransferWithAttributes(transfer, emptyList())),
             sourceRecorder = SampleGeneratorSourceRecorder(repositories.transferSourceQueries, deviceId),
         )


### PR DESCRIPTION
## Summary
- Rename `createTransfersWithAttributesAndSources` → `createTransfers`
- Rename `updateTransferAndAttributes` → `updateTransfer`
- Cleaner, more concise method names while maintaining full functionality

## Test plan
- [ ] Verify all existing tests pass
- [ ] Confirm no behavioral changes, only renames

🤖 Generated with [Claude Code](https://claude.com/claude-code)