### PR TITLE
Harden build warning checks

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -25,7 +25,9 @@ runs:
         distribution: 'corretto'  # Corretto includes jmod files required by ProGuard (Temurin removed them in JDK 24+ per JEP 493)
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@v6
       with:
-        gradle-version: 9.2.0
+        # Gradle version sync: keep this aligned with gradle/wrapper/gradle-wrapper.properties
+        # and .github/workflows/lint-format.yml.
+        gradle-version: 9.4.1
         cache-read-only: ${{ inputs.cache-read-only }}

--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -19,8 +19,10 @@ runs:
         sudo udevadm trigger --name-match=kvm
 
     - name: Set up JDK 25
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
+        # JVM version sync: keep this aligned with gradle/libs.versions.toml,
+        # .github/workflows/lint-format.yml, and AGENTS.md.
         java-version: '25'
         distribution: 'corretto'  # Corretto includes jmod files required by ProGuard (Temurin removed them in JDK 24+ per JEP 493)
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,9 +44,13 @@ updates:
           - "*test*"
           - "*mockk*"
 
-  # GitHub Actions (if any workflow files exist)
+  # GitHub Actions. "/" covers .github/workflows; local composite actions need their own directories.
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/codecov-upload"
+      - "/.github/actions/gradle-run"
+      - "/.github/actions/gradle-setup"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -63,4 +67,4 @@ updates:
       # Group GitHub Actions together
       github-actions:
         patterns:
-          - "actions/*"
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,17 +59,17 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          # Android API level sync: update with gradle/libs.versions.toml, the Gradle managed device,
+          # Android emulator API level sync: update with the Gradle managed device,
           # .idea/runConfigurations/Android_Tests.xml, and AGENTS.md.
-          key: avd-pixel6-api37-${{ runner.os }}
+          key: avd-pixel6-api36-${{ runner.os }}
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          # Android API level sync: update with gradle/libs.versions.toml, the Gradle managed device,
+          # Android emulator API level sync: update with the Gradle managed device,
           # .idea/runConfigurations/Android_Tests.xml, and AGENTS.md.
-          api-level: 37
+          api-level: 36
           arch: x86_64
           profile: pixel_6
           target: google_apis
@@ -82,9 +82,9 @@ jobs:
         timeout-minutes: 20
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          # Android API level sync: update with gradle/libs.versions.toml, the Gradle managed device,
+          # Android emulator API level sync: update with the Gradle managed device,
           # .idea/runConfigurations/Android_Tests.xml, and AGENTS.md.
-          api-level: 37
+          api-level: 36
           arch: x86_64
           profile: pixel_6
           target: google_apis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,13 +59,17 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-pixel6-api34-${{ runner.os }}
+          # Android API level sync: update with gradle/libs.versions.toml, the Gradle managed device,
+          # .idea/runConfigurations/Android_Tests.xml, and AGENTS.md.
+          key: avd-pixel6-api37-${{ runner.os }}
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
+          # Android API level sync: update with gradle/libs.versions.toml, the Gradle managed device,
+          # .idea/runConfigurations/Android_Tests.xml, and AGENTS.md.
+          api-level: 37
           arch: x86_64
           profile: pixel_6
           target: google_apis
@@ -78,14 +82,16 @@ jobs:
         timeout-minutes: 20
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 34
+          # Android API level sync: update with gradle/libs.versions.toml, the Gradle managed device,
+          # .idea/runConfigurations/Android_Tests.xml, and AGENTS.md.
+          api-level: 37
           arch: x86_64
           profile: pixel_6
           target: google_apis
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
-          script: ./gradlew connectedAndroidDeviceTest createAndroidDeviceTestCoverageReport --stacktrace
+          script: ./gradlew connectedAndroidDeviceTest createAndroidDeviceTestCoverageReport --stacktrace --console=plain
 
       - name: Upload coverage and test results to Codecov
         if: always()

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
+          # JVM version sync: keep this aligned with gradle/libs.versions.toml,
+          # .github/actions/gradle-setup/action.yml, and AGENTS.md.
           java-version: '25'
           distribution: 'corretto'
 

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         with:
-          gradle-version: 9.2.0
+          # Gradle version sync: keep this aligned with gradle/wrapper/gradle-wrapper.properties
+          # and .github/actions/gradle-setup/action.yml.
+          gradle-version: 9.4.1
 
       - name: Run lintFormat
         run: ./gradlew lintFormat --no-daemon -Dktlint.ignoreFailures=true --continue

--- a/.idea/runConfigurations/Android_Tests.xml
+++ b/.idea/runConfigurations/Android_Tests.xml
@@ -10,8 +10,8 @@
       </option>
       <option name="taskNames">
         <list>
-          <!-- Android API level sync: update with gradle/libs.versions.toml, the Gradle managed device, CI emulator, and AGENTS.md. -->
-          <option value="pixel6api37AndroidDeviceTest" />
+          <!-- Android emulator API level sync: update with the Gradle managed device, CI emulator, and AGENTS.md. -->
+          <option value="pixel6api36AndroidDeviceTest" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/.idea/runConfigurations/Android_Tests.xml
+++ b/.idea/runConfigurations/Android_Tests.xml
@@ -10,7 +10,8 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="pixel6api34AndroidDeviceTest" />
+          <!-- Android API level sync: update with gradle/libs.versions.toml, the Gradle managed device, CI emulator, and AGENTS.md. -->
+          <option value="pixel6api37AndroidDeviceTest" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 | `./gradlew build` | Build all, run tests, coverage, dependency health |
 | `./gradlew :app:main:jvm:run` | Run JVM application |
 | `./gradlew :app:main:android:installDebug` | Install Android debug APK |
-| `./gradlew :app:ui:core:pixel6api34AndroidDeviceTest` | Run Android UI tests on managed device |
+| `./gradlew :app:ui:core:pixel6api37AndroidDeviceTest` | Run Android UI tests on managed device |
 | `./gradlew lintFormat` | Format code (ktlint + sort dependencies) |
 | `./gradlew buildHealth` | Check dependency health |
 | `./gradlew detekt` | Static analysis |
@@ -107,7 +107,7 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 - Use `runComposeUiTest` for UI tests
 - Android tests require manifest with `ComponentActivity` declaration
 - Share test sources via `kotlin.srcDir("src/commonTest/kotlin")`
-- **Android Device Tests**: Use `:app:ui:core:pixel6api34AndroidDeviceTest` for UI tests on managed device emulator
+- **Android Device Tests**: Use `:app:ui:core:pixel6api37AndroidDeviceTest` for UI tests on managed device emulator. Android API level sync: update this with `gradle/libs.versions.toml`, the Gradle managed device, CI emulator, and IntelliJ Android Tests run configuration.
 - **Test Stability**: Always call `waitForIdle()` after `waitUntilDoesNotExist()` to ensure recompositions complete before test ends
 
 ### Platform Support

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 
 ## Technology Stack
 
-- **Language**: Kotlin | **Build**: Gradle | **JVM**: 25
+- **Language**: Kotlin | **Build**: Gradle | **JVM**: 25. JVM version sync: keep this aligned with `gradle/libs.versions.toml`, `.github/actions/gradle-setup/action.yml`, and `.github/workflows/lint-format.yml`.
 - **Database**: SQLite via SQLDelight | **DI**: Metro 
 - **UI**: Compose Multiplatform with Material 3
 - **Object Mapping**: Mappie | **Code Quality**: Detekt, ktlint
@@ -116,7 +116,7 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 
 ### Common Issues
 
-1. **Java**: Requires JDK 25 toolchain
+1. **Java**: Requires JDK 25 toolchain. JVM version sync: update this with `gradle/libs.versions.toml`, `.github/actions/gradle-setup/action.yml`, and `.github/workflows/lint-format.yml`.
 2. **Metro**: Keep Kotlin version aligned (2.2.21). Components/modules must be `interface`
 3. **SQLDelight**: `execute()`/`update()`/`delete()` return `Long`, not `Unit`
 4. **Configuration Cache**: Enabled for faster builds; invalidates on build file changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 | `./gradlew build` | Build all, run tests, coverage, dependency health |
 | `./gradlew :app:main:jvm:run` | Run JVM application |
 | `./gradlew :app:main:android:installDebug` | Install Android debug APK |
-| `./gradlew :app:ui:core:pixel6api37AndroidDeviceTest` | Run Android UI tests on managed device |
+| `./gradlew :app:ui:core:pixel6api36AndroidDeviceTest` | Run Android UI tests on managed device |
 | `./gradlew lintFormat` | Format code (ktlint + sort dependencies) |
 | `./gradlew buildHealth` | Check dependency health |
 | `./gradlew detekt` | Static analysis |
@@ -107,7 +107,7 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 - Use `runComposeUiTest` for UI tests
 - Android tests require manifest with `ComponentActivity` declaration
 - Share test sources via `kotlin.srcDir("src/commonTest/kotlin")`
-- **Android Device Tests**: Use `:app:ui:core:pixel6api37AndroidDeviceTest` for UI tests on managed device emulator. Android API level sync: update this with `gradle/libs.versions.toml`, the Gradle managed device, CI emulator, and IntelliJ Android Tests run configuration.
+- **Android Device Tests**: Use `:app:ui:core:pixel6api36AndroidDeviceTest` for UI tests on managed device emulator. Android emulator API level sync: update this with the Gradle managed device, CI emulator, and IntelliJ Android Tests run configuration.
 - **Test Stability**: Always call `waitForIdle()` after `waitUntilDoesNotExist()` to ensure recompositions complete before test ends
 
 ### Platform Support

--- a/app/db/core/src/androidMain/kotlin/com/moneymanager/database/AndroidDatabaseManager.kt
+++ b/app/db/core/src/androidMain/kotlin/com/moneymanager/database/AndroidDatabaseManager.kt
@@ -17,7 +17,9 @@ private val DEFAULT_DB_LOCATION = DbLocation(DEFAULT_DATABASE_NAME)
  * Manages SQLite databases using Android's built-in database support.
  * Stateless - does not track open databases.
  */
