### PR TITLE
Fix account audit API source link not expanding JSON tree for main accounts

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -788,8 +788,9 @@ fun ApiSessionTrafficScreen(
                                                     highlightJsonPath.startsWithJsonPath(it.jsonPath.value)
                                                 }
                                         ) ||
-                                            // Highlight by requestId alone when no jsonPath match (entity/account sources)
-                                            (highlightJsonPath == null && highlightRequestId != null)
+                                            // Highlight by requestId when jsonPath doesn't match any transaction
+                                            // (e.g. main account sources stored at $.accounts[0], not transaction paths)
+                                            highlightRequestId != null
                                     )
                             ApiTrafficPairCard(
                                 pair = pair,


### PR DESCRIPTION
## Summary

- The API source link in an account's audit view was not expanding the JSON tree to the relevant location when the account is a main account (not a counterparty from a transaction response)
- Root cause: the `isHighlighted` condition required `highlightJsonPath == null` for the requestId-based fallback, but main accounts have a jsonPath (e.g. `$.accounts[0]`) that simply doesn't match any response transaction
- Fix: remove the `highlightJsonPath == null` guard so the card is highlighted whenever `highlightRequestId` matches, passing `highlightJsonPath` through to `ApiTrafficPairCard` for JSON tree expansion

## Test plan

- [ ] Open audit view for a main account (not a counterparty) that was imported via API
- [ ] Click the "API Import" source link
- [ ] Verify the API session traffic screen scrolls to the correct request and expands the JSON tree to the account's path
- [ ] Verify existing behaviour for transaction audit sources (counterparty paths like `$.transactions[0].counterparty`) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API session highlighting to work more reliably in additional scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->