### PR TITLE
Harden build warning checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 
 ## Build Commands
 
-**Important**: Always use `--console=plain`. Don't use `--no-daemon`. On Windows, use `./gradlew.bat` directly.
+**Important**: Always use `--console=plain`. Don't use `--no-daemon`. On Windows, use `./gradlew.bat` directly. A full `./gradlew build` always takes longer than 2 minutes, so never run it with a short timeout; use at least 20 minutes.
 
 | Command | Description |
 |---------|-------------|

--- a/gradle/build-logic/build.gradle.kts
+++ b/gradle/build-logic/build.gradle.kts
@@ -19,6 +19,10 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
     }
 }
 
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.addAll(listOf("-Xlint:all", "-Werror"))
+}
+
 dependencies {
     compileOnly(libs.develocity.gradle.plugin)
     implementation(libs.android.gradle.plugin)

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
@@ -24,6 +24,11 @@ fun KotlinMultiplatformExtension.configureAndroidTarget() {
             jvmTarget.set(JvmTarget.fromTarget(libs.findVersion("jvm-target").get().toString()))
         }
 
+        lint {
+            warningsAsErrors = true
+            abortOnError = true
+        }
+
         // Enable instrumented tests with Gradle Managed Device
         withDeviceTest {
             // Enable code coverage for instrumented tests

--- a/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-convention.gradle.kts
@@ -32,6 +32,7 @@ tasks {
 
     withType<JavaCompile>().configureEach {
         targetCompatibility = jvmTargetVersion
+        options.compilerArgs.addAll(listOf("-Xlint:all", "-Werror"))
     }
 
     // Make detekt aggregate task include KMP source-set tasks without invoking


### PR DESCRIPTION
## Summary
- Treat Java compiler warnings as errors in build logic and Kotlin convention builds
- Configure Android lint warnings to fail builds
- Document the long timeout needed for full builds

## Verification
- ./gradlew.bat build --console=plain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build guidance with revised timeout requirements.

* **Chores**
  * Enhanced compilation configuration to enforce stricter lint checks and treat warnings as errors across Java and Kotlin builds.
  * Configured Android lint behavior to enforce strict error handling for improved code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->