-class AndroidDatabaseManager(private val context: Context) : DatabaseManager {
+class AndroidDatabaseManager(
+    private val context: Context,
+) : DatabaseManager {
     override suspend fun openDatabase(location: DbLocation): MoneyManagerDatabaseWrapper =
         withContext(Dispatchers.IO) {
             // Check if this is a new database before opening

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseState.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseState.kt
@@ -27,5 +27,7 @@ sealed class DatabaseState {
      *
      * @property error The error that occurred
      */
-    data class Error(val error: Throwable) : DatabaseState()
+    data class Error(
+        val error: Throwable,
+    ) : DatabaseState()
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/MoneyManagerDatabaseWrapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/MoneyManagerDatabaseWrapper.kt
@@ -5,7 +5,9 @@ import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
 import com.moneymanager.database.sql.MoneyManagerDatabase
 
-class MoneyManagerDatabaseWrapper(private val driver: SqlDriver) : MoneyManagerDatabase by MoneyManagerDatabase(driver) {
+class MoneyManagerDatabaseWrapper(
+    private val driver: SqlDriver,
+) : MoneyManagerDatabase by MoneyManagerDatabase(driver) {
     /**
      * Execute a SQL statement on the database.
      * Delegates to the underlying SqlDriver.

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/csv/CsvTableManager.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/csv/CsvTableManager.kt
@@ -12,7 +12,9 @@ import com.moneymanager.domain.model.csv.ImportStatus
  * Manages dynamic CSV tables in the database.
  * These tables are created at runtime to store imported CSV data.
  */
-class CsvTableManager(private val database: MoneyManagerDatabaseWrapper) {
+class CsvTableManager(
+    private val database: MoneyManagerDatabaseWrapper,
+) {
     /**
      * Creates a new table to store CSV data.
      *

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/csv/CsvTransferMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/csv/CsvTransferMapper.kt
@@ -384,8 +384,8 @@ class CsvTransferMapper(
      * Extracts attribute values from CSV row based on strategy.attributeMappings.
      * Skips attributes with blank values.
      */
-    private fun extractAttributes(values: List<String>): List<Pair<String, String>> {
-        return strategy.attributeMappings.mapNotNull { mapping ->
+    private fun extractAttributes(values: List<String>): List<Pair<String, String>> =
+        strategy.attributeMappings.mapNotNull { mapping ->
             val value = getColumnValueOrNull(mapping.columnName, values)?.trim()
             if (value.isNullOrBlank()) {
                 null
@@ -393,7 +393,6 @@ class CsvTransferMapper(
                 mapping.attributeTypeName to value
             }
         }
-    }
 
     /**
      * Gets a column value by name, returning null if the column doesn't exist.
@@ -507,12 +506,11 @@ class CsvTransferMapper(
     private fun getAccountName(
         mapping: AccountLookupMapping,
         values: List<String>,
-    ): String {
-        return mapping.allColumns
+    ): String =
+        mapping.allColumns
             .map { getColumnValue(it, values) }
             .firstOrNull { it.isNotBlank() }
             .orEmpty()
-    }
 
     /**
      * Result of resolving a RegexAccountMapping to an account name.
@@ -616,8 +614,8 @@ class CsvTransferMapper(
     private fun parseTimezone(
         mapping: FieldMapping?,
         values: List<String>,
-    ): TimeZone {
-        return when (mapping) {
+    ): TimeZone =
+        when (mapping) {
             is HardCodedTimezoneMapping -> TimeZone.of(mapping.timezoneId)
             is TimezoneLookupMapping -> {
                 val tzId = getColumnValue(mapping.columnName, values).trim()
@@ -625,17 +623,15 @@ class CsvTransferMapper(
             }
             else -> TimeZone.currentSystemDefault()
         }
-    }
 
     private fun parseDescription(
         mapping: FieldMapping,
         values: List<String>,
-    ): String {
-        return when (mapping) {
+    ): String =
+        when (mapping) {
             is DirectColumnMapping -> getDirectColumnValue(mapping, values)
             else -> throw IllegalArgumentException("Invalid description mapping type: ${mapping::class}")
         }
-    }
 
     /**
      * Gets the effective value from a DirectColumnMapping,
@@ -644,18 +640,17 @@ class CsvTransferMapper(
     private fun getDirectColumnValue(
         mapping: DirectColumnMapping,
         values: List<String>,
-    ): String {
-        return mapping.allColumns
+    ): String =
+        mapping.allColumns
             .map { getColumnValue(it, values) }
             .firstOrNull { it.isNotBlank() }
             .orEmpty()
-    }
 
     private fun parseCurrency(
         mapping: FieldMapping,
         values: List<String>,
-    ): Currency? {
-        return when (mapping) {
+    ): Currency? =
+        when (mapping) {
             is HardCodedCurrencyMapping -> existingCurrencies[mapping.currencyId]
             is CurrencyLookupMapping -> {
                 val code = getColumnValue(mapping.columnName, values).trim().uppercase()
@@ -663,7 +658,6 @@ class CsvTransferMapper(
             }
             else -> throw IllegalArgumentException("Invalid currency mapping type: ${mapping::class}")
         }
-    }
 
     private fun getColumnValue(
         columnName: String,
@@ -679,7 +673,8 @@ class CsvTransferMapper(
 
     private fun parseBigDecimal(value: String): BigDecimal {
         val cleaned =
-            value.trim()
+            value
+                .trim()
                 .replace(",", "") // Remove thousand separators
                 .replace(" ", "")
                 .replace("$", "")

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/TransferSourceMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/TransferSourceMapper.kt
@@ -18,8 +18,8 @@ object TransferSourceFromRevisionMapper :
     IdConversions,
     InstantConversions,
     SourceTypeConversions {
-    override fun map(from: SelectByTransactionIdAndRevision): TransferSource {
-        return mapping {
+    override fun map(from: SelectByTransactionIdAndRevision): TransferSource =
+        mapping {
             TransferSource::deviceInfo fromValue
                 DeviceRepositoryImpl.createDeviceInfo(
                     platformName = from.platform_name,
@@ -31,7 +31,6 @@ object TransferSourceFromRevisionMapper :
             TransferSource::csvSource fromValue
                 mapCsvSource(toSourceType(from.source_type), from.csv_import_id, from.csv_row_index, from.csv_file_name)
         }
-    }
 }
 
 object TransferSourceFromTransactionIdMapper :
@@ -39,8 +38,8 @@ object TransferSourceFromTransactionIdMapper :
     IdConversions,
     InstantConversions,
     SourceTypeConversions {
-    override fun map(from: SelectAllByTransactionId): TransferSource {
-        return mapping {
+    override fun map(from: SelectAllByTransactionId): TransferSource =
+        mapping {
             TransferSource::deviceInfo fromValue
                 DeviceRepositoryImpl.createDeviceInfo(
                     platformName = from.platform_name,
@@ -52,7 +51,6 @@ object TransferSourceFromTransactionIdMapper :
             TransferSource::csvSource fromValue
                 mapCsvSource(toSourceType(from.source_type), from.csv_import_id, from.csv_row_index, from.csv_file_name)
         }
-    }
 }
 
 object TransferSourceFromAuditMapper :

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/AccountRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/AccountRepositoryImpl.kt
@@ -24,13 +24,15 @@ class AccountRepositoryImpl(
     private val transferQueries = database.transferQueries
 
     override fun getAllAccounts(): Flow<List<Account>> =
-        queries.selectAll()
+        queries
+            .selectAll()
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map(AccountMapper::mapList)
 
     override fun getAccountById(id: AccountId): Flow<Account?> =
-        queries.selectById(id.id)
+        queries
+            .selectById(id.id)
             .asFlow()
             .mapToOneOrNull(Dispatchers.Default)
             .map { it?.let(AccountMapper::map) }
@@ -91,11 +93,12 @@ class AccountRepositoryImpl(
         accountB: AccountId,
     ): List<Transfer> =
         withContext(Dispatchers.Default) {
-            transferQueries.selectTransfersBetweenAccounts(
-                accountA = accountA.id,
-                accountB = accountB.id,
-                TransferMapper::mapRaw,
-            ).executeAsList()
+            transferQueries
+                .selectTransfersBetweenAccounts(
+                    accountA = accountA.id,
+                    accountB = accountB.id,
+                    TransferMapper::mapRaw,
+                ).executeAsList()
         }
 
     override suspend fun deleteAccountAndMoveTransactions(

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/AttributeTypeRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/AttributeTypeRepositoryImpl.kt
@@ -18,7 +18,8 @@ class AttributeTypeRepositoryImpl(
     private val queries = database.attributeTypeQueries
 
     override fun getAll(): Flow<List<AttributeType>> =
-        queries.selectAll()
+        queries
+            .selectAll()
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map { list ->
@@ -31,7 +32,8 @@ class AttributeTypeRepositoryImpl(
             }
 
     override fun getById(id: AttributeTypeId): Flow<AttributeType?> =
-        queries.selectById(id.id)
+        queries
+            .selectById(id.id)
             .asFlow()
             .mapToOneOrNull(Dispatchers.Default)
             .map { row ->
@@ -44,7 +46,8 @@ class AttributeTypeRepositoryImpl(
             }
 
     override fun getByName(name: String): Flow<AttributeType?> =
-        queries.selectByName(name)
+        queries
+            .selectByName(name)
             .asFlow()
             .mapToOneOrNull(Dispatchers.Default)
             .map { row ->

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/AuditRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/AuditRepositoryImpl.kt
@@ -36,7 +36,8 @@ class AuditRepositoryImpl(
     override suspend fun getAuditHistoryForTransfer(transferId: TransferId): List<TransferAuditEntry> =
         withContext(Dispatchers.Default) {
             val entries =
-                queries.selectAuditHistoryForTransfer(transferId.id)
+                queries
+                    .selectAuditHistoryForTransfer(transferId.id)
                     .executeAsList()
                     .map(TransferAuditEntryMapper::map)
 
@@ -45,42 +46,48 @@ class AuditRepositoryImpl(
 
     override suspend fun getAuditHistoryForAccount(accountId: AccountId): List<AccountAuditEntry> =
         withContext(Dispatchers.Default) {
-            queries.selectAuditHistoryForAccount(accountId.id)
+            queries
+                .selectAuditHistoryForAccount(accountId.id)
                 .executeAsList()
                 .map(AccountAuditEntryMapper::map)
         }
 
     override suspend fun getAuditHistoryForPerson(personId: PersonId): List<PersonAuditEntry> =
         withContext(Dispatchers.Default) {
-            queries.selectAuditHistoryForPerson(personId.id)
+            queries
+                .selectAuditHistoryForPerson(personId.id)
                 .executeAsList()
                 .map(PersonAuditEntryMapper::map)
         }
 
     override suspend fun getAuditHistoryForPersonAccountOwnership(ownershipId: Long): List<PersonAccountOwnershipAuditEntry> =
         withContext(Dispatchers.Default) {
-            queries.selectAuditHistoryForPersonAccountOwnership(ownershipId)
+            queries
+                .selectAuditHistoryForPersonAccountOwnership(ownershipId)
                 .executeAsList()
                 .map(PersonAccountOwnershipAuditEntryMapper::map)
         }
 
     override suspend fun getOwnershipAuditHistoryForAccount(accountId: AccountId): List<PersonAccountOwnershipAuditEntry> =
         withContext(Dispatchers.Default) {
-            queries.selectOwnershipAuditHistoryForAccount(accountId.id)
+            queries
+                .selectOwnershipAuditHistoryForAccount(accountId.id)
                 .executeAsList()
                 .map(OwnershipAuditHistoryForAccountMapper::map)
         }
 
     override suspend fun getAuditHistoryForCurrency(currencyId: CurrencyId): List<CurrencyAuditEntry> =
         withContext(Dispatchers.Default) {
-            queries.selectAuditHistoryForCurrency(currencyId.id)
+            queries
+                .selectAuditHistoryForCurrency(currencyId.id)
                 .executeAsList()
                 .map(CurrencyAuditEntryMapper::map)
         }
 
     override suspend fun getAuditHistoryForCategory(categoryId: Long): List<CategoryAuditEntry> =
         withContext(Dispatchers.Default) {
-            queries.selectAuditHistoryForCategory(categoryId)
+            queries
+                .selectAuditHistoryForCategory(categoryId)
                 .executeAsList()
                 .map(CategoryAuditEntryMapper::map)
         }
@@ -91,7 +98,8 @@ class AuditRepositoryImpl(
     ): List<TransferAuditEntry> {
         // Fetch all attribute audit entries for this transfer
         val allAttributeChanges =
-            queries.selectAttributeAuditByTransfer(transferId.id)
+            queries
+                .selectAttributeAuditByTransfer(transferId.id)
                 .executeAsList()
                 .map { row ->
                     TransferAttributeAuditEntry(

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CategoryRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CategoryRepositoryImpl.kt
@@ -22,13 +22,15 @@ class CategoryRepositoryImpl(
     private val queries = database.categoryQueries
 
     override fun getAllCategories(): Flow<List<Category>> =
-        queries.selectAll()
+        queries
+            .selectAll()
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map(CategoryMapper::mapList)
 
     override fun getCategoryBalances(): Flow<List<CategoryBalance>> =
-        queries.selectAllCategoryBalances()
+        queries
+            .selectAllCategoryBalances()
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map { list ->
@@ -48,19 +50,22 @@ class CategoryRepositoryImpl(
             }
 
     override fun getCategoryById(id: Long): Flow<Category?> =
-        queries.selectById(id)
+        queries
+            .selectById(id)
             .asFlow()
             .mapToOneOrNull(Dispatchers.Default)
             .map { it?.let(CategoryMapper::map) }
 
     override fun getTopLevelCategories(): Flow<List<Category>> =
-        queries.selectTopLevel()
+        queries
+            .selectTopLevel()
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map(CategoryMapper::mapList)
 
     override fun getCategoriesByParent(parentId: Long): Flow<List<Category>> =
-        queries.selectByParent(parentId)
+        queries
+            .selectByParent(parentId)
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map(CategoryMapper::mapList)

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvAccountMappingRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvAccountMappingRepositoryImpl.kt
@@ -26,13 +26,15 @@ class CsvAccountMappingRepositoryImpl(
     private val queries = database.csvAccountMappingQueries
 
     override fun getMappingsForStrategy(strategyId: CsvImportStrategyId): Flow<List<CsvAccountMapping>> =
-        queries.selectByStrategyId(strategyId.id.toString())
+        queries
+            .selectByStrategyId(strategyId.id.toString())
             .asFlow()
             .mapToList(coroutineContext)
             .map { mappings -> mappings.map(::toDomain) }
 
     override fun getMappingById(id: Long): Flow<CsvAccountMapping?> =
-        queries.selectById(id)
+        queries
+            .selectById(id)
             .asFlow()
             .mapToOneOrNull(coroutineContext)
             .map { it?.let(::toDomain) }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportRepositoryImpl.kt
@@ -78,14 +78,16 @@ class CsvImportRepositoryImpl(
             }
         }
 
-    override fun getAllImports(): Flow<List<CsvImport>> {
-        return csvImportQueries.selectAllImports()
+    override fun getAllImports(): Flow<List<CsvImport>> =
+        csvImportQueries
+            .selectAllImports()
             .asFlow()
             .mapToList(coroutineContext)
             .map { imports ->
                 imports.map { import ->
                     val columns =
-                        csvImportQueries.selectColumnsByImportId(import.id)
+                        csvImportQueries
+                            .selectColumnsByImportId(import.id)
                             .executeAsList()
                             .map { col ->
                                 CsvColumn(
@@ -116,16 +118,17 @@ class CsvImportRepositoryImpl(
                     )
                 }
             }
-    }
 
     override fun getImport(id: CsvImportId): Flow<CsvImport?> {
         val importFlow =
-            csvImportQueries.selectImportById(id.id.toString())
+            csvImportQueries
+                .selectImportById(id.id.toString())
                 .asFlow()
                 .mapToOneOrNull(coroutineContext)
 
         val columnsFlow =
-            csvImportQueries.selectColumnsByImportId(id.id.toString())
+            csvImportQueries
+                .selectColumnsByImportId(id.id.toString())
                 .asFlow()
                 .mapToList(coroutineContext)
 
@@ -268,7 +271,8 @@ class CsvImportRepositoryImpl(
         withContext(coroutineContext) {
             csvImportQueries.selectImportsByChecksum(checksum).executeAsList().map { import ->
                 val columns =
-                    csvImportQueries.selectColumnsByImportId(import.id)
+                    csvImportQueries
+                        .selectColumnsByImportId(import.id)
                         .executeAsList()
                         .map { col ->
                             CsvColumn(

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyRepositoryImpl.kt
@@ -27,19 +27,22 @@ class CsvImportStrategyRepositoryImpl(
     private val queries = database.csvImportStrategyQueries
 
     override fun getAllStrategies(): Flow<List<CsvImportStrategy>> =
-        queries.selectAll()
+        queries
+            .selectAll()
             .asFlow()
             .mapToList(coroutineContext)
             .map { strategies -> strategies.map(::toDomain) }
 
     override fun getStrategyById(id: CsvImportStrategyId): Flow<CsvImportStrategy?> =
-        queries.selectById(id.id.toString())
+        queries
+            .selectById(id.id.toString())
             .asFlow()
             .mapToOneOrNull(coroutineContext)
             .map { it?.let(::toDomain) }
 
     override fun getStrategyByName(name: String): Flow<CsvImportStrategy?> =
-        queries.selectByName(name)
+        queries
+            .selectByName(name)
             .asFlow()
             .mapToOneOrNull(coroutineContext)
             .map { it?.let(::toDomain) }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CurrencyRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CurrencyRepositoryImpl.kt
@@ -20,19 +20,22 @@ class CurrencyRepositoryImpl(
     private val queries = database.currencyQueries
 
     override fun getAllCurrencies(): Flow<List<Currency>> =
-        queries.selectAll()
+        queries
+            .selectAll()
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map(CurrencyMapper::mapList)
 
     override fun getCurrencyById(id: CurrencyId): Flow<Currency?> =
-        queries.selectById(id.id)
+        queries
+            .selectById(id.id)
             .asFlow()
             .mapToOneOrNull(Dispatchers.Default)
             .map { it?.let(CurrencyMapper::map) }
 
     override fun getCurrencyByCode(code: String): Flow<Currency?> =
-        queries.selectByCode(code)
+        queries
+            .selectByCode(code)
             .asFlow()
             .mapToOneOrNull(Dispatchers.Default)
             .map { it?.let(CurrencyMapper::map) }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/DeviceRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/DeviceRepositoryImpl.kt
@@ -9,12 +9,11 @@ import com.moneymanager.domain.repository.DeviceRepository
 class DeviceRepositoryImpl(
     private val database: MoneyManagerDatabaseWrapper,
 ) : DeviceRepository {
-    override fun getOrCreateDevice(deviceInfo: DeviceInfo): DeviceId {
-        return when (deviceInfo) {
+    override fun getOrCreateDevice(deviceInfo: DeviceInfo): DeviceId =
+        when (deviceInfo) {
             is DeviceInfo.Jvm -> getOrCreateJvmDevice(deviceInfo)
             is DeviceInfo.Android -> getOrCreateAndroidDevice(deviceInfo)
         }
-    }
 
     private fun getOrCreateJvmDevice(deviceInfo: DeviceInfo.Jvm): DeviceId {
         // Get or create OS
@@ -27,10 +26,11 @@ class DeviceRepositoryImpl(
 
         // Try to find existing device
         val existingDevice =
-            database.deviceQueries.selectByAttributesJvm(
-                os_id = osId,
-                machine_id = machineId,
-            ).executeAsOneOrNull()
+            database.deviceQueries
+                .selectByAttributesJvm(
+                    os_id = osId,
+                    machine_id = machineId,
+                ).executeAsOneOrNull()
 
         if (existingDevice != null) {
             return DeviceId(existingDevice)
@@ -43,10 +43,11 @@ class DeviceRepositoryImpl(
         )
         // Re-query to get the ID (lastInsertRowId doesn't work reliably with JDBC)
         return DeviceId(
-            database.deviceQueries.selectByAttributesJvm(
-                os_id = osId,
-                machine_id = machineId,
-            ).executeAsOne(),
+            database.deviceQueries
+                .selectByAttributesJvm(
+                    os_id = osId,
+                    machine_id = machineId,
+                ).executeAsOne(),
         )
     }
 
@@ -61,10 +62,11 @@ class DeviceRepositoryImpl(
 
         // Try to find existing device
         val existingDevice =
-            database.deviceQueries.selectByAttributesAndroid(
-                device_make_id = makeId,
-                device_model_id = modelId,
-            ).executeAsOneOrNull()
+            database.deviceQueries
+                .selectByAttributesAndroid(
+                    device_make_id = makeId,
+                    device_model_id = modelId,
+                ).executeAsOneOrNull()
 
         if (existingDevice != null) {
             return DeviceId(existingDevice)
@@ -77,10 +79,11 @@ class DeviceRepositoryImpl(
         )
         // Re-query to get the ID (lastInsertRowId doesn't work reliably with JDBC)
         return DeviceId(
-            database.deviceQueries.selectByAttributesAndroid(
-                device_make_id = makeId,
-                device_model_id = modelId,
-            ).executeAsOne(),
+            database.deviceQueries
+                .selectByAttributesAndroid(
+                    device_make_id = makeId,
+                    device_model_id = modelId,
+                ).executeAsOne(),
         )
     }
 

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/PersonAccountOwnershipRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/PersonAccountOwnershipRepositoryImpl.kt
@@ -20,19 +20,22 @@ class PersonAccountOwnershipRepositoryImpl(
     private val queries = database.personQueries
 
     override fun getOwnershipsByPerson(personId: PersonId): Flow<List<PersonAccountOwnership>> =
-        queries.ownershipSelectByPerson(personId.id)
+        queries
+            .ownershipSelectByPerson(personId.id)
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map(PersonAccountOwnershipMapper::mapList)
 
     override fun getOwnershipsByAccount(accountId: AccountId): Flow<List<PersonAccountOwnership>> =
-        queries.ownershipSelectByAccount(accountId.id)
+        queries
+            .ownershipSelectByAccount(accountId.id)
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map(PersonAccountOwnershipMapper::mapList)
 
     override fun getOwnershipById(id: Long): Flow<PersonAccountOwnership?> =
-        queries.ownershipSelectById(id)
+        queries
+            .ownershipSelectById(id)
             .asFlow()
             .mapToOneOrNull(Dispatchers.Default)
             .map { it?.let(PersonAccountOwnershipMapper::map) }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/PersonRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/PersonRepositoryImpl.kt
@@ -19,13 +19,15 @@ class PersonRepositoryImpl(
     private val queries = database.personQueries
 
     override fun getAllPeople(): Flow<List<Person>> =
-        queries.selectAll()
+        queries
+            .selectAll()
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map(PersonMapper::mapList)
 
     override fun getPersonById(id: PersonId): Flow<Person?> =
-        queries.selectById(id.id)
+        queries
+            .selectById(id.id)
             .asFlow()
             .mapToOneOrNull(Dispatchers.Default)
             .map { it?.let(PersonMapper::map) }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/SettingsRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/SettingsRepositoryImpl.kt
@@ -16,7 +16,8 @@ class SettingsRepositoryImpl(
     private val queries = database.settingsQueries
 
     override fun getDefaultCurrencyId(): Flow<CurrencyId?> =
-        queries.selectDefaultCurrencyId()
+        queries
+            .selectDefaultCurrencyId()
             .asFlow()
             .mapToOneOrNull(Dispatchers.Default)
             .map { it?.let(::CurrencyId) }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionRepositoryImpl.kt
@@ -41,7 +41,8 @@ class TransactionRepositoryImpl(
         if (transfers.isEmpty()) return transfers
         val ids = transfers.map { it.id.id }
         val attributesByTransferId =
-            transferAttributeQueries.selectByTransactionIds(ids)
+            transferAttributeQueries
+                .selectByTransactionIds(ids)
                 .executeAsList()
                 .groupBy { TransferId(it.transaction_id) }
                 .mapValues { (_, rows) ->
@@ -67,13 +68,15 @@ class TransactionRepositoryImpl(
     }
 
     override fun getTransactionById(id: Long): Flow<Transfer?> =
-        transferQueries.selectById(id, TransferMapper::mapRaw)
+        transferQueries
+            .selectById(id, TransferMapper::mapRaw)
             .asFlow()
             .mapToOneOrNull(Dispatchers.Default)
             .map { loadAttributesForTransfer(it) }
 
     override fun getTransactionsByAccount(accountId: AccountId): Flow<List<Transfer>> =
-        transferQueries.selectByAccount(accountId.id, accountId.id, TransferMapper::mapRaw)
+        transferQueries
+            .selectByAccount(accountId.id, accountId.id, TransferMapper::mapRaw)
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map { loadAttributesForTransfers(it) }
@@ -82,12 +85,12 @@ class TransactionRepositoryImpl(
         startDate: Instant,
         endDate: Instant,
     ): Flow<List<Transfer>> =
-        transferQueries.selectByDateRange(
-            startDate.toEpochMilliseconds(),
-            endDate.toEpochMilliseconds(),
-            TransferMapper::mapRaw,
-        )
-            .asFlow()
+        transferQueries
+            .selectByDateRange(
+                startDate.toEpochMilliseconds(),
+                endDate.toEpochMilliseconds(),
+                TransferMapper::mapRaw,
+            ).asFlow()
             .mapToList(Dispatchers.Default)
             .map { loadAttributesForTransfers(it) }
 
@@ -96,19 +99,20 @@ class TransactionRepositoryImpl(
         startDate: Instant,
         endDate: Instant,
     ): Flow<List<Transfer>> =
-        transferQueries.selectByAccountAndDateRange(
-            accountId.id,
-            accountId.id,
-            startDate.toEpochMilliseconds(),
-            endDate.toEpochMilliseconds(),
-            TransferMapper::mapRaw,
-        )
-            .asFlow()
+        transferQueries
+            .selectByAccountAndDateRange(
+                accountId.id,
+                accountId.id,
+                startDate.toEpochMilliseconds(),
+                endDate.toEpochMilliseconds(),
+                TransferMapper::mapRaw,
+            ).asFlow()
             .mapToList(Dispatchers.Default)
             .map { loadAttributesForTransfers(it) }
 
     override fun getAccountBalances(): Flow<List<AccountBalance>> =
-        transferQueries.selectAllBalances()
+        transferQueries
+            .selectAllBalances()
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map(AccountBalanceMapper::mapList)
@@ -120,15 +124,13 @@ class TransactionRepositoryImpl(
     ): PagingResult<AccountRow> =
         withContext(Dispatchers.Default) {
             val items =
-                transferQueries.selectRunningBalanceByAccountPaginated(
-                    accountId.id,
-                    pagingInfo?.lastTimestamp?.toEpochMilliseconds(),
-                    pagingInfo?.lastId?.id,
-                    (pageSize + 1).toLong(),
-                ) { id, timestamp, description, account_id, transaction_amount, running_balance,
-                    currency_id, currency_code, currency_name, currency_scale_factor, source_account_id, target_account_id,
-                    ->
-                    AccountRowMapper.mapRaw(
+                transferQueries
+                    .selectRunningBalanceByAccountPaginated(
+                        accountId.id,
+                        pagingInfo?.lastTimestamp?.toEpochMilliseconds(),
+                        pagingInfo?.lastId?.id,
+                        (pageSize + 1).toLong(),
+                    ) {
                         id,
                         timestamp,
                         description,
@@ -141,9 +143,22 @@ class TransactionRepositoryImpl(
                         currency_scale_factor,
                         source_account_id,
                         target_account_id,
-                    )
-                }
-                    .executeAsList()
+                        ->
+                        AccountRowMapper.mapRaw(
+                            id,
+                            timestamp,
+                            description,
+                            account_id,
+                            transaction_amount,
+                            running_balance,
+                            currency_id,
+                            currency_code,
+                            currency_name,
+                            currency_scale_factor,
+                            source_account_id,
+                            target_account_id,
+                        )
+                    }.executeAsList()
 
             val hasMore = items.size > pageSize
             val pageItems = if (hasMore) items.take(pageSize) else items
@@ -178,15 +193,13 @@ class TransactionRepositoryImpl(
     ): PagingResult<AccountRow> =
         withContext(Dispatchers.Default) {
             val items =
-                transferQueries.selectRunningBalanceByAccountPaginatedBackward(
-                    accountId.id,
-                    firstTimestamp.toEpochMilliseconds(),
-                    firstId.id,
-                    (pageSize + 1).toLong(),
-                ) { id, timestamp, description, account_id, transaction_amount, running_balance,
-                    currency_id, currency_code, currency_name, currency_scale_factor, source_account_id, target_account_id,
-                    ->
-                    AccountRowMapper.mapRaw(
+                transferQueries
+                    .selectRunningBalanceByAccountPaginatedBackward(
+                        accountId.id,
+                        firstTimestamp.toEpochMilliseconds(),
+                        firstId.id,
+                        (pageSize + 1).toLong(),
+                    ) {
                         id,
                         timestamp,
                         description,
@@ -199,9 +212,22 @@ class TransactionRepositoryImpl(
                         currency_scale_factor,
                         source_account_id,
                         target_account_id,
-                    )
-                }
-                    .executeAsList()
+                        ->
+                        AccountRowMapper.mapRaw(
+                            id,
+                            timestamp,
+                            description,
+                            account_id,
+                            transaction_amount,
+                            running_balance,
+                            currency_id,
+                            currency_code,
+                            currency_name,
+                            currency_scale_factor,
+                            source_account_id,
+                            target_account_id,
+                        )
+                    }.executeAsList()
                     // Reverse to get correct display order (newest first)
                     .reversed()
 
@@ -238,21 +264,24 @@ class TransactionRepositoryImpl(
         withContext(Dispatchers.Default) {
             // First, get the transaction to find its timestamp
             val transaction =
-                transferQueries.selectById(transactionId.id, TransferMapper::mapRaw)
+                transferQueries
+                    .selectById(transactionId.id, TransferMapper::mapRaw)
                     .executeAsOneOrNull()
                     ?: throw IllegalArgumentException("Transaction not found: $transactionId")
 
             // Get the row position of the transaction (0-indexed, sorted by timestamp DESC)
             val rowPosition =
-                transferQueries.getTransactionRowPosition(
-                    accountId = accountId.id,
-                    targetTimestamp = transaction.timestamp.toEpochMilliseconds(),
-                    targetId = transactionId.id,
-                ).executeAsOne()
+                transferQueries
+                    .getTransactionRowPosition(
+                        accountId = accountId.id,
+                        targetTimestamp = transaction.timestamp.toEpochMilliseconds(),
+                        targetId = transactionId.id,
+                    ).executeAsOne()
 
             // Get total count to know if there are more items
             val totalCount =
-                transferQueries.countTransactionsByAccount(accountId.id)
+                transferQueries
+                    .countTransactionsByAccount(accountId.id)
                     .executeAsOne()
 
             // Calculate offset to center the transaction in the page
@@ -266,14 +295,12 @@ class TransactionRepositoryImpl(
 
             // Load the page
             val items =
-                transferQueries.selectRunningBalanceByAccountOffset(
-                    accountId = accountId.id,
-                    limit = pageSize.toLong(),
-                    offset = offset,
-                ) { id, timestamp, description, account_id, transaction_amount, running_balance,
-                    currency_id, currency_code, currency_name, currency_scale_factor, source_account_id, target_account_id,
-                    ->
-                    AccountRowMapper.mapRaw(
+                transferQueries
+                    .selectRunningBalanceByAccountOffset(
+                        accountId = accountId.id,
+                        limit = pageSize.toLong(),
+                        offset = offset,
+                    ) {
                         id,
                         timestamp,
                         description,
@@ -286,9 +313,22 @@ class TransactionRepositoryImpl(
                         currency_scale_factor,
                         source_account_id,
                         target_account_id,
-                    )
-                }
-                    .executeAsList()
+                        ->
+                        AccountRowMapper.mapRaw(
+                            id,
+                            timestamp,
+                            description,
+                            account_id,
+                            transaction_amount,
+                            running_balance,
+                            currency_id,
+                            currency_code,
+                            currency_name,
+                            currency_scale_factor,
+                            source_account_id,
+                            target_account_id,
+                        )
+                    }.executeAsList()
 
             // Find the target transaction's index within the loaded page
             val targetIndex =

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferAttributeRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferAttributeRepositoryImpl.kt
@@ -21,7 +21,8 @@ class TransferAttributeRepositoryImpl(
     private val queries = database.transferAttributeQueries
 
     override fun getByTransaction(transactionId: TransferId): Flow<List<TransferAttribute>> =
-        queries.selectByTransaction(transactionId.id)
+        queries
+            .selectByTransaction(transactionId.id)
             .asFlow()
             .mapToList(Dispatchers.Default)
             .map { list ->

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferSourceRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferSourceRepositoryImpl.kt
@@ -57,12 +57,8 @@ class TransferSourceRepositoryImpl(
             // Get device_id from the CSV import metadata
             val csvImport =
                 csvImportQueries
-                    .selectImportByTableName(
-                        csvImportQueries
-                            .selectImportById(csvImportId.toString())
-                            .executeAsOne()
-                            .table_name,
-                    ).executeAsOne()
+                    .selectImportById(csvImportId.toString())
+                    .executeAsOne()
 
             // Insert base TransferSource record
             queries.insertCsvImportBase(

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferSourceRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferSourceRepositoryImpl.kt
@@ -41,7 +41,8 @@ class TransferSourceRepositoryImpl(
                 device_id = deviceId.id,
             )
 
-            queries.selectByTransactionIdAndRevision(transactionId.id, revisionId)
+            queries
+                .selectByTransactionIdAndRevision(transactionId.id, revisionId)
                 .executeAsOne()
                 .let(TransferSourceFromRevisionMapper::map)
         }
@@ -55,10 +56,13 @@ class TransferSourceRepositoryImpl(
         withContext(Dispatchers.Default) {
             // Get device_id from the CSV import metadata
             val csvImport =
-                csvImportQueries.selectImportByTableName(
-                    csvImportQueries.selectImportById(csvImportId.toString())
-                        .executeAsOne().table_name,
-                ).executeAsOne()
+                csvImportQueries
+                    .selectImportByTableName(
+                        csvImportQueries
+                            .selectImportById(csvImportId.toString())
+                            .executeAsOne()
+                            .table_name,
+                    ).executeAsOne()
 
             // Insert base TransferSource record
             queries.insertCsvImportBase(
@@ -74,7 +78,8 @@ class TransferSourceRepositoryImpl(
                 csv_row_index = rowIndex,
             )
 
-            queries.selectByTransactionIdAndRevision(transactionId.id, revisionId)
+            queries
+                .selectByTransactionIdAndRevision(transactionId.id, revisionId)
                 .executeAsOne()
                 .let(TransferSourceFromRevisionMapper::map)
         }
@@ -109,7 +114,8 @@ class TransferSourceRepositoryImpl(
 
     override suspend fun getSourcesForTransaction(transactionId: TransferId): List<TransferSource> =
         withContext(Dispatchers.Default) {
-            queries.selectAllByTransactionId(transactionId.id)
+            queries
+                .selectAllByTransactionId(transactionId.id)
                 .executeAsList()
                 .map(TransferSourceFromTransactionIdMapper::map)
         }
@@ -119,7 +125,8 @@ class TransferSourceRepositoryImpl(
         revisionId: Long,
     ): TransferSource? =
         withContext(Dispatchers.Default) {
-            queries.selectByTransactionIdAndRevision(transactionId.id, revisionId)
+            queries
+                .selectByTransactionIdAndRevision(transactionId.id, revisionId)
                 .executeAsOneOrNull()
                 ?.let(TransferSourceFromRevisionMapper::map)
         }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
@@ -73,12 +73,16 @@ sealed interface Resolution {
     /**
      * Map to an existing entity by ID.
      */
-    data class MapToExisting(val id: Long) : Resolution
+    data class MapToExisting(
+        val id: Long,
+    ) : Resolution
 
     /**
      * Create a new entity with the given name.
      */
-    data class CreateNew(val name: String) : Resolution
+    data class CreateNew(
+        val name: String,
+    ) : Resolution
 }
 
 /**
@@ -129,16 +133,17 @@ class CsvStrategyExportService(
                 },
             attributeMappings = strategy.attributeMappings,
             accountMappings =
-                accountMappings?.map { mapping ->
-                    val account =
-                        accountsById[mapping.accountId]
-                            ?: error("Missing account for id ${mapping.accountId.id} in CsvAccountMapping")
-                    CsvAccountMappingExport(
-                        columnName = mapping.columnName,
-                        valuePattern = mapping.valuePattern.pattern,
-                        accountName = account.name,
-                    )
-                }.orEmpty(),
+                accountMappings
+                    ?.map { mapping ->
+                        val account =
+                            accountsById[mapping.accountId]
+                                ?: error("Missing account for id ${mapping.accountId.id} in CsvAccountMapping")
+                        CsvAccountMappingExport(
+                            columnName = mapping.columnName,
+                            valuePattern = mapping.valuePattern.pattern,
+                            accountName = account.name,
+                        )
+                    }.orEmpty(),
         )
     }
 

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/IncrementalMaterializedViewRefreshTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/IncrementalMaterializedViewRefreshTest.kt
@@ -42,15 +42,16 @@ class IncrementalMaterializedViewRefreshTest : DbTest() {
      */
     private fun countPendingChanges(): Long {
         val sql = "SELECT COUNT(*) FROM pending_materialized_view_changes"
-        return database.executeQuery(
-            identifier = null,
-            sql = sql,
-            mapper = { cursor ->
-                cursor.next()
-                QueryResult.Value(cursor.getLong(0)!!)
-            },
-            parameters = 0,
-        ).value
+        return database
+            .executeQuery(
+                identifier = null,
+                sql = sql,
+                mapper = { cursor ->
+                    cursor.next()
+                    QueryResult.Value(cursor.getLong(0)!!)
+                },
+                parameters = 0,
+            ).value
     }
 
     /**
@@ -59,24 +60,25 @@ class IncrementalMaterializedViewRefreshTest : DbTest() {
      */
     private fun selectBalancesFromView(): List<BalanceViewRecord> {
         val sql = "SELECT account_id, currency_id, balance FROM account_balance_view ORDER BY account_id, currency_id"
-        return database.executeQuery(
-            identifier = null,
-            sql = sql,
-            mapper = { cursor ->
-                val results = mutableListOf<BalanceViewRecord>()
-                while (cursor.next().value) {
-                    results.add(
-                        BalanceViewRecord(
-                            accountId = cursor.getLong(0)!!,
-                            currencyId = cursor.getLong(1)!!,
-                            balance = cursor.getLong(2),
-                        ),
-                    )
-                }
-                QueryResult.Value(results)
-            },
-            parameters = 0,
-        ).value
+        return database
+            .executeQuery(
+                identifier = null,
+                sql = sql,
+                mapper = { cursor ->
+                    val results = mutableListOf<BalanceViewRecord>()
+                    while (cursor.next().value) {
+                        results.add(
+                            BalanceViewRecord(
+                                accountId = cursor.getLong(0)!!,
+                                currencyId = cursor.getLong(1)!!,
+                                balance = cursor.getLong(2),
+                            ),
+                        )
+                    }
+                    QueryResult.Value(results)
+                },
+                parameters = 0,
+            ).value
     }
 
     // Helper to verify materialized views match the source views
@@ -86,7 +88,8 @@ class IncrementalMaterializedViewRefreshTest : DbTest() {
 
         // Query both materialized views and views
         val materializedBalances =
-            database.transferQueries.selectAllBalances()
+            database.transferQueries
+                .selectAllBalances()
                 .executeAsList()
                 .sortedWith(compareBy({ it.account_id }, { it.currency_id }))
 
@@ -727,14 +730,16 @@ class IncrementalMaterializedViewRefreshTest : DbTest() {
             // Do incremental refresh
             repositories.maintenanceService.refreshMaterializedViews()
             val incrementalBalances =
-                database.transferQueries.selectAllBalances()
+                database.transferQueries
+                    .selectAllBalances()
                     .executeAsList()
                     .sortedBy { "${it.account_id}-${it.currency_id}" }
 
             // Do full refresh
             repositories.maintenanceService.fullRefreshMaterializedViews()
             val fullBalances =
-                database.transferQueries.selectAllBalances()
+                database.transferQueries
+                    .selectAllBalances()
                     .executeAsList()
                     .sortedBy { "${it.account_id}-${it.currency_id}" }
 

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/audit/AuditFunctionalTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/audit/AuditFunctionalTest.kt
@@ -73,26 +73,27 @@ class AuditFunctionalTest : DbTest() {
             ORDER BY account_audit.audit_timestamp DESC, account_audit.id DESC
             """.trimIndent()
 
-        return database.executeQuery(
-            identifier = null,
-            sql = sql,
-            mapper = { cursor ->
-                val results = mutableListOf<AccountAuditRecord>()
-                while (cursor.next().value) {
-                    results.add(
-                        AccountAuditRecord(
-                            auditId = cursor.getLong(0)!!,
-                            auditTimestamp = cursor.getLong(1)!!,
-                            auditType = cursor.getString(2)!!,
-                            id = cursor.getLong(3)!!,
-                            name = cursor.getString(4)!!,
-                        ),
-                    )
-                }
-                QueryResult.Value(results)
-            },
-            parameters = 0,
-        ).value
+        return database
+            .executeQuery(
+                identifier = null,
+                sql = sql,
+                mapper = { cursor ->
+                    val results = mutableListOf<AccountAuditRecord>()
+                    while (cursor.next().value) {
+                        results.add(
+                            AccountAuditRecord(
+                                auditId = cursor.getLong(0)!!,
+                                auditTimestamp = cursor.getLong(1)!!,
+                                auditType = cursor.getString(2)!!,
+                                id = cursor.getLong(3)!!,
+                                name = cursor.getString(4)!!,
+                            ),
+                        )
+                    }
+                    QueryResult.Value(results)
+                },
+                parameters = 0,
+            ).value
     }
 
     /**
@@ -115,27 +116,28 @@ class AuditFunctionalTest : DbTest() {
             ORDER BY currency_audit.audit_timestamp DESC, currency_audit.id DESC
             """.trimIndent()
 
-        return database.executeQuery(
-            identifier = null,
-            sql = sql,
-            mapper = { cursor ->
-                val results = mutableListOf<CurrencyAuditRecord>()
-                while (cursor.next().value) {
-                    results.add(
-                        CurrencyAuditRecord(
-                            auditId = cursor.getLong(0)!!,
-                            auditTimestamp = cursor.getLong(1)!!,
-                            auditType = cursor.getString(2)!!,
-                            id = cursor.getLong(3)!!,
-                            code = cursor.getString(4)!!,
-                            name = cursor.getString(5)!!,
-                        ),
-                    )
-                }
-                QueryResult.Value(results)
-            },
-            parameters = 0,
-        ).value
+        return database
+            .executeQuery(
+                identifier = null,
+                sql = sql,
+                mapper = { cursor ->
+                    val results = mutableListOf<CurrencyAuditRecord>()
+                    while (cursor.next().value) {
+                        results.add(
+                            CurrencyAuditRecord(
+                                auditId = cursor.getLong(0)!!,
+                                auditTimestamp = cursor.getLong(1)!!,
+                                auditType = cursor.getString(2)!!,
+                                id = cursor.getLong(3)!!,
+                                code = cursor.getString(4)!!,
+                                name = cursor.getString(5)!!,
+                            ),
+                        )
+                    }
+                    QueryResult.Value(results)
+                },
+                parameters = 0,
+            ).value
     }
 
     /**
@@ -157,26 +159,27 @@ class AuditFunctionalTest : DbTest() {
             ORDER BY category_audit.audit_timestamp DESC, category_audit.id DESC
             """.trimIndent()
 
-        return database.executeQuery(
-            identifier = null,
-            sql = sql,
-            mapper = { cursor ->
-                val results = mutableListOf<CategoryAuditRecord>()
-                while (cursor.next().value) {
-                    results.add(
-                        CategoryAuditRecord(
-                            auditId = cursor.getLong(0)!!,
-                            auditTimestamp = cursor.getLong(1)!!,
-                            auditType = cursor.getString(2)!!,
-                            id = cursor.getLong(3)!!,
-                            name = cursor.getString(4)!!,
-                        ),
-                    )
-                }
-                QueryResult.Value(results)
-            },
-            parameters = 0,
-        ).value
+        return database
+            .executeQuery(
+                identifier = null,
+                sql = sql,
+                mapper = { cursor ->
+                    val results = mutableListOf<CategoryAuditRecord>()
+                    while (cursor.next().value) {
+                        results.add(
+                            CategoryAuditRecord(
+                                auditId = cursor.getLong(0)!!,
+                                auditTimestamp = cursor.getLong(1)!!,
+                                auditType = cursor.getString(2)!!,
+                                id = cursor.getLong(3)!!,
+                                name = cursor.getString(4)!!,
+                            ),
+                        )
+                    }
+                    QueryResult.Value(results)
+                },
+                parameters = 0,
+            ).value
     }
 
     @Test

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvDuplicateDetectionTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvDuplicateDetectionTest.kt
@@ -57,8 +57,8 @@ class CsvDuplicateDetectionTest {
             CsvColumn(CsvColumnId(Uuid.random()), 3, "Amount"),
         )
 
-    private fun createStrategy(attributeMappings: List<AttributeColumnMapping> = emptyList()): CsvImportStrategy {
-        return CsvImportStrategy(
+    private fun createStrategy(attributeMappings: List<AttributeColumnMapping> = emptyList()): CsvImportStrategy =
+        CsvImportStrategy(
             id = CsvImportStrategyId(Uuid.random()),
             name = "Test Strategy",
             identificationColumns = setOf("Date", "Description", "Amount"),
@@ -114,7 +114,6 @@ class CsvDuplicateDetectionTest {
             createdAt = Clock.System.now(),
             updatedAt = Clock.System.now(),
         )
-    }
 
     private fun createExistingTransfer(
         transactionId: String,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvImportDuplicateDetectionIntegrationTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CsvImportDuplicateDetectionIntegrationTest.kt
@@ -62,7 +62,11 @@ class CsvImportDuplicateDetectionIntegrationTest : DbTest() {
                 openingDate = Clock.System.now(),
             )
         repositories.accountRepository.createAccount(sourceAccount)
-        sourceAccount = repositories.accountRepository.getAllAccounts().first().first { it.name == "Test Source" }
+        sourceAccount =
+            repositories.accountRepository
+                .getAllAccounts()
+                .first()
+                .first { it.name == "Test Source" }
 
         targetAccount =
             Account(
@@ -71,11 +75,15 @@ class CsvImportDuplicateDetectionIntegrationTest : DbTest() {
                 openingDate = Clock.System.now(),
             )
         repositories.accountRepository.createAccount(targetAccount)
-        targetAccount = repositories.accountRepository.getAllAccounts().first().first { it.name == "Test Target" }
+        targetAccount =
+            repositories.accountRepository
+                .getAllAccounts()
+                .first()
+                .first { it.name == "Test Target" }
     }
 
-    private fun createTestStrategy(): CsvImportStrategy {
-        return CsvImportStrategy(
+    private fun createTestStrategy(): CsvImportStrategy =
+        CsvImportStrategy(
             id = CsvImportStrategyId(Uuid.random()),
             name = "Test Strategy",
             identificationColumns = setOf("Date", "Description", "Amount"),
@@ -138,16 +146,14 @@ class CsvImportDuplicateDetectionIntegrationTest : DbTest() {
             createdAt = Clock.System.now(),
             updatedAt = Clock.System.now(),
         )
-    }
 
-    private fun createTestColumns(): List<CsvColumn> {
-        return listOf(
+    private fun createTestColumns(): List<CsvColumn> =
+        listOf(
             CsvColumn(CsvColumnId(Uuid.random()), 0, "Transaction ID"),
             CsvColumn(CsvColumnId(Uuid.random()), 1, "Date"),
             CsvColumn(CsvColumnId(Uuid.random()), 2, "Description"),
             CsvColumn(CsvColumnId(Uuid.random()), 3, "Amount"),
         )
-    }
 
     @Test
     fun `full import flow should detect duplicates using existing transfers from repository`() =
@@ -190,10 +196,11 @@ class CsvImportDuplicateDetectionIntegrationTest : DbTest() {
 
             // Query back the created transfer
             val createdTransfersList =
-                repositories.transactionRepository.getTransactionsByDateRange(
-                    startDate = timestamp,
-                    endDate = timestamp,
-                ).first()
+                repositories.transactionRepository
+                    .getTransactionsByDateRange(
+                        startDate = timestamp,
+                        endDate = timestamp,
+                    ).first()
             val existingTransferId = createdTransfersList.first { it.description == "Coffee" }.id
 
             // Verify transfer was created
@@ -210,11 +217,12 @@ class CsvImportDuplicateDetectionIntegrationTest : DbTest() {
 
             // Fetch existing transfers by account and date range (optimized approach)
             val existingTransfers =
-                repositories.transactionRepository.getTransactionsByAccountAndDateRange(
-                    accountId = sourceAccount.id,
-                    startDate = timestamp,
-                    endDate = timestamp,
-                ).first()
+                repositories.transactionRepository
+                    .getTransactionsByAccountAndDateRange(
+                        accountId = sourceAccount.id,
+                        startDate = timestamp,
+                        endDate = timestamp,
+                    ).first()
 
             // Build ExistingTransferInfo list like ApplyStrategyDialog does
             val existingTransferInfoList =
@@ -231,7 +239,8 @@ class CsvImportDuplicateDetectionIntegrationTest : DbTest() {
                                 val attributeValue =
                                     transfer.attributes
                                         .firstOrNull { it.attributeType.name == mapping.attributeTypeName }
-                                        ?.value.orEmpty()
+                                        ?.value
+                                        .orEmpty()
                                 mapping.columnName to attributeValue
                             }
 
@@ -248,7 +257,10 @@ class CsvImportDuplicateDetectionIntegrationTest : DbTest() {
 
             // Create mapper with existing transfers
             val accountsByName =
-                repositories.accountRepository.getAllAccounts().first().associateBy { it.name }
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .associateBy { it.name }
             val currenciesById = mapOf(testCurrency.id to testCurrency)
             val currenciesByCode = mapOf("GBP" to testCurrency)
 
@@ -266,9 +278,11 @@ class CsvImportDuplicateDetectionIntegrationTest : DbTest() {
             val rows =
                 listOf(
                     // Duplicate - same transaction ID
-                    com.moneymanager.domain.model.csv.CsvRow(1, listOf("TX001", "01/01/2024", "Coffee", "3.50")),
+                    com.moneymanager.domain.model.csv
+                        .CsvRow(1, listOf("TX001", "01/01/2024", "Coffee", "3.50")),
                     // New transaction
-                    com.moneymanager.domain.model.csv.CsvRow(2, listOf("TX002", "02/01/2024", "Lunch", "12.00")),
+                    com.moneymanager.domain.model.csv
+                        .CsvRow(2, listOf("TX002", "02/01/2024", "Lunch", "12.00")),
                 )
 
             val prep = mapper.prepareImport(rows)
@@ -322,10 +336,11 @@ class CsvImportDuplicateDetectionIntegrationTest : DbTest() {
 
             // Query back the created transfer
             val createdTransfersList =
-                repositories.transactionRepository.getTransactionsByDateRange(
-                    startDate = timestamp,
-                    endDate = timestamp,
-                ).first()
+                repositories.transactionRepository
+                    .getTransactionsByDateRange(
+                        startDate = timestamp,
+                        endDate = timestamp,
+                    ).first()
             val existingTransferId = createdTransfersList.first { it.description == "Coffee" }.id
 
             // Create strategy WITHOUT unique identifier attributes
@@ -342,11 +357,12 @@ class CsvImportDuplicateDetectionIntegrationTest : DbTest() {
 
             // Fetch existing transfers by account and date range
             val existingTransfers =
-                repositories.transactionRepository.getTransactionsByAccountAndDateRange(
-                    accountId = sourceAccount.id,
-                    startDate = timestamp,
-                    endDate = timestamp,
-                ).first()
+                repositories.transactionRepository
+                    .getTransactionsByAccountAndDateRange(
+                        accountId = sourceAccount.id,
+                        startDate = timestamp,
+                        endDate = timestamp,
+                    ).first()
             val existingTransferInfoList =
                 existingTransfers.map { transfer ->
                     ExistingTransferInfo(
@@ -358,7 +374,10 @@ class CsvImportDuplicateDetectionIntegrationTest : DbTest() {
                 }
 
             val accountsByName =
-                repositories.accountRepository.getAllAccounts().first().associateBy { it.name }
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .associateBy { it.name }
             val currenciesById = mapOf(testCurrency.id to testCurrency)
             val currenciesByCode = mapOf("GBP" to testCurrency)
 
@@ -380,7 +399,8 @@ class CsvImportDuplicateDetectionIntegrationTest : DbTest() {
                         listOf("TX001", "01/01/2024", "Coffee", "3.50"),
                     ),
                     // New transaction
-                    com.moneymanager.domain.model.csv.CsvRow(2, listOf("TX002", "02/01/2024", "Lunch", "12.00")),
+                    com.moneymanager.domain.model.csv
+                        .CsvRow(2, listOf("TX002", "02/01/2024", "Lunch", "12.00")),
                 )
 
             val prep = mapper.prepareImport(rows)

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/CsvAccountMappingRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/CsvAccountMappingRepositoryImplTest.kt
@@ -36,7 +36,11 @@ class CsvAccountMappingRepositoryImplTest : DbTest() {
         val strategyId = CsvImportStrategyId(Uuid.random())
 
         // Create required currency first
-        val currency = repositories.currencyRepository.getAllCurrencies().first().first()
+        val currency =
+            repositories.currencyRepository
+                .getAllCurrencies()
+                .first()
+                .first()
 
         // Create accounts that the strategy references
         val sourceAccount =

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/CurrencyRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/CurrencyRepositoryImplTest.kt
@@ -96,7 +96,11 @@ class CurrencyRepositoryImplTest : DbTest() {
     fun `upsertCurrencyByCode should be case sensitive`() =
         runTest {
             // Given - USD is already seeded
-            val initialCount = repositories.currencyRepository.getAllCurrencies().first().size
+            val initialCount =
+                repositories.currencyRepository
+                    .getAllCurrencies()
+                    .first()
+                    .size
 
             // When
             val lowercaseId = repositories.currencyRepository.upsertCurrencyByCode("usd", "US Dollar Lowercase")
@@ -116,7 +120,11 @@ class CurrencyRepositoryImplTest : DbTest() {
     fun `upsertCurrencyByCode should handle rapid consecutive calls for same code`() =
         runTest {
             // Given
-            val initialCount = repositories.currencyRepository.getAllCurrencies().first().size
+            val initialCount =
+                repositories.currencyRepository
+                    .getAllCurrencies()
+                    .first()
+                    .size
 
             // When - simulate rapid upserts for a new currency
             val id1 = repositories.currencyRepository.upsertCurrencyByCode("BTC", "Bitcoin")

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/DeviceRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/DeviceRepositoryImplTest.kt
@@ -25,23 +25,24 @@ class DeviceRepositoryImplTest : DbTest() {
      */
     private fun selectAllPlatforms(): List<PlatformRecord> {
         val sql = "SELECT id, name FROM platform"
-        return database.executeQuery(
-            identifier = null,
-            sql = sql,
-            mapper = { cursor ->
-                val results = mutableListOf<PlatformRecord>()
-                while (cursor.next().value) {
-                    results.add(
-                        PlatformRecord(
-                            id = cursor.getLong(0)!!,
-                            name = cursor.getString(1)!!,
-                        ),
-                    )
-                }
-                QueryResult.Value(results)
-            },
-            parameters = 0,
-        ).value
+        return database
+            .executeQuery(
+                identifier = null,
+                sql = sql,
+                mapper = { cursor ->
+                    val results = mutableListOf<PlatformRecord>()
+                    while (cursor.next().value) {
+                        results.add(
+                            PlatformRecord(
+                                id = cursor.getLong(0)!!,
+                                name = cursor.getString(1)!!,
+                            ),
+                        )
+                    }
+                    QueryResult.Value(results)
+                },
+                parameters = 0,
+            ).value
     }
 
     @Test

--- a/app/db/schemaspy/build.gradle.kts
+++ b/app/db/schemaspy/build.gradle.kts
@@ -20,7 +20,11 @@ val createDatabaseForSchemaSpy by tasks.registering(JavaExec::class) {
     group = "documentation"
     description = "Create a SQLite database file with the schema for SchemaSpy analysis"
 
-    val dbFile = layout.buildDirectory.file("schemaspy-temp.db").get().asFile
+    val dbFile =
+        layout.buildDirectory
+            .file("schemaspy-temp.db")
+            .get()
+            .asFile
 
     // Use the runtime classpath which includes SQLDelight generated code
     classpath = sourceSets["main"].runtimeClasspath
@@ -51,8 +55,16 @@ tasks.register<JavaExec>("generateSchemaSpyDocs") {
     classpath = schemaspyConfiguration
     mainClass.set("org.schemaspy.Main")
 
-    val outputDir = layout.buildDirectory.dir("schemaspy").get().asFile
-    val dbFile = layout.buildDirectory.file("schemaspy-temp.db").get().asFile
+    val outputDir =
+        layout.buildDirectory
+            .dir("schemaspy")
+            .get()
+            .asFile
+    val dbFile =
+        layout.buildDirectory
+            .file("schemaspy-temp.db")
+            .get()
+            .asFile
 
     doFirst {
         // Create output directory
@@ -65,12 +77,18 @@ tasks.register<JavaExec>("generateSchemaSpyDocs") {
     environment("PATH", "C:\\Program Files\\Graphviz\\bin;${System.getenv("PATH")}")
 
     args(
-        "-t", "sqlite-xerial",
-        "-db", dbFile.absolutePath,
-        "-o", outputDir.absolutePath,
-        "-cat", "%",
-        "-s", "main",
-        "-u", "",
+        "-t",
+        "sqlite-xerial",
+        "-db",
+        dbFile.absolutePath,
+        "-o",
+        outputDir.absolutePath,
+        "-cat",
+        "%",
+        "-s",
+        "main",
+        "-u",
+        "",
         "-sso",
         "-norows",
     )

--- a/app/di/core/src/androidMain/kotlin/com/moneymanager/di/AppComponentParams.kt
+++ b/app/di/core/src/androidMain/kotlin/com/moneymanager/di/AppComponentParams.kt
@@ -2,4 +2,6 @@ package com.moneymanager.di
 
 import android.content.Context
 
-actual data class AppComponentParams(val context: Context)
+actual data class AppComponentParams(
+    val context: Context,
+)

--- a/app/di/core/src/androidMain/kotlin/com/moneymanager/di/VersionReader.android.kt
+++ b/app/di/core/src/androidMain/kotlin/com/moneymanager/di/VersionReader.android.kt
@@ -21,14 +21,14 @@ fun initializeVersionReader(context: Context) {
  * Android implementation of version reader.
  * Reads the VERSION file from the assets folder.
  */
-actual fun readAppVersion(): AppVersion {
-    return try {
+actual fun readAppVersion(): AppVersion =
+    try {
         val versionString =
-            androidContext.assets.open("VERSION")
+            androidContext.assets
+                .open("VERSION")
                 .bufferedReader()
                 .use { it.readText().trim() }
         AppVersion(versionString)
     } catch (_: Exception) {
         AppVersion("Unknown")
     }
-}

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/AppVersionModule.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/AppVersionModule.kt
@@ -9,7 +9,5 @@ import dev.zacsweers.metro.SingleIn
 interface AppVersionModule {
     @Provides
     @SingleIn(AppScope::class)
-    fun provideAppVersion(): AppVersion {
-        return readAppVersion()
-    }
+    fun provideAppVersion(): AppVersion = readAppVersion()
 }

--- a/app/di/core/src/jvmMain/kotlin/com/moneymanager/di/VersionReader.jvm.kt
+++ b/app/di/core/src/jvmMain/kotlin/com/moneymanager/di/VersionReader.jvm.kt
@@ -6,12 +6,11 @@ import com.moneymanager.domain.model.AppVersion
  * JVM implementation of version reader.
  * Reads the VERSION file from the classpath resources.
  */
-actual fun readAppVersion(): AppVersion {
-    return try {
+actual fun readAppVersion(): AppVersion =
+    try {
         val versionStream = object {}.javaClass.getResourceAsStream("/VERSION")
         val versionString = versionStream?.bufferedReader()?.use { it.readText().trim() } ?: "Unknown"
         AppVersion(versionString)
     } catch (_: Exception) {
         AppVersion("Unknown")
     }
-}

--- a/app/main/android/build.gradle.kts
+++ b/app/main/android/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     sourceSets {
         getByName("main") {
-            assets.srcDirs("src/main/assets")
+            assets.directories.add("src/main/assets")
         }
     }
 }
@@ -37,10 +37,10 @@ tasks.matching { it.name.startsWith("explodeAssetSource") }.configureEach {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation(compose.components.resources)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.compose.runtime)
+    implementation(libs.compose.components.resources)
     implementation(libs.kotlinx.coroutines.core)
     implementation(projects.app.db.core)
     implementation(projects.app.di.core)

--- a/app/main/android/src/main/kotlin/com/moneymanager/android/MainActivity.kt
+++ b/app/main/android/src/main/kotlin/com/moneymanager/android/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -30,6 +31,7 @@ private const val TAG = "MainActivity"
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
 
         // Set up global exception handler for schema errors
         val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()

--- a/app/main/android/src/main/kotlin/com/moneymanager/android/MainActivity.kt
+++ b/app/main/android/src/main/kotlin/com/moneymanager/android/MainActivity.kt
@@ -71,7 +71,10 @@ private sealed class AppDatabaseState {
         val databaseComponent: DatabaseComponent,
     ) : AppDatabaseState()
 
-    data class Error(val location: DbLocation, val error: Throwable) : AppDatabaseState()
+    data class Error(
+        val location: DbLocation,
+        val error: Throwable,
+    ) : AppDatabaseState()
 }
 
 @Suppress("FunctionName")

--- a/app/main/jvm/build.gradle.kts
+++ b/app/main/jvm/build.gradle.kts
@@ -38,7 +38,10 @@ compose.desktop {
         buildTypes.release {
             proguard {
                 isEnabled.set(true)
-                version.set(libs.versions.proguard.get().toString())
+                version.set(
+                    libs.versions.proguard
+                        .get(),
+                )
                 configurationFiles.from(project.file("proguard-rules.pro"))
             }
         }
@@ -46,7 +49,8 @@ compose.desktop {
         // Add required Java modules for the bundled JRE
         jvmArgs +=
             listOf(
-                "--add-modules", "java.sql",
+                "--add-modules",
+                "java.sql",
             )
 
         nativeDistributions {

--- a/app/main/jvm/src/main/kotlin/com/moneymanager/Main.kt
+++ b/app/main/jvm/src/main/kotlin/com/moneymanager/Main.kt
@@ -57,7 +57,10 @@ private sealed class AppDatabaseState {
         val databaseComponent: DatabaseComponent,
     ) : AppDatabaseState()
 
-    data class Error(val location: DbLocation, val error: Throwable) : AppDatabaseState()
+    data class Error(
+        val location: DbLocation,
+        val error: Throwable,
+    ) : AppDatabaseState()
 }
 
 @Composable

--- a/app/model/core/src/androidMain/kotlin/com/moneymanager/domain/model/DbLocation.kt
+++ b/app/model/core/src/androidMain/kotlin/com/moneymanager/domain/model/DbLocation.kt
@@ -1,6 +1,8 @@
 package com.moneymanager.domain.model
 
-actual data class DbLocation(val name: String) {
+actual data class DbLocation(
+    val name: String,
+) {
     /**
      * On Android, checking file existence requires Context.
      * Use [com.moneymanager.database.DatabaseManager.databaseExists] for actual file existence checks.

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Account.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Account.kt
@@ -15,6 +15,8 @@ data class Account(
 
 @Serializable
 @JvmInline
-value class AccountId(val id: Long) {
+value class AccountId(
+    val id: Long,
+) {
     override fun toString() = id.toString()
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AppVersion.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AppVersion.kt
@@ -4,4 +4,6 @@ package com.moneymanager.domain.model
  * Type-safe wrapper for the application version string.
  */
 @JvmInline
-value class AppVersion(val value: String)
+value class AppVersion(
+    val value: String,
+)

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AttributeType.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AttributeType.kt
@@ -9,6 +9,8 @@ data class AttributeType(
 
 @Serializable
 @JvmInline
-value class AttributeTypeId(val id: Long) {
+value class AttributeTypeId(
+    val id: Long,
+) {
     override fun toString() = id.toString()
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/CurrencyScaleFactors.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/CurrencyScaleFactors.kt
@@ -86,9 +86,7 @@ object CurrencyScaleFactors {
      * @param currencyCode The ISO 4217 currency code (e.g., "USD", "JPY", "BHD")
      * @return The scale factor for the currency (e.g., 100 for USD, 1 for JPY, 1000 for BHD)
      */
-    fun getScaleFactor(currencyCode: String): Int {
-        return scaleFactors[currencyCode.uppercase()] ?: DEFAULT_SCALE_FACTOR
-    }
+    fun getScaleFactor(currencyCode: String): Int = scaleFactors[currencyCode.uppercase()] ?: DEFAULT_SCALE_FACTOR
 
     /**
      * Gets the number of decimal places for a given ISO 4217 currency code.

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/DeviceId.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/DeviceId.kt
@@ -1,6 +1,8 @@
 package com.moneymanager.domain.model
 
 @JvmInline
-value class DeviceId(val id: Long) {
+value class DeviceId(
+    val id: Long,
+) {
     override fun toString() = id.toString()
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/EntitySource.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/EntitySource.kt
@@ -7,7 +7,9 @@ import kotlin.time.Instant
 /**
  * Represents the entity types that can have source tracking.
  */
-enum class EntityType(val id: Long) {
+enum class EntityType(
+    val id: Long,
+) {
     ACCOUNT(1),
     PERSON(2),
     CURRENCY(3),

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Money.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Money.kt
@@ -62,9 +62,7 @@ data class Money(
      * @param multiplier The value to multiply by
      * @return A new Money instance with the product
      */
-    operator fun times(multiplier: Long): Money {
-        return Money(amount * multiplier, currency)
-    }
+    operator fun times(multiplier: Long): Money = Money(amount * multiplier, currency)
 
     /**
      * Multiplies this Money amount by a scalar value.
@@ -72,9 +70,7 @@ data class Money(
      * @param multiplier The value to multiply by
      * @return A new Money instance with the product
      */
-    operator fun times(multiplier: Int): Money {
-        return Money(amount * multiplier, currency)
-    }
+    operator fun times(multiplier: Int): Money = Money(amount * multiplier, currency)
 
     /**
      * Divides this Money amount by a scalar value.
@@ -82,9 +78,7 @@ data class Money(
      * @param divisor The value to divide by
      * @return A new Money instance with the quotient
      */
-    operator fun div(divisor: Long): Money {
-        return Money(amount / divisor, currency)
-    }
+    operator fun div(divisor: Long): Money = Money(amount / divisor, currency)
 
     /**
      * Divides this Money amount by a scalar value.
@@ -92,18 +86,14 @@ data class Money(
      * @param divisor The value to divide by
      * @return A new Money instance with the quotient
      */
-    operator fun div(divisor: Int): Money {
-        return Money(amount / divisor, currency)
-    }
+    operator fun div(divisor: Int): Money = Money(amount / divisor, currency)
 
     /**
      * Negates this Money amount.
      *
      * @return A new Money instance with the negated amount
      */
-    operator fun unaryMinus(): Money {
-        return Money(-amount, currency)
-    }
+    operator fun unaryMinus(): Money = Money(-amount, currency)
 
     /**
      * Compares this Money amount with another.
@@ -143,9 +133,7 @@ data class Money(
      *
      * @return A new Money instance with the absolute amount
      */
-    fun abs(): Money {
-        return if (amount < 0) Money(-amount, currency) else this
-    }
+    fun abs(): Money = if (amount < 0) Money(-amount, currency) else this
 
     private fun requireSameCurrency(other: Money) {
         require(currency.id == other.currency.id) {
@@ -180,9 +168,7 @@ data class Money(
         fun fromDisplayValue(
             displayValue: String,
             currency: Currency,
-        ): Money {
-            return fromDisplayValue(BigDecimal(displayValue), currency)
-        }
+        ): Money = fromDisplayValue(BigDecimal(displayValue), currency)
 
         /**
          * Creates a zero Money instance for a given currency.
@@ -190,8 +176,6 @@ data class Money(
          * @param currency The currency of the amount
          * @return A new Money instance with zero amount
          */
-        fun zero(currency: Currency): Money {
-            return Money(0L, currency)
-        }
+        fun zero(currency: Currency): Money = Money(0L, currency)
     }
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Person.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Person.kt
@@ -26,6 +26,8 @@ data class Person(
 
 @Serializable
 @JvmInline
-value class PersonId(val id: Long) {
+value class PersonId(
+    val id: Long,
+) {
     override fun toString() = id.toString()
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/SourceType.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/SourceType.kt
@@ -4,7 +4,9 @@ package com.moneymanager.domain.model
  * Represents the source/origin of a transfer audit entry.
  * Tracks how each change (INSERT, UPDATE, DELETE) was initiated.
  */
-enum class SourceType(val id: Int) {
+enum class SourceType(
+    val id: Int,
+) {
     /** Manual entry by user */
     MANUAL(1),
 

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Transfer.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Transfer.kt
@@ -16,6 +16,8 @@ data class Transfer(
 )
 
 @JvmInline
-value class TransferId(override val id: Long) : TransactionId {
+value class TransferId(
+    override val id: Long,
+) : TransactionId {
     override fun toString() = id.toString()
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csv/CsvColumn.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csv/CsvColumn.kt
@@ -7,7 +7,9 @@ import kotlin.uuid.Uuid
 @JvmInline
 value class CsvColumnId
     @OptIn(ExperimentalUuidApi::class)
-    constructor(val id: Uuid) {
+    constructor(
+        val id: Uuid,
+    ) {
         @OptIn(ExperimentalUuidApi::class)
         override fun toString() = id.toString()
     }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csv/CsvImport.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csv/CsvImport.kt
@@ -12,7 +12,9 @@ import kotlin.uuid.Uuid
 @JvmInline
 value class CsvImportId
     @OptIn(ExperimentalUuidApi::class)
-    constructor(val id: Uuid) {
+    constructor(
+        val id: Uuid,
+    ) {
         @OptIn(ExperimentalUuidApi::class)
         override fun toString() = id.toString()
     }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategyId.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategyId.kt
@@ -5,6 +5,8 @@ package com.moneymanager.domain.model.csvstrategy
 import kotlin.uuid.Uuid
 
 @JvmInline
-value class CsvImportStrategyId(val id: Uuid) {
+value class CsvImportStrategyId(
+    val id: Uuid,
+) {
     override fun toString() = id.toString()
 }

--- a/app/model/core/src/jvmMain/kotlin/com/moneymanager/domain/model/DbLocation.kt
+++ b/app/model/core/src/jvmMain/kotlin/com/moneymanager/domain/model/DbLocation.kt
@@ -3,7 +3,9 @@ package com.moneymanager.domain.model
 import java.nio.file.Path
 import kotlin.io.path.exists
 
-actual data class DbLocation(val path: Path) {
+actual data class DbLocation(
+    val path: Path,
+) {
     actual fun exists() = path.exists()
 
     override fun toString() = path.toString()

--- a/app/ui/core/build.gradle.kts
+++ b/app/ui/core/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
                 api(projects.app.db.core)
                 api(projects.app.model.core)
 
-                implementation(compose.components.resources)
+                implementation(libs.compose.components.resources)
                 implementation(libs.human.readable)
                 implementation(libs.kmlogging)
                 implementation(libs.kotlinx.datetime)

--- a/app/ui/core/build.gradle.kts
+++ b/app/ui/core/build.gradle.kts
@@ -10,12 +10,12 @@ kotlin {
                 api(libs.kotlinx.coroutines.core)
                 api(projects.app.db.core)
                 api(projects.app.model.core)
+                api(projects.utils.bigdecimal)
 
                 implementation(libs.compose.components.resources)
                 implementation(libs.human.readable)
                 implementation(libs.kmlogging)
                 implementation(libs.kotlinx.datetime)
-                implementation(projects.utils.bigdecimal)
                 implementation(projects.utils.compose.filePicker)
                 implementation(projects.utils.compose.scrollbar)
                 implementation(projects.utils.currency)
@@ -63,6 +63,7 @@ kotlin {
                 api(libs.compose.ui.unit.desktop)
                 api(projects.app.db.core)
                 api(projects.app.model.core)
+                api(projects.utils.bigdecimal)
 
                 implementation(libs.compose.animation.core.desktop)
                 implementation(libs.compose.animation.desktop)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -109,12 +109,14 @@ fun MoneyManagerApp(
         var transactionRefreshTrigger by remember { mutableStateOf(0) }
 
         var defaultCurrencyLoaded by remember { mutableStateOf(false) }
-        val defaultCurrencyId by settingsRepository.getDefaultCurrencyId()
+        val defaultCurrencyId by settingsRepository
+            .getDefaultCurrencyId()
             .onEach { defaultCurrencyLoaded = true }
             .collectAsStateWithSchemaErrorHandling(initial = null)
 
         // Use schema-error-aware collection for flows that may fail on old databases
-        val accounts by accountRepository.getAllAccounts()
+        val accounts by accountRepository
+            .getAllAccounts()
             .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
         MaterialTheme {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -5,7 +5,9 @@ package com.moneymanager.ui
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
@@ -129,6 +131,8 @@ fun MoneyManagerApp(
                 modifier =
                     Modifier
                         .fillMaxSize()
+                        .systemBarsPadding()
+                        .imePadding()
                         .mouseButtonNavigation(
                             onBack = { navigationHistory.navigateBack() },
                             onForward = { navigationHistory.navigateForward() },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/audit/AuditEntryDiff.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/audit/AuditEntryDiff.kt
@@ -35,7 +35,8 @@ data class AuditEntryDiff(
     val hasChanges: Boolean
         get() =
             listOf(timestamp, description, sourceAccountId, targetAccountId, amount)
-                .any { it is FieldChange.Changed } || attributeChanges.isNotEmpty()
+                .any { it is FieldChange.Changed } ||
+                attributeChanges.isNotEmpty()
 }
 
 /**

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/audit/AuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/audit/AuditScreen.kt
@@ -32,7 +32,10 @@ import org.lighthousegames.logging.logging
 
 private val logger = logging()
 
-data class AuditScreenData<D>(val title: String, val diffs: List<D>)
+data class AuditScreenData<D>(
+    val title: String,
+    val diffs: List<D>,
+)
 
 @Composable
 fun <D : Any> AuditScreen(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/audit/FieldChange.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/audit/FieldChange.kt
@@ -8,22 +8,31 @@ sealed class FieldChange<out T> {
     /**
      * Field value changed from [oldValue] to [newValue].
      */
-    data class Changed<T>(val oldValue: T, val newValue: T) : FieldChange<T>()
+    data class Changed<T>(
+        val oldValue: T,
+        val newValue: T,
+    ) : FieldChange<T>()
 
     /**
      * Field value remained the same.
      */
-    data class Unchanged<T>(val value: T) : FieldChange<T>()
+    data class Unchanged<T>(
+        val value: T,
+    ) : FieldChange<T>()
 
     /**
      * Field was created with this initial [value] (INSERT operation).
      */
-    data class Created<T>(val value: T) : FieldChange<T>()
+    data class Created<T>(
+        val value: T,
+    ) : FieldChange<T>()
 
     /**
      * Field was deleted with this final [value] (DELETE operation).
      */
-    data class Deleted<T>(val value: T) : FieldChange<T>()
+    data class Deleted<T>(
+        val value: T,
+    ) : FieldChange<T>()
 
     /**
      * Gets the current/new value from any change type.

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/AccountPicker.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/AccountPicker.kt
@@ -60,7 +60,8 @@ fun AccountPicker(
     excludeAccountId: AccountId? = null,
     isError: Boolean = false,
 ) {
-    val accounts by accountRepository.getAllAccounts()
+    val accounts by accountRepository
+        .getAllAccounts()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     var expanded by remember { mutableStateOf(false) }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
@@ -75,9 +75,11 @@ fun CreateAccountDialog(
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var isSaving by remember { mutableStateOf(false) }
 
-    val categories by categoryRepository.getAllCategories()
+    val categories by categoryRepository
+        .getAllCategories()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val people by personRepository.getAllPeople()
+    val people by personRepository
+        .getAllPeople()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     val scope = rememberSchemaAwareCoroutineScope()
 
@@ -224,7 +226,9 @@ fun CreateAccountDialog(
                                 selectedOwnerIds.forEach { personId ->
                                     val ownershipId =
                                         personAccountOwnershipRepository.createOwnership(
-                                            personId = com.moneymanager.domain.model.PersonId(personId),
+                                            personId =
+                                                com.moneymanager.domain.model
+                                                    .PersonId(personId),
                                             accountId = accountId,
                                         )
                                     // Record source for ownership audit trail

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
@@ -36,6 +36,7 @@ import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.DeviceId
 import com.moneymanager.domain.model.EntityType
+import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
@@ -226,9 +227,7 @@ fun CreateAccountDialog(
                                 selectedOwnerIds.forEach { personId ->
                                     val ownershipId =
                                         personAccountOwnershipRepository.createOwnership(
-                                            personId =
-                                                com.moneymanager.domain.model
-                                                    .PersonId(personId),
+                                            personId = PersonId(personId),
                                             accountId = accountId,
                                         )
                                     // Record source for ownership audit trail

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CurrencyPicker.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CurrencyPicker.kt
@@ -48,7 +48,8 @@ fun CurrencyPicker(
     placeholder: String = "Type to search...",
     isError: Boolean = false,
 ) {
-    val currencies by currencyRepository.getAllCurrencies()
+    val currencies by currencyRepository
+        .getAllCurrencies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     var expanded by remember { mutableStateOf(false) }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
@@ -71,11 +71,14 @@ fun EditAccountDialog(
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var isSaving by remember { mutableStateOf(false) }
 
-    val categories by categoryRepository.getAllCategories()
+    val categories by categoryRepository
+        .getAllCategories()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val people by personRepository.getAllPeople()
+    val people by personRepository
+        .getAllPeople()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val existingOwnerships by personAccountOwnershipRepository.getOwnershipsByAccount(account.id)
+    val existingOwnerships by personAccountOwnershipRepository
+        .getOwnershipsByAccount(account.id)
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     var selectedOwnerIds by remember(existingOwnerships) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTable.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTable.kt
@@ -85,8 +85,7 @@ fun CsvPreviewTable(
                         .border(
                             width = 1.dp,
                             color = MaterialTheme.colorScheme.outline,
-                        )
-                        .padding(8.dp),
+                        ).padding(8.dp),
             ) {
                 SelectableText(
                     text = "Row",
@@ -105,8 +104,7 @@ fun CsvPreviewTable(
                         .border(
                             width = 1.dp,
                             color = MaterialTheme.colorScheme.outline,
-                        )
-                        .padding(8.dp),
+                        ).padding(8.dp),
             ) {
                 SelectableText(
                     text = "Status",
@@ -125,8 +123,7 @@ fun CsvPreviewTable(
                         .border(
                             width = 1.dp,
                             color = MaterialTheme.colorScheme.outline,
-                        )
-                        .padding(8.dp),
+                        ).padding(8.dp),
             ) {
                 SelectableText(
                     text = "Transaction",
@@ -146,8 +143,7 @@ fun CsvPreviewTable(
                             .border(
                                 width = 1.dp,
                                 color = MaterialTheme.colorScheme.outline,
-                            )
-                            .padding(8.dp),
+                            ).padding(8.dp),
                 ) {
                     SelectableText(
                         text = column.originalName,
@@ -189,8 +185,7 @@ fun CsvPreviewTable(
                                         .border(
                                             width = 1.dp,
                                             color = MaterialTheme.colorScheme.outlineVariant,
-                                        )
-                                        .padding(8.dp),
+                                        ).padding(8.dp),
                             ) {
                                 SelectableText(
                                     text = row.rowIndex.toString(),
@@ -215,8 +210,7 @@ fun CsvPreviewTable(
                                         .border(
                                             width = 1.dp,
                                             color = MaterialTheme.colorScheme.outlineVariant,
-                                        )
-                                        .padding(8.dp),
+                                        ).padding(8.dp),
                                 contentAlignment = Alignment.Center,
                             ) {
                                 row.importStatus?.let { status ->
@@ -263,8 +257,7 @@ fun CsvPreviewTable(
                                                 .border(
                                                     width = 1.dp,
                                                     color = MaterialTheme.colorScheme.outlineVariant,
-                                                )
-                                                .padding(8.dp),
+                                                ).padding(8.dp),
                                     ) {
                                         SelectableText(
                                             text = value,
@@ -350,12 +343,10 @@ private fun TransferIdCell(
                     } else {
                         Modifier
                     },
-                )
-                .border(
+                ).border(
                     width = 1.dp,
                     color = MaterialTheme.colorScheme.outlineVariant,
-                )
-                .padding(8.dp),
+                ).padding(8.dp),
     ) {
         if (transferId != null) {
             Text(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/error/SchemaAwareCoroutineScope.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/error/SchemaAwareCoroutineScope.kt
@@ -69,6 +69,4 @@ fun ProvideSchemaAwareScope(content: @Composable () -> Unit) {
  * Use this instead of rememberCoroutineScope() when you need schema-aware error handling.
  */
 @Composable
-fun rememberSchemaAwareCoroutineScope(): CoroutineScope {
-    return LocalSchemaAwareScope.current
-}
+fun rememberSchemaAwareCoroutineScope(): CoroutineScope = LocalSchemaAwareScope.current

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/error/SchemaErrorAwareFlow.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/error/SchemaErrorAwareFlow.kt
@@ -21,8 +21,8 @@ private val logger = logging()
 fun <T> Flow<T>.collectAsStateWithSchemaErrorHandling(
     initial: T,
     databaseLocation: String = "default",
-): State<T> {
-    return produceState(initial, this) {
+): State<T> =
+    produceState(initial, this) {
         catch { e ->
             if (SchemaErrorDetector.isSchemaError(e)) {
                 logger.error(e) { "Schema error in Flow collection: ${e.message}" }
@@ -32,4 +32,3 @@ fun <T> Flow<T>.collectAsStateWithSchemaErrorHandling(
             }
         }.collect { value = it }
     }
-}

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/NavigationHistory.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/NavigationHistory.kt
@@ -9,7 +9,9 @@ import androidx.compose.runtime.setValue
  * Manages navigation history with back/forward stack support.
  */
 @Stable
-class NavigationHistory(initialScreen: Screen) {
+class NavigationHistory(
+    initialScreen: Screen,
+) {
     private val backStack = mutableListOf<Screen>()
     private val forwardStack = mutableListOf<Screen>()
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
@@ -8,8 +8,12 @@ import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.CsvImportId
 
-sealed class Screen(val title: String) {
-    data class Accounts(val scrollToAccountId: AccountId? = null) : Screen("Accounts")
+sealed class Screen(
+    val title: String,
+) {
+    data class Accounts(
+        val scrollToAccountId: AccountId? = null,
+    ) : Screen("Accounts")
 
     data object Currencies : Screen("Currencies")
 
@@ -33,21 +37,29 @@ sealed class Screen(val title: String) {
     data class CsvImportDetail(
         val importId: CsvImportId,
         val scrollToRowIndex: Long? = null,
-    ) :
-        Screen("CSV Import")
+    ) : Screen("CSV Import")
 
-    data class AuditHistory(val transferId: TransferId) :
-        Screen("Audit History")
+    data class AuditHistory(
+        val transferId: TransferId,
+    ) : Screen("Audit History")
 
-    data class AccountAuditHistory(val accountId: AccountId, val accountName: String) :
-        Screen("Account Audit: $accountName")
+    data class AccountAuditHistory(
+        val accountId: AccountId,
+        val accountName: String,
+    ) : Screen("Account Audit: $accountName")
 
-    data class PersonAuditHistory(val personId: PersonId, val personName: String) :
-        Screen("Person Audit: $personName")
+    data class PersonAuditHistory(
+        val personId: PersonId,
+        val personName: String,
+    ) : Screen("Person Audit: $personName")
 
-    data class CurrencyAuditHistory(val currencyId: CurrencyId, val currencyCode: String) :
-        Screen("Currency Audit: $currencyCode")
+    data class CurrencyAuditHistory(
+        val currencyId: CurrencyId,
+        val currencyCode: String,
+    ) : Screen("Currency Audit: $currencyCode")
 
-    data class CategoryAuditHistory(val categoryId: Long, val categoryName: String) :
-        Screen("Category Audit: $categoryName")
+    data class CategoryAuditHistory(
+        val categoryId: Long,
+        val categoryName: String,
+    ) : Screen("Category Audit: $categoryName")
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
@@ -56,11 +56,14 @@ fun AccountsScreen(
     onAuditClick: (Account) -> Unit = {},
 ) {
     // Use schema-error-aware collection for flows that may fail on old databases
-    val accounts by accountRepository.getAllAccounts()
+    val accounts by accountRepository
+        .getAllAccounts()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val balances by transactionRepository.getAccountBalances()
+    val balances by transactionRepository
+        .getAccountBalances()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val categories by categoryRepository.getAllCategories()
+    val categories by categoryRepository
+        .getAllCategories()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     var showCreateDialog by remember { mutableStateOf(false) }
     var accountToEdit by remember { mutableStateOf<Account?>(null) }
@@ -182,9 +185,11 @@ fun AccountCard(
 ) {
     var showDeleteDialog by remember { mutableStateOf(false) }
 
-    val ownerships by personAccountOwnershipRepository.getOwnershipsByAccount(account.id)
+    val ownerships by personAccountOwnershipRepository
+        .getOwnershipsByAccount(account.id)
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val allPeople by personRepository.getAllPeople()
+    val allPeople by personRepository
+        .getAllPeople()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     val owners =
         ownerships.mapNotNull { ownership ->
@@ -318,7 +323,8 @@ fun CreateAccountDialog(
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var isSaving by remember { mutableStateOf(false) }
 
-    val categories by categoryRepository.getAllCategories()
+    val categories by categoryRepository
+        .getAllCategories()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     val scope = rememberSchemaAwareCoroutineScope()
 
@@ -471,7 +477,8 @@ fun DeleteAccountDialog(
     var dropdownExpanded by remember { mutableStateOf(false) }
     val scope = rememberSchemaAwareCoroutineScope()
 
-    val allAccounts by accountRepository.getAllAccounts()
+    val allAccounts by accountRepository
+        .getAllAccounts()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     val otherAccounts = allAccounts.filter { it.id != account.id }
 
@@ -655,7 +662,8 @@ fun CreateCategoryDialog(
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var isSaving by remember { mutableStateOf(false) }
 
-    val categories by categoryRepository.getAllCategories()
+    val categories by categoryRepository
+        .getAllCategories()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     val scope = rememberSchemaAwareCoroutineScope()
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
@@ -93,11 +93,14 @@ fun CategoriesScreen(
     currencyRepository: CurrencyRepository,
     onAuditClick: (Category) -> Unit = {},
 ) {
-    val categories by categoryRepository.getAllCategories()
+    val categories by categoryRepository
+        .getAllCategories()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val categoryBalances by categoryRepository.getCategoryBalances()
+    val categoryBalances by categoryRepository
+        .getCategoryBalances()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val currencies by currencyRepository.getAllCurrencies()
+    val currencies by currencyRepository
+        .getAllCurrencies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     var expandedIds by remember { mutableStateOf(emptySet<Long>()) }
@@ -133,7 +136,8 @@ fun CategoriesScreen(
                 val maxMoney =
                     categoryBalances
                         .filter { it.balance.currency.id == currency.id }
-                        .maxByOrNull { kotlin.math.abs(it.balance.amount) }?.balance
+                        .maxByOrNull { kotlin.math.abs(it.balance.amount) }
+                        ?.balance
                 val formattedMax = maxMoney?.let { formatAmount(it) } ?: formatAmount(0.0, currency)
                 // Estimate width: ~8dp per character + 16dp padding
                 val balanceWidth = (formattedMax.length * 8 + 16).dp
@@ -439,8 +443,7 @@ fun CategoryTreeItem(
                 .onGloballyPositioned { coordinates ->
                     val position = coordinates.positionInRoot()
                     onPositionChanged(position.y, position.y + coordinates.size.height)
-                }
-                .graphicsLayer {
+                }.graphicsLayer {
                     if (isDragging) {
                         translationY = dragOffset.y
                         scaleX = 1.02f
@@ -448,8 +451,7 @@ fun CategoryTreeItem(
                         alpha = 0.9f
                         shadowElevation = 8f
                     }
-                }
-                .then(
+                }.then(
                     if (isDraggable) {
                         Modifier.pointerInput(node.category.id) {
                             detectDragGestures(
@@ -610,7 +612,8 @@ fun CreateCategoryDialogInCategories(
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var isSaving by remember { mutableStateOf(false) }
 
-    val categories by categoryRepository.getAllCategories()
+    val categories by categoryRepository
+        .getAllCategories()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     val scope = rememberSchemaAwareCoroutineScope()
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import com.moneymanager.bigdecimal.BigDecimal
 import com.moneymanager.compose.scrollbar.VerticalScrollbarForLazyList
 import com.moneymanager.domain.model.Category
 import com.moneymanager.domain.model.CategoryBalance
@@ -138,7 +139,7 @@ fun CategoriesScreen(
                         .filter { it.balance.currency.id == currency.id }
                         .maxByOrNull { kotlin.math.abs(it.balance.amount) }
                         ?.balance
-                val formattedMax = maxMoney?.let { formatAmount(it) } ?: formatAmount(0.0, currency)
+                val formattedMax = maxMoney?.let { formatAmount(it) } ?: formatAmount(BigDecimal.ZERO, currency)
                 // Estimate width: ~8dp per character + 16dp padding
                 val balanceWidth = (formattedMax.length * 8 + 16).dp
                 // Also consider header text width (currency code)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
@@ -84,7 +84,8 @@ fun CsvImportDetailScreen(
     onTransferClick: ((TransferId, Boolean) -> Unit)? = null,
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
-    val import by csvImportRepository.getImport(importId)
+    val import by csvImportRepository
+        .getImport(importId)
         .collectAsStateWithSchemaErrorHandling(initial = null)
     var rows by remember { mutableStateOf<List<CsvRow>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
@@ -99,7 +100,8 @@ fun CsvImportDetailScreen(
     var hasMatchingStrategy by remember { mutableStateOf(false) }
 
     // Observe strategies to re-check when new ones are added
-    val strategies by csvImportStrategyRepository.getAllStrategies()
+    val strategies by csvImportStrategyRepository
+        .getAllStrategies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     // Check if there's a matching strategy for this import's columns
@@ -115,23 +117,30 @@ fun CsvImportDetailScreen(
     // Determine amount column index by looking for common amount column names
     val amountColumnIndex =
         remember(import) {
-            import?.columns?.indexOfFirst { column ->
-                val name = column.originalName.lowercase()
-                name == "amount" || name == "value" || name == "total" ||
-                    name == "debit" || name == "credit" || name.contains("amount")
-            }?.takeIf { it >= 0 }
+            import
+                ?.columns
+                ?.indexOfFirst { column ->
+                    val name = column.originalName.lowercase()
+                    name == "amount" ||
+                        name == "value" ||
+                        name == "total" ||
+                        name == "debit" ||
+                        name == "credit" ||
+                        name.contains("amount")
+                }?.takeIf { it >= 0 }
         }
 
     // Load rows when import is available or after import completes
     LaunchedEffect(import, rowsRefreshTrigger) {
-        scope.launch {
-            import?.let {
-                isLoading = true
-                // Load all rows - the actual row count is stored in the import metadata
-                rows = csvImportRepository.getImportRows(importId, limit = it.rowCount, offset = 0)
-                isLoading = false
-            }
-        }.join()
+        scope
+            .launch {
+                import?.let {
+                    isLoading = true
+                    // Load all rows - the actual row count is stored in the import metadata
+                    rows = csvImportRepository.getImportRows(importId, limit = it.rowCount, offset = 0)
+                    isLoading = false
+                }
+            }.join()
     }
 
     Column(
@@ -311,7 +320,8 @@ fun CsvImportDetailScreen(
                         onDuplicateSourceClick = { transferId, isPositiveAmount ->
                             scope.launch {
                                 val source =
-                                    transferSourceRepository.getSourcesForTransaction(transferId)
+                                    transferSourceRepository
+                                        .getSourcesForTransaction(transferId)
                                         .filter { it.sourceType == SourceType.CSV_IMPORT }
                                         .minByOrNull { it.revisionId }
                                 val csvSource = source?.csvSource

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
@@ -134,10 +134,18 @@ fun CsvImportDetailScreen(
     LaunchedEffect(import, rowsRefreshTrigger) {
         scope
             .launch {
-                import?.let {
+                val currentImport = import
+                if (currentImport == null) {
+                    rows = emptyList()
+                    isLoading = false
+                    return@launch
+                }
+
+                try {
                     isLoading = true
                     // Load all rows - the actual row count is stored in the import metadata
-                    rows = csvImportRepository.getImportRows(importId, limit = it.rowCount, offset = 0)
+                    rows = csvImportRepository.getImportRows(importId, limit = currentImport.rowCount, offset = 0)
+                } finally {
                     isLoading = false
                 }
             }.join()

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
@@ -50,7 +50,8 @@ fun CsvImportsScreen(
     onStrategiesClick: () -> Unit = {},
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
-    val imports by csvImportRepository.getAllImports()
+    val imports by csvImportRepository
+        .getAllImports()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     var isImporting by remember { mutableStateOf(false) }
     var importError by remember { mutableStateOf<String?>(null) }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CurrenciesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CurrenciesScreen.kt
@@ -32,7 +32,8 @@ fun CurrenciesScreen(
     deviceId: DeviceId,
     onAuditClick: (Currency) -> Unit = {},
 ) {
-    val currencies by currencyRepository.getAllCurrencies()
+    val currencies by currencyRepository
+        .getAllCurrencies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     var showCreateDialog by remember { mutableStateOf(false) }
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CurrencyAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CurrencyAuditScreen.kt
@@ -65,8 +65,8 @@ private data class CurrencyAuditDiff(
 private fun computeCurrencyAuditDiffs(
     entries: List<CurrencyAuditEntry>,
     currentCurrency: Currency?,
-): List<CurrencyAuditDiff> {
-    return entries.mapIndexed { index, entry ->
+): List<CurrencyAuditDiff> =
+    entries.mapIndexed { index, entry ->
         when (entry.auditType) {
             AuditType.INSERT ->
                 CurrencyAuditDiff(
@@ -144,7 +144,6 @@ private fun computeCurrencyAuditDiffs(
             }
         }
     }
-}
 
 @Composable
 private fun CurrencyAuditDiffCard(diff: CurrencyAuditDiff) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
@@ -54,7 +54,8 @@ fun PeopleScreen(
     deviceId: DeviceId,
     onAuditClick: (Person) -> Unit = {},
 ) {
-    val people by personRepository.getAllPeople()
+    val people by personRepository
+        .getAllPeople()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     var showCreateDialog by remember { mutableStateOf(false) }
     var personToEdit by remember { mutableStateOf<Person?>(null) }
@@ -100,7 +101,8 @@ fun PeopleScreen(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     items(people) { person ->
-                        val ownerships by personAccountOwnershipRepository.getOwnershipsByPerson(person.id)
+                        val ownerships by personAccountOwnershipRepository
+                            .getOwnershipsByPerson(person.id)
                             .collectAsStateWithSchemaErrorHandling(initial = emptyList())
                         PersonCard(
                             person = person,
@@ -142,7 +144,8 @@ fun PeopleScreen(
 
     val currentPersonToDelete = personToDelete
     if (currentPersonToDelete != null) {
-        val ownerships by personAccountOwnershipRepository.getOwnershipsByPerson(currentPersonToDelete.id)
+        val ownerships by personAccountOwnershipRepository
+            .getOwnershipsByPerson(currentPersonToDelete.id)
             .collectAsStateWithSchemaErrorHandling(initial = emptyList())
         DeletePersonConfirmationDialog(
             person = currentPersonToDelete,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PersonAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PersonAuditScreen.kt
@@ -65,8 +65,8 @@ private data class PersonAuditDiff(
 private fun computePersonAuditDiffs(
     entries: List<PersonAuditEntry>,
     currentPerson: Person?,
-): List<PersonAuditDiff> {
-    return entries.mapIndexed { index, entry ->
+): List<PersonAuditDiff> =
+    entries.mapIndexed { index, entry ->
         when (entry.auditType) {
             AuditType.INSERT ->
                 PersonAuditDiff(
@@ -144,7 +144,6 @@ private fun computePersonAuditDiffs(
             }
         }
     }
-}
 
 @Composable
 private fun PersonAuditDiffCard(diff: PersonAuditDiff) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/SettingsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/SettingsScreen.kt
@@ -147,7 +147,8 @@ fun SettingsScreen(
         )
 
         // Preferences Section
-        val defaultCurrencyId by settingsRepository.getDefaultCurrencyId()
+        val defaultCurrencyId by settingsRepository
+            .getDefaultCurrencyId()
             .collectAsStateWithSchemaErrorHandling(initial = null)
 
         Card(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -108,11 +108,14 @@ fun ApplyStrategyDialog(
     onImportComplete: (CsvImportResult) -> Unit,
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
-    val strategies by csvImportStrategyRepository.getAllStrategies()
+    val strategies by csvImportStrategyRepository
+        .getAllStrategies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val accounts by accountRepository.getAllAccounts()
+    val accounts by accountRepository
+        .getAllAccounts()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val currencies by currencyRepository.getAllCurrencies()
+    val currencies by currencyRepository
+        .getAllCurrencies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     var selectedStrategy by remember { mutableStateOf<CsvImportStrategy?>(null) }
@@ -229,7 +232,9 @@ fun ApplyStrategyDialog(
                                 try {
                                     val account =
                                         Account(
-                                            id = com.moneymanager.domain.model.AccountId(0),
+                                            id =
+                                                com.moneymanager.domain.model
+                                                    .AccountId(0),
                                             name = newAccount.name,
                                             openingDate = Clock.System.now(),
                                             categoryId = newAccount.categoryId,
@@ -333,13 +338,15 @@ fun ApplyStrategyDialog(
 
                             // Fetch existing transfers within the CSV's date range that involve any of the CSV's accounts
                             val existingTransfers =
-                                allAccountIds.flatMap { accountId ->
-                                    transactionRepository.getTransactionsByAccountAndDateRange(
-                                        accountId = accountId,
-                                        startDate = minTimestamp,
-                                        endDate = maxTimestamp,
-                                    ).first()
-                                }.distinctBy { it.id }
+                                allAccountIds
+                                    .flatMap { accountId ->
+                                        transactionRepository
+                                            .getTransactionsByAccountAndDateRange(
+                                                accountId = accountId,
+                                                startDate = minTimestamp,
+                                                endDate = maxTimestamp,
+                                            ).first()
+                                    }.distinctBy { it.id }
 
                             val existingTransferInfoList =
                                 existingTransfers.map { transfer ->
@@ -357,7 +364,8 @@ fun ApplyStrategyDialog(
                                                 val attributeValue =
                                                     transfer.attributes
                                                         .firstOrNull { it.attributeType.name == mapping.attributeTypeName }
-                                                        ?.value.orEmpty()
+                                                        ?.value
+                                                        .orEmpty()
                                                 mapping.columnName to attributeValue
                                             }
 
@@ -767,8 +775,7 @@ private fun ImportPreviewSection(prep: ImportPreparation) {
                         .background(
                             MaterialTheme.colorScheme.surfaceVariant,
                             MaterialTheme.shapes.small,
-                        )
-                        .padding(8.dp),
+                        ).padding(8.dp),
             ) {
                 prep.newAccounts.forEach { account ->
                     Text(
@@ -795,8 +802,7 @@ private fun ImportPreviewSection(prep: ImportPreparation) {
                         .background(
                             MaterialTheme.colorScheme.errorContainer,
                             MaterialTheme.shapes.small,
-                        )
-                        .padding(8.dp),
+                        ).padding(8.dp),
             ) {
                 prep.errorRows.take(5).forEach { error ->
                     Text(
@@ -841,8 +847,7 @@ private fun StatCard(
                 .background(
                     color.copy(alpha = 0.1f),
                     MaterialTheme.shapes.small,
-                )
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+                ).padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
         Text(
             text = count.toString(),

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -49,6 +49,7 @@ import com.moneymanager.database.csv.StrategyMatcher
 import com.moneymanager.database.sql.TransferSourceQueries
 import com.moneymanager.domain.getDeviceInfo
 import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
@@ -232,9 +233,7 @@ fun ApplyStrategyDialog(
                                 try {
                                     val account =
                                         Account(
-                                            id =
-                                                com.moneymanager.domain.model
-                                                    .AccountId(0),
+                                            id = AccountId(0),
                                             name = newAccount.name,
                                             openingDate = Clock.System.now(),
                                             categoryId = newAccount.categoryId,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ColumnDetector.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ColumnDetector.kt
@@ -197,14 +197,12 @@ object ColumnDetector {
                             row.values.getOrNull(col.columnIndex)?.isNotBlank() == true
                         }
                     Triple(col.originalName, filledCount, isPreferredFallback(col.originalName))
-                }
-                .filter { (_, count, _) -> count > 0 }
+                }.filter { (_, count, _) -> count > 0 }
                 // Sort by: preferred columns first, then by coverage
                 .sortedWith(
                     compareByDescending<Triple<String, Int, Boolean>> { (_, _, preferred) -> preferred }
                         .thenByDescending { (_, count, _) -> count },
-                )
-                .map { (name, _, _) -> name }
+                ).map { (name, _, _) -> name }
 
         // Return top candidate(s) - typically just the best one
         return candidateColumns.take(1)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CreateCsvStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CreateCsvStrategyDialog.kt
@@ -1470,7 +1470,9 @@ private fun AttributeMappingsEditor(
                     val attributeTypeName = mapping?.attributeTypeName ?: columnName
                     val isUniqueIdentifier = mapping?.isUniqueIdentifier ?: false
                     val sampleValue =
-                        firstRow?.values?.getOrNull(column.columnIndex)
+                        firstRow
+                            ?.values
+                            ?.getOrNull(column.columnIndex)
                             .orEmpty()
 
                     AttributeColumnMappingRow(
@@ -1837,9 +1839,11 @@ private fun RegexRulesEditor(
                             remember(rule.pattern, rows, columnIndex) {
                                 try {
                                     val regex = Regex(rule.pattern, RegexOption.IGNORE_CASE)
-                                    rows.mapNotNull { row ->
-                                        row.values.getOrNull(columnIndex)?.takeIf { it.isNotBlank() }
-                                    }.filter { regex.containsMatchIn(it) }.distinct()
+                                    rows
+                                        .mapNotNull { row ->
+                                            row.values.getOrNull(columnIndex)?.takeIf { it.isNotBlank() }
+                                        }.filter { regex.containsMatchIn(it) }
+                                        .distinct()
                                 } catch (_: Exception) {
                                     emptyList()
                                 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
@@ -82,7 +82,8 @@ fun CsvStrategiesScreen(
     onStrategyClick: (CsvImportStrategy) -> Unit = {},
     onBack: () -> Unit = {},
 ) {
-    val strategies by csvImportStrategyRepository.getAllStrategies()
+    val strategies by csvImportStrategyRepository
+        .getAllStrategies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     // Edit flow state

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ImportStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ImportStrategyDialog.kt
@@ -91,11 +91,14 @@ fun ImportStrategyDialog(
     onDismiss: () -> Unit,
     onImportSuccess: () -> Unit,
 ) {
-    val accounts by accountRepository.getAllAccounts()
+    val accounts by accountRepository
+        .getAllAccounts()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val categories by categoryRepository.getAllCategories()
+    val categories by categoryRepository
+        .getAllCategories()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val currencies by currencyRepository.getAllCurrencies()
+    val currencies by currencyRepository
+        .getAllCurrencies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     var resolutions by remember {
@@ -114,7 +117,8 @@ fun ImportStrategyDialog(
         }
 
     // Check for name conflict
-    val existingStrategies by csvImportStrategyRepository.getAllStrategies()
+    val existingStrategies by csvImportStrategyRepository
+        .getAllStrategies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     val nameConflict = existingStrategies.any { it.name == strategyName }
 
@@ -304,8 +308,7 @@ private fun resolveAccountMappings(
                 ?: resolutions.entries
                     .firstOrNull { (reference) ->
                         reference.type == ReferenceType.ACCOUNT && reference.name == mapping.accountName
-                    }
-                    ?.value
+                    }?.value
         val account =
             when (resolution) {
                 is Resolution.CreateNew ->
@@ -384,7 +387,10 @@ private fun ReferenceResolutionRow(
                         text = reference.name,
                         style = MaterialTheme.typography.titleSmall,
                     )
-                    val refType = reference.type.name.lowercase().replaceFirstChar { it.uppercase() }
+                    val refType =
+                        reference.type.name
+                            .lowercase()
+                            .replaceFirstChar { it.uppercase() }
                     val fieldName =
                         reference.fieldType
                             ?.name

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/StrategyDialogs.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/StrategyDialogs.kt
@@ -182,7 +182,8 @@ fun SelectCsvImportDialog(
     onCsvSelected: (CsvImport) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val imports by csvImportRepository.getAllImports()
+    val imports by csvImportRepository
+        .getAllImports()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     AlertDialog(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionAuditScreen.kt
@@ -57,7 +57,8 @@ fun TransactionAuditScreen(
     onCsvSourceClick: (CsvImportId, Long) -> Unit = { _, _ -> },
     onBack: () -> Unit,
 ) {
-    val accounts by accountRepository.getAllAccounts()
+    val accounts by accountRepository
+        .getAllAccounts()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     AuditScreen(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.moneymanager.bigdecimal.BigDecimal
 import com.moneymanager.database.DatabaseMaintenanceService
 import com.moneymanager.database.ManualSourceRecorder
 import com.moneymanager.database.sql.EntitySourceQueries
@@ -160,6 +161,11 @@ fun TransactionEditDialog(
         }
     }
 
+    val parsedAmount =
+        remember(amount) {
+            runCatching { BigDecimal(amount.trim()) }.getOrNull()
+        }
+
     // Check if any field has changed from the original transaction (edit mode only)
     val hasChanges =
         remember(
@@ -167,6 +173,7 @@ fun TransactionEditDialog(
             targetAccountId,
             currencyId,
             amount,
+            parsedAmount,
             description,
             selectedDate,
             selectedHour,
@@ -180,14 +187,14 @@ fun TransactionEditDialog(
                     targetAccountId != null &&
                     currencyId != null &&
                     amount.isNotBlank() &&
-                    amount.toDoubleOrNull() != null &&
-                    amount.toDouble() > 0 &&
+                    parsedAmount != null &&
+                    parsedAmount > BigDecimal.ZERO &&
                     sourceAccountId != targetAccountId
             } else {
                 sourceAccountId != transaction.sourceAccountId ||
                     targetAccountId != transaction.targetAccountId ||
                     currencyId != transaction.amount.currency.id ||
-                    amount != transaction.amount.toDisplayValue().toString() ||
+                    parsedAmount != transaction.amount.toDisplayValue() ||
                     description != transaction.description ||
                     selectedDate != transactionDateTime!!.date ||
                     selectedHour != transactionDateTime.hour ||
@@ -412,14 +419,15 @@ fun TransactionEditDialog(
         confirmButton = {
             TextButton(
                 onClick = {
+                    val validAmount = parsedAmount
                     when {
                         sourceAccountId == null -> errorMessage = "Source account is required"
                         targetAccountId == null -> errorMessage = "Target account is required"
                         sourceAccountId == targetAccountId -> errorMessage = "Source and target accounts must be different"
                         currencyId == null -> errorMessage = "Currency is required"
                         amount.isBlank() -> errorMessage = "Amount is required"
-                        amount.toDoubleOrNull() == null -> errorMessage = "Invalid amount"
-                        amount.toDouble() <= 0 -> errorMessage = "Amount must be greater than 0"
+                        validAmount == null -> errorMessage = "Invalid amount"
+                        validAmount <= BigDecimal.ZERO -> errorMessage = "Amount must be greater than 0"
                         description.isBlank() -> errorMessage = "Description is required"
                         else -> {
                             isSaving = true
@@ -443,7 +451,7 @@ fun TransactionEditDialog(
                                             sourceAccountId != transaction.sourceAccountId ||
                                                 targetAccountId != transaction.targetAccountId ||
                                                 currencyId != transaction.amount.currency.id ||
-                                                amount != transaction.amount.toDisplayValue().toString() ||
+                                                validAmount != transaction.amount.toDisplayValue() ||
                                                 description.trim() != transaction.description ||
                                                 timestamp != transaction.timestamp
 
@@ -456,7 +464,7 @@ fun TransactionEditDialog(
                                                     description = description.trim(),
                                                     sourceAccountId = sourceAccountId!!,
                                                     targetAccountId = targetAccountId!!,
-                                                    amount = Money.fromDisplayValue(amount, currency),
+                                                    amount = Money.fromDisplayValue(validAmount, currency),
                                                 )
                                             } else {
                                                 null
@@ -520,7 +528,7 @@ fun TransactionEditDialog(
                                                 description = description.trim(),
                                                 sourceAccountId = sourceAccountId!!,
                                                 targetAccountId = targetAccountId!!,
-                                                amount = Money.fromDisplayValue(amount, currency),
+                                                amount = Money.fromDisplayValue(validAmount, currency),
                                             )
 
                                         // Build attributes to save (only non-blank ones)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
@@ -95,7 +95,15 @@ fun TransactionEditDialog(
     var sourceAccountId by remember { mutableStateOf(transaction?.sourceAccountId ?: preSelectedSourceAccountId) }
     var targetAccountId by remember { mutableStateOf(transaction?.targetAccountId) }
     var currencyId by remember { mutableStateOf(transaction?.amount?.currency?.id ?: preSelectedCurrencyId) }
-    var amount by remember { mutableStateOf(transaction?.amount?.toDisplayValue()?.toString().orEmpty()) }
+    var amount by remember {
+        mutableStateOf(
+            transaction
+                ?.amount
+                ?.toDisplayValue()
+                ?.toString()
+                .orEmpty(),
+        )
+    }
     var description by remember { mutableStateOf(transaction?.description.orEmpty()) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var isSaving by remember { mutableStateOf(false) }
@@ -166,7 +174,7 @@ fun TransactionEditDialog(
             editableAttributes,
             originalAttributes,
         ) {
-            if (!isEditMode || transaction == null) {
+            if (transaction == null) {
                 // In create mode, enable save only when all required fields are filled and valid
                 sourceAccountId != null &&
                     targetAccountId != null &&
@@ -428,7 +436,7 @@ fun TransactionEditDialog(
                                             .atTime(selectedHour, selectedMinute, originalSecond, originalNanosecond)
                                             .toInstant(TimeZone.currentSystemDefault())
 
-                                    if (isEditMode && transaction != null) {
+                                    if (transaction != null) {
                                         // EDIT MODE: Update existing transaction
                                         // Check if transfer fields actually changed
                                         val transferFieldsChanged =

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -88,11 +88,14 @@ fun AccountTransactionsScreen(
     initialCurrencyId: CurrencyId? = null,
     externalRefreshTrigger: Int = 0,
 ) {
-    val allAccounts by accountRepository.getAllAccounts()
+    val allAccounts by accountRepository
+        .getAllAccounts()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val currencies by currencyRepository.getAllCurrencies()
+    val currencies by currencyRepository
+        .getAllCurrencies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val accountBalances by transactionRepository.getAccountBalances()
+    val accountBalances by transactionRepository
+        .getAccountBalances()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     // Selected account state - synced with parent's accountId parameter
@@ -417,13 +420,11 @@ fun AccountTransactionsScreen(
                                                         isCellSelected -> MaterialTheme.colorScheme.secondaryContainer
                                                         else -> MaterialTheme.colorScheme.surface
                                                     },
-                                                )
-                                                .clickable {
+                                                ).clickable {
                                                     selectedAccountId = account.id
                                                     selectedCurrencyId = null // Clear currency to show all currencies
                                                     onAccountClick(account.id, account.name, null)
-                                                }
-                                                .padding(vertical = 4.dp),
+                                                }.padding(vertical = 4.dp),
                                         contentAlignment = Alignment.Center,
                                     ) {
                                         Text(
@@ -468,8 +469,7 @@ fun AccountTransactionsScreen(
                                                         } else {
                                                             MaterialTheme.colorScheme.surface
                                                         },
-                                                    )
-                                                    .padding(vertical = 4.dp),
+                                                    ).padding(vertical = 4.dp),
                                         ) {
                                             Text(
                                                 text = "${currency?.code ?: "?"}:",
@@ -526,8 +526,7 @@ fun AccountTransactionsScreen(
                                                                 selectedAccountId = account.id
                                                                 selectedCurrencyId = currencyId
                                                                 onAccountClick(account.id, account.name, currencyId)
-                                                            }
-                                                            .padding(vertical = 4.dp),
+                                                            }.padding(vertical = 4.dp),
                                                     contentAlignment = Alignment.Center,
                                                 ) {
                                                     if (balance != null) {
@@ -690,9 +689,10 @@ fun AccountTransactionsScreen(
 
                         // Now find the index in the filtered list (which now includes this currency)
                         val index =
-                            runningBalances.filter {
-                                it.transactionAmount.currency.id == transaction.transactionAmount.currency.id
-                            }.indexOfFirst { it.transactionId.id == targetTransferId.id }
+                            runningBalances
+                                .filter {
+                                    it.transactionAmount.currency.id == transaction.transactionAmount.currency.id
+                                }.indexOfFirst { it.transactionId.id == targetTransferId.id }
 
                         if (index >= 0) {
                             // Scroll to the transaction

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/CategoryNode.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/CategoryNode.kt
@@ -31,12 +31,14 @@ fun buildCategoryForest(categories: List<Category>): List<CategoryNode> {
         depth: Int,
     ): CategoryNode {
         val children =
-            childrenByParentId[category.id].orEmpty()
+            childrenByParentId[category.id]
+                .orEmpty()
                 .map { buildSubtree(it, depth + 1) }
         return CategoryNode(category = category, children = children, depth = depth)
     }
 
-    return childrenByParentId[null].orEmpty()
+    return childrenByParentId[null]
+        .orEmpty()
         .map { buildSubtree(it, depth = 0) }
 }
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/CurrencyFormatting.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/CurrencyFormatting.kt
@@ -1,5 +1,6 @@
 package com.moneymanager.ui.util
 
+import com.moneymanager.bigdecimal.BigDecimal
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.Money
 import com.moneymanager.currency.Currency as CurrencyFormatter
@@ -12,14 +13,14 @@ import com.moneymanager.currency.Currency as CurrencyFormatter
  * @return Formatted currency string (e.g., "$1,234.56" for USD)
  */
 fun formatAmount(
-    amount: Number,
+    amount: BigDecimal,
     currency: Currency,
 ): String =
     try {
         CurrencyFormatter(currency.code).format(amount)
-    } catch (e: IllegalArgumentException) {
+    } catch (_: IllegalArgumentException) {
         // Fallback for unknown currency codes - just format as number with currency code
-        String.format("%.2f %s", amount.toDouble(), currency.code)
+        "$amount ${currency.code}"
     }
 
 /**
@@ -28,4 +29,4 @@ fun formatAmount(
  * @param money The Money value to format
  * @return Formatted currency string (e.g., "$1,234.56" for USD)
  */
-fun formatAmount(money: Money): String = formatAmount(money.toDisplayValue().toDouble(), money.currency)
+fun formatAmount(money: Money): String = formatAmount(money.toDisplayValue(), money.currency)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/CurrencyFormatting.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/CurrencyFormatting.kt
@@ -14,14 +14,13 @@ import com.moneymanager.currency.Currency as CurrencyFormatter
 fun formatAmount(
     amount: Number,
     currency: Currency,
-): String {
-    return try {
+): String =
+    try {
         CurrencyFormatter(currency.code).format(amount)
     } catch (e: IllegalArgumentException) {
         // Fallback for unknown currency codes - just format as number with currency code
         String.format("%.2f %s", amount.toDouble(), currency.code)
     }
-}
 
 /**
  * Formats a Money value using the embedded currency.
@@ -29,6 +28,4 @@ fun formatAmount(
  * @param money The Money value to format
  * @return Formatted currency string (e.g., "$1,234.56" for USD)
  */
-fun formatAmount(money: Money): String {
-    return formatAmount(money.toDisplayValue().toDouble(), money.currency)
-}
+fun formatAmount(money: Money): String = formatAmount(money.toDisplayValue().toDouble(), money.currency)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/SampleDataGenerator.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/SampleDataGenerator.kt
@@ -63,14 +63,34 @@ suspend fun generateSampleData(
     // Pick 10-20 popular currencies (or all if less than 20)
     val popularCurrencyCodes =
         listOf(
-            "USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "CNY", "INR", "MXN",
-            "BRL", "KRW", "SGD", "NZD", "SEK", "NOK", "DKK", "PLN", "THB", "ZAR",
+            "USD",
+            "EUR",
+            "GBP",
+            "JPY",
+            "CAD",
+            "AUD",
+            "CHF",
+            "CNY",
+            "INR",
+            "MXN",
+            "BRL",
+            "KRW",
+            "SGD",
+            "NZD",
+            "SEK",
+            "NOK",
+            "DKK",
+            "PLN",
+            "THB",
+            "ZAR",
         )
 
     val selectedCurrencies =
-        allCurrencies.filter { currency ->
-            popularCurrencyCodes.contains(currency.code)
-        }.take(20).ifEmpty { allCurrencies.take(20) }
+        allCurrencies
+            .filter { currency ->
+                popularCurrencyCodes.contains(currency.code)
+            }.take(20)
+            .ifEmpty { allCurrencies.take(20) }
 
     check(selectedCurrencies.isNotEmpty()) { "No currencies available for sample data generation." }
 
@@ -440,16 +460,46 @@ suspend fun generateSampleData(
 private fun generateAccountNames(count: Int): List<String> {
     val prefixes =
         listOf(
-            "Personal", "Business", "Savings", "Emergency", "Investment", "Retirement",
-            "Travel", "Education", "Health", "Entertainment", "Shopping", "Food",
-            "Transport", "Utilities", "Mortgage", "Rent", "Vacation", "Hobby",
-            "Charity", "Gift", "Project", "Revenue", "Expense", "Cash",
+            "Personal",
+            "Business",
+            "Savings",
+            "Emergency",
+            "Investment",
+            "Retirement",
+            "Travel",
+            "Education",
+            "Health",
+            "Entertainment",
+            "Shopping",
+            "Food",
+            "Transport",
+            "Utilities",
+            "Mortgage",
+            "Rent",
+            "Vacation",
+            "Hobby",
+            "Charity",
+            "Gift",
+            "Project",
+            "Revenue",
+            "Expense",
+            "Cash",
         )
 
     val suffixes =
         listOf(
-            "Checking", "Savings", "Account", "Fund", "Wallet", "Reserve",
-            "Portfolio", "Budget", "Stash", "Pool", "Treasury", "Vault",
+            "Checking",
+            "Savings",
+            "Account",
+            "Fund",
+            "Wallet",
+            "Reserve",
+            "Portfolio",
+            "Budget",
+            "Stash",
+            "Pool",
+            "Treasury",
+            "Vault",
         )
 
     val names = mutableListOf<String>()
@@ -546,8 +596,8 @@ private data class CategoryWithChildren(
     val children: List<Category>,
 )
 
-private fun generateCategoryHierarchy(): List<CategoryWithChildren> {
-    return listOf(
+private fun generateCategoryHierarchy(): List<CategoryWithChildren> =
+    listOf(
         CategoryWithChildren(
             category = Category(name = "Income"),
             children =
@@ -728,7 +778,6 @@ private fun generateCategoryHierarchy(): List<CategoryWithChildren> {
                 ),
         ),
     )
-}
 
 data class GenerationProgress(
     val accountsCreated: Int = 0,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -421,7 +421,8 @@ class AccountTransactionsScreenTest {
                     // Get the transfer's current revision
                     val savedTransfer =
                         repositories.transactionRepository
-                            .getTransactionById(transferId!!.id).first()!!
+                            .getTransactionById(transferId!!.id)
+                            .first()!!
                     // Note: For revisionId = 1 (newly created transfers), adding attributes
                     // doesn't bump the revision - they're part of the initial creation.
                     // Only existing transfers (revisionId > 1) get bumped when adding attributes.
@@ -433,7 +434,8 @@ class AccountTransactionsScreenTest {
                     // Verify the attribute type was created
                     val attributeType =
                         repositories.attributeTypeRepository
-                            .getByName("Reference Number").first()
+                            .getByName("Reference Number")
+                            .first()
                     assertTrue(
                         attributeType != null,
                         "Attribute type 'Reference Number' should exist in database",
@@ -442,7 +444,8 @@ class AccountTransactionsScreenTest {
                     // Verify the attribute was saved
                     val attributes =
                         repositories.transferAttributeRepository
-                            .getByTransaction(transferId).first()
+                            .getByTransaction(transferId)
+                            .first()
                     assertTrue(
                         attributes.any { it.value == "REF-12345" && it.attributeType.name == "Reference Number" },
                         "Attribute with value 'REF-12345' should exist in database. Found: $attributes",
@@ -866,9 +869,7 @@ class AccountTransactionsScreenTest {
             return newId
         }
 
-        override suspend fun createAccountsBatch(accounts: List<Account>): List<AccountId> {
-            return accounts.map { createAccount(it) }
-        }
+        override suspend fun createAccountsBatch(accounts: List<Account>): List<AccountId> = accounts.map { createAccount(it) }
 
         override suspend fun updateAccount(account: Account): Long {
             accountsFlow.value =
@@ -927,32 +928,33 @@ class AccountTransactionsScreenTest {
             // One from the source account's perspective (outgoing = negative)
             // One from the target account's perspective (incoming = positive)
             val allRows =
-                transfers.flatMap { transfer ->
-                    listOf(
-                        // Source account's perspective (outgoing = negative)
-                        AccountRow(
-                            transactionId = transfer.id,
-                            timestamp = transfer.timestamp,
-                            description = transfer.description,
-                            accountId = transfer.sourceAccountId,
-                            transactionAmount = Money(-transfer.amount.amount, transfer.amount.currency),
-                            runningBalance = transfer.amount,
-                            sourceAccountId = transfer.sourceAccountId,
-                            targetAccountId = transfer.targetAccountId,
-                        ),
-                        // Target account's perspective (incoming = positive)
-                        AccountRow(
-                            transactionId = transfer.id,
-                            timestamp = transfer.timestamp,
-                            description = transfer.description,
-                            accountId = transfer.targetAccountId,
-                            transactionAmount = transfer.amount,
-                            runningBalance = transfer.amount,
-                            sourceAccountId = transfer.sourceAccountId,
-                            targetAccountId = transfer.targetAccountId,
-                        ),
-                    )
-                }.filter { it.accountId == accountId }
+                transfers
+                    .flatMap { transfer ->
+                        listOf(
+                            // Source account's perspective (outgoing = negative)
+                            AccountRow(
+                                transactionId = transfer.id,
+                                timestamp = transfer.timestamp,
+                                description = transfer.description,
+                                accountId = transfer.sourceAccountId,
+                                transactionAmount = Money(-transfer.amount.amount, transfer.amount.currency),
+                                runningBalance = transfer.amount,
+                                sourceAccountId = transfer.sourceAccountId,
+                                targetAccountId = transfer.targetAccountId,
+                            ),
+                            // Target account's perspective (incoming = positive)
+                            AccountRow(
+                                transactionId = transfer.id,
+                                timestamp = transfer.timestamp,
+                                description = transfer.description,
+                                accountId = transfer.targetAccountId,
+                                transactionAmount = transfer.amount,
+                                runningBalance = transfer.amount,
+                                sourceAccountId = transfer.sourceAccountId,
+                                targetAccountId = transfer.targetAccountId,
+                            ),
+                        )
+                    }.filter { it.accountId == accountId }
                     .sortedByDescending { it.timestamp }
 
             // Simple pagination for testing
@@ -992,30 +994,31 @@ class AccountTransactionsScreenTest {
             pageSize: Int,
         ): PageWithTargetIndex<AccountRow> {
             val allRows =
-                transfers.flatMap { transfer ->
-                    listOf(
-                        AccountRow(
-                            transactionId = transfer.id,
-                            timestamp = transfer.timestamp,
-                            description = transfer.description,
-                            accountId = transfer.sourceAccountId,
-                            transactionAmount = Money(-transfer.amount.amount, transfer.amount.currency),
-                            runningBalance = transfer.amount,
-                            sourceAccountId = transfer.sourceAccountId,
-                            targetAccountId = transfer.targetAccountId,
-                        ),
-                        AccountRow(
-                            transactionId = transfer.id,
-                            timestamp = transfer.timestamp,
-                            description = transfer.description,
-                            accountId = transfer.targetAccountId,
-                            transactionAmount = transfer.amount,
-                            runningBalance = transfer.amount,
-                            sourceAccountId = transfer.sourceAccountId,
-                            targetAccountId = transfer.targetAccountId,
-                        ),
-                    )
-                }.filter { it.accountId == accountId }
+                transfers
+                    .flatMap { transfer ->
+                        listOf(
+                            AccountRow(
+                                transactionId = transfer.id,
+                                timestamp = transfer.timestamp,
+                                description = transfer.description,
+                                accountId = transfer.sourceAccountId,
+                                transactionAmount = Money(-transfer.amount.amount, transfer.amount.currency),
+                                runningBalance = transfer.amount,
+                                sourceAccountId = transfer.sourceAccountId,
+                                targetAccountId = transfer.targetAccountId,
+                            ),
+                            AccountRow(
+                                transactionId = transfer.id,
+                                timestamp = transfer.timestamp,
+                                description = transfer.description,
+                                accountId = transfer.targetAccountId,
+                                transactionAmount = transfer.amount,
+                                runningBalance = transfer.amount,
+                                sourceAccountId = transfer.sourceAccountId,
+                                targetAccountId = transfer.targetAccountId,
+                            ),
+                        )
+                    }.filter { it.accountId == accountId }
                     .sortedByDescending { it.timestamp }
 
             val targetIndex = allRows.indexOfFirst { it.transactionId.id == transactionId.id }
@@ -1198,7 +1201,8 @@ class AccountTransactionsScreenTest {
 
     private class FakeDeviceRepository : com.moneymanager.domain.repository.DeviceRepository {
         override fun getOrCreateDevice(deviceInfo: DeviceInfo): com.moneymanager.domain.model.DeviceId =
-            com.moneymanager.domain.model.DeviceId(1L)
+            com.moneymanager.domain.model
+                .DeviceId(1L)
 
         override suspend fun getDeviceById(id: com.moneymanager.domain.model.DeviceId): DeviceInfo? = null
     }
@@ -1209,7 +1213,8 @@ class AccountTransactionsScreenTest {
         override fun getPersonById(id: com.moneymanager.domain.model.PersonId): Flow<com.moneymanager.domain.model.Person?> = flowOf(null)
 
         override suspend fun createPerson(person: com.moneymanager.domain.model.Person): com.moneymanager.domain.model.PersonId =
-            com.moneymanager.domain.model.PersonId(1L)
+            com.moneymanager.domain.model
+                .PersonId(1L)
 
         override suspend fun updatePerson(person: com.moneymanager.domain.model.Person) = Unit
 
@@ -1254,9 +1259,8 @@ class AccountTransactionsScreenTest {
                     sql: String,
                     parameters: Int,
                     binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                ): app.cash.sqldelight.db.QueryResult<Long> {
+                ): app.cash.sqldelight.db.QueryResult<Long> =
                     throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-                }
 
                 override fun <R> executeQuery(
                     identifier: Int?,
@@ -1264,13 +1268,11 @@ class AccountTransactionsScreenTest {
                     mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>,
                     parameters: Int,
                     binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                ): app.cash.sqldelight.db.QueryResult<R> {
+                ): app.cash.sqldelight.db.QueryResult<R> =
                     throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-                }
 
-                override fun newTransaction(): app.cash.sqldelight.db.QueryResult<app.cash.sqldelight.Transacter.Transaction> {
+                override fun newTransaction(): app.cash.sqldelight.db.QueryResult<app.cash.sqldelight.Transacter.Transaction> =
                     throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-                }
 
                 override fun addListener(
                     vararg queryKeys: String,
@@ -1285,7 +1287,8 @@ class AccountTransactionsScreenTest {
                 override fun notifyListeners(vararg queryKeys: String) = Unit
             }
 
-        return com.moneymanager.database.sql.TransferSourceQueries(stubDriver)
+        return com.moneymanager.database.sql
+            .TransferSourceQueries(stubDriver)
     }
 
     /**
@@ -1305,9 +1308,8 @@ class AccountTransactionsScreenTest {
                         sql: String,
                         parameters: Int,
                         binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                    ): app.cash.sqldelight.db.QueryResult<Long> {
+                    ): app.cash.sqldelight.db.QueryResult<Long> =
                         throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-                    }
 
                     override fun <R> executeQuery(
                         identifier: Int?,
@@ -1315,13 +1317,11 @@ class AccountTransactionsScreenTest {
                         mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>,
                         parameters: Int,
                         binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                    ): app.cash.sqldelight.db.QueryResult<R> {
+                    ): app.cash.sqldelight.db.QueryResult<R> =
                         throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-                    }
 
-                    override fun newTransaction(): app.cash.sqldelight.db.QueryResult<app.cash.sqldelight.Transacter.Transaction> {
+                    override fun newTransaction(): app.cash.sqldelight.db.QueryResult<app.cash.sqldelight.Transacter.Transaction> =
                         throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-                    }
 
                     override fun addListener(
                         vararg queryKeys: String,
@@ -1336,7 +1336,8 @@ class AccountTransactionsScreenTest {
                     override fun notifyListeners(vararg queryKeys: String) = Unit
                 }
 
-            return com.moneymanager.database.sql.EntitySourceQueries(stubDriver)
+            return com.moneymanager.database.sql
+                .EntitySourceQueries(stubDriver)
         }
     }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
@@ -7,7 +7,14 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlPreparedStatement
 import com.moneymanager.database.DatabaseMaintenanceService
+import com.moneymanager.database.sql.EntitySourceQueries
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountBalance
 import com.moneymanager.domain.model.AccountId
@@ -19,6 +26,9 @@ import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.PageWithTargetIndex
 import com.moneymanager.domain.model.PagingInfo
 import com.moneymanager.domain.model.PagingResult
+import com.moneymanager.domain.model.Person
+import com.moneymanager.domain.model.PersonAccountOwnership
+import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.SourceRecorder
 import com.moneymanager.domain.model.TransactionId
 import com.moneymanager.domain.model.Transfer
@@ -568,36 +578,32 @@ class AccountsScreenTest {
     }
 
     private class FakePersonRepository : PersonRepository {
-        override fun getAllPeople() = flowOf(emptyList<com.moneymanager.domain.model.Person>())
+        override fun getAllPeople() = flowOf(emptyList<Person>())
 
-        override fun getPersonById(id: com.moneymanager.domain.model.PersonId) = flowOf(null as com.moneymanager.domain.model.Person?)
+        override fun getPersonById(id: PersonId) = flowOf(null as Person?)
 
-        override suspend fun createPerson(person: com.moneymanager.domain.model.Person) =
-            com.moneymanager.domain.model
-                .PersonId(0)
+        override suspend fun createPerson(person: Person) = PersonId(0)
 
-        override suspend fun updatePerson(person: com.moneymanager.domain.model.Person) {}
+        override suspend fun updatePerson(person: Person) {}
 
-        override suspend fun deletePerson(id: com.moneymanager.domain.model.PersonId) {}
+        override suspend fun deletePerson(id: PersonId) {}
     }
 
     private class FakePersonAccountOwnershipRepository : PersonAccountOwnershipRepository {
-        override fun getOwnershipsByPerson(personId: com.moneymanager.domain.model.PersonId) =
-            flowOf(emptyList<com.moneymanager.domain.model.PersonAccountOwnership>())
+        override fun getOwnershipsByPerson(personId: PersonId) = flowOf(emptyList<PersonAccountOwnership>())
 
-        override fun getOwnershipsByAccount(accountId: AccountId) =
-            flowOf(emptyList<com.moneymanager.domain.model.PersonAccountOwnership>())
+        override fun getOwnershipsByAccount(accountId: AccountId) = flowOf(emptyList<PersonAccountOwnership>())
 
-        override fun getOwnershipById(id: Long) = flowOf(null as com.moneymanager.domain.model.PersonAccountOwnership?)
+        override fun getOwnershipById(id: Long) = flowOf(null as PersonAccountOwnership?)
 
         override suspend fun createOwnership(
-            personId: com.moneymanager.domain.model.PersonId,
+            personId: PersonId,
             accountId: AccountId,
         ) = 0L
 
         override suspend fun deleteOwnership(id: Long) {}
 
-        override suspend fun deleteOwnershipsByPerson(personId: com.moneymanager.domain.model.PersonId) {}
+        override suspend fun deleteOwnershipsByPerson(personId: PersonId) {}
 
         override suspend fun deleteOwnershipsByAccount(accountId: AccountId) {}
     }
@@ -619,48 +625,45 @@ class AccountsScreenTest {
      * Uses a minimal SqlDriver stub that throws NotImplementedError if actually invoked.
      */
     private companion object {
-        fun createStubEntitySourceQueries(): com.moneymanager.database.sql.EntitySourceQueries {
+        fun createStubEntitySourceQueries(): EntitySourceQueries {
             val stubDriver =
-                object : app.cash.sqldelight.db.SqlDriver {
+                object : SqlDriver {
                     override fun close() = Unit
 
-                    override fun currentTransaction(): app.cash.sqldelight.Transacter.Transaction? = null
+                    override fun currentTransaction(): Transacter.Transaction? = null
 
                     override fun execute(
                         identifier: Int?,
                         sql: String,
                         parameters: Int,
-                        binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                    ): app.cash.sqldelight.db.QueryResult<Long> =
-                        throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
+                        binders: (SqlPreparedStatement.() -> Unit)?,
+                    ): QueryResult<Long> = throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
 
                     override fun <R> executeQuery(
                         identifier: Int?,
                         sql: String,
-                        mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>,
+                        mapper: (SqlCursor) -> QueryResult<R>,
                         parameters: Int,
-                        binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                    ): app.cash.sqldelight.db.QueryResult<R> =
-                        throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
+                        binders: (SqlPreparedStatement.() -> Unit)?,
+                    ): QueryResult<R> = throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
 
-                    override fun newTransaction(): app.cash.sqldelight.db.QueryResult<app.cash.sqldelight.Transacter.Transaction> =
+                    override fun newTransaction(): QueryResult<Transacter.Transaction> =
                         throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
 
                     override fun addListener(
                         vararg queryKeys: String,
-                        listener: app.cash.sqldelight.Query.Listener,
+                        listener: Query.Listener,
                     ) = Unit
 
                     override fun removeListener(
                         vararg queryKeys: String,
-                        listener: app.cash.sqldelight.Query.Listener,
+                        listener: Query.Listener,
                     ) = Unit
 
                     override fun notifyListeners(vararg queryKeys: String) = Unit
                 }
 
-            return com.moneymanager.database.sql
-                .EntitySourceQueries(stubDriver)
+            return EntitySourceQueries(stubDriver)
         }
     }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
@@ -425,9 +425,7 @@ class AccountsScreenTest {
             return newId
         }
 
-        override suspend fun createAccountsBatch(accounts: List<Account>): List<AccountId> {
-            return accounts.map { createAccount(it) }
-        }
+        override suspend fun createAccountsBatch(accounts: List<Account>): List<AccountId> = accounts.map { createAccount(it) }
 
         override suspend fun updateAccount(account: Account): Long {
             accountsFlow.value =
@@ -574,7 +572,9 @@ class AccountsScreenTest {
 
         override fun getPersonById(id: com.moneymanager.domain.model.PersonId) = flowOf(null as com.moneymanager.domain.model.Person?)
 
-        override suspend fun createPerson(person: com.moneymanager.domain.model.Person) = com.moneymanager.domain.model.PersonId(0)
+        override suspend fun createPerson(person: com.moneymanager.domain.model.Person) =
+            com.moneymanager.domain.model
+                .PersonId(0)
 
         override suspend fun updatePerson(person: com.moneymanager.domain.model.Person) {}
 
@@ -631,9 +631,8 @@ class AccountsScreenTest {
                         sql: String,
                         parameters: Int,
                         binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                    ): app.cash.sqldelight.db.QueryResult<Long> {
+                    ): app.cash.sqldelight.db.QueryResult<Long> =
                         throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-                    }
 
                     override fun <R> executeQuery(
                         identifier: Int?,
@@ -641,13 +640,11 @@ class AccountsScreenTest {
                         mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>,
                         parameters: Int,
                         binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                    ): app.cash.sqldelight.db.QueryResult<R> {
+                    ): app.cash.sqldelight.db.QueryResult<R> =
                         throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-                    }
 
-                    override fun newTransaction(): app.cash.sqldelight.db.QueryResult<app.cash.sqldelight.Transacter.Transaction> {
+                    override fun newTransaction(): app.cash.sqldelight.db.QueryResult<app.cash.sqldelight.Transacter.Transaction> =
                         throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-                    }
 
                     override fun addListener(
                         vararg queryKeys: String,
@@ -662,7 +659,8 @@ class AccountsScreenTest {
                     override fun notifyListeners(vararg queryKeys: String) = Unit
                 }
 
-            return com.moneymanager.database.sql.EntitySourceQueries(stubDriver)
+            return com.moneymanager.database.sql
+                .EntitySourceQueries(stubDriver)
         }
     }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CurrenciesScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CurrenciesScreenTest.kt
@@ -182,9 +182,8 @@ class CurrenciesScreenTest {
                         sql: String,
                         parameters: Int,
                         binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                    ): app.cash.sqldelight.db.QueryResult<Long> {
+                    ): app.cash.sqldelight.db.QueryResult<Long> =
                         throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-                    }
 
                     override fun <R> executeQuery(
                         identifier: Int?,
@@ -192,13 +191,11 @@ class CurrenciesScreenTest {
                         mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>,
                         parameters: Int,
                         binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                    ): app.cash.sqldelight.db.QueryResult<R> {
+                    ): app.cash.sqldelight.db.QueryResult<R> =
                         throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-                    }
 
-                    override fun newTransaction(): app.cash.sqldelight.db.QueryResult<app.cash.sqldelight.Transacter.Transaction> {
+                    override fun newTransaction(): app.cash.sqldelight.db.QueryResult<app.cash.sqldelight.Transacter.Transaction> =
                         throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-                    }
 
                     override fun addListener(
                         vararg queryKeys: String,
@@ -213,7 +210,8 @@ class CurrenciesScreenTest {
                     override fun notifyListeners(vararg queryKeys: String) = Unit
                 }
 
-            return com.moneymanager.database.sql.EntitySourceQueries(stubDriver)
+            return com.moneymanager.database.sql
+                .EntitySourceQueries(stubDriver)
         }
     }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CurrenciesScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CurrenciesScreenTest.kt
@@ -7,6 +7,13 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlPreparedStatement
+import com.moneymanager.database.sql.EntitySourceQueries
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.DeviceId
@@ -170,48 +177,45 @@ class CurrenciesScreenTest {
      * Uses a minimal SqlDriver stub that throws NotImplementedError if actually invoked.
      */
     private companion object {
-        fun createStubEntitySourceQueries(): com.moneymanager.database.sql.EntitySourceQueries {
+        fun createStubEntitySourceQueries(): EntitySourceQueries {
             val stubDriver =
-                object : app.cash.sqldelight.db.SqlDriver {
+                object : SqlDriver {
                     override fun close() = Unit
 
-                    override fun currentTransaction(): app.cash.sqldelight.Transacter.Transaction? = null
+                    override fun currentTransaction(): Transacter.Transaction? = null
 
                     override fun execute(
                         identifier: Int?,
                         sql: String,
                         parameters: Int,
-                        binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                    ): app.cash.sqldelight.db.QueryResult<Long> =
-                        throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
+                        binders: (SqlPreparedStatement.() -> Unit)?,
+                    ): QueryResult<Long> = throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
 
                     override fun <R> executeQuery(
                         identifier: Int?,
                         sql: String,
-                        mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>,
+                        mapper: (SqlCursor) -> QueryResult<R>,
                         parameters: Int,
-                        binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                    ): app.cash.sqldelight.db.QueryResult<R> =
-                        throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
+                        binders: (SqlPreparedStatement.() -> Unit)?,
+                    ): QueryResult<R> = throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
 
-                    override fun newTransaction(): app.cash.sqldelight.db.QueryResult<app.cash.sqldelight.Transacter.Transaction> =
+                    override fun newTransaction(): QueryResult<Transacter.Transaction> =
                         throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
 
                     override fun addListener(
                         vararg queryKeys: String,
-                        listener: app.cash.sqldelight.Query.Listener,
+                        listener: Query.Listener,
                     ) = Unit
 
                     override fun removeListener(
                         vararg queryKeys: String,
-                        listener: app.cash.sqldelight.Query.Listener,
+                        listener: Query.Listener,
                     ) = Unit
 
                     override fun notifyListeners(vararg queryKeys: String) = Unit
                 }
 
-            return com.moneymanager.database.sql
-                .EntitySourceQueries(stubDriver)
+            return EntitySourceQueries(stubDriver)
         }
     }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/test/TestMoneyManagerApp.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/test/TestMoneyManagerApp.kt
@@ -26,7 +26,10 @@ private sealed class TestDatabaseState {
         val databaseComponent: DatabaseComponent,
     ) : TestDatabaseState()
 
-    data class Error(val location: DbLocation, val error: Throwable) : TestDatabaseState()
+    data class Error(
+        val location: DbLocation,
+        val error: Throwable,
+    ) : TestDatabaseState()
 }
 
 /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 kotlin.code.style=official
+org.gradle.kotlin.dsl.allWarningsAsErrors=true
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 

--- a/gradle/build-logic/build.gradle.kts
+++ b/gradle/build-logic/build.gradle.kts
@@ -14,6 +14,7 @@ java {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     compilerOptions {
+        allWarningsAsErrors.set(true)
         jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvm.target.get()))
     }
 }

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
@@ -47,6 +47,8 @@ configure<ApplicationExtension> {
     lint {
         warningsAsErrors = true
         abortOnError = true
+        // API 37 is currently beta, so stay on the latest stable SDK while keeping other lint warnings fatal.
+        disable += "OldTargetApi"
     }
 }
 

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
@@ -43,6 +43,11 @@ configure<ApplicationExtension> {
         sourceCompatibility = JavaVersion.toVersion(jvmTargetVersion)
         targetCompatibility = JavaVersion.toVersion(jvmTargetVersion)
     }
+
+    lint {
+        warningsAsErrors = true
+        abortOnError = true
+    }
 }
 
 // Disable Compose mapping file generation to work around Java 25 compatibility issue

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
@@ -1,6 +1,6 @@
-@file:Suppress("DEPRECATION")
-
+import com.android.build.api.dsl.ManagedVirtualDevice.PageAlignment.FORCE_16KB_PAGES
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 plugins {
     id("moneymanager.kotlin-convention")
@@ -9,12 +9,12 @@ plugins {
 }
 
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+// Android API level sync: update with gradle/libs.versions.toml, .github/workflows/build.yml,
+// .idea/runConfigurations/Android_Tests.xml, and AGENTS.md.
+val androidTestManagedDeviceNames = listOf("pixel6api37")
 
-kotlin {
-    jvm()
-
-    // Configure Android target using the new plugin's DSL
-    androidLibrary {
+fun KotlinMultiplatformExtension.configureAndroidTarget() {
+    android {
         // Use group (set by kotlin-convention based on project path)
         // Sanitize hyphens in group name for valid Android package name
         namespace = "com.moneymanager.${project.group.toString().replace("-", ".")}"
@@ -32,22 +32,30 @@ kotlin {
 
             managedDevices {
                 localDevices {
-                    // Create a managed device named "pixel6api34"
-                    create("pixel6api34") {
+                    create("pixel6api37") {
                         device = "Pixel 6"
-                        apiLevel = 34
+                        apiLevel = 37
+                        pageAlignment = FORCE_16KB_PAGES
                         systemImageSource = "aosp-atd"
                     }
                 }
                 // Create a device group for running all tests
                 groups {
                     create("allDevices") {
-                        targetDevices.add(allDevices["pixel6api34"])
+                        androidTestManagedDeviceNames.forEach { deviceName ->
+                            targetDevices.add(allDevices[deviceName])
+                        }
                     }
                 }
             }
         }
     }
+}
+
+kotlin {
+    jvm()
+
+    configureAndroidTarget()
 
     jvmToolchain(libs.findVersion("jvm-toolchain").get().toString().toInt())
 
@@ -71,4 +79,4 @@ tasks.named("build") {
 }
 
 // Configure build scan integration for Android device tests
-configureAndroidTestBuildScan(listOf("pixel6api34"))
+configureAndroidTestBuildScan(androidTestManagedDeviceNames)

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
@@ -1,4 +1,3 @@
-import com.android.build.api.dsl.ManagedVirtualDevice.PageAlignment.FORCE_16KB_PAGES
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
@@ -9,9 +8,9 @@ plugins {
 }
 
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
-// Android API level sync: update with gradle/libs.versions.toml, .github/workflows/build.yml,
+// Android emulator API level sync: update with .github/workflows/build.yml,
 // .idea/runConfigurations/Android_Tests.xml, and AGENTS.md.
-val androidTestManagedDeviceNames = listOf("pixel6api37")
+val androidTestManagedDeviceNames = listOf("pixel6api36")
 
 fun KotlinMultiplatformExtension.configureAndroidTarget() {
     android {
@@ -32,10 +31,9 @@ fun KotlinMultiplatformExtension.configureAndroidTarget() {
 
             managedDevices {
                 localDevices {
-                    create("pixel6api37") {
+                    create("pixel6api36") {
                         device = "Pixel 6"
-                        apiLevel = 37
-                        pageAlignment = FORCE_16KB_PAGES
+                        apiLevel = 36
                         systemImageSource = "aosp-atd"
                     }
                 }

--- a/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-convention.gradle.kts
@@ -20,6 +20,7 @@ tasks {
 
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         compilerOptions {
+            allWarningsAsErrors.set(true)
             jvmTarget.set(JvmTarget.fromTarget(jvmTargetVersion))
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+# Android API level sync: update this with the Gradle managed device, CI emulator, and IntelliJ Android Tests run configuration.
 android-compileSdk = "37"
 develocity = "4.4.0"
 android-gradle-plugin = "9.1.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
-# Android API level sync: update this with the Gradle managed device, CI emulator, and IntelliJ Android Tests run configuration.
+# App Android API level sync: keep compile and target SDK aligned.
+# Emulator API level sync lives with the Gradle managed device and CI because SDK 37 emulator packages are not available on GitHub's stable SDK channel yet.
 android-compileSdk = "37"
 develocity = "4.4.0"
 android-gradle-plugin = "9.1.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 android-compileSdk = "36"
-develocity = "4.3"
+develocity = "4.4.0"
 android-gradle-plugin = "9.1.1"
 android-minSdk = "30"
-android-targetSdk = "35"
+android-targetSdk = "36"
 androidx-activity-compose = "1.13.0"
 androidx-compose = "1.10.6"
-androidx-compose-material-icons = "1.7.6"
+androidx-compose-material-icons = "1.7.8"
 androidx-compose-material3 = "1.4.0"
 androidx-sqlite = "2.6.2"
 androidx-test-core = "1.7.0"
@@ -17,8 +17,9 @@ compose-plugin = "1.10.3"
 compose-material-icons-desktop = "1.7.3"
 compose-material3-desktop = "1.9.0"
 compose-ui-test = "1.9.3"
-dependency-analysis = "3.7.0"
+dependency-analysis = "3.8.0"
 detekt = "2.0.0-alpha.2"
+diamondedge-logging = "2.1.1"
 gradle-doctor = "0.12.1"
 human-readable = "1.12.3"
 jvm-target = "25"
@@ -29,7 +30,7 @@ kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization = "1.11.0"
 kover = "0.9.8"
-ktlint = "12.1.2"
+ktlint = "14.2.0"
 log4j = "2.25.4"
 mappie = "2.3.20-2.4.1"
 proguard = "7.8.2"
@@ -70,6 +71,7 @@ compose-desktop-macos-arm64 = { module = "org.jetbrains.compose.desktop:desktop-
 compose-desktop-macos-x64 = { module = "org.jetbrains.compose.desktop:desktop-jvm-macos-x64", version.ref = "compose-plugin" }
 compose-desktop-windows-x64 = { module = "org.jetbrains.compose.desktop:desktop-jvm-windows-x64", version.ref = "compose-plugin" }
 compose-components-resources-desktop = { module = "org.jetbrains.compose.components:components-resources-desktop", version.ref = "compose-plugin" }
+compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose-plugin" }
 compose-foundation-desktop = { module = "org.jetbrains.compose.foundation:foundation-desktop", version.ref = "compose-plugin" }
 compose-foundation-layout-desktop = { module = "org.jetbrains.compose.foundation:foundation-layout-desktop", version.ref = "compose-plugin" }
 compose-gradle-plugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-plugin" }
@@ -86,7 +88,7 @@ compose-ui-unit-desktop = { module = "org.jetbrains.compose.ui:ui-unit-desktop",
 dependency-analysis-gradle-plugin = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dependency-analysis" }
 detekt-gradle-plugin = { module = "dev.detekt:dev.detekt.gradle.plugin", version.ref = "detekt" }
 develocity-gradle-plugin = { module = "com.gradle:develocity-gradle-plugin", version.ref = "develocity" }
-diamondedge-logging = { module = "com.diamondedge:logging", version.ref = "kmlogging" }
+diamondedge-logging = { module = "com.diamondedge:logging", version.ref = "diamondedge-logging" }
 human-readable = { module = "nl.jacobras:Human-Readable", version.ref = "human-readable" }
 kmlogging = { module = "org.lighthousegames:logging", version.ref = "kmlogging" }
 kotlin-compose-compiler-gradle-plugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,8 @@ detekt = "2.0.0-alpha.2"
 diamondedge-logging = "2.1.1"
 gradle-doctor = "0.12.1"
 human-readable = "1.12.3"
+# JVM version sync: keep jvm-target and jvm-toolchain aligned with .github/actions/gradle-setup/action.yml,
+# .github/workflows/lint-format.yml, and AGENTS.md.
 jvm-target = "25"
 jvm-toolchain = "25"
 kmlogging = "2.0.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-android-compileSdk = "36"
+android-compileSdk = "37"
 develocity = "4.4.0"
 android-gradle-plugin = "9.1.1"
 android-minSdk = "30"
-android-targetSdk = "36"
+android-targetSdk = "37"
 androidx-activity-compose = "1.13.0"
 androidx-compose = "1.10.6"
 androidx-compose-material-icons = "1.7.8"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-# App Android API level sync: keep compile and target SDK aligned.
-# Emulator API level sync lives with the Gradle managed device and CI because SDK 37 emulator packages are not available on GitHub's stable SDK channel yet.
-android-compileSdk = "37"
+# Android API level sync: keep compile SDK, target SDK, the Gradle managed device, CI emulator,
+# and IntelliJ Android Tests run configuration aligned. API 37 is beta.
+android-compileSdk = "36"
 develocity = "4.4.0"
 android-gradle-plugin = "9.1.1"
 android-minSdk = "30"
-android-targetSdk = "37"
+android-targetSdk = "36"
 androidx-activity-compose = "1.13.0"
 androidx-compose = "1.10.6"
 androidx-compose-material-icons = "1.7.8"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+# Gradle version sync: keep this aligned with .github/actions/gradle-setup/action.yml
+# and .github/workflows/lint-format.yml.
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true

--- a/test/app/db/src/commonMain/kotlin/com/moneymanager/test/database/DbTest.kt
+++ b/test/app/db/src/commonMain/kotlin/com/moneymanager/test/database/DbTest.kt
@@ -50,10 +50,11 @@ open class DbTest {
         )
         // Query back the created transfer by its details (timestamp + description should be unique enough for tests)
         val allTransfers =
-            repositories.transactionRepository.getTransactionsByDateRange(
-                startDate = transfer.timestamp,
-                endDate = transfer.timestamp,
-            ).first()
+            repositories.transactionRepository
+                .getTransactionsByDateRange(
+                    startDate = transfer.timestamp,
+                    endDate = transfer.timestamp,
+                ).first()
         return allTransfers.first { it.description == transfer.description }
     }
 }

--- a/utils/bigdecimal/src/jvmAndroidMain/kotlin/com/moneymanager/bigdecimal/BigDecimal.kt
+++ b/utils/bigdecimal/src/jvmAndroidMain/kotlin/com/moneymanager/bigdecimal/BigDecimal.kt
@@ -30,45 +30,25 @@ actual class BigDecimal : Comparable<BigDecimal> {
         this.value = value
     }
 
-    actual operator fun plus(augend: BigDecimal): BigDecimal {
-        return BigDecimal(value.add(augend.value))
-    }
+    actual operator fun plus(augend: BigDecimal): BigDecimal = BigDecimal(value.add(augend.value))
 
-    actual operator fun minus(subtrahend: BigDecimal): BigDecimal {
-        return BigDecimal(value.subtract(subtrahend.value))
-    }
+    actual operator fun minus(subtrahend: BigDecimal): BigDecimal = BigDecimal(value.subtract(subtrahend.value))
 
-    actual operator fun times(multiplicand: BigDecimal): BigDecimal {
-        return BigDecimal(value.multiply(multiplicand.value))
-    }
+    actual operator fun times(multiplicand: BigDecimal): BigDecimal = BigDecimal(value.multiply(multiplicand.value))
 
-    actual operator fun div(divisor: BigDecimal): BigDecimal {
-        return BigDecimal(value.divide(divisor.value, 10, RoundingMode.HALF_UP))
-    }
+    actual operator fun div(divisor: BigDecimal): BigDecimal = BigDecimal(value.divide(divisor.value, 10, RoundingMode.HALF_UP))
 
-    actual operator fun unaryMinus(): BigDecimal {
-        return BigDecimal(value.negate())
-    }
+    actual operator fun unaryMinus(): BigDecimal = BigDecimal(value.negate())
 
-    actual fun abs(): BigDecimal {
-        return BigDecimal(value.abs())
-    }
+    actual fun abs(): BigDecimal = BigDecimal(value.abs())
 
-    actual override operator fun compareTo(other: BigDecimal): Int {
-        return value.compareTo(other.value)
-    }
+    actual override operator fun compareTo(other: BigDecimal): Int = value.compareTo(other.value)
 
-    actual fun toDouble(): Double {
-        return value.toDouble()
-    }
+    actual fun toDouble(): Double = value.toDouble()
 
-    actual fun toLong(): Long {
-        return value.toLong()
-    }
+    actual fun toLong(): Long = value.toLong()
 
-    actual override fun toString(): String {
-        return value.stripTrailingZeros().toPlainString()
-    }
+    actual override fun toString(): String = value.stripTrailingZeros().toPlainString()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -76,9 +56,7 @@ actual class BigDecimal : Comparable<BigDecimal> {
         return value.compareTo(other.value) == 0
     }
 
-    override fun hashCode(): Int {
-        return value.stripTrailingZeros().hashCode()
-    }
+    override fun hashCode(): Int = value.stripTrailingZeros().hashCode()
 
     actual companion object {
         actual val ZERO: BigDecimal = BigDecimal(java.math.BigDecimal.ZERO)

--- a/utils/compose/filePicker/src/androidMain/kotlin/com/moneymanager/compose/filepicker/FilePicker.kt
+++ b/utils/compose/filePicker/src/androidMain/kotlin/com/moneymanager/compose/filepicker/FilePicker.kt
@@ -61,8 +61,8 @@ private fun readFileContent(
 private fun getFileName(
     context: Context,
     uri: Uri,
-): String? {
-    return context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+): String? =
+    context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
         if (cursor.moveToFirst()) {
             val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
             if (nameIndex >= 0) {
@@ -74,7 +74,6 @@ private fun getFileName(
             null
         }
     }
-}
 
 private fun getLastModified(
     context: Context,

--- a/utils/currency/build.gradle.kts
+++ b/utils/currency/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
 
 kotlin {
     sourceSets {
+        commonMain {
+            dependencies {
+                api(projects.utils.bigdecimal)
+            }
+        }
+
         // Shared source set for JVM and Android (both have access to java.text.NumberFormat)
         val jvmAndroidMain by creating {
             dependsOn(commonMain.get())

--- a/utils/currency/build.gradle.kts
+++ b/utils/currency/build.gradle.kts
@@ -18,6 +18,9 @@ kotlin {
 
         jvmMain {
             dependsOn(jvmAndroidMain)
+            dependencies {
+                api(projects.utils.bigdecimal)
+            }
         }
 
         androidMain {

--- a/utils/currency/src/commonMain/kotlin/com/moneymanager/currency/Currency.kt
+++ b/utils/currency/src/commonMain/kotlin/com/moneymanager/currency/Currency.kt
@@ -1,5 +1,7 @@
 package com.moneymanager.currency
 
+import com.moneymanager.bigdecimal.BigDecimal
+
 /**
  * Represents a currency with formatting capabilities.
  *
@@ -25,6 +27,14 @@ expect class Currency(
      * @return The formatted currency string (e.g., "$1,234.56" for USD)
      */
     fun format(amount: Number): String
+
+    /**
+     * Formats the given amount as a currency string without converting through floating point.
+     *
+     * @param amount The decimal amount to format
+     * @return The formatted currency string (e.g., "$1,234.56" for USD)
+     */
+    fun format(amount: BigDecimal): String
 
     companion object {
         /**

--- a/utils/currency/src/commonMain/kotlin/com/moneymanager/currency/Currency.kt
+++ b/utils/currency/src/commonMain/kotlin/com/moneymanager/currency/Currency.kt
@@ -5,7 +5,9 @@ package com.moneymanager.currency
  *
  * @param code ISO 4217 currency code (e.g., "USD", "GBP", "EUR")
  */
-expect class Currency(code: String) {
+expect class Currency(
+    code: String,
+) {
     /**
      * The ISO 4217 currency code.
      */

--- a/utils/currency/src/jvmAndroidMain/kotlin/com/moneymanager/currency/Currency.kt
+++ b/utils/currency/src/jvmAndroidMain/kotlin/com/moneymanager/currency/Currency.kt
@@ -2,6 +2,7 @@
 
 package com.moneymanager.currency
 
+import com.moneymanager.bigdecimal.BigDecimal
 import java.text.NumberFormat
 import java.util.Locale
 import java.util.Currency as JavaCurrency
@@ -19,6 +20,8 @@ actual class Currency actual constructor(
         get() = javaCurrency.displayName
 
     actual fun format(amount: Number): String = formatter.format(amount)
+
+    actual fun format(amount: BigDecimal): String = formatter.format(java.math.BigDecimal(amount.toString()))
 
     actual companion object {
         actual fun getAllCurrencies(): List<Currency> =

--- a/utils/currency/src/jvmAndroidMain/kotlin/com/moneymanager/currency/Currency.kt
+++ b/utils/currency/src/jvmAndroidMain/kotlin/com/moneymanager/currency/Currency.kt
@@ -6,7 +6,9 @@ import java.text.NumberFormat
 import java.util.Locale
 import java.util.Currency as JavaCurrency
 
-actual class Currency actual constructor(actual val code: String) {
+actual class Currency actual constructor(
+    actual val code: String,
+) {
     private val javaCurrency: JavaCurrency = JavaCurrency.getInstance(code)
     private val formatter: NumberFormat =
         NumberFormat.getCurrencyInstance().apply {
@@ -20,7 +22,8 @@ actual class Currency actual constructor(actual val code: String) {
 
     actual companion object {
         actual fun getAllCurrencies(): List<Currency> =
-            JavaCurrency.getAvailableCurrencies()
+            JavaCurrency
+                .getAvailableCurrencies()
                 .map { Currency(it.currencyCode) }
                 .sortedBy { it.code }
 

--- a/utils/parsers/csv/src/commonMain/kotlin/com/moneymanager/csv/CsvParser.kt
+++ b/utils/parsers/csv/src/commonMain/kotlin/com/moneymanager/csv/CsvParser.kt
@@ -139,15 +139,14 @@ class CsvParser {
     private fun normalizeRows(
         rows: List<List<String>>,
         columnCount: Int,
-    ): List<List<String>> {
-        return rows.map { row ->
+    ): List<List<String>> =
+        rows.map { row ->
             when {
                 row.size < columnCount -> row + List(columnCount - row.size) { "" }
                 row.size > columnCount -> row.take(columnCount)
                 else -> row
             }
         }
-    }
 
     private fun calculateDelimiterScore(
         lines: List<String>,


### PR DESCRIPTION
## Summary
- promote Android lint warnings to build-failing errors
- enable warnings-as-errors for Gradle Kotlin DSL scripts and Kotlin compile tasks
- update lint-reported dependency versions and target SDK, then apply required ktlint formatting

## Verification
- ./gradlew.bat build --console=plain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Currency formatting now accepts high-precision amounts (BigDecimal).
* **UX**
  * App enables edge-to-edge display and adjusts layouts for system bars and on-screen keyboard.
  * Transaction entry now uses precise amount parsing and stronger validation.
* **Chores**
  * Build/tooling updated: compiler warnings treated as errors; Android target and assorted libs bumped.
  * Widespread code-style standardization (expression bodies, trailing commas) for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->