### PR TITLE
feat(csv): add CSV strategy editing and improve re-apply flow

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -315,6 +315,11 @@ fun MoneyManagerApp(
                             }
                             CsvStrategiesScreen(
                                 csvImportStrategyRepository = csvImportStrategyRepository,
+                                csvImportRepository = csvImportRepository,
+                                accountRepository = accountRepository,
+                                categoryRepository = categoryRepository,
+                                currencyRepository = currencyRepository,
+                                attributeTypeRepository = attributeTypeRepository,
                                 onBack = { currentScreen = Screen.CsvImports },
                             )
                         }


### PR DESCRIPTION
## Summary
- Add edit button (✏️) to CSV strategy cards for editing existing strategies
- Add `SelectCsvImportDialog` for choosing which CSV file to use as sample data when editing
- Modify `CreateCsvStrategyDialog` to support edit mode with pre-populated form fields
- Filter re-apply preview to only show error/unprocessed rows (not all rows)

Closes #210

## Changes

### CSV Strategy Editing
- **CsvStrategyDialogs.kt**: Added `SelectCsvImportDialog` and `extractFormStateFromStrategy()` helper. Modified `CreateCsvStrategyDialog` to accept optional `existingStrategy` parameter for edit mode.
- **CsvStrategiesScreen.kt**: Added edit flow state management, edit button on strategy cards, and wired up the dialogs.
- **MoneyManagerApp.kt**: Wired additional repository dependencies to `CsvStrategiesScreen`.

### Re-apply Flow Improvement
- **ApplyStrategyDialog.kt**: Filter rows at the start of the composable to only show rows that need processing (ERROR status or never processed). Shows helpful message when all rows already imported.

## Test plan
- [ ] Navigate to Import Strategies screen
- [ ] Click the edit button (✏️) on a strategy card
- [ ] Verify `SelectCsvImportDialog` shows available CSV imports
- [ ] Select a CSV file and verify edit dialog opens with pre-populated values
- [ ] Modify the strategy and save - verify changes are persisted
- [ ] Re-apply a strategy on a CSV with some already-imported rows
- [ ] Verify only error/unprocessed rows are shown in the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)