### PR TITLE
refactor(db): extract CSV fields from TransferSource to CsvTransferSource

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/MoneyManagerDatabaseWrapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/MoneyManagerDatabaseWrapper.kt
@@ -84,6 +84,7 @@ class MoneyManagerDatabaseWrapper(private val driver: SqlDriver) : MoneyManagerD
             "TransactionId",
             "SourceType",
             "TransferSource",
+            "CsvTransferSource",
             "Platform",
             "OsName",
             "MachineName",

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
@@ -44,10 +44,16 @@ class CsvImportSourceRecorder(
     private val rowIndexForTransfer: (TransferId) -> Long,
 ) : SourceRecorder {
     override fun insert(transfer: Transfer) {
-        queries.insertCsvImport(
+        // Insert base TransferSource record
+        queries.insertCsvImportBase(
             transfer.id.id.toString(),
             transfer.revisionId,
             deviceId,
+        )
+        // Get the auto-generated ID and insert CSV-specific details
+        val transferSourceId = queries.lastInsertedId().executeAsOne()
+        queries.insertCsvImportDetails(
+            transferSourceId,
             csvImportId.id.toString(),
             rowIndexForTransfer(transfer.id),
         )

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferSourceRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferSourceRepositoryImpl.kt
@@ -60,13 +60,20 @@ class TransferSourceRepositoryImpl(
                         .executeAsOne().tableName,
                 ).executeAsOne()
 
-            queries.insertCsvImport(
+            // Insert base TransferSource record
+            queries.insertCsvImportBase(
                 transactionId = transactionId.toString(),
                 revisionId = revisionId,
                 deviceId = csvImport.device_id,
+            )
+            // Get the auto-generated ID and insert CSV-specific details
+            val transferSourceId = queries.lastInsertedId().executeAsOne()
+            queries.insertCsvImportDetails(
+                id = transferSourceId,
                 csvImportId = csvImportId.toString(),
                 csvRowIndex = rowIndex,
             )
+
             queries.selectByTransactionIdAndRevision(transactionId.toString(), revisionId)
                 .executeAsOne()
                 .let(TransferSourceFromRevisionMapper::map)
@@ -83,10 +90,16 @@ class TransferSourceRepositoryImpl(
 
             queries.transaction {
                 sources.forEach { source ->
-                    queries.insertCsvImport(
+                    // Insert base TransferSource record
+                    queries.insertCsvImportBase(
                         transactionId = source.transactionId.toString(),
                         revisionId = source.revisionId,
                         deviceId = deviceId,
+                    )
+                    // Get the auto-generated ID and insert CSV-specific details
+                    val transferSourceId = queries.lastInsertedId().executeAsOne()
+                    queries.insertCsvImportDetails(
+                        id = transferSourceId,
                         csvImportId = csvImportId.toString(),
                         csvRowIndex = source.rowIndex,
                     )

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Audit.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Audit.sq
@@ -120,8 +120,8 @@ SELECT
     TransferSource.deviceId,
     SourceType.id AS sourceTypeId,
     SourceType.name AS sourceType,
-    TransferSource.csvImportId AS source_csv_import_id,
-    TransferSource.csvRowIndex AS source_csv_row_index,
+    CsvTransferSource.csvImportId AS source_csv_import_id,
+    CsvTransferSource.csvRowIndex AS source_csv_row_index,
     CsvImportMetadata.originalFileName AS source_csv_file_name,
     Platform.name AS sourcePlatformName,
     OsName.name AS source_os_name,
@@ -135,7 +135,8 @@ JOIN Currency ON Transfer_Audit.currencyId = Currency.id
 LEFT JOIN TransferSource ON Transfer_Audit.id = TransferSource.transactionId
     AND Transfer_Audit.revisionId = TransferSource.revisionId
 LEFT JOIN SourceType ON TransferSource.sourceTypeId = SourceType.id
-LEFT JOIN CsvImportMetadata ON TransferSource.csvImportId = CsvImportMetadata.id
+LEFT JOIN CsvTransferSource ON TransferSource.id = CsvTransferSource.id
+LEFT JOIN CsvImportMetadata ON CsvTransferSource.csvImportId = CsvImportMetadata.id
 LEFT JOIN Device ON TransferSource.deviceId = Device.id
 LEFT JOIN Platform ON Device.platform_id = Platform.id
 LEFT JOIN OsName ON Device.os_id = OsName.id

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/TransferSource.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/TransferSource.sq
@@ -8,24 +8,33 @@ CREATE TABLE TransferSource (
     sourceTypeId INTEGER NOT NULL,
     -- Device that performed the action (always required)
     deviceId INTEGER NOT NULL,
-    -- CSV import fields (NULL for MANUAL sources)
-    csvImportId TEXT,
-    csvRowIndex INTEGER,
     -- Timestamp (defaults to current epoch milliseconds)
     createdAt INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
     FOREIGN KEY (transactionId) REFERENCES TransactionId(id),
     FOREIGN KEY (sourceTypeId) REFERENCES SourceType(id),
     FOREIGN KEY (deviceId) REFERENCES Device(id),
-    UNIQUE (transactionId, revisionId),
-    -- CSV sources must have import ID and row index
-    CHECK (sourceTypeId != 2 OR (csvImportId IS NOT NULL AND csvRowIndex IS NOT NULL))
+    UNIQUE (transactionId, revisionId)
 );
 
 CREATE INDEX IF NOT EXISTS idx_transfer_source_transaction ON TransferSource(transactionId);
 CREATE INDEX IF NOT EXISTS idx_transfer_source_type ON TransferSource(sourceTypeId);
-CREATE INDEX IF NOT EXISTS idx_transfer_source_csv_import ON TransferSource(csvImportId);
 CREATE INDEX IF NOT EXISTS idx_transfer_source_transaction_revision ON TransferSource(transactionId, revisionId);
 CREATE INDEX IF NOT EXISTS idx_transfer_source_device ON TransferSource(deviceId);
+
+-- CsvTransferSource: CSV-specific data for CSV_IMPORT sources (sourceTypeId = 2)
+-- 1:1 relationship with TransferSource
+CREATE TABLE CsvTransferSource (
+    id INTEGER PRIMARY KEY,  -- Same as TransferSource.id
+    csvImportId TEXT NOT NULL,
+    csvRowIndex INTEGER NOT NULL,
+    FOREIGN KEY (id) REFERENCES TransferSource(id),
+    FOREIGN KEY (csvImportId) REFERENCES CsvImportMetadata(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_csv_transfer_source_import ON CsvTransferSource(csvImportId);
+
+-- Note: Validation that CsvTransferSource.id references a CSV_IMPORT source (sourceTypeId = 2)
+-- is enforced at the application level. SQLDelight's dialect doesn't support trigger validation syntax.
 
 -- Select source by transaction ID and revision with device info
 selectByTransactionIdAndRevision:
@@ -35,8 +44,8 @@ SELECT
     TransferSource.revisionId,
     TransferSource.sourceTypeId,
     TransferSource.deviceId,
-    TransferSource.csvImportId,
-    TransferSource.csvRowIndex,
+    CsvTransferSource.csvImportId,
+    CsvTransferSource.csvRowIndex,
     TransferSource.createdAt,
     SourceType.name AS sourceType,
     CsvImportMetadata.originalFileName AS csvFileName,
@@ -53,7 +62,8 @@ LEFT JOIN OsName ON Device.os_id = OsName.id
 LEFT JOIN MachineName ON Device.machine_id = MachineName.id
 LEFT JOIN DeviceMake ON Device.device_make_id = DeviceMake.id
 LEFT JOIN DeviceModel ON Device.device_model_id = DeviceModel.id
-LEFT JOIN CsvImportMetadata ON TransferSource.csvImportId = CsvImportMetadata.id
+LEFT JOIN CsvTransferSource ON TransferSource.id = CsvTransferSource.id
+LEFT JOIN CsvImportMetadata ON CsvTransferSource.csvImportId = CsvImportMetadata.id
 WHERE TransferSource.transactionId = ? AND TransferSource.revisionId = ?;
 
 -- Select all sources for a transaction (across all revisions)
@@ -64,8 +74,8 @@ SELECT
     TransferSource.revisionId,
     TransferSource.sourceTypeId,
     TransferSource.deviceId,
-    TransferSource.csvImportId,
-    TransferSource.csvRowIndex,
+    CsvTransferSource.csvImportId,
+    CsvTransferSource.csvRowIndex,
     TransferSource.createdAt,
     SourceType.name AS sourceType,
     CsvImportMetadata.originalFileName AS csvFileName,
@@ -82,7 +92,8 @@ LEFT JOIN OsName ON Device.os_id = OsName.id
 LEFT JOIN MachineName ON Device.machine_id = MachineName.id
 LEFT JOIN DeviceMake ON Device.device_make_id = DeviceMake.id
 LEFT JOIN DeviceModel ON Device.device_model_id = DeviceModel.id
-LEFT JOIN CsvImportMetadata ON TransferSource.csvImportId = CsvImportMetadata.id
+LEFT JOIN CsvTransferSource ON TransferSource.id = CsvTransferSource.id
+LEFT JOIN CsvImportMetadata ON CsvTransferSource.csvImportId = CsvImportMetadata.id
 WHERE TransferSource.transactionId = ?
 ORDER BY TransferSource.revisionId DESC;
 
@@ -94,14 +105,24 @@ INSERT INTO TransferSource (
 )
 VALUES (?, ?, 1, ?);
 
--- Insert a new source record for CSV import
-insertCsvImport:
+-- Insert a new source record for CSV import (base record)
+insertCsvImportBase:
 INSERT INTO TransferSource (
     transactionId, revisionId, sourceTypeId,
-    deviceId,
-    csvImportId, csvRowIndex
+    deviceId
 )
-VALUES (?, ?, 2, ?, ?, ?);
+VALUES (?, ?, 2, ?);
+
+-- Insert CSV-specific details (must be called after insertCsvImportBase)
+insertCsvImportDetails:
+INSERT INTO CsvTransferSource (
+    id, csvImportId, csvRowIndex
+)
+VALUES (?, ?, ?);
+
+-- Get the last inserted TransferSource ID
+lastInsertedId:
+SELECT last_insert_rowid();
 
 -- Insert a new source record for sample data generator
 insertSampleGenerator:


### PR DESCRIPTION
## Summary

- Extracts `csvImportId` and `csvRowIndex` columns from `TransferSource` table into a new `CsvTransferSource` table
- Creates a 1:1 foreign key relationship between `CsvTransferSource.id` and `TransferSource.id`
- Normalizes the schema by separating CSV-specific metadata from the base transfer source record
- Updates all queries to LEFT JOIN `CsvTransferSource` for CSV fields
- Splits `insertCsvImport` into `insertCsvImportBase` + `insertCsvImportDetails` for two-step inserts

## Test plan

- [x] Build passes (`./gradlew build`)
- [x] All existing tests pass
- [ ] Manually verify CSV import creates records in both tables
- [ ] Verify audit history displays correctly for CSV-imported transfers

Fixes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)