### PR TITLE
feat(csv): persist import errors in database and display in CSV view

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportRepositoryImpl.kt
@@ -168,6 +168,7 @@ class CsvImportRepositoryImpl(
 
             tableManager.queryRows(
                 tableName = import.table_name,
+                csvImportId = id.id.toString(),
                 columnCount = import.column_count.toInt(),
                 limit = limit,
                 offset = offset,
@@ -229,5 +230,30 @@ class CsvImportRepositoryImpl(
                     ?: return@withContext
 
             tableManager.updateRowStatus(import.table_name, rowIndex, status, transferId)
+        }
+
+    override suspend fun saveError(
+        id: CsvImportId,
+        rowIndex: Long,
+        errorMessage: String,
+    ): Unit =
+        withContext(coroutineContext) {
+            csvImportQueries.insertOrReplaceError(
+                csv_import_id = id.id.toString(),
+                row_index = rowIndex,
+                error_message = errorMessage,
+                error_timestamp = Clock.System.now().toEpochMilliseconds(),
+            )
+        }
+
+    override suspend fun clearError(
+        id: CsvImportId,
+        rowIndex: Long,
+    ): Unit =
+        withContext(coroutineContext) {
+            csvImportQueries.deleteError(
+                csv_import_id = id.id.toString(),
+                row_index = rowIndex,
+            )
         }
 }

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/CsvImport.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/CsvImport.sq
@@ -80,3 +80,29 @@ VALUES (?, ?, ?, ?);
 
 deleteColumnsByImportId:
 DELETE FROM csv_column_metadata WHERE import_id = ?;
+
+-- Error tracking for CSV imports
+CREATE TABLE csv_import_error (
+    csv_import_id TEXT NOT NULL,
+    row_index INTEGER NOT NULL,
+    error_message TEXT NOT NULL,
+    error_timestamp INTEGER NOT NULL,
+    PRIMARY KEY (csv_import_id, row_index),
+    FOREIGN KEY (csv_import_id) REFERENCES csv_import_metadata(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_csv_import_error_import ON csv_import_error(csv_import_id);
+
+-- csv_import_error queries
+insertOrReplaceError:
+INSERT OR REPLACE INTO csv_import_error (csv_import_id, row_index, error_message, error_timestamp)
+VALUES (?, ?, ?, ?);
+
+deleteError:
+DELETE FROM csv_import_error WHERE csv_import_id = ? AND row_index = ?;
+
+deleteErrorsForImport:
+DELETE FROM csv_import_error WHERE csv_import_id = ?;
+
+getErrorsForImport:
+SELECT * FROM csv_import_error WHERE csv_import_id = ? ORDER BY row_index;

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csv/CsvRow.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csv/CsvRow.kt
@@ -10,11 +10,13 @@ import com.moneymanager.domain.model.TransferId
  * @property rowIndex The 1-based row index from the original CSV file
  * @property values The column values, indexed by column position (0-based)
  * @property transferId The ID of the transfer created from this row, null if not yet imported
- * @property importStatus The import status of this row (IMPORTED, DUPLICATE, UPDATED), null if not yet processed
+ * @property importStatus The import status of this row (IMPORTED, DUPLICATE, UPDATED, ERROR), null if not yet processed
+ * @property errorMessage The error message if import failed for this row, null if no error
  */
 data class CsvRow(
     val rowIndex: Long,
     val values: List<String>,
     val transferId: TransferId? = null,
     val importStatus: ImportStatus? = null,
+    val errorMessage: String? = null,
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/CsvImportRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/CsvImportRepository.kt
@@ -90,4 +90,29 @@ interface CsvImportRepository {
         status: String,
         transferId: TransferId? = null,
     )
+
+    /**
+     * Saves an error message for a specific row.
+     * Replaces any existing error for the same row.
+     *
+     * @param id The import ID
+     * @param rowIndex The row index that failed
+     * @param errorMessage The error message to save
+     */
+    suspend fun saveError(
+        id: CsvImportId,
+        rowIndex: Long,
+        errorMessage: String,
+    )
+
+    /**
+     * Clears the error for a specific row (e.g., when re-import succeeds).
+     *
+     * @param id The import ID
+     * @param rowIndex The row index to clear error for
+     */
+    suspend fun clearError(
+        id: CsvImportId,
+        rowIndex: Long,
+    )
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTable.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTable.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -49,81 +50,21 @@ fun CsvPreviewTable(
     val horizontalScrollState = rememberScrollState()
     val lazyListState = rememberLazyListState()
 
-    Column(modifier = modifier) {
-        // Header row
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .horizontalScroll(horizontalScrollState)
-                    .background(MaterialTheme.colorScheme.surfaceVariant),
-        ) {
-            // Row index column header
-            Box(
+    SelectionContainer {
+        Column(modifier = modifier) {
+            // Header row
+            Row(
                 modifier =
                     Modifier
-                        .width(ROW_INDEX_COLUMN_WIDTH)
-                        .border(
-                            width = 1.dp,
-                            color = MaterialTheme.colorScheme.outline,
-                        )
-                        .padding(8.dp),
+                        .fillMaxWidth()
+                        .horizontalScroll(horizontalScrollState)
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
             ) {
-                Text(
-                    text = "Row",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-
-            // Status column header
-            Box(
-                modifier =
-                    Modifier
-                        .width(STATUS_COLUMN_WIDTH)
-                        .border(
-                            width = 1.dp,
-                            color = MaterialTheme.colorScheme.outline,
-                        )
-                        .padding(8.dp),
-            ) {
-                Text(
-                    text = "Status",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-
-            // Transfer ID column header
-            Box(
-                modifier =
-                    Modifier
-                        .width(TRANSFER_COLUMN_WIDTH)
-                        .border(
-                            width = 1.dp,
-                            color = MaterialTheme.colorScheme.outline,
-                        )
-                        .padding(8.dp),
-            ) {
-                Text(
-                    text = "Transaction Id",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-
-            // CSV columns
-            columns.sortedBy { it.columnIndex }.forEach { column ->
+                // Row index column header
                 Box(
                     modifier =
                         Modifier
-                            .width(columnWidth)
+                            .width(ROW_INDEX_COLUMN_WIDTH)
                             .border(
                                 width = 1.dp,
                                 color = MaterialTheme.colorScheme.outline,
@@ -131,119 +72,103 @@ fun CsvPreviewTable(
                             .padding(8.dp),
                 ) {
                     Text(
-                        text = column.originalName,
+                        text = "Row",
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Bold,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-            }
-        }
 
-        // Data rows with vertical scrollbar
-        Box(modifier = Modifier.weight(1f)) {
-            LazyColumn(state = lazyListState) {
-                itemsIndexed(rows) { _, row ->
-                    val isFailed = row.rowIndex in failedRowIndexes
-                    val rowBackground =
-                        if (isFailed) {
-                            MaterialTheme.colorScheme.errorContainer
-                        } else {
-                            MaterialTheme.colorScheme.surface
-                        }
+                // Status column header
+                Box(
+                    modifier =
+                        Modifier
+                            .width(STATUS_COLUMN_WIDTH)
+                            .border(
+                                width = 1.dp,
+                                color = MaterialTheme.colorScheme.outline,
+                            )
+                            .padding(8.dp),
+                ) {
+                    Text(
+                        text = "Status",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
 
-                    Row(
+                // Transfer ID column header
+                Box(
+                    modifier =
+                        Modifier
+                            .width(TRANSFER_COLUMN_WIDTH)
+                            .border(
+                                width = 1.dp,
+                                color = MaterialTheme.colorScheme.outline,
+                            )
+                            .padding(8.dp),
+                ) {
+                    Text(
+                        text = "Transaction Id",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+
+                // CSV columns
+                columns.sortedBy { it.columnIndex }.forEach { column ->
+                    Box(
                         modifier =
                             Modifier
-                                .fillMaxWidth()
-                                .horizontalScroll(horizontalScrollState)
-                                .background(rowBackground),
-                    ) {
-                        // Row index cell
-                        Box(
-                            modifier =
-                                Modifier
-                                    .width(ROW_INDEX_COLUMN_WIDTH)
-                                    .border(
-                                        width = 1.dp,
-                                        color = MaterialTheme.colorScheme.outlineVariant,
-                                    )
-                                    .padding(8.dp),
-                        ) {
-                            Text(
-                                text = row.rowIndex.toString(),
-                                style = MaterialTheme.typography.bodySmall,
-                                fontWeight = if (isFailed) FontWeight.Bold else FontWeight.Normal,
-                                color =
-                                    if (isFailed) {
-                                        MaterialTheme.colorScheme.onErrorContainer
-                                    } else {
-                                        MaterialTheme.colorScheme.onSurface
-                                    },
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
-
-                        // Status cell
-                        Box(
-                            modifier =
-                                Modifier
-                                    .width(STATUS_COLUMN_WIDTH)
-                                    .border(
-                                        width = 1.dp,
-                                        color = MaterialTheme.colorScheme.outlineVariant,
-                                    )
-                                    .padding(8.dp),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            row.importStatus?.let { status ->
-                                val (statusText, statusColor) =
-                                    when (status) {
-                                        ImportStatus.IMPORTED -> "New" to MaterialTheme.colorScheme.primary
-                                        ImportStatus.DUPLICATE -> "Duplicate" to MaterialTheme.colorScheme.secondary
-                                        ImportStatus.UPDATED -> "Updated" to MaterialTheme.colorScheme.tertiary
-                                        ImportStatus.ERROR -> "Error" to MaterialTheme.colorScheme.error
-                                    }
-                                Text(
-                                    text = statusText,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = statusColor,
-                                    fontWeight = FontWeight.Bold,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
+                                .width(columnWidth)
+                                .border(
+                                    width = 1.dp,
+                                    color = MaterialTheme.colorScheme.outline,
                                 )
-                            }
-                        }
-
-                        // Determine if amount is positive from the amount column
-                        val isPositiveAmount =
-                            amountColumnIndex?.let { idx ->
-                                if (idx in row.values.indices) {
-                                    val amountStr = row.values[idx].trim()
-                                    // Parse the amount string - positive if it doesn't start with '-'
-                                    // Also handle parentheses notation (123) as negative
-                                    !amountStr.startsWith("-") && !amountStr.startsWith("(")
-                                } else {
-                                    true
-                                }
-                            } ?: true
-
-                        // Transfer ID cell
-                        TransferIdCell(
-                            transferId = row.transferId,
-                            isPositiveAmount = isPositiveAmount,
-                            onClick = onTransferClick,
+                                .padding(8.dp),
+                    ) {
+                        Text(
+                            text = column.originalName,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                         )
+                    }
+                }
+            }
 
-                        // CSV data cells
-                        row.values.forEachIndexed { index, value ->
-                            if (index < columns.size) {
+            // Data rows with vertical scrollbar
+            Box(modifier = Modifier.weight(1f)) {
+                LazyColumn(state = lazyListState) {
+                    itemsIndexed(rows) { _, row ->
+                        val isFailed = row.rowIndex in failedRowIndexes
+                        val hasError = row.errorMessage != null
+                        val rowBackground =
+                            if (isFailed || hasError) {
+                                MaterialTheme.colorScheme.errorContainer
+                            } else {
+                                MaterialTheme.colorScheme.surface
+                            }
+
+                        Column {
+                            Row(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .horizontalScroll(horizontalScrollState)
+                                        .background(rowBackground),
+                            ) {
+                                // Row index cell
                                 Box(
                                     modifier =
                                         Modifier
-                                            .width(columnWidth)
+                                            .width(ROW_INDEX_COLUMN_WIDTH)
                                             .border(
                                                 width = 1.dp,
                                                 color = MaterialTheme.colorScheme.outlineVariant,
@@ -251,8 +176,9 @@ fun CsvPreviewTable(
                                             .padding(8.dp),
                                 ) {
                                     Text(
-                                        text = value,
+                                        text = row.rowIndex.toString(),
                                         style = MaterialTheme.typography.bodySmall,
+                                        fontWeight = if (isFailed) FontWeight.Bold else FontWeight.Normal,
                                         color =
                                             if (isFailed) {
                                                 MaterialTheme.colorScheme.onErrorContainer
@@ -263,23 +189,121 @@ fun CsvPreviewTable(
                                         overflow = TextOverflow.Ellipsis,
                                     )
                                 }
+
+                                // Status cell
+                                Box(
+                                    modifier =
+                                        Modifier
+                                            .width(STATUS_COLUMN_WIDTH)
+                                            .border(
+                                                width = 1.dp,
+                                                color = MaterialTheme.colorScheme.outlineVariant,
+                                            )
+                                            .padding(8.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    row.importStatus?.let { status ->
+                                        val (statusText, statusColor) =
+                                            when (status) {
+                                                ImportStatus.IMPORTED -> "New" to MaterialTheme.colorScheme.primary
+                                                ImportStatus.DUPLICATE -> "Duplicate" to MaterialTheme.colorScheme.secondary
+                                                ImportStatus.UPDATED -> "Updated" to MaterialTheme.colorScheme.tertiary
+                                                ImportStatus.ERROR -> "Error" to MaterialTheme.colorScheme.error
+                                            }
+                                        Text(
+                                            text = statusText,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = statusColor,
+                                            fontWeight = FontWeight.Bold,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                    }
+                                }
+
+                                // Determine if amount is positive from the amount column
+                                val isPositiveAmount =
+                                    amountColumnIndex?.let { idx ->
+                                        if (idx in row.values.indices) {
+                                            val amountStr = row.values[idx].trim()
+                                            // Parse the amount string - positive if it doesn't start with '-'
+                                            // Also handle parentheses notation (123) as negative
+                                            !amountStr.startsWith("-") && !amountStr.startsWith("(")
+                                        } else {
+                                            true
+                                        }
+                                    } ?: true
+
+                                // Transfer ID cell
+                                TransferIdCell(
+                                    transferId = row.transferId,
+                                    isPositiveAmount = isPositiveAmount,
+                                    onClick = onTransferClick,
+                                )
+
+                                // CSV data cells
+                                row.values.forEachIndexed { index, value ->
+                                    if (index < columns.size) {
+                                        Box(
+                                            modifier =
+                                                Modifier
+                                                    .width(columnWidth)
+                                                    .border(
+                                                        width = 1.dp,
+                                                        color = MaterialTheme.colorScheme.outlineVariant,
+                                                    )
+                                                    .padding(8.dp),
+                                        ) {
+                                            Text(
+                                                text = value,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color =
+                                                    if (isFailed) {
+                                                        MaterialTheme.colorScheme.onErrorContainer
+                                                    } else {
+                                                        MaterialTheme.colorScheme.onSurface
+                                                    },
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis,
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Error message row (shown below data row when there's an error)
+                            row.errorMessage?.let { error ->
+                                Row(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .background(MaterialTheme.colorScheme.errorContainer)
+                                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                                ) {
+                                    Text(
+                                        text = error,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.error,
+                                        fontWeight = FontWeight.Medium,
+                                    )
+                                }
                             }
                         }
                     }
                 }
+
+                VerticalScrollbarForLazyList(
+                    lazyListState = lazyListState,
+                    modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+                )
             }
 
-            VerticalScrollbarForLazyList(
-                lazyListState = lazyListState,
-                modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+            // Horizontal scrollbar at the bottom
+            HorizontalScrollbarForScrollState(
+                scrollState = horizontalScrollState,
+                modifier = Modifier.fillMaxWidth(),
             )
         }
-
-        // Horizontal scrollbar at the bottom
-        HorizontalScrollbarForScrollState(
-            scrollState = horizontalScrollState,
-            modifier = Modifier.fillMaxWidth(),
-        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `csv_import_error` table to store error messages with CSV import/row references
- Persist error messages during import (mapping errors and runtime errors)
- Clear errors when rows succeed on re-import (cascade delete also handles CSV deletion)
- Display error messages underneath failed rows in CSV preview table
- Make CSV table text selectable with `SelectionContainer`

Closes #264

## Test plan
- [ ] Import a CSV with rows that will fail (e.g., invalid account references)
- [ ] Verify error messages are displayed underneath failed rows
- [ ] Close and reopen the CSV import detail view - errors should persist
- [ ] Re-import with fixed data - errors should be cleared for successful rows
- [ ] Verify text in CSV table is selectable and copyable
- [ ] Delete a CSV import - verify errors are cascade deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)