### PR TITLE
Fix CSV source links in audit history

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/csv/CsvTableManager.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/csv/CsvTableManager.kt
@@ -89,9 +89,24 @@ class CsvTableManager(private val database: MoneyManagerDatabaseWrapper) {
         val columns = (0 until columnCount).joinToString(", ") { "t.col_$it" }
         val sql =
             """
-            SELECT t.row_index, t.transaction_id, t.import_status, e.error_message, $columns
+            SELECT
+                t.row_index,
+                COALESCE(NULLIF(t.transaction_id, '0'), source_rows.transaction_id) AS transaction_id,
+                t.import_status,
+                e.error_message,
+                $columns
             FROM $tableName t
             LEFT JOIN csv_import_error e ON e.csv_import_id = '$csvImportId' AND e.row_index = t.row_index
+            LEFT JOIN (
+                SELECT
+                    csv_transfer_source.csv_import_id,
+                    csv_transfer_source.csv_row_index,
+                    MIN(transfer_source.transaction_id) AS transaction_id
+                FROM csv_transfer_source
+                JOIN transfer_source ON transfer_source.id = csv_transfer_source.id
+                GROUP BY csv_transfer_source.csv_import_id, csv_transfer_source.csv_row_index
+            ) source_rows ON source_rows.csv_import_id = '$csvImportId'
+                AND source_rows.csv_row_index = t.row_index
             ORDER BY t.row_index
             LIMIT $limit OFFSET $offset
             """.trimIndent()

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/csv/CsvTableManager.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/csv/CsvTableManager.kt
@@ -104,6 +104,7 @@ class CsvTableManager(private val database: MoneyManagerDatabaseWrapper) {
                     MIN(transfer_source.transaction_id) AS transaction_id
                 FROM csv_transfer_source
                 JOIN transfer_source ON transfer_source.id = csv_transfer_source.id
+                WHERE csv_transfer_source.csv_import_id = '$csvImportId'
                 GROUP BY csv_transfer_source.csv_import_id, csv_transfer_source.csv_row_index
             ) source_rows ON source_rows.csv_import_id = '$csvImportId'
                 AND source_rows.csv_row_index = t.row_index

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/CsvImportRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/CsvImportRepositoryImplTest.kt
@@ -2,6 +2,12 @@
 
 package com.moneymanager.database.repository
 
+import com.moneymanager.bigdecimal.BigDecimal
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
 import com.moneymanager.test.database.DbTest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -10,6 +16,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
@@ -171,5 +178,73 @@ class CsvImportRepositoryImplTest : DbTest() {
 
             val matches = repositories.csvImportRepository.findImportsByChecksum("nonexistent")
             assertTrue(matches.isEmpty())
+        }
+
+    @Test
+    fun `getImportRows should resolve placeholder transfer id from CSV source records`() =
+        runTest {
+            val importId =
+                repositories.csvImportRepository.createImport(
+                    fileName = "test.csv",
+                    headers = headers,
+                    rows = rows,
+                    fileChecksum = "source_lookup_checksum",
+                    fileLastModified = lastModified,
+                )
+
+            val currencyId = repositories.currencyRepository.upsertCurrencyByCode("GBP", "British Pound")
+            val currency = repositories.currencyRepository.getCurrencyById(currencyId).first()!!
+
+            repositories.accountRepository.createAccount(
+                Account(
+                    id = AccountId(0),
+                    name = "Source",
+                    openingDate = Clock.System.now(),
+                ),
+            )
+            repositories.accountRepository.createAccount(
+                Account(
+                    id = AccountId(0),
+                    name = "Target",
+                    openingDate = Clock.System.now(),
+                ),
+            )
+            val accounts = repositories.accountRepository.getAllAccounts().first()
+            val sourceAccount = accounts.first { it.name == "Source" }
+            val targetAccount = accounts.first { it.name == "Target" }
+
+            val createdTransfer =
+                createTransfer(
+                    Transfer(
+                        id = TransferId(0),
+                        timestamp = Clock.System.now(),
+                        description = "CSV transfer",
+                        sourceAccountId = sourceAccount.id,
+                        targetAccountId = targetAccount.id,
+                        amount = Money.fromDisplayValue(BigDecimal("12.34"), currency),
+                    ),
+                )
+
+            val createdSource =
+                repositories.transferSourceRepository.getSourceByRevision(
+                    transactionId = createdTransfer.id,
+                    revisionId = createdTransfer.revisionId,
+                )
+            assertNotNull(createdSource)
+            transferSourceQueries.insertCsvImportDetails(
+                id = createdSource.id,
+                csv_import_id = importId.id.toString(),
+                csv_row_index = 1,
+            )
+            repositories.csvImportRepository.updateRowStatus(
+                id = importId,
+                rowIndex = 1,
+                status = "IMPORTED",
+                transferId = TransferId(0),
+            )
+
+            val importRows = repositories.csvImportRepository.getImportRows(importId, limit = 10, offset = 0)
+
+            assertEquals(createdTransfer.id, importRows.first { it.rowIndex == 1L }.transferId)
         }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -68,6 +68,7 @@ import com.moneymanager.ui.screens.csvstrategy.CsvStrategiesScreen
 import com.moneymanager.ui.screens.transactions.AccountTransactionsScreen
 import com.moneymanager.ui.screens.transactions.TransactionAuditScreen
 import com.moneymanager.ui.screens.transactions.TransactionEditDialog
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
@@ -371,6 +372,7 @@ fun MoneyManagerApp(
                         is Screen.CsvImportDetail -> {
                             CsvImportDetailScreen(
                                 importId = screen.importId,
+                                scrollToRowIndex = screen.scrollToRowIndex,
                                 csvImportRepository = csvImportRepository,
                                 csvImportStrategyRepository = csvImportStrategyRepository,
                                 csvAccountMappingRepository = csvAccountMappingRepository,
@@ -382,38 +384,39 @@ fun MoneyManagerApp(
                                 personRepository = personRepository,
                                 personAccountOwnershipRepository = personAccountOwnershipRepository,
                                 maintenanceService = maintenanceService,
+                                transferSourceRepository = transferSourceRepository,
                                 transferSourceQueries = transferSourceQueries,
                                 entitySourceQueries = entitySourceQueries,
                                 deviceRepository = deviceRepository,
                                 deviceId = deviceId,
                                 onBack = { navigationHistory.navigateBack() },
                                 onDeleted = { navigationHistory.navigateTo(Screen.CsvImports) },
+                                onCsvSourceClick = { importId, rowIndex ->
+                                    navigationHistory.navigateTo(Screen.CsvImportDetail(importId, rowIndex))
+                                },
                                 onTransferClick = { transferId, isPositiveAmount ->
                                     scope.launch {
-                                        transactionRepository
-                                            .getTransactionById(transferId.id)
-                                            .collect { transfer ->
-                                                transfer?.let {
-                                                    // Navigate to target account if positive (money coming in),
-                                                    // source account if negative (money going out)
-                                                    val accountId =
-                                                        if (isPositiveAmount) {
-                                                            transfer.targetAccountId
-                                                        } else {
-                                                            transfer.sourceAccountId
-                                                        }
-                                                    val account = accounts.find { a -> a.id == accountId }
-                                                    if (account != null) {
-                                                        navigationHistory.navigateTo(
-                                                            Screen.AccountTransactions(
-                                                                accountId = account.id,
-                                                                accountName = account.name,
-                                                                scrollToTransferId = transferId,
-                                                            ),
-                                                        )
-                                                    }
-                                                }
+                                        val transfer =
+                                            transactionRepository
+                                                .getTransactionById(transferId.id)
+                                                .first()
+                                                ?: return@launch
+                                        // Navigate to target account if positive (money coming in),
+                                        // source account if negative (money going out)
+                                        val accountId =
+                                            if (isPositiveAmount) {
+                                                transfer.targetAccountId
+                                            } else {
+                                                transfer.sourceAccountId
                                             }
+                                        val account = accounts.find { a -> a.id == accountId }
+                                        navigationHistory.navigateTo(
+                                            Screen.AccountTransactions(
+                                                accountId = accountId,
+                                                accountName = account?.name ?: accountId.toString(),
+                                                scrollToTransferId = transferId,
+                                            ),
+                                        )
                                     }
                                 },
                             )
@@ -447,6 +450,9 @@ fun MoneyManagerApp(
                                 accountRepository = accountRepository,
                                 transactionRepository = transactionRepository,
                                 currentDeviceId = deviceId,
+                                onCsvSourceClick = { importId, rowIndex ->
+                                    navigationHistory.navigateTo(Screen.CsvImportDetail(importId, rowIndex))
+                                },
                                 onBack = { navigationHistory.navigateBack() },
                             )
                         }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTable.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTable.kt
@@ -15,12 +15,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
@@ -46,16 +51,20 @@ fun CsvPreviewTable(
     amountColumnIndex: Int? = null,
     failedRowIndexes: Set<Long> = emptySet(),
     scrollToRowIndex: Long? = null,
-    onDuplicateSourceClick: ((TransferId) -> Unit)? = null,
+    onDuplicateSourceClick: ((TransferId, Boolean) -> Unit)? = null,
     onTransferClick: ((TransferId, Boolean) -> Unit)? = null,
 ) {
     val horizontalScrollState = rememberScrollState()
     val lazyListState = rememberLazyListState()
 
-    LaunchedEffect(scrollToRowIndex, rows) {
-        val targetIndex = rows.indexOfFirst { it.rowIndex == scrollToRowIndex }
+    val scrolledToRowIndex = remember { mutableStateOf<Long?>(null) }
+    LaunchedEffect(scrollToRowIndex, rows.size) {
+        val targetRowIndex = scrollToRowIndex ?: return@LaunchedEffect
+        if (scrolledToRowIndex.value == targetRowIndex) return@LaunchedEffect
+        val targetIndex = rows.indexOfFirst { it.rowIndex == targetRowIndex }
         if (targetIndex >= 0) {
             lazyListState.animateScrollToItem(targetIndex)
+            scrolledToRowIndex.value = targetRowIndex
         }
     }
 
@@ -79,7 +88,7 @@ fun CsvPreviewTable(
                         )
                         .padding(8.dp),
             ) {
-                Text(
+                SelectableText(
                     text = "Row",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Bold,
@@ -99,7 +108,7 @@ fun CsvPreviewTable(
                         )
                         .padding(8.dp),
             ) {
-                Text(
+                SelectableText(
                     text = "Status",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Bold,
@@ -119,7 +128,7 @@ fun CsvPreviewTable(
                         )
                         .padding(8.dp),
             ) {
-                Text(
+                SelectableText(
                     text = "Transaction",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Bold,
@@ -140,7 +149,7 @@ fun CsvPreviewTable(
                             )
                             .padding(8.dp),
                 ) {
-                    Text(
+                    SelectableText(
                         text = column.originalName,
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Bold,
@@ -159,8 +168,8 @@ fun CsvPreviewTable(
                     val hasError = row.errorMessage != null
                     val rowBackground =
                         when {
-                            row.rowIndex == scrollToRowIndex -> MaterialTheme.colorScheme.primaryContainer
                             isFailed || hasError -> MaterialTheme.colorScheme.errorContainer
+                            row.rowIndex == scrollToRowIndex -> MaterialTheme.colorScheme.primaryContainer
                             else -> MaterialTheme.colorScheme.surface
                         }
 
@@ -183,7 +192,7 @@ fun CsvPreviewTable(
                                         )
                                         .padding(8.dp),
                             ) {
-                                Text(
+                                SelectableText(
                                     text = row.rowIndex.toString(),
                                     style = MaterialTheme.typography.bodySmall,
                                     fontWeight = if (isFailed) FontWeight.Bold else FontWeight.Normal,
@@ -218,7 +227,7 @@ fun CsvPreviewTable(
                                             ImportStatus.UPDATED -> "Updated" to MaterialTheme.colorScheme.tertiary
                                             ImportStatus.ERROR -> "Error" to MaterialTheme.colorScheme.error
                                         }
-                                    Text(
+                                    SelectableText(
                                         text = statusText,
                                         style = MaterialTheme.typography.bodySmall,
                                         color = statusColor,
@@ -229,18 +238,11 @@ fun CsvPreviewTable(
                                 }
                             }
 
-                            // Determine if amount is positive from the amount column
                             val isPositiveAmount =
-                                amountColumnIndex?.let { idx ->
-                                    if (idx in row.values.indices) {
-                                        val amountStr = row.values[idx].trim()
-                                        // Parse the amount string - positive if it doesn't start with '-'
-                                        // Also handle parentheses notation (123) as negative
-                                        !amountStr.startsWith("-") && !amountStr.startsWith("(")
-                                    } else {
-                                        true
-                                    }
-                                } ?: true
+                                isRowAmountPositive(
+                                    row = row,
+                                    amountColumnIndex = amountColumnIndex,
+                                )
 
                             // Transfer ID cell
                             TransferIdCell(
@@ -264,7 +266,7 @@ fun CsvPreviewTable(
                                                 )
                                                 .padding(8.dp),
                                     ) {
-                                        Text(
+                                        SelectableText(
                                             text = value,
                                             style = MaterialTheme.typography.bodySmall,
                                             color =
@@ -290,7 +292,7 @@ fun CsvPreviewTable(
                                         .background(MaterialTheme.colorScheme.errorContainer)
                                         .padding(horizontal = 16.dp, vertical = 8.dp),
                             ) {
-                                Text(
+                                SelectableText(
                                     text = error,
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.error,
@@ -321,14 +323,19 @@ private fun TransferIdCell(
     importStatus: ImportStatus?,
     transferId: TransferId?,
     isPositiveAmount: Boolean,
-    onDuplicateSourceClick: ((TransferId) -> Unit)?,
+    onDuplicateSourceClick: ((TransferId, Boolean) -> Unit)?,
     onClick: ((TransferId, Boolean) -> Unit)?,
 ) {
     val isDuplicate = importStatus == ImportStatus.DUPLICATE
     val clickAction =
         when {
             transferId == null -> null
-            isDuplicate && onDuplicateSourceClick != null -> ({ onDuplicateSourceClick(transferId) })
+            isDuplicate && onDuplicateSourceClick != null -> (
+                {
+                    onDuplicateSourceClick(transferId, isPositiveAmount)
+                }
+            )
+            isDuplicate -> null
             onClick != null -> ({ onClick(transferId, isPositiveAmount) })
             else -> null
         }
@@ -360,5 +367,39 @@ private fun TransferIdCell(
                 overflow = TextOverflow.Ellipsis,
             )
         }
+    }
+}
+
+private fun isRowAmountPositive(
+    row: CsvRow,
+    amountColumnIndex: Int?,
+): Boolean =
+    amountColumnIndex?.let { index ->
+        val amount = row.values.getOrNull(index)?.trim()
+        amount == null || (!amount.startsWith("-") && !amount.startsWith("("))
+    } ?: true
+
+@Composable
+private fun SelectableText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    style: TextStyle = TextStyle.Default,
+    fontWeight: FontWeight? = null,
+    textDecoration: TextDecoration? = null,
+    maxLines: Int = Int.MAX_VALUE,
+    overflow: TextOverflow = TextOverflow.Clip,
+) {
+    SelectionContainer {
+        Text(
+            text = text,
+            modifier = modifier,
+            color = color,
+            style = style,
+            fontWeight = fontWeight,
+            textDecoration = textDecoration,
+            maxLines = maxLines,
+            overflow = overflow,
+        )
     }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTable.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTable.kt
@@ -15,10 +15,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -33,7 +33,7 @@ import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.model.csv.ImportStatus
 
-private val TRANSFER_COLUMN_WIDTH = 100.dp
+private val TRANSFER_COLUMN_WIDTH = 120.dp
 private val ROW_INDEX_COLUMN_WIDTH = 60.dp
 private val STATUS_COLUMN_WIDTH = 90.dp
 
@@ -45,297 +45,317 @@ fun CsvPreviewTable(
     columnWidth: Dp = 150.dp,
     amountColumnIndex: Int? = null,
     failedRowIndexes: Set<Long> = emptySet(),
+    scrollToRowIndex: Long? = null,
+    onDuplicateSourceClick: ((TransferId) -> Unit)? = null,
     onTransferClick: ((TransferId, Boolean) -> Unit)? = null,
 ) {
     val horizontalScrollState = rememberScrollState()
     val lazyListState = rememberLazyListState()
 
-    SelectionContainer {
-        Column(modifier = modifier) {
-            // Header row
-            Row(
+    LaunchedEffect(scrollToRowIndex, rows) {
+        val targetIndex = rows.indexOfFirst { it.rowIndex == scrollToRowIndex }
+        if (targetIndex >= 0) {
+            lazyListState.animateScrollToItem(targetIndex)
+        }
+    }
+
+    Column(modifier = modifier) {
+        // Header row
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(horizontalScrollState)
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+        ) {
+            // Row index column header
+            Box(
                 modifier =
                     Modifier
-                        .fillMaxWidth()
-                        .horizontalScroll(horizontalScrollState)
-                        .background(MaterialTheme.colorScheme.surfaceVariant),
-            ) {
-                // Row index column header
-                Box(
-                    modifier =
-                        Modifier
-                            .width(ROW_INDEX_COLUMN_WIDTH)
-                            .border(
-                                width = 1.dp,
-                                color = MaterialTheme.colorScheme.outline,
-                            )
-                            .padding(8.dp),
-                ) {
-                    Text(
-                        text = "Row",
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Bold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-
-                // Status column header
-                Box(
-                    modifier =
-                        Modifier
-                            .width(STATUS_COLUMN_WIDTH)
-                            .border(
-                                width = 1.dp,
-                                color = MaterialTheme.colorScheme.outline,
-                            )
-                            .padding(8.dp),
-                ) {
-                    Text(
-                        text = "Status",
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Bold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-
-                // Transfer ID column header
-                Box(
-                    modifier =
-                        Modifier
-                            .width(TRANSFER_COLUMN_WIDTH)
-                            .border(
-                                width = 1.dp,
-                                color = MaterialTheme.colorScheme.outline,
-                            )
-                            .padding(8.dp),
-                ) {
-                    Text(
-                        text = "Transaction Id",
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Bold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-
-                // CSV columns
-                columns.sortedBy { it.columnIndex }.forEach { column ->
-                    Box(
-                        modifier =
-                            Modifier
-                                .width(columnWidth)
-                                .border(
-                                    width = 1.dp,
-                                    color = MaterialTheme.colorScheme.outline,
-                                )
-                                .padding(8.dp),
-                    ) {
-                        Text(
-                            text = column.originalName,
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Bold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
+                        .width(ROW_INDEX_COLUMN_WIDTH)
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline,
                         )
-                    }
-                }
+                        .padding(8.dp),
+            ) {
+                Text(
+                    text = "Row",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
 
-            // Data rows with vertical scrollbar
-            Box(modifier = Modifier.weight(1f)) {
-                LazyColumn(state = lazyListState) {
-                    itemsIndexed(rows) { _, row ->
-                        val isFailed = row.rowIndex in failedRowIndexes
-                        val hasError = row.errorMessage != null
-                        val rowBackground =
-                            if (isFailed || hasError) {
-                                MaterialTheme.colorScheme.errorContainer
-                            } else {
-                                MaterialTheme.colorScheme.surface
-                            }
+            // Status column header
+            Box(
+                modifier =
+                    Modifier
+                        .width(STATUS_COLUMN_WIDTH)
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                        .padding(8.dp),
+            ) {
+                Text(
+                    text = "Status",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
 
-                        Column {
-                            Row(
+            // Transaction navigation column header
+            Box(
+                modifier =
+                    Modifier
+                        .width(TRANSFER_COLUMN_WIDTH)
+                        .border(
+                            width = 1.dp,
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                        .padding(8.dp),
+            ) {
+                Text(
+                    text = "Transaction",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            // CSV columns
+            columns.sortedBy { it.columnIndex }.forEach { column ->
+                Box(
+                    modifier =
+                        Modifier
+                            .width(columnWidth)
+                            .border(
+                                width = 1.dp,
+                                color = MaterialTheme.colorScheme.outline,
+                            )
+                            .padding(8.dp),
+                ) {
+                    Text(
+                        text = column.originalName,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+
+        // Data rows with vertical scrollbar
+        Box(modifier = Modifier.weight(1f)) {
+            LazyColumn(state = lazyListState) {
+                itemsIndexed(rows) { _, row ->
+                    val isFailed = row.rowIndex in failedRowIndexes
+                    val hasError = row.errorMessage != null
+                    val rowBackground =
+                        when {
+                            row.rowIndex == scrollToRowIndex -> MaterialTheme.colorScheme.primaryContainer
+                            isFailed || hasError -> MaterialTheme.colorScheme.errorContainer
+                            else -> MaterialTheme.colorScheme.surface
+                        }
+
+                    Column {
+                        Row(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .horizontalScroll(horizontalScrollState)
+                                    .background(rowBackground),
+                        ) {
+                            // Row index cell
+                            Box(
                                 modifier =
                                     Modifier
-                                        .fillMaxWidth()
-                                        .horizontalScroll(horizontalScrollState)
-                                        .background(rowBackground),
+                                        .width(ROW_INDEX_COLUMN_WIDTH)
+                                        .border(
+                                            width = 1.dp,
+                                            color = MaterialTheme.colorScheme.outlineVariant,
+                                        )
+                                        .padding(8.dp),
                             ) {
-                                // Row index cell
-                                Box(
-                                    modifier =
-                                        Modifier
-                                            .width(ROW_INDEX_COLUMN_WIDTH)
-                                            .border(
-                                                width = 1.dp,
-                                                color = MaterialTheme.colorScheme.outlineVariant,
-                                            )
-                                            .padding(8.dp),
-                                ) {
+                                Text(
+                                    text = row.rowIndex.toString(),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    fontWeight = if (isFailed) FontWeight.Bold else FontWeight.Normal,
+                                    color =
+                                        if (isFailed) {
+                                            MaterialTheme.colorScheme.onErrorContainer
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurface
+                                        },
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+
+                            // Status cell
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .width(STATUS_COLUMN_WIDTH)
+                                        .border(
+                                            width = 1.dp,
+                                            color = MaterialTheme.colorScheme.outlineVariant,
+                                        )
+                                        .padding(8.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                row.importStatus?.let { status ->
+                                    val (statusText, statusColor) =
+                                        when (status) {
+                                            ImportStatus.IMPORTED -> "New" to MaterialTheme.colorScheme.primary
+                                            ImportStatus.DUPLICATE -> "Duplicate" to MaterialTheme.colorScheme.secondary
+                                            ImportStatus.UPDATED -> "Updated" to MaterialTheme.colorScheme.tertiary
+                                            ImportStatus.ERROR -> "Error" to MaterialTheme.colorScheme.error
+                                        }
                                     Text(
-                                        text = row.rowIndex.toString(),
+                                        text = statusText,
                                         style = MaterialTheme.typography.bodySmall,
-                                        fontWeight = if (isFailed) FontWeight.Bold else FontWeight.Normal,
-                                        color =
-                                            if (isFailed) {
-                                                MaterialTheme.colorScheme.onErrorContainer
-                                            } else {
-                                                MaterialTheme.colorScheme.onSurface
-                                            },
+                                        color = statusColor,
+                                        fontWeight = FontWeight.Bold,
                                         maxLines = 1,
                                         overflow = TextOverflow.Ellipsis,
                                     )
                                 }
+                            }
 
-                                // Status cell
-                                Box(
-                                    modifier =
-                                        Modifier
-                                            .width(STATUS_COLUMN_WIDTH)
-                                            .border(
-                                                width = 1.dp,
-                                                color = MaterialTheme.colorScheme.outlineVariant,
-                                            )
-                                            .padding(8.dp),
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    row.importStatus?.let { status ->
-                                        val (statusText, statusColor) =
-                                            when (status) {
-                                                ImportStatus.IMPORTED -> "New" to MaterialTheme.colorScheme.primary
-                                                ImportStatus.DUPLICATE -> "Duplicate" to MaterialTheme.colorScheme.secondary
-                                                ImportStatus.UPDATED -> "Updated" to MaterialTheme.colorScheme.tertiary
-                                                ImportStatus.ERROR -> "Error" to MaterialTheme.colorScheme.error
-                                            }
+                            // Determine if amount is positive from the amount column
+                            val isPositiveAmount =
+                                amountColumnIndex?.let { idx ->
+                                    if (idx in row.values.indices) {
+                                        val amountStr = row.values[idx].trim()
+                                        // Parse the amount string - positive if it doesn't start with '-'
+                                        // Also handle parentheses notation (123) as negative
+                                        !amountStr.startsWith("-") && !amountStr.startsWith("(")
+                                    } else {
+                                        true
+                                    }
+                                } ?: true
+
+                            // Transfer ID cell
+                            TransferIdCell(
+                                importStatus = row.importStatus,
+                                transferId = row.transferId,
+                                isPositiveAmount = isPositiveAmount,
+                                onDuplicateSourceClick = onDuplicateSourceClick,
+                                onClick = onTransferClick,
+                            )
+
+                            // CSV data cells
+                            row.values.forEachIndexed { index, value ->
+                                if (index < columns.size) {
+                                    Box(
+                                        modifier =
+                                            Modifier
+                                                .width(columnWidth)
+                                                .border(
+                                                    width = 1.dp,
+                                                    color = MaterialTheme.colorScheme.outlineVariant,
+                                                )
+                                                .padding(8.dp),
+                                    ) {
                                         Text(
-                                            text = statusText,
+                                            text = value,
                                             style = MaterialTheme.typography.bodySmall,
-                                            color = statusColor,
-                                            fontWeight = FontWeight.Bold,
+                                            color =
+                                                if (isFailed) {
+                                                    MaterialTheme.colorScheme.onErrorContainer
+                                                } else {
+                                                    MaterialTheme.colorScheme.onSurface
+                                                },
                                             maxLines = 1,
                                             overflow = TextOverflow.Ellipsis,
                                         )
                                     }
                                 }
-
-                                // Determine if amount is positive from the amount column
-                                val isPositiveAmount =
-                                    amountColumnIndex?.let { idx ->
-                                        if (idx in row.values.indices) {
-                                            val amountStr = row.values[idx].trim()
-                                            // Parse the amount string - positive if it doesn't start with '-'
-                                            // Also handle parentheses notation (123) as negative
-                                            !amountStr.startsWith("-") && !amountStr.startsWith("(")
-                                        } else {
-                                            true
-                                        }
-                                    } ?: true
-
-                                // Transfer ID cell
-                                TransferIdCell(
-                                    transferId = row.transferId,
-                                    isPositiveAmount = isPositiveAmount,
-                                    onClick = onTransferClick,
-                                )
-
-                                // CSV data cells
-                                row.values.forEachIndexed { index, value ->
-                                    if (index < columns.size) {
-                                        Box(
-                                            modifier =
-                                                Modifier
-                                                    .width(columnWidth)
-                                                    .border(
-                                                        width = 1.dp,
-                                                        color = MaterialTheme.colorScheme.outlineVariant,
-                                                    )
-                                                    .padding(8.dp),
-                                        ) {
-                                            Text(
-                                                text = value,
-                                                style = MaterialTheme.typography.bodySmall,
-                                                color =
-                                                    if (isFailed) {
-                                                        MaterialTheme.colorScheme.onErrorContainer
-                                                    } else {
-                                                        MaterialTheme.colorScheme.onSurface
-                                                    },
-                                                maxLines = 1,
-                                                overflow = TextOverflow.Ellipsis,
-                                            )
-                                        }
-                                    }
-                                }
                             }
+                        }
 
-                            // Error message row (shown below data row when there's an error)
-                            row.errorMessage?.let { error ->
-                                Row(
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .background(MaterialTheme.colorScheme.errorContainer)
-                                            .padding(horizontal = 16.dp, vertical = 8.dp),
-                                ) {
-                                    Text(
-                                        text = error,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.error,
-                                        fontWeight = FontWeight.Medium,
-                                    )
-                                }
+                        // Error message row (shown below data row when there's an error)
+                        row.errorMessage?.let { error ->
+                            Row(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .background(MaterialTheme.colorScheme.errorContainer)
+                                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                            ) {
+                                Text(
+                                    text = error,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.error,
+                                    fontWeight = FontWeight.Medium,
+                                )
                             }
                         }
                     }
                 }
-
-                VerticalScrollbarForLazyList(
-                    lazyListState = lazyListState,
-                    modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
-                )
             }
 
-            // Horizontal scrollbar at the bottom
-            HorizontalScrollbarForScrollState(
-                scrollState = horizontalScrollState,
-                modifier = Modifier.fillMaxWidth(),
+            VerticalScrollbarForLazyList(
+                lazyListState = lazyListState,
+                modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
             )
         }
+
+        // Horizontal scrollbar at the bottom
+        HorizontalScrollbarForScrollState(
+            scrollState = horizontalScrollState,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }
 
 @Composable
 private fun TransferIdCell(
+    importStatus: ImportStatus?,
     transferId: TransferId?,
     isPositiveAmount: Boolean,
+    onDuplicateSourceClick: ((TransferId) -> Unit)?,
     onClick: ((TransferId, Boolean) -> Unit)?,
 ) {
+    val isDuplicate = importStatus == ImportStatus.DUPLICATE
+    val clickAction =
+        when {
+            transferId == null -> null
+            isDuplicate && onDuplicateSourceClick != null -> ({ onDuplicateSourceClick(transferId) })
+            onClick != null -> ({ onClick(transferId, isPositiveAmount) })
+            else -> null
+        }
+
     Box(
         modifier =
             Modifier
                 .width(TRANSFER_COLUMN_WIDTH)
-                .border(
-                    width = 1.dp,
-                    color = MaterialTheme.colorScheme.outlineVariant,
-                )
                 .then(
-                    if (transferId != null && onClick != null) {
-                        Modifier.clickable { onClick(transferId, isPositiveAmount) }
+                    if (clickAction != null) {
+                        Modifier.clickable { clickAction() }
                     } else {
                         Modifier
                     },
+                )
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant,
                 )
                 .padding(8.dp),
     ) {
         if (transferId != null) {
             Text(
-                text = "View →",
+                text = if (isDuplicate && onDuplicateSourceClick != null) "Source ->" else "View ->",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.primary,
-                textDecoration = if (onClick != null) TextDecoration.Underline else TextDecoration.None,
+                textDecoration = if (clickAction != null) TextDecoration.Underline else TextDecoration.None,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
@@ -30,7 +30,10 @@ sealed class Screen(val title: String) {
         val selectedCurrencyId: CurrencyId? = null,
     ) : Screen(accountName)
 
-    data class CsvImportDetail(val importId: CsvImportId) :
+    data class CsvImportDetail(
+        val importId: CsvImportId,
+        val scrollToRowIndex: Long? = null,
+    ) :
         Screen("CSV Import")
 
     data class AuditHistory(val transferId: TransferId) :

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
@@ -308,7 +308,7 @@ fun CsvImportDetailScreen(
                         amountColumnIndex = amountColumnIndex,
                         failedRowIndexes = failedRowIndexes,
                         scrollToRowIndex = scrollToRowIndex,
-                        onDuplicateSourceClick = { transferId ->
+                        onDuplicateSourceClick = { transferId, isPositiveAmount ->
                             scope.launch {
                                 val source =
                                     transferSourceRepository.getSourcesForTransaction(transferId)
@@ -319,7 +319,7 @@ fun CsvImportDetailScreen(
                                 if (sourceImportId != null) {
                                     onCsvSourceClick(sourceImportId, csvSource.rowIndex)
                                 } else {
-                                    onTransferClick?.invoke(transferId, true)
+                                    onTransferClick?.invoke(transferId, isPositiveAmount)
                                 }
                             }
                         },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
@@ -33,6 +33,7 @@ import com.moneymanager.database.DatabaseMaintenanceService
 import com.moneymanager.database.sql.EntitySourceQueries
 import com.moneymanager.database.sql.TransferSourceQueries
 import com.moneymanager.domain.model.DeviceId
+import com.moneymanager.domain.model.SourceType
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.csv.CsvRow
@@ -47,6 +48,7 @@ import com.moneymanager.domain.repository.DeviceRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.TransactionRepository
+import com.moneymanager.domain.repository.TransferSourceRepository
 import com.moneymanager.ui.components.csv.CsvPreviewTable
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -59,6 +61,7 @@ import kotlinx.datetime.toLocalDateTime
 @Composable
 fun CsvImportDetailScreen(
     importId: CsvImportId,
+    scrollToRowIndex: Long? = null,
     csvImportRepository: CsvImportRepository,
     csvImportStrategyRepository: CsvImportStrategyRepository,
     csvAccountMappingRepository: CsvAccountMappingRepository,
@@ -70,12 +73,14 @@ fun CsvImportDetailScreen(
     personRepository: PersonRepository,
     personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     maintenanceService: DatabaseMaintenanceService,
+    transferSourceRepository: TransferSourceRepository,
     transferSourceQueries: TransferSourceQueries,
     entitySourceQueries: EntitySourceQueries,
     deviceRepository: DeviceRepository,
     deviceId: DeviceId,
     onBack: () -> Unit,
     onDeleted: () -> Unit,
+    onCsvSourceClick: (CsvImportId, Long) -> Unit = { _, _ -> },
     onTransferClick: ((TransferId, Boolean) -> Unit)? = null,
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
@@ -302,6 +307,22 @@ fun CsvImportDetailScreen(
                         modifier = Modifier.fillMaxSize(),
                         amountColumnIndex = amountColumnIndex,
                         failedRowIndexes = failedRowIndexes,
+                        scrollToRowIndex = scrollToRowIndex,
+                        onDuplicateSourceClick = { transferId ->
+                            scope.launch {
+                                val source =
+                                    transferSourceRepository.getSourcesForTransaction(transferId)
+                                        .filter { it.sourceType == SourceType.CSV_IMPORT }
+                                        .minByOrNull { it.revisionId }
+                                val csvSource = source?.csvSource
+                                val sourceImportId = csvSource?.importId
+                                if (sourceImportId != null) {
+                                    onCsvSourceClick(sourceImportId, csvSource.rowIndex)
+                                } else {
+                                    onTransferClick?.invoke(transferId, true)
+                                }
+                            }
+                        },
                         onTransferClick = onTransferClick,
                     )
                 }
@@ -357,6 +378,7 @@ fun CsvImportDetailScreen(
             attributeTypeRepository = attributeTypeRepository,
             maintenanceService = maintenanceService,
             transferSourceQueries = transferSourceQueries,
+            transferSourceRepository = transferSourceRepository,
             deviceRepository = deviceRepository,
             onDismiss = { showApplyStrategyDialog = false },
             onImportComplete = { result ->

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -51,6 +51,7 @@ import com.moneymanager.domain.getDeviceInfo
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csv.CsvRow
@@ -65,6 +66,7 @@ import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
 import com.moneymanager.domain.repository.DeviceRepository
 import com.moneymanager.domain.repository.TransactionRepository
+import com.moneymanager.domain.repository.TransferSourceRepository
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.flow.first
@@ -100,6 +102,7 @@ fun ApplyStrategyDialog(
     attributeTypeRepository: AttributeTypeRepository,
     maintenanceService: DatabaseMaintenanceService,
     transferSourceQueries: TransferSourceQueries,
+    transferSourceRepository: TransferSourceRepository,
     deviceRepository: DeviceRepository,
     onDismiss: () -> Unit,
     onImportComplete: (CsvImportResult) -> Unit,
@@ -428,7 +431,6 @@ fun ApplyStrategyDialog(
 
                             // Create transfers and track which rows they came from
                             logger.info { "Starting to create $validCount transfers" }
-                            val rowTransferMap = mutableMapOf<Long, com.moneymanager.domain.model.TransferId>()
                             val failedRows = mutableListOf<CsvImportResult.FailedRow>()
                             var successCount = 0
                             val deviceId = deviceRepository.getOrCreateDevice(getDeviceInfo())
@@ -449,6 +451,7 @@ fun ApplyStrategyDialog(
 
                                     when (importStatus) {
                                         ImportStatus.IMPORTED -> {
+                                            var createdTransferId: TransferId? = null
                                             // Create new transfer
                                             transactionRepository.createTransfers(
                                                 transfers = listOf(transfer),
@@ -458,19 +461,22 @@ fun ApplyStrategyDialog(
                                                         queries = transferSourceQueries,
                                                         deviceId = deviceId,
                                                         csvImportId = csvImport.id,
-                                                        rowIndexForTransfer = { originalRowIndex },
+                                                        rowIndexForTransfer = { generatedTransferId ->
+                                                            createdTransferId = generatedTransferId
+                                                            originalRowIndex
+                                                        },
                                                     ),
                                             )
+                                            val rowTransferId = createdTransferId ?: transfer.id
                                             // Update row with status and transfer ID
                                             csvImportRepository.updateRowStatus(
                                                 csvImport.id,
                                                 originalRowIndex,
                                                 ImportStatus.IMPORTED.name,
-                                                transfer.id,
+                                                rowTransferId,
                                             )
                                             // Clear any previous error for this row (re-import success)
                                             csvImportRepository.clearError(csvImport.id, originalRowIndex)
-                                            rowTransferMap[originalRowIndex] = transfer.id
                                             successCount++
                                         }
                                         ImportStatus.DUPLICATE -> {
@@ -493,6 +499,16 @@ fun ApplyStrategyDialog(
                                                     newAttributes = attributes,
                                                     transactionId = existingTransferId,
                                                 )
+                                                val updatedTransfer =
+                                                    transactionRepository.getTransactionById(existingTransferId.id).first()
+                                                if (updatedTransfer != null) {
+                                                    transferSourceRepository.recordCsvImportSource(
+                                                        transactionId = existingTransferId,
+                                                        revisionId = updatedTransfer.revisionId,
+                                                        csvImportId = csvImport.id,
+                                                        rowIndex = originalRowIndex,
+                                                    )
+                                                }
                                                 csvImportRepository.updateRowStatus(
                                                     csvImport.id,
                                                     originalRowIndex,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionAuditScreen.kt
@@ -2,10 +2,14 @@ package com.moneymanager.ui.screens.transactions
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -20,6 +24,7 @@ import com.moneymanager.domain.model.DeviceInfo
 import com.moneymanager.domain.model.SourceType
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.TransferSource
+import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.AuditRepository
 import com.moneymanager.domain.repository.TransactionRepository
@@ -49,6 +54,7 @@ fun TransactionAuditScreen(
     accountRepository: AccountRepository,
     transactionRepository: TransactionRepository,
     currentDeviceId: DeviceId? = null,
+    onCsvSourceClick: (CsvImportId, Long) -> Unit = { _, _ -> },
     onBack: () -> Unit,
 ) {
     val accounts by accountRepository.getAllAccounts()
@@ -100,6 +106,7 @@ fun TransactionAuditScreen(
                 diff = diff,
                 accounts = accounts,
                 currentDeviceId = currentDeviceId,
+                onCsvSourceClick = onCsvSourceClick,
             )
         },
     )
@@ -110,6 +117,7 @@ private fun TransactionAuditDiffCard(
     diff: AuditEntryDiff,
     accounts: List<Account>,
     currentDeviceId: DeviceId? = null,
+    onCsvSourceClick: (CsvImportId, Long) -> Unit = { _, _ -> },
 ) {
     AuditDiffCard(
         auditType = diff.auditType,
@@ -117,9 +125,9 @@ private fun TransactionAuditDiffCard(
         revisionId = diff.revisionId,
     ) {
         when (diff.auditType) {
-            AuditType.INSERT -> InsertDiffContent(diff, accounts, currentDeviceId)
-            AuditType.UPDATE -> UpdateDiffContent(diff, accounts, currentDeviceId)
-            AuditType.DELETE -> DeleteDiffContent(diff, accounts, currentDeviceId)
+            AuditType.INSERT -> InsertDiffContent(diff, accounts, currentDeviceId, onCsvSourceClick)
+            AuditType.UPDATE -> UpdateDiffContent(diff, accounts, currentDeviceId, onCsvSourceClick)
+            AuditType.DELETE -> DeleteDiffContent(diff, accounts, currentDeviceId, onCsvSourceClick)
         }
     }
 }
@@ -129,6 +137,7 @@ private fun InsertDiffContent(
     diff: AuditEntryDiff,
     accounts: List<Account>,
     currentDeviceId: DeviceId? = null,
+    onCsvSourceClick: (CsvImportId, Long) -> Unit = { _, _ -> },
 ) {
     val transactionDateTime = diff.timestamp.value().toLocalDateTime(TimeZone.currentSystemDefault())
     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -143,7 +152,7 @@ private fun InsertDiffContent(
         FieldValueRow("Amount", formatAmount(diff.amount.value()), labelWidth = LABEL_WIDTH)
         FieldValueRow("Description", diff.description.value().ifBlank { "(none)" }, labelWidth = LABEL_WIDTH)
         AttributesSection(diff.attributeChanges)
-        SourceInfoSection(diff.source, currentDeviceId = currentDeviceId)
+        SourceInfoSection(diff.source, currentDeviceId = currentDeviceId, onCsvSourceClick = onCsvSourceClick)
     }
 }
 
@@ -152,6 +161,7 @@ private fun UpdateDiffContent(
     diff: AuditEntryDiff,
     accounts: List<Account>,
     currentDeviceId: DeviceId? = null,
+    onCsvSourceClick: (CsvImportId, Long) -> Unit = { _, _ -> },
 ) {
     val hasAnyChanges = diff.hasChanges
 
@@ -225,7 +235,7 @@ private fun UpdateDiffContent(
                 AttributeChangesSection(significantAttrChanges)
             }
         }
-        SourceInfoSection(diff.source, currentDeviceId = currentDeviceId)
+        SourceInfoSection(diff.source, currentDeviceId = currentDeviceId, onCsvSourceClick = onCsvSourceClick)
     }
 }
 
@@ -234,6 +244,7 @@ private fun DeleteDiffContent(
     diff: AuditEntryDiff,
     accounts: List<Account>,
     currentDeviceId: DeviceId? = null,
+    onCsvSourceClick: (CsvImportId, Long) -> Unit = { _, _ -> },
 ) {
     val errorColor = MaterialTheme.colorScheme.error
     val transactionDateTime = diff.timestamp.value().toLocalDateTime(TimeZone.currentSystemDefault())
@@ -249,7 +260,12 @@ private fun DeleteDiffContent(
         FieldValueRow("Amount", formatAmount(diff.amount.value()), errorColor, labelWidth = LABEL_WIDTH)
         FieldValueRow("Description", diff.description.value().ifBlank { "(none)" }, errorColor, labelWidth = LABEL_WIDTH)
         AttributesSection(diff.attributeChanges, errorColor)
-        SourceInfoSection(diff.source, currentDeviceId = currentDeviceId, labelColor = errorColor.copy(alpha = 0.8f))
+        SourceInfoSection(
+            diff.source,
+            currentDeviceId = currentDeviceId,
+            labelColor = errorColor.copy(alpha = 0.8f),
+            onCsvSourceClick = onCsvSourceClick,
+        )
     }
 }
 
@@ -411,6 +427,7 @@ private fun SourceInfoSection(
     source: TransferSource?,
     currentDeviceId: DeviceId? = null,
     labelColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    onCsvSourceClick: (CsvImportId, Long) -> Unit = { _, _ -> },
 ) {
     if (source == null) return
 
@@ -449,8 +466,26 @@ private fun SourceInfoSection(
                 if (csvSource != null) {
                     val fileName = csvSource.fileName ?: "Unknown file"
                     FieldValueRow("Origin", "CSV Import$thisDeviceSuffix", labelWidth = LABEL_WIDTH)
-                    FieldValueRow("File", fileName, labelWidth = LABEL_WIDTH)
-                    FieldValueRow("Row", (csvSource.rowIndex + 1).toString(), labelWidth = LABEL_WIDTH)
+                    val csvImportId = csvSource.importId
+                    if (csvImportId != null) {
+                        CsvSourceLinkRow(
+                            label = "File",
+                            value = fileName,
+                            csvImportId = csvImportId,
+                            rowIndex = csvSource.rowIndex,
+                            onCsvSourceClick = onCsvSourceClick,
+                        )
+                        CsvSourceLinkRow(
+                            label = "Row",
+                            value = csvSource.rowIndex.toString(),
+                            csvImportId = csvImportId,
+                            rowIndex = csvSource.rowIndex,
+                            onCsvSourceClick = onCsvSourceClick,
+                        )
+                    } else {
+                        FieldValueRow("File", fileName, labelWidth = LABEL_WIDTH)
+                        FieldValueRow("Row", csvSource.rowIndex.toString(), labelWidth = LABEL_WIDTH)
+                    }
                 } else {
                     FieldValueRow("Origin", "CSV Import$thisDeviceSuffix", labelWidth = LABEL_WIDTH)
                 }
@@ -482,6 +517,34 @@ private fun SourceInfoSection(
             SourceType.SYSTEM -> {
                 FieldValueRow("Origin", "System", labelWidth = LABEL_WIDTH)
             }
+        }
+    }
+}
+
+@Composable
+private fun CsvSourceLinkRow(
+    label: String,
+    value: String,
+    csvImportId: CsvImportId,
+    rowIndex: Long,
+    onCsvSourceClick: (CsvImportId, Long) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "$label:",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(LABEL_WIDTH),
+        )
+        TextButton(
+            onClick = { onCsvSourceClick(csvImportId, rowIndex) },
+            contentPadding = PaddingValues(0.dp),
+        ) {
+            Text(value)
         }
     }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTableTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTableTest.kt
@@ -4,6 +4,7 @@ package com.moneymanager.ui.components.csv
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
@@ -58,5 +59,79 @@ class CsvPreviewTableTest {
 
             assertEquals(TransferId(42), clickedTransferId)
             assertEquals(true, clickedIsPositiveAmount)
+        }
+
+    @Test
+    fun duplicateLink_clickInvokesDuplicateSourceCallbackWithAmountSign() =
+        runComposeUiTest {
+            var clickedTransferId: TransferId? = null
+            var clickedIsPositiveAmount: Boolean? = null
+
+            setContent {
+                MaterialTheme {
+                    CsvPreviewTable(
+                        columns =
+                            listOf(
+                                CsvColumn(
+                                    id = CsvColumnId(Uuid.random()),
+                                    columnIndex = 0,
+                                    originalName = "Amount",
+                                ),
+                            ),
+                        rows =
+                            listOf(
+                                CsvRow(
+                                    rowIndex = 1,
+                                    values = listOf("-12.34"),
+                                    transferId = TransferId(42),
+                                    importStatus = ImportStatus.DUPLICATE,
+                                ),
+                            ),
+                        amountColumnIndex = 0,
+                        onDuplicateSourceClick = { transferId, isPositiveAmount ->
+                            clickedTransferId = transferId
+                            clickedIsPositiveAmount = isPositiveAmount
+                        },
+                    )
+                }
+            }
+
+            onNodeWithText("Source ->").performClick()
+            waitForIdle()
+
+            assertEquals(TransferId(42), clickedTransferId)
+            assertEquals(false, clickedIsPositiveAmount)
+        }
+
+    @Test
+    fun duplicateLink_withoutDuplicateSourceCallbackIsNotClickable() =
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    CsvPreviewTable(
+                        columns =
+                            listOf(
+                                CsvColumn(
+                                    id = CsvColumnId(Uuid.random()),
+                                    columnIndex = 0,
+                                    originalName = "Amount",
+                                ),
+                            ),
+                        rows =
+                            listOf(
+                                CsvRow(
+                                    rowIndex = 1,
+                                    values = listOf("12.34"),
+                                    transferId = TransferId(42),
+                                    importStatus = ImportStatus.DUPLICATE,
+                                ),
+                            ),
+                        amountColumnIndex = 0,
+                        onTransferClick = { _, _ -> error("Duplicate rows should not fall through to transfer click") },
+                    )
+                }
+            }
+
+            onNodeWithText("View ->").assertHasNoClickAction()
         }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTableTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTableTest.kt
@@ -1,0 +1,62 @@
+@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.ui.components.csv
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.csv.CsvColumn
+import com.moneymanager.domain.model.csv.CsvColumnId
+import com.moneymanager.domain.model.csv.CsvRow
+import com.moneymanager.domain.model.csv.ImportStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalTestApi::class)
+class CsvPreviewTableTest {
+    @Test
+    fun viewLink_clickInvokesTransferCallback() =
+        runComposeUiTest {
+            var clickedTransferId: TransferId? = null
+            var clickedIsPositiveAmount: Boolean? = null
+
+            setContent {
+                MaterialTheme {
+                    CsvPreviewTable(
+                        columns =
+                            listOf(
+                                CsvColumn(
+                                    id = CsvColumnId(Uuid.random()),
+                                    columnIndex = 0,
+                                    originalName = "Amount",
+                                ),
+                            ),
+                        rows =
+                            listOf(
+                                CsvRow(
+                                    rowIndex = 1,
+                                    values = listOf("12.34"),
+                                    transferId = TransferId(42),
+                                    importStatus = ImportStatus.IMPORTED,
+                                ),
+                            ),
+                        amountColumnIndex = 0,
+                        onTransferClick = { transferId, isPositiveAmount ->
+                            clickedTransferId = transferId
+                            clickedIsPositiveAmount = isPositiveAmount
+                        },
+                    )
+                }
+            }
+
+            onNodeWithText("View ->").performClick()
+            waitForIdle()
+
+            assertEquals(TransferId(42), clickedTransferId)
+            assertEquals(true, clickedIsPositiveAmount)
+        }
+}


### PR DESCRIPTION
## Summary
- Link transaction audit CSV sources back to the original CSV import row
- Make duplicate CSV rows navigate to the original CSV source row
- Store generated transfer IDs on newly imported CSV rows and resolve legacy placeholder IDs through csv_transfer_source
- Add DB and Compose UI regressions for CSV row transfer links

Fixes #360

## Verification
- ./gradlew.bat :app:db:core:jvmTest --tests com.moneymanager.database.repository.CsvImportRepositoryImplTest --console=plain
- ./gradlew.bat :app:ui:core:jvmTest --tests com.moneymanager.ui.components.csv.CsvPreviewTableTest --console=plain
- ./gradlew.bat :app:ui:core:compileKotlinJvm --console=plain
- ./gradlew.bat :app:ui:core:ktlintCommonMainSourceSetCheck :app:ui:core:ktlintCommonTestSourceSetCheck --console=plain
- ./gradlew.bat :app:db:core:ktlintCommonMainSourceSetCheck :app:db:core:ktlintCommonTestSourceSetCheck --console=plain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - CSV import preview now scrolls to and highlights specific rows
  - Duplicate transfer sources in CSV imports are clickable for direct navigation to the original source row
  - CSV source records in transaction audit screens are now clickable for quick navigation

* **Bug Fixes**
  - Improved handling of placeholder transfer identifiers in CSV imports with fallback resolution to actual source data

* **Tests**
  - Added test coverage for CSV import placeholder transfer ID resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->