### PR TITLE
Allow fallback CSV columns as attributes

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CreateCsvStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CreateCsvStrategyDialog.kt
@@ -109,6 +109,14 @@ enum class TimezoneMode {
     FROM_COLUMN,
 }
 
+internal fun attributeCandidateColumns(
+    csvColumns: List<CsvColumn>,
+    primaryFieldColumnNames: Set<String?>,
+): List<CsvColumn> {
+    val usedPrimaryFieldColumns = primaryFieldColumnNames.filterNotNull().toSet()
+    return csvColumns.filter { it.originalName !in usedPrimaryFieldColumns }
+}
+
 /**
  * Target account mapping mode for CSV import.
  */
@@ -828,32 +836,30 @@ fun CreateCsvStrategyDialog(
                 )
                 Spacer(modifier = Modifier.height(4.dp))
 
-                // Calculate used columns
-                val usedColumns =
-                    setOfNotNull(
-                        dateColumnName,
-                        timeColumnName,
-                        descriptionColumnName,
-                        amountColumnName,
-                        targetAccountColumnName,
-                        currencyColumnName,
-                        timezoneColumnName,
-                    ) +
-                        targetAccountFallbackColumns +
-                        descriptionFallbackColumns
+                val attributeColumns =
+                    attributeCandidateColumns(
+                        csvColumns = csvColumns,
+                        primaryFieldColumnNames =
+                            setOf(
+                                dateColumnName,
+                                timeColumnName,
+                                descriptionColumnName,
+                                amountColumnName,
+                                targetAccountColumnName,
+                                currencyColumnName,
+                                timezoneColumnName,
+                            ),
+                    )
 
-                // Show unused columns for attribute selection
-                val unusedColumns = csvColumns.filter { it.originalName !in usedColumns }
-
-                if (unusedColumns.isEmpty()) {
+                if (attributeColumns.isEmpty()) {
                     Text(
-                        "All columns are used by field mappings",
+                        "No columns available for attributes",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 } else {
                     AttributeMappingsEditor(
-                        columns = unusedColumns,
+                        columns = attributeColumns,
                         mappings = attributeMappings,
                         onMappingsChanged = { attributeMappings = it },
                         existingAttributeTypes = existingAttributeTypes,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/csvstrategy/AttributeCandidateColumnsTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/csvstrategy/AttributeCandidateColumnsTest.kt
@@ -1,0 +1,54 @@
+@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.ui.screens.csvstrategy
+
+import com.moneymanager.domain.model.csv.CsvColumn
+import com.moneymanager.domain.model.csv.CsvColumnId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+class AttributeCandidateColumnsTest {
+    @Test
+    fun `attribute candidates include fallback columns`() {
+        val columns =
+            listOf(
+                csvColumn(0, "Date"),
+                csvColumn(1, "Description"),
+                csvColumn(2, "Amount"),
+                csvColumn(3, "Name"),
+                csvColumn(4, "Type"),
+            )
+
+        val candidates =
+            attributeCandidateColumns(
+                csvColumns = columns,
+                primaryFieldColumnNames = setOf("Date", "Description", "Amount", "Name"),
+            )
+
+        assertEquals(listOf("Type"), candidates.map { it.originalName })
+    }
+
+    @Test
+    fun `attribute candidates exclude primary field columns`() {
+        val columns =
+            listOf(
+                csvColumn(0, "Date"),
+                csvColumn(1, "Description"),
+                csvColumn(2, "Amount"),
+            )
+
+        val candidates =
+            attributeCandidateColumns(
+                csvColumns = columns,
+                primaryFieldColumnNames = setOf("Date", "Description", "Amount"),
+            )
+
+        assertEquals(emptyList(), candidates)
+    }
+
+    private fun csvColumn(
+        index: Int,
+        name: String,
+    ): CsvColumn = CsvColumn(CsvColumnId(Uuid.random()), index, name)
+}


### PR DESCRIPTION
## Summary
- Keep fallback CSV columns available in the attribute mappings selector
- Add unit coverage for attribute candidate column filtering

Closes #366

## Tests
- ./gradlew.bat :app:ui:core:jvmTest --console=plain
- ./gradlew.bat lintFormat --console=plain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV column handling in the strategy dialog to better distinguish between columns used for field mappings and those available for attributes.
  * Updated error messaging to clarify when no columns are available for attributes.

* **Tests**
  * Added comprehensive test coverage for attribute column validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->