### PR TITLE
Migrate Android app to AGP built-in Kotlin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,11 +2,6 @@ kotlin.code.style=official
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 
-# Disable AGP 9.0 new DSL and built-in Kotlin until Detekt supports them
-# (https://github.com/detekt/detekt/issues/8981)
-android.newDsl=false
-android.builtInKotlin=false
-android.suppressUnsupportedOptionWarnings=android.newDsl,android.builtInKotlin
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 
 # Configuration cache for faster builds

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
@@ -1,18 +1,13 @@
 import com.android.build.api.dsl.ApplicationExtension
+import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
-plugins {
-    id("moneymanager.kotlin-convention")
-    id("org.jetbrains.compose")
-    id("org.jetbrains.kotlin.plugin.compose")
-}
-
-// Apply Android and Kotlin Android plugins outside the plugins block to avoid
-// AGP 9.0 KotlinBaseApiPlugin conflict during precompiled script plugin accessor generation
 apply(plugin = "com.android.application")
-apply(plugin = "org.jetbrains.kotlin.android")
+apply(plugin = "moneymanager.kotlin-convention")
+apply(plugin = "org.jetbrains.compose")
+apply(plugin = "org.jetbrains.kotlin.plugin.compose")
 
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 val jvmTargetVersion = libs.findVersion("jvm-target").get().toString()
@@ -57,6 +52,6 @@ configure<ComposeCompilerGradlePluginExtension> {
 }
 
 // Override ktlint android setting for Android modules
-ktlint {
+configure<KtlintExtension> {
     android.set(true)
 }


### PR DESCRIPTION
## Summary
- remove AGP built-in Kotlin opt-out properties
- stop applying the deprecated org.jetbrains.kotlin.android plugin in the Android app convention
- apply AGP before shared Kotlin/Detekt conventions so built-in Kotlin initializes before Detekt reacts

## Testing
- ./gradlew.bat :app:main:android:help --console=plain
- ./gradlew.bat :app:main:android:assembleDebug --console=plain
- ./gradlew.bat :app:main:android:detekt --console=plain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration to enable Android Gradle Plugin 9.0 features and modernize plugin application patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->