### PR TITLE
Fix detekt KMP source set analysis

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -31,6 +31,7 @@ naming:
   FunctionNaming:
     ignoreAnnotated:
       - 'Composable'
+      - 'Test'
   FunctionParameterNaming:
     active: false
   VariableNaming:

--- a/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-convention.gradle.kts
@@ -33,9 +33,17 @@ tasks {
         targetCompatibility = jvmTargetVersion
     }
 
-    // Make detekt aggregate task include type-resolution tasks for KMP modules
+    // Make detekt aggregate task include KMP source-set tasks without invoking
+    // compilation-based type resolution, which currently reports false
+    // expect/actual compiler errors for shared JVM/Android source sets.
     named("detekt") {
-        dependsOn(matching { it.name.startsWith("detektMain") || it.name.startsWith("detektTest") })
+        dependsOn(
+            matching {
+                it.name.startsWith("detekt") &&
+                    it.name.endsWith("SourceSet") &&
+                    !it.name.startsWith("detektBaseline")
+            },
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- run aggregate detekt through KMP source-set tasks instead of compilation type-resolution tasks
- allow @Test functions to use backtick-style names

## Verification
- ./gradlew.bat detekt --console=plain --rerun-tasks
- ./gradlew.bat detekt --console=plain
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Refined code quality checking and build system configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->