### PR TITLE
fix(ui): preserve scroll position and currency selection in navigation history

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -90,7 +90,7 @@ fun MoneyManagerApp(
 ) {
     ProvideSchemaAwareScope {
         val scope = rememberSchemaAwareCoroutineScope()
-        val navigationHistory = remember { NavigationHistory(Screen.Accounts) }
+        val navigationHistory = remember { NavigationHistory(Screen.Accounts()) }
         val currentScreen = navigationHistory.currentScreen
         var showTransactionDialog by remember { mutableStateOf(false) }
         var preSelectedAccountId by remember { mutableStateOf<AccountId?>(null) }
@@ -149,7 +149,7 @@ fun MoneyManagerApp(
                             icon = { Text("\uD83D\uDCB0") },
                             label = { Text("Accounts") },
                             selected = currentScreen is Screen.Accounts || currentScreen is Screen.AccountTransactions,
-                            onClick = { navigationHistory.navigateTo(Screen.Accounts) },
+                            onClick = { navigationHistory.navigateTo(Screen.Accounts()) },
                         )
                         NavigationBarItem(
                             icon = { Text("\uD83D\uDCB1") },
@@ -216,7 +216,11 @@ fun MoneyManagerApp(
                                 transactionRepository = transactionRepository,
                                 personRepository = personRepository,
                                 personAccountOwnershipRepository = personAccountOwnershipRepository,
+                                scrollToAccountId = screen.scrollToAccountId,
                                 onAccountClick = { account ->
+                                    // Replace current screen with one that remembers the clicked account
+                                    // so that navigating back will scroll to this account
+                                    navigationHistory.replaceCurrentScreen(Screen.Accounts(scrollToAccountId = account.id))
                                     navigationHistory.navigateTo(Screen.AccountTransactions(account.id, account.name))
                                 },
                             )
@@ -295,13 +299,20 @@ fun MoneyManagerApp(
                                 onCurrencyIdChange = { currencyId ->
                                     currentlyViewedCurrencyId = currencyId
                                 },
-                                onAccountClick = { accountId, accountName ->
-                                    navigationHistory.navigateTo(Screen.AccountTransactions(accountId, accountName))
+                                onAccountClick = { accountId, accountName, currencyId ->
+                                    navigationHistory.navigateTo(
+                                        Screen.AccountTransactions(
+                                            accountId = accountId,
+                                            accountName = accountName,
+                                            selectedCurrencyId = currencyId,
+                                        ),
+                                    )
                                 },
                                 onAuditClick = { transferId ->
                                     navigationHistory.navigateTo(Screen.AuditHistory(transferId))
                                 },
                                 scrollToTransferId = screen.scrollToTransferId,
+                                initialCurrencyId = screen.selectedCurrencyId,
                                 externalRefreshTrigger = transactionRefreshTrigger,
                             )
                         }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
@@ -3,11 +3,12 @@
 package com.moneymanager.ui.navigation
 
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.CsvImportId
 
 sealed class Screen(val title: String) {
-    data object Accounts : Screen("Accounts")
+    data class Accounts(val scrollToAccountId: AccountId? = null) : Screen("Accounts")
 
     data object Currencies : Screen("Currencies")
 
@@ -25,6 +26,7 @@ sealed class Screen(val title: String) {
         val accountId: AccountId,
         val accountName: String,
         val scrollToTransferId: TransferId? = null,
+        val selectedCurrencyId: CurrencyId? = null,
     ) : Screen(accountName)
 
     data class CsvImportDetail(val importId: CsvImportId) :

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
@@ -44,6 +44,7 @@ fun AccountsScreen(
     transactionRepository: TransactionRepository,
     personRepository: PersonRepository,
     personAccountOwnershipRepository: PersonAccountOwnershipRepository,
+    scrollToAccountId: AccountId?,
     onAccountClick: (Account) -> Unit,
 ) {
     // Use schema-error-aware collection for flows that may fail on old databases
@@ -90,12 +91,23 @@ fun AccountsScreen(
             }
         } else {
             val lazyListState = rememberLazyListState()
+
+            // Scroll to the specified account when navigating back
+            LaunchedEffect(scrollToAccountId, accounts) {
+                if (scrollToAccountId != null && accounts.isNotEmpty()) {
+                    val index = accounts.indexOfFirst { it.id == scrollToAccountId }
+                    if (index >= 0) {
+                        lazyListState.animateScrollToItem(index)
+                    }
+                }
+            }
+
             Box(modifier = Modifier.fillMaxSize()) {
                 LazyColumn(
                     state = lazyListState,
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    items(accounts) { account ->
+                    items(accounts, key = { it.id.id }) { account ->
                         val accountBalances = balances.filter { it.accountId == account.id }
                         val category = categories.find { it.id == account.categoryId }
                         AccountCard(

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
@@ -51,6 +51,7 @@ class AccountsScreenTest {
                         transactionRepository = FakeTransactionRepository(),
                         personRepository = FakePersonRepository(),
                         personAccountOwnershipRepository = FakePersonAccountOwnershipRepository(),
+                        scrollToAccountId = null,
                         onAccountClick = {},
                     )
                 }
@@ -90,6 +91,7 @@ class AccountsScreenTest {
                         transactionRepository = FakeTransactionRepository(),
                         personRepository = FakePersonRepository(),
                         personAccountOwnershipRepository = FakePersonAccountOwnershipRepository(),
+                        scrollToAccountId = null,
                         onAccountClick = {},
                     )
                 }
@@ -115,6 +117,7 @@ class AccountsScreenTest {
                         transactionRepository = FakeTransactionRepository(),
                         personRepository = FakePersonRepository(),
                         personAccountOwnershipRepository = FakePersonAccountOwnershipRepository(),
+                        scrollToAccountId = null,
                         onAccountClick = {},
                     )
                 }
@@ -139,6 +142,7 @@ class AccountsScreenTest {
                         transactionRepository = FakeTransactionRepository(),
                         personRepository = FakePersonRepository(),
                         personAccountOwnershipRepository = FakePersonAccountOwnershipRepository(),
+                        scrollToAccountId = null,
                         onAccountClick = {},
                     )
                 }
@@ -173,6 +177,7 @@ class AccountsScreenTest {
                         transactionRepository = FakeTransactionRepository(),
                         personRepository = FakePersonRepository(),
                         personAccountOwnershipRepository = FakePersonAccountOwnershipRepository(),
+                        scrollToAccountId = null,
                         onAccountClick = {},
                     )
                 }
@@ -204,6 +209,7 @@ class AccountsScreenTest {
                         transactionRepository = FakeTransactionRepository(),
                         personRepository = FakePersonRepository(),
                         personAccountOwnershipRepository = FakePersonAccountOwnershipRepository(),
+                        scrollToAccountId = null,
                         onAccountClick = {},
                     )
                 }
@@ -232,6 +238,7 @@ class AccountsScreenTest {
                         transactionRepository = FakeTransactionRepository(),
                         personRepository = FakePersonRepository(),
                         personAccountOwnershipRepository = FakePersonAccountOwnershipRepository(),
+                        scrollToAccountId = null,
                         onAccountClick = {},
                     )
                 }
@@ -262,6 +269,7 @@ class AccountsScreenTest {
                         transactionRepository = FakeTransactionRepository(),
                         personRepository = FakePersonRepository(),
                         personAccountOwnershipRepository = FakePersonAccountOwnershipRepository(),
+                        scrollToAccountId = null,
                         onAccountClick = {},
                     )
                 }
@@ -300,6 +308,7 @@ class AccountsScreenTest {
                         transactionRepository = FakeTransactionRepository(),
                         personRepository = FakePersonRepository(),
                         personAccountOwnershipRepository = FakePersonAccountOwnershipRepository(),
+                        scrollToAccountId = null,
                         onAccountClick = {},
                     )
                 }
@@ -350,6 +359,7 @@ class AccountsScreenTest {
                         transactionRepository = FakeTransactionRepository(),
                         personRepository = FakePersonRepository(),
                         personAccountOwnershipRepository = FakePersonAccountOwnershipRepository(),
+                        scrollToAccountId = null,
                         onAccountClick = {},
                     )
                 }


### PR DESCRIPTION
## Summary
- Adds scroll-to-account functionality when navigating back to accounts list from transactions view
- Fixes matrix cell selection to properly select account+currency on first click
- Preserves currency selection in navigation history so back button restores both account and currency

Fixes #292

## Test plan
- [ ] Click on an account in the accounts list, then press back - verify list scrolls to that account
- [ ] In transactions view, click on a balance cell (account+currency) - verify it selects that specific cell immediately
- [ ] After selecting a cell, press back - verify the previous account+currency selection is restored
- [ ] Click on account header in matrix - verify it shows all currencies for that account

🤖 Generated with [Claude Code](https://claude.com/claude-code)