### PR TITLE
feat(csv): add RegexAccountMapping for pattern-based account matching

### DIFF
--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvImportErrorHandlingTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvImportErrorHandlingTest.kt
@@ -179,7 +179,6 @@ class CsvImportErrorHandlingTest {
                             fieldType = TransferField.TARGET_ACCOUNT,
                             columnName = "Name",
                             fallbackColumns = fallbackColumns,
-                            createIfMissing = true,
                         ),
                     TransferField.TIMESTAMP to
                         DateTimeParsingMapping(

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
@@ -40,7 +40,6 @@ data class HardCodedAccountMapping(
 
 /**
  * Looks up an account by name from a CSV column.
- * Can optionally create a new account if not found.
  *
  * When [fallbackColumns] is specified, if the primary [columnName] is empty,
  * each fallback column is tried in order until a non-empty value is found.
@@ -53,7 +52,41 @@ data class AccountLookupMapping(
     override val fieldType: TransferField,
     val columnName: String,
     val fallbackColumns: List<String> = emptyList(),
-    val createIfMissing: Boolean = true,
+    val defaultCategoryId: Long = Category.UNCATEGORIZED_ID,
+) : FieldMapping {
+    /**
+     * Returns all columns to check in priority order (primary first, then fallbacks).
+     */
+    val allColumns: List<String>
+        get() = listOf(columnName) + fallbackColumns
+}
+
+/**
+ * A single regex rule that maps matched values to a specific account name.
+ */
+@Serializable
+data class RegexRule(
+    val pattern: String,
+    val accountName: String,
+)
+
+/**
+ * Maps CSV column values to accounts using regex pattern matching.
+ * Rules are evaluated in order; first match wins.
+ * If no rules match, uses the raw column value for account lookup.
+ * All matching is case-insensitive.
+ *
+ * When [fallbackColumns] is specified and no regex rules match, if the primary
+ * [columnName] is empty, each fallback column is tried in order until a non-empty
+ * value is found.
+ */
+@Serializable
+data class RegexAccountMapping(
+    override val id: FieldMappingId,
+    override val fieldType: TransferField,
+    val columnName: String,
+    val rules: List<RegexRule>,
+    val fallbackColumns: List<String> = emptyList(),
     val defaultCategoryId: Long = Category.UNCATEGORIZED_ID,
 ) : FieldMapping {
     /**

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
@@ -77,6 +77,16 @@ fun CsvImportDetailScreen(
     var importResultMessage by remember { mutableStateOf<String?>(null) }
     var failedRowIndexes by remember { mutableStateOf<Set<Long>>(emptySet()) }
     var rowsRefreshTrigger by remember { mutableStateOf(0) }
+    var hasMatchingStrategy by remember { mutableStateOf(false) }
+
+    // Check if there's a matching strategy for this import's columns
+    LaunchedEffect(import) {
+        import?.let { csvImport ->
+            val columnNames = csvImport.columns.map { it.originalName }.toSet()
+            val matchingStrategy = csvImportStrategyRepository.findMatchingStrategy(columnNames)
+            hasMatchingStrategy = matchingStrategy != null
+        }
+    }
 
     // Determine amount column index by looking for common amount column names
     val amountColumnIndex =
@@ -128,11 +138,16 @@ fun CsvImportDetailScreen(
                 Spacer(modifier = Modifier.width(8.dp))
                 TextButton(
                     onClick = { showApplyStrategyDialog = true },
-                    enabled = !isDeleting && import != null && rows.isNotEmpty(),
+                    enabled = !isDeleting && import != null && rows.isNotEmpty() && hasMatchingStrategy,
                 ) {
                     Text(
                         text = "Apply Strategy",
-                        color = MaterialTheme.colorScheme.primary,
+                        color =
+                            if (hasMatchingStrategy) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                            },
                     )
                 }
                 Spacer(modifier = Modifier.width(8.dp))


### PR DESCRIPTION
## Summary

- Adds new `RegexAccountMapping` type that maps CSV column values to accounts using regex pattern matching
- Handles cases like Paxos payments where account names vary (e.g., "103611797paxos Te", "350709785paxos Te") but should all map to the same "Paxos" account
- Supports multiple regex rules evaluated in order (first match wins), with case-insensitive matching
- Falls back to column value when no rules match (like `AccountLookupMapping`)
- Adds UI with radio buttons for "Direct Lookup" vs "Regex Match" mode, with live preview of matches
- Greys out Apply Strategy button when no matching strategy exists for the imported CSV

Closes #254

## Test plan

- [ ] Create a new CSV import strategy with regex mode enabled
- [ ] Add regex rules like `.*paxos.*` -> "Paxos" 
- [ ] Verify the preview shows which rows match each rule
- [ ] Apply the strategy to a CSV import and verify accounts are created correctly
- [ ] Verify unmatched rows fall back to using the column value
- [ ] Verify the Apply Strategy button is greyed out when no matching strategy exists
- [ ] Run `./gradlew build` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)