### PR TITLE
Replace deprecated datetime Instant imports

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/audit/AuditDiffCard.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/audit/AuditDiffCard.kt
@@ -15,9 +15,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.AuditType
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Instant
 
 @Composable
 fun AuditDiffCard(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoryAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoryAuditScreen.kt
@@ -19,7 +19,7 @@ import com.moneymanager.ui.audit.FieldChangeRow
 import com.moneymanager.ui.audit.FieldValueRow
 import com.moneymanager.ui.audit.SourceInfoSection
 import kotlinx.coroutines.flow.first
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 @Composable
 fun CategoryAuditScreen(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CurrencyAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CurrencyAuditScreen.kt
@@ -20,7 +20,7 @@ import com.moneymanager.ui.audit.FieldChangeRow
 import com.moneymanager.ui.audit.FieldValueRow
 import com.moneymanager.ui.audit.SourceInfoSection
 import kotlinx.coroutines.flow.first
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 @Composable
 fun CurrencyAuditScreen(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PersonAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PersonAuditScreen.kt
@@ -20,7 +20,7 @@ import com.moneymanager.ui.audit.FieldChangeRow
 import com.moneymanager.ui.audit.FieldValueRow
 import com.moneymanager.ui.audit.SourceInfoSection
 import kotlinx.coroutines.flow.first
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 @Composable
 fun PersonAuditScreen(


### PR DESCRIPTION
## Summary
- replace remaining UI audit imports of deprecated kotlinx.datetime.Instant with kotlin.time.Instant
- keep kotlinx-datetime timezone conversion extensions in place

## Testing
- ./gradlew.bat --console=plain :app:ui:core:compileKotlinJvm
- ./gradlew.bat --console=plain lintFormat
- ./gradlew.bat --console=plain build (fails in unrelated JVM UI E2E tests waiting for 'Your Accounts': SchemaAwareCoroutineScopeE2ETest.schemaAwareScope_allowsRecovery_whenCsvTableHasOldSchema, CreateAccountWithNewCategoryE2ETest.createAccount_withNewlyCreatedCategory_shouldSucceed, TransactionAttributeAuditE2ETest.createTransaction_withAttribute_shouldShowAttributeInAuditRevision1)

Closes #354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated timestamp handling across audit features to enhance system compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->