### PR TITLE
feat: migrate currency IDs from UUID to autoincrement integers

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountBalanceMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountBalanceMapper.kt
@@ -1,5 +1,3 @@
-@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
-
 package com.moneymanager.database.mapper
 
 import com.moneymanager.database.sql.SelectAllBalances
@@ -8,7 +6,6 @@ import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Money
 import tech.mappie.api.ObjectMappie
-import kotlin.uuid.Uuid
 
 object AccountBalanceMapper : ObjectMappie<SelectAllBalances, AccountBalance>(), IdConversions {
     override fun map(from: SelectAllBalances): AccountBalance =
@@ -19,7 +16,7 @@ object AccountBalanceMapper : ObjectMappie<SelectAllBalances, AccountBalance>(),
 
 private fun SelectAllBalances.toCurrency(): Currency =
     Currency(
-        id = CurrencyId(Uuid.parse(currency_id)),
+        id = CurrencyId(currency_id),
         code = currency_code,
         name = currency_name,
         scaleFactor = currency_scale_factor,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountRowMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountRowMapper.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+@file:OptIn(kotlin.time.ExperimentalTime::class)
 
 package com.moneymanager.database.mapper
 
@@ -9,9 +9,9 @@ import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.TransferId
 import kotlin.time.Instant.Companion.fromEpochMilliseconds
-import kotlin.uuid.Uuid
 
 object AccountRowMapper {
+    @Suppress("LongParameterList")
     fun mapRaw(
         id: Long,
         timestamp: Long,
@@ -19,7 +19,7 @@ object AccountRowMapper {
         account_id: Long,
         transaction_amount: Long,
         running_balance: Long,
-        currency_id: String,
+        currency_id: Long,
         currency_code: String,
         currency_name: String,
         currency_scale_factor: Long,
@@ -35,7 +35,7 @@ object AccountRowMapper {
                 Money(
                     transaction_amount,
                     Currency(
-                        id = CurrencyId(Uuid.parse(currency_id)),
+                        id = CurrencyId(currency_id),
                         code = currency_code,
                         name = currency_name,
                         scaleFactor = currency_scale_factor,
@@ -45,7 +45,7 @@ object AccountRowMapper {
                 Money(
                     running_balance,
                     Currency(
-                        id = CurrencyId(Uuid.parse(currency_id)),
+                        id = CurrencyId(currency_id),
                         code = currency_code,
                         name = currency_name,
                         scaleFactor = currency_scale_factor,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/IdConversions.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/IdConversions.kt
@@ -1,16 +1,13 @@
-@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
-
 package com.moneymanager.database.mapper
 
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.TransferId
-import kotlin.uuid.Uuid
 
 interface IdConversions {
     fun toAccountId(id: Long): AccountId = AccountId(id)
 
-    fun toCurrencyId(id: String): CurrencyId = CurrencyId(Uuid.parse(id))
+    fun toCurrencyId(id: Long): CurrencyId = CurrencyId(id)
 
     fun toTransferId(id: Long): TransferId = TransferId(id)
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/TransferAuditEntryMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/TransferAuditEntryMapper.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+@file:OptIn(kotlin.time.ExperimentalTime::class)
 
 package com.moneymanager.database.mapper
 
@@ -8,7 +8,6 @@ import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.TransferAuditEntry
 import tech.mappie.api.ObjectMappie
-import kotlin.uuid.Uuid
 
 object TransferAuditEntryMapper :
     ObjectMappie<SelectAuditHistoryForTransfer, TransferAuditEntry>(),
@@ -24,7 +23,7 @@ object TransferAuditEntryMapper :
 
 private fun SelectAuditHistoryForTransfer.toCurrency(): Currency =
     Currency(
-        id = CurrencyId(Uuid.parse(currency_id)),
+        id = CurrencyId(currency_id),
         code = currency_code,
         name = currency_name,
         scaleFactor = currency_scale_factor,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/TransferAuditEntryWithSourceMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/TransferAuditEntryWithSourceMapper.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+@file:OptIn(kotlin.time.ExperimentalTime::class)
 
 package com.moneymanager.database.mapper
 
@@ -8,7 +8,6 @@ import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.TransferAuditEntry
 import tech.mappie.api.ObjectMappie
-import kotlin.uuid.Uuid
 
 object TransferAuditEntryWithSourceMapper :
     ObjectMappie<SelectAuditHistoryForTransferWithSource, TransferAuditEntry>(),
@@ -28,7 +27,7 @@ object TransferAuditEntryWithSourceMapper :
 
 private fun SelectAuditHistoryForTransferWithSource.toCurrency(): Currency =
     Currency(
-        id = CurrencyId(Uuid.parse(currency_id)),
+        id = CurrencyId(currency_id),
         code = currency_code,
         name = currency_name,
         scaleFactor = currency_scale_factor,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/TransferMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/TransferMapper.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+@file:OptIn(kotlin.time.ExperimentalTime::class)
 
 package com.moneymanager.database.mapper
 
@@ -9,7 +9,6 @@ import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import kotlin.time.Instant.Companion.fromEpochMilliseconds
-import kotlin.uuid.Uuid
 
 object TransferMapper {
     @Suppress("LongParameterList")
@@ -21,14 +20,14 @@ object TransferMapper {
         source_account_id: Long,
         target_account_id: Long,
         amount: Long,
-        currency_id: String,
+        currency_id: Long,
         currency_code: String,
         currency_name: String,
         currency_scale_factor: Long,
     ): Transfer {
         val currency =
             Currency(
-                id = CurrencyId(Uuid.parse(currency_id)),
+                id = CurrencyId(currency_id),
                 code = currency_code,
                 name = currency_name,
                 scaleFactor = currency_scale_factor,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CategoryRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CategoryRepositoryImpl.kt
@@ -1,5 +1,3 @@
-@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
-
 package com.moneymanager.database.repository
 
 import app.cash.sqldelight.coroutines.asFlow
@@ -17,7 +15,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
-import kotlin.uuid.Uuid
 
 class CategoryRepositoryImpl(
     private val database: MoneyManagerDatabase,
@@ -38,7 +35,7 @@ class CategoryRepositoryImpl(
                 list.map { row ->
                     val currency =
                         Currency(
-                            id = CurrencyId(Uuid.parse(row.currency_id)),
+                            id = CurrencyId(row.currency_id),
                             code = row.currency_code,
                             name = row.currency_name,
                             scaleFactor = row.currency_scale_factor,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionRepositoryImpl.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+@file:OptIn(kotlin.time.ExperimentalTime::class)
 
 package com.moneymanager.database.repository
 
@@ -356,7 +356,7 @@ class TransactionRepositoryImpl(
                                 description = transfer.description,
                                 source_account_id = transfer.sourceAccountId.id,
                                 target_account_id = transfer.targetAccountId.id,
-                                currency_id = transfer.amount.currency.id.toString(),
+                                currency_id = transfer.amount.currency.id.id,
                                 amount = transfer.amount.amount,
                             )
 
@@ -410,7 +410,7 @@ class TransactionRepositoryImpl(
                         description = transfer.description,
                         source_account_id = transfer.sourceAccountId.id,
                         target_account_id = transfer.targetAccountId.id,
-                        currency_id = transfer.amount.currency.id.toString(),
+                        currency_id = transfer.amount.currency.id.id,
                         amount = transfer.amount.amount,
                         id = transfer.id.id,
                     )

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Audit.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Audit.sq
@@ -23,7 +23,7 @@ CREATE TABLE currency_audit (
     audit_id INTEGER PRIMARY KEY AUTOINCREMENT,
     audit_timestamp INTEGER NOT NULL,
     audit_type_id INTEGER NOT NULL,
-    id TEXT NOT NULL,
+    id INTEGER NOT NULL,
     code TEXT NOT NULL,
     name TEXT NOT NULL,
     scale_factor INTEGER NOT NULL,
@@ -62,7 +62,7 @@ CREATE TABLE transfer_audit (
     description TEXT NOT NULL,
     source_account_id INTEGER NOT NULL,
     target_account_id INTEGER NOT NULL,
-    currency_id TEXT NOT NULL,
+    currency_id INTEGER NOT NULL,
     amount INTEGER NOT NULL,
     FOREIGN KEY (audit_type_id) REFERENCES audit_type(id)
 );

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Currency.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Currency.sq
@@ -1,14 +1,5 @@
 CREATE TABLE currency (
-    id TEXT PRIMARY KEY NOT NULL
-        CHECK (
-            length(id) = 36
-            AND substr(id, 9, 1) = '-'
-            AND substr(id, 14, 1) = '-'
-            AND substr(id, 19, 1) = '-'
-            AND substr(id, 24, 1) = '-'
-            AND substr(id, 15, 1) IN ('1','2','3','4','5','6','7','8')
-            AND lower(substr(id, 20, 1)) IN ('8','9','a','b')
-        ),
+    id INTEGER PRIMARY KEY NOT NULL,
     code TEXT NOT NULL UNIQUE CHECK(length(trim(code)) > 0),
     name TEXT NOT NULL CHECK(length(trim(name)) > 0),
     scale_factor INTEGER NOT NULL DEFAULT 100
@@ -24,8 +15,11 @@ selectByCode:
 SELECT * FROM currency WHERE code = ?;
 
 insert:
-INSERT INTO currency(id, code, name, scale_factor)
-VALUES (?, ?, ?, ?);
+INSERT INTO currency(code, name, scale_factor)
+VALUES (?, ?, ?);
+
+lastInsertedId:
+SELECT last_insert_rowid();
 
 update:
 UPDATE currency

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Transfer.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Transfer.sq
@@ -5,16 +5,7 @@ CREATE TABLE transfer (
     description TEXT NOT NULL,
     source_account_id INTEGER NOT NULL,
     target_account_id INTEGER NOT NULL,
-    currency_id TEXT NOT NULL
-        CHECK (
-            length(currency_id) = 36
-            AND substr(currency_id, 9, 1) = '-'
-            AND substr(currency_id, 14, 1) = '-'
-            AND substr(currency_id, 19, 1) = '-'
-            AND substr(currency_id, 24, 1) = '-'
-            AND substr(currency_id, 15, 1) IN ('1','2','3','4','5','6','7','8')
-            AND lower(substr(currency_id, 20, 1)) IN ('8','9','a','b')
-        ),
+    currency_id INTEGER NOT NULL,
     amount INTEGER NOT NULL,
     CHECK (source_account_id != target_account_id),
     FOREIGN KEY (id) REFERENCES transaction_id(id) ON DELETE RESTRICT,
@@ -30,7 +21,7 @@ CREATE INDEX IF NOT EXISTS idx_transfer_currency ON transfer(currency_id);
 -- Materialized table for account balances (manually refreshed)
 CREATE TABLE account_balance_materialized_view (
     account_id INTEGER NOT NULL,
-    currency_id TEXT NOT NULL,
+    currency_id INTEGER NOT NULL,
     balance INTEGER NOT NULL,
     PRIMARY KEY (account_id, currency_id),
     FOREIGN KEY (account_id) REFERENCES account(id) ON DELETE CASCADE,
@@ -46,7 +37,7 @@ CREATE TABLE running_balance_materialized_view (
     timestamp INTEGER NOT NULL,
     description TEXT NOT NULL,
     account_id INTEGER NOT NULL,
-    currency_id TEXT NOT NULL,
+    currency_id INTEGER NOT NULL,
     transaction_amount INTEGER NOT NULL,
     running_balance INTEGER NOT NULL,
     PRIMARY KEY (id, account_id),
@@ -117,7 +108,7 @@ FROM (
 -- Table to track pending changes for incremental refresh
 CREATE TABLE pending_materialized_view_changes (
     account_id INTEGER NOT NULL,
-    currency_id TEXT NOT NULL,
+    currency_id INTEGER NOT NULL,
     min_timestamp INTEGER NOT NULL,
     PRIMARY KEY (account_id, currency_id),
     FOREIGN KEY (account_id) REFERENCES account(id) ON DELETE CASCADE,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/IncrementalMaterializedViewRefreshTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/IncrementalMaterializedViewRefreshTest.kt
@@ -21,7 +21,7 @@ import kotlin.time.Clock
  */
 private data class BalanceViewRecord(
     val accountId: Long,
-    val currencyId: String,
+    val currencyId: Long,
     val balance: Long?,
 )
 
@@ -68,7 +68,7 @@ class IncrementalMaterializedViewRefreshTest : DbTest() {
                     results.add(
                         BalanceViewRecord(
                             accountId = cursor.getLong(0)!!,
-                            currencyId = cursor.getString(1)!!,
+                            currencyId = cursor.getLong(1)!!,
                             balance = cursor.getLong(2),
                         ),
                     )
@@ -88,7 +88,7 @@ class IncrementalMaterializedViewRefreshTest : DbTest() {
         val materializedBalances =
             database.transferQueries.selectAllBalances()
                 .executeAsList()
-                .sortedBy { "${it.account_id}-${it.currency_id}" }
+                .sortedWith(compareBy({ it.account_id }, { it.currency_id }))
 
         val viewBalances = selectBalancesFromView()
 
@@ -616,7 +616,7 @@ class IncrementalMaterializedViewRefreshTest : DbTest() {
             // Verify the new currency appears in balances
             val balances = database.transferQueries.selectAllBalances().executeAsList()
             assertTrue(
-                balances.any { it.currency_id == eurId.toString() },
+                balances.any { it.currency_id == eurId.id },
                 "New currency should appear in materialized view",
             )
         }

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvAccountMappingTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvAccountMappingTest.kt
@@ -39,7 +39,7 @@ import kotlin.uuid.Uuid
  * 2. Multiple CSV values to be consolidated to a single account
  */
 class CsvAccountMappingTest {
-    private val testCurrencyId = CurrencyId(Uuid.random())
+    private val testCurrencyId = CurrencyId(1L)
     private val testCurrency =
         Currency(
             id = testCurrencyId,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvDuplicateDetectionTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvDuplicateDetectionTest.kt
@@ -36,7 +36,7 @@ import kotlin.uuid.Uuid
  * Tests for duplicate detection in CSV imports using unique identifier columns.
  */
 class CsvDuplicateDetectionTest {
-    private val testCurrencyId = CurrencyId(Uuid.random())
+    private val testCurrencyId = CurrencyId(1L)
     private val testCurrency =
         Currency(
             id = testCurrencyId,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvImportErrorHandlingTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvImportErrorHandlingTest.kt
@@ -36,7 +36,7 @@ import kotlin.uuid.Uuid
  * - Re-import should only process ERROR rows
  */
 class CsvImportErrorHandlingTest {
-    private val testCurrencyId = CurrencyId(Uuid.random())
+    private val testCurrencyId = CurrencyId(1L)
     private val testCurrency =
         Currency(
             id = testCurrencyId,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvTransferMapperTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvTransferMapperTest.kt
@@ -36,7 +36,7 @@ import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
 class CsvTransferMapperTest {
-    private val testCurrencyId = CurrencyId(Uuid.random())
+    private val testCurrencyId = CurrencyId(1L)
     private val testCurrency =
         Currency(
             id = testCurrencyId,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/StrategyMatcherTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/StrategyMatcherTest.kt
@@ -69,7 +69,7 @@ class StrategyMatcherTest {
                         HardCodedCurrencyMapping(
                             id = FieldMappingId(Uuid.random()),
                             fieldType = TransferField.CURRENCY,
-                            currencyId = CurrencyId(Uuid.random()),
+                            currencyId = CurrencyId(1L),
                         ),
                 ),
             createdAt = now,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/json/FieldMappingJsonCodecTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/json/FieldMappingJsonCodecTest.kt
@@ -188,7 +188,7 @@ class FieldMappingJsonCodecTest {
 
     @Test
     fun `encode and decode HardCodedCurrencyMapping`() {
-        val currencyId = CurrencyId(Uuid.random())
+        val currencyId = CurrencyId(1L)
         val mapping =
             HardCodedCurrencyMapping(
                 id = FieldMappingId(Uuid.random()),
@@ -225,7 +225,7 @@ class FieldMappingJsonCodecTest {
 
     @Test
     fun `encode and decode complete strategy mappings`() {
-        val currencyId = CurrencyId(Uuid.random())
+        val currencyId = CurrencyId(1L)
         val mappings =
             mapOf(
                 TransferField.SOURCE_ACCOUNT to

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Currency.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Currency.kt
@@ -1,15 +1,11 @@
-@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
-
 package com.moneymanager.domain.model
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
-import kotlin.uuid.Uuid
 
 /**
  * Represents a currency in the system.
  *
- * @property id Unique identifier for the currency (UUID)
+ * @property id Unique identifier for the currency (auto-incrementing integer)
  * @property code ISO 4217 currency code (e.g., "USD", "EUR", "GBP")
  * @property name Human-readable name of the currency (e.g., "US Dollar")
  * @property scaleFactor The factor used to convert between stored amounts and display amounts.
@@ -28,7 +24,7 @@ data class Currency(
 @Serializable
 @JvmInline
 value class CurrencyId(
-    @Contextual val id: Uuid,
+    val id: Long,
 ) {
     override fun toString() = id.toString()
 }

--- a/app/model/core/src/commonTest/kotlin/com/moneymanager/domain/model/MoneyTest.kt
+++ b/app/model/core/src/commonTest/kotlin/com/moneymanager/domain/model/MoneyTest.kt
@@ -1,5 +1,3 @@
-@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
-
 package com.moneymanager.domain.model
 
 import com.moneymanager.bigdecimal.BigDecimal
@@ -8,12 +6,11 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.uuid.Uuid
 
 class MoneyTest {
     private val usd =
         Currency(
-            id = CurrencyId(Uuid.random()),
+            id = CurrencyId(1L),
             code = "USD",
             name = "US Dollar",
             scaleFactor = 100,
@@ -21,7 +18,7 @@ class MoneyTest {
 
     private val jpy =
         Currency(
-            id = CurrencyId(Uuid.random()),
+            id = CurrencyId(2L),
             code = "JPY",
             name = "Japanese Yen",
             scaleFactor = 1,
@@ -29,7 +26,7 @@ class MoneyTest {
 
     private val bhd =
         Currency(
-            id = CurrencyId(Uuid.random()),
+            id = CurrencyId(3L),
             code = "BHD",
             name = "Bahraini Dinar",
             scaleFactor = 1000,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -75,7 +75,6 @@ import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Instant
-import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalTestApi::class)
 class AccountTransactionsScreenTest {
@@ -86,7 +85,7 @@ class AccountTransactionsScreenTest {
             val now = Clock.System.now()
             val usdCurrency =
                 Currency(
-                    id = CurrencyId(Uuid.random()),
+                    id = CurrencyId(1L),
                     code = "USD",
                     name = "US Dollar",
                     scaleFactor = 100,
@@ -179,7 +178,7 @@ class AccountTransactionsScreenTest {
             val now = Clock.System.now()
             val usdCurrency =
                 Currency(
-                    id = CurrencyId(Uuid.random()),
+                    id = CurrencyId(1L),
                     code = "USD",
                     name = "US Dollar",
                     scaleFactor = 100,
@@ -1038,7 +1037,7 @@ class AccountTransactionsScreenTest {
         override suspend fun upsertCurrencyByCode(
             code: String,
             name: String,
-        ): CurrencyId = CurrencyId(Uuid.random())
+        ): CurrencyId = CurrencyId(1L)
 
         override suspend fun updateCurrency(currency: Currency) {}
 

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CategoriesScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CategoriesScreenTest.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalTestApi::class)
 class CategoriesScreenTest {
@@ -925,7 +924,7 @@ class CategoriesScreenTest {
             val existing = currenciesFlow.value.find { it.code == code }
             if (existing != null) return existing.id
 
-            val newId = CurrencyId(Uuid.random())
+            val newId = CurrencyId((currenciesFlow.value.maxOfOrNull { it.id.id } ?: 0L) + 1L)
             val newCurrency = Currency(id = newId, code = code, name = name)
             currenciesFlow.value = currenciesFlow.value + newCurrency
             return newId

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CurrenciesScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CurrenciesScreenTest.kt
@@ -14,7 +14,6 @@ import com.moneymanager.ui.error.ProvideSchemaAwareScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlin.test.Test
-import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalTestApi::class)
 class CurrenciesScreenTest {
@@ -68,7 +67,7 @@ class CurrenciesScreenTest {
         runComposeUiTest {
             val testCurrency =
                 Currency(
-                    id = CurrencyId(Uuid.random()),
+                    id = CurrencyId(1L),
                     code = "USD",
                     name = "US Dollar",
                 )
@@ -89,9 +88,9 @@ class CurrenciesScreenTest {
         runComposeUiTest {
             val currencies =
                 listOf(
-                    Currency(id = CurrencyId(Uuid.random()), code = "USD", name = "US Dollar"),
-                    Currency(id = CurrencyId(Uuid.random()), code = "EUR", name = "Euro"),
-                    Currency(id = CurrencyId(Uuid.random()), code = "GBP", name = "British Pound"),
+                    Currency(id = CurrencyId(1L), code = "USD", name = "US Dollar"),
+                    Currency(id = CurrencyId(2L), code = "EUR", name = "Euro"),
+                    Currency(id = CurrencyId(3L), code = "GBP", name = "British Pound"),
                 )
             val repository = FakeCurrencyRepository(currencies)
 


### PR DESCRIPTION
## Summary
- Replace UUID-based `CurrencyId` with auto-incrementing `Long` for consistency with `AccountId` and `TransferId`
- Update all database tables (`currency`, `transfer`, audit tables, materialized views) to use `INTEGER` instead of `TEXT` for currency IDs
- Simplify mappers and repository implementations by removing UUID parsing logic

Closes #278

## Test plan
- [x] All existing tests pass after migration
- [x] Build completes successfully
- [x] Verify currency CRUD operations work correctly
- [x] Verify transactions with currencies function properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)