### PR TITLE
fix: replace unsupported Unicode export icon with Material Share icon

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
@@ -18,8 +18,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -367,9 +370,9 @@ fun CsvStrategyCard(
                 IconButton(
                     onClick = onExportClick,
                 ) {
-                    Text(
-                        text = "\u2B71",
-                        style = MaterialTheme.typography.titleMedium,
+                    Icon(
+                        imageVector = Icons.Filled.Share,
+                        contentDescription = "Export",
                     )
                 }
                 IconButton(


### PR DESCRIPTION
## Summary
- Replaced Unicode character `⭱` (U+2B71) in the CSV strategy export button with Material `Icons.Filled.Share`
- The Unicode character wasn't available in macOS system fonts, rendering as a question mark
- Material icons use vector graphics and render consistently across all platforms

Closes #311

## Test plan
- [ ] Run JVM app on macOS and verify the export icon renders correctly
- [ ] Run JVM app on Windows and verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the export button visual appearance to display a proper Share icon instead of a text glyph symbol, improving UI clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->