### PR TITLE
fix(build): apply kotlin-multiplatform-convention to compose plugin

### DIFF
--- a/gradle/build-logic/src/main/kotlin/moneymanager.compose-multiplatform-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.compose-multiplatform-convention.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
     id("moneymanager.android-convention")
+    id("moneymanager.kotlin-multiplatform-convention")
     id("org.jetbrains.compose")
 }


### PR DESCRIPTION
## Summary
- Applies `kotlin-multiplatform-convention` plugin to the `compose-multiplatform-convention` plugin
- Ensures consistent multiplatform module configuration for all Compose modules

## Test plan
- [ ] Run `./gradlew build --console=plain` to verify build succeeds
- [ ] Verify all Compose modules compile correctly
- [ ] Check that buildHealth passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)