### PR TITLE
Add copy buttons to API session JSON tree and traffic headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 - Import types explicitly, never use fully qualified names in code
 - Comments should explain "why", not "what" - prefer self-documenting code
 - Never skip `buildHealth` checks
+- **Never use `@Suppress("DEPRECATION")`** to silence deprecated API warnings. Always migrate to the replacement API instead (e.g. use `LocalClipboard` instead of `LocalClipboardManager`).
 
 ### Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 - Import types explicitly, never use fully qualified names in code
 - Comments should explain "why", not "what" - prefer self-documenting code
 - Never skip `buildHealth` checks
+- **Never use `@Suppress("DEPRECATION")`** to silence deprecated API warnings. Always migrate to the replacement API instead (e.g. use `LocalClipboard` instead of `LocalClipboardManager`).
 
 ### Testing
 

--- a/app/ui/core/build.gradle.kts
+++ b/app/ui/core/build.gradle.kts
@@ -53,6 +53,7 @@ kotlin {
                 implementation(libs.androidx.compose.ui.graphics)
                 implementation(libs.androidx.compose.ui.text)
                 implementation(libs.diamondedge.logging)
+                implementation(libs.kotlinx.serialization.core)
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.http)
             }
@@ -79,7 +80,9 @@ kotlin {
                 implementation(libs.compose.material3.desktop)
                 implementation(libs.compose.ui.graphics.desktop)
                 implementation(libs.compose.ui.text.desktop)
+                implementation(libs.compose.ui.util.desktop)
                 implementation(libs.diamondedge.logging)
+                implementation(libs.kotlinx.serialization.core)
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.http)
             }

--- a/app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/util/ClipboardUtils.android.kt
+++ b/app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/util/ClipboardUtils.android.kt
@@ -1,0 +1,9 @@
+package com.moneymanager.ui.util
+
+import android.content.ClipData
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+
+actual suspend fun Clipboard.setPlainText(text: String) {
+    setClipEntry(ClipEntry(ClipData.newPlainText("", text)))
+}

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -35,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -42,8 +44,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -80,7 +81,9 @@ import com.moneymanager.ui.monzo.MonzoImportResult
 import com.moneymanager.ui.monzo.downloadMonzoAccounts
 import com.moneymanager.ui.monzo.downloadMonzoTransactions
 import com.moneymanager.ui.monzo.importMonzoSessionTransactions
+import com.moneymanager.ui.util.ContentCopyIcon
 import com.moneymanager.ui.util.displayDateTime
+import com.moneymanager.ui.util.setPlainText
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -95,7 +98,6 @@ import kotlin.time.Instant
 private val logger = logging()
 
 @Composable
-@Suppress("DEPRECATION")
 fun ApiSessionsScreen(
     apiSessionRepository: ApiSessionRepository,
     accountRepository: AccountRepository,
@@ -113,7 +115,7 @@ fun ApiSessionsScreen(
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
     val backgroundTasks = LocalBackgroundTaskManager.current
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
 
     var credentials by remember { mutableStateOf<List<MonzoCredential>>(emptyList()) }
     var sessionsByCredential by remember { mutableStateOf<Map<MonzoCredentialId, List<ApiSession>>>(emptyMap()) }
@@ -361,7 +363,7 @@ fun ApiSessionsScreen(
                                 },
                                 onSessionClick = onSessionClick,
                                 onRevokeSession = { sessionToRevoke = it },
-                                onCopyError = { error -> clipboardManager.setText(AnnotatedString(error)) },
+                                onCopyError = { error -> scope.launch { clipboard.setPlainText(error) } },
                             )
                         }
                     }
@@ -907,6 +909,8 @@ private fun RequestTrafficItem(
     timestamp: String,
     body: String,
 ) {
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     Column(
         modifier =
             Modifier
@@ -919,6 +923,7 @@ private fun RequestTrafficItem(
         TrafficItemHeader(
             title = title,
             timestamp = timestamp,
+            onCopy = { scope.launch { clipboard.setPlainText(body) } },
         )
         SelectionContainer {
             Text(
@@ -941,6 +946,15 @@ private fun ResponseTrafficItem(
     highlightJsonPath: String? = null,
     onHighlightPositioned: ((Float) -> Unit)? = null,
 ) {
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    val prettyJson =
+        remember(json) {
+            runCatching {
+                val element = Json.parseToJsonElement(json)
+                Json { prettyPrint = true }.encodeToString(element)
+            }.getOrDefault(json)
+        }
     Column(
         modifier =
             Modifier
@@ -953,6 +967,7 @@ private fun ResponseTrafficItem(
         TrafficItemHeader(
             title = title,
             timestamp = timestamp,
+            onCopy = { scope.launch { clipboard.setPlainText(prettyJson) } },
         )
         JsonViewer(
             json = json,
@@ -967,16 +982,31 @@ private fun ResponseTrafficItem(
 private fun TrafficItemHeader(
     title: String,
     timestamp: String,
+    onCopy: (() -> Unit)? = null,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.labelLarge,
-        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.weight(1f),
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.labelLarge,
+            )
+            if (onCopy != null) {
+                Icon(
+                    imageVector = ContentCopyIcon,
+                    contentDescription = "Copy",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(14.dp).clickable(onClick = onCopy),
+                )
+            }
+        }
         Text(
             text = timestamp,
             style = MaterialTheme.typography.labelSmall,
@@ -1145,6 +1175,10 @@ private fun JsonTreeNode(
                 },
             )
 
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    val prettyPrinter = remember { Json { prettyPrint = true } }
+
     Row(
         modifier = lineModifier,
         verticalAlignment = Alignment.CenterVertically,
@@ -1162,6 +1196,15 @@ private fun JsonTreeNode(
         nodeTransaction?.let { transaction ->
             JsonTransactionStatus(transaction = transaction)
         }
+        Icon(
+            imageVector = ContentCopyIcon,
+            contentDescription = "Copy",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier =
+                Modifier
+                    .size(14.dp)
+                    .clickable { scope.launch { clipboard.setPlainText(prettyPrinter.encodeToString<JsonElement>(element)) } },
+        )
     }
     if (expanded) {
         when (element) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -788,8 +788,9 @@ fun ApiSessionTrafficScreen(
                                                     highlightJsonPath.startsWithJsonPath(it.jsonPath.value)
                                                 }
                                         ) ||
-                                            // Highlight by requestId alone when no jsonPath match (entity/account sources)
-                                            (highlightJsonPath == null && highlightRequestId != null)
+                                            // Highlight by requestId when jsonPath doesn't match any transaction
+                                            // (e.g. main account sources stored at $.accounts[0], not transaction paths)
+                                            highlightRequestId != null
                                     )
                             ApiTrafficPairCard(
                                 pair = pair,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
@@ -84,6 +85,7 @@ import com.moneymanager.ui.monzo.importMonzoSessionTransactions
 import com.moneymanager.ui.util.ContentCopyIcon
 import com.moneymanager.ui.util.displayDateTime
 import com.moneymanager.ui.util.setPlainText
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -1026,6 +1028,22 @@ private fun JsonViewer(
         remember(json) {
             runCatching { Json.parseToJsonElement(json) }.getOrNull()
         }
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    val prettyPrinter = remember { Json { prettyPrint = true } }
+    // Parse the highlight path into segments (e.g. "$.transactions[0]" → ["transactions", "0"])
+    val highlightSegments =
+        remember(highlightJsonPath) {
+            parseJsonPathSegments(highlightJsonPath)
+        }
+    val latestTransactionByJsonPath =
+        remember(responseTransactions) {
+            responseTransactions
+                .groupBy { it.jsonPath.value }
+                .mapValues { (_, transactions) ->
+                    transactions.maxBy { it.id.id }
+                }
+        }
 
     if (jsonElement == null) {
         SelectionContainer {
@@ -1038,19 +1056,6 @@ private fun JsonViewer(
             )
         }
     } else {
-        // Parse the highlight path into segments (e.g. "$.transactions[0]" → ["transactions", "0"])
-        val highlightSegments =
-            remember(highlightJsonPath) {
-                parseJsonPathSegments(highlightJsonPath)
-            }
-        val latestTransactionByJsonPath =
-            remember(responseTransactions) {
-                responseTransactions
-                    .groupBy { it.jsonPath.value }
-                    .mapValues { (_, transactions) ->
-                        transactions.maxBy { it.id.id }
-                    }
-            }
         Column {
             JsonTreeNode(
                 label = null,
@@ -1060,6 +1065,9 @@ private fun JsonViewer(
                 latestTransactionByJsonPath = latestTransactionByJsonPath,
                 remainingHighlightSegments = highlightSegments,
                 onHighlightPositioned = onHighlightPositioned,
+                clipboard = clipboard,
+                copyScope = scope,
+                prettyPrinter = prettyPrinter,
             )
         }
     }
@@ -1106,6 +1114,9 @@ private fun JsonTreeNode(
     element: JsonElement,
     jsonPath: String,
     depth: Int,
+    clipboard: Clipboard,
+    copyScope: CoroutineScope,
+    prettyPrinter: Json,
     latestTransactionByJsonPath: Map<String, ApiResponseTransaction> = emptyMap(),
     remainingHighlightSegments: List<String>? = null,
     forceExpandSubtree: Boolean = false,
@@ -1175,10 +1186,6 @@ private fun JsonTreeNode(
                 },
             )
 
-    val clipboard = LocalClipboard.current
-    val scope = rememberCoroutineScope()
-    val prettyPrinter = remember { Json { prettyPrint = true } }
-
     Row(
         modifier = lineModifier,
         verticalAlignment = Alignment.CenterVertically,
@@ -1203,7 +1210,7 @@ private fun JsonTreeNode(
             modifier =
                 Modifier
                     .size(14.dp)
-                    .clickable { scope.launch { clipboard.setPlainText(prettyPrinter.encodeToString<JsonElement>(element)) } },
+                    .clickable { copyScope.launch { clipboard.setPlainText(prettyPrinter.encodeToString<JsonElement>(element)) } },
         )
     }
     if (expanded) {
@@ -1222,6 +1229,9 @@ private fun JsonTreeNode(
                         element = value,
                         jsonPath = jsonObjectChildPath(jsonPath, key),
                         depth = depth + 1,
+                        clipboard = clipboard,
+                        copyScope = copyScope,
+                        prettyPrinter = prettyPrinter,
                         latestTransactionByJsonPath = latestTransactionByJsonPath,
                         remainingHighlightSegments = nextSegments,
                         forceExpandSubtree = forceExpandSubtree || isHighlightTarget,
@@ -1244,6 +1254,9 @@ private fun JsonTreeNode(
                         element = value,
                         jsonPath = "$jsonPath[$index]",
                         depth = depth + 1,
+                        clipboard = clipboard,
+                        copyScope = copyScope,
+                        prettyPrinter = prettyPrinter,
                         latestTransactionByJsonPath = latestTransactionByJsonPath,
                         remainingHighlightSegments = nextSegments,
                         forceExpandSubtree = forceExpandSubtree || isHighlightTarget,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/ClipboardUtils.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/ClipboardUtils.kt
@@ -1,0 +1,5 @@
+package com.moneymanager.ui.util
+
+import androidx.compose.ui.platform.Clipboard
+
+expect suspend fun Clipboard.setPlainText(text: String)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/Icons.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/Icons.kt
@@ -1,0 +1,47 @@
+package com.moneymanager.ui.util
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val ContentCopyIcon: ImageVector by lazy {
+    ImageVector
+        .Builder(
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+        ).path(
+            fill = SolidColor(Color.Black),
+            pathFillType = PathFillType.NonZero,
+        ) {
+            moveTo(16f, 1f)
+            horizontalLineTo(4f)
+            curveToRelative(-1.1f, 0f, -2f, 0.9f, -2f, 2f)
+            verticalLineToRelative(14f)
+            horizontalLineToRelative(2f)
+            verticalLineTo(3f)
+            horizontalLineToRelative(12f)
+            verticalLineTo(1f)
+            close()
+            moveTo(19f, 5f)
+            horizontalLineTo(8f)
+            curveToRelative(-1.1f, 0f, -2f, 0.9f, -2f, 2f)
+            verticalLineToRelative(14f)
+            curveToRelative(0f, 1.1f, 0.9f, 2f, 2f, 2f)
+            horizontalLineToRelative(11f)
+            curveToRelative(1.1f, 0f, 2f, -0.9f, 2f, -2f)
+            verticalLineTo(7f)
+            curveToRelative(0f, -1.1f, -0.9f, -2f, -2f, -2f)
+            close()
+            moveTo(19f, 21f)
+            horizontalLineTo(8f)
+            verticalLineTo(7f)
+            horizontalLineToRelative(11f)
+            verticalLineToRelative(14f)
+            close()
+        }.build()
+}

--- a/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/util/ClipboardUtils.jvm.kt
+++ b/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/util/ClipboardUtils.jvm.kt
@@ -1,0 +1,11 @@
+package com.moneymanager.ui.util
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import java.awt.datatransfer.StringSelection
+
+@OptIn(ExperimentalComposeUiApi::class)
+actual suspend fun Clipboard.setPlainText(text: String) {
+    setClipEntry(ClipEntry(StringSelection(text)))
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ compose-ui-graphics-desktop = { module = "org.jetbrains.compose.ui:ui-graphics-d
 compose-ui-text-desktop = { module = "org.jetbrains.compose.ui:ui-text-desktop", version.ref = "compose-plugin" }
 compose-ui-test-desktop = { module = "org.jetbrains.compose.ui:ui-test-desktop", version.ref = "compose-plugin" }
 compose-ui-unit-desktop = { module = "org.jetbrains.compose.ui:ui-unit-desktop", version.ref = "compose-plugin" }
+compose-ui-util-desktop = { module = "org.jetbrains.compose.ui:ui-util-desktop", version.ref = "compose-plugin" }
 dependency-analysis-gradle-plugin = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dependency-analysis" }
 detekt-gradle-plugin = { module = "dev.detekt:dev.detekt.gradle.plugin", version.ref = "detekt" }
 develocity-gradle-plugin = { module = "com.gradle:develocity-gradle-plugin", version.ref = "develocity" }


### PR DESCRIPTION
## Summary

- Each JSON tree node now has a copy icon (14dp) that copies the node's subtree as pretty-printed JSON to the clipboard
- Request/response section headers have an inline copy icon next to the title (e.g. "Request #1 📋") that copies the full body/JSON
- Migrated all clipboard usage from deprecated `LocalClipboardManager` to `LocalClipboard` with a `Clipboard.setPlainText` expect/actual — JVM uses AWT `StringSelection`, Android uses `ClipData`
- Added `ContentCopyIcon` as a custom `ImageVector` (no extended-icons dependency needed)
- Added guideline to `CLAUDE.md` and `AGENTS.md`: never use `@Suppress("DEPRECATION")`, always migrate to the replacement API

## Test plan

- [ ] Open API Traffic view for a session, verify copy icon appears on every JSON tree node
- [ ] Click a JSON node copy icon — paste should produce pretty-printed JSON for that subtree
- [ ] Click the copy icon next to "Request #N" — paste should produce the request body
- [ ] Click the copy icon next to "Response #N" — paste should produce the full pretty-printed JSON response
- [ ] Verify row height of JSON tree nodes is unchanged from before
- [ ] Run `./gradlew build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add copy actions throughout API sessions UI: per-item copy for requests/responses, per-line copy in JSON viewer, and a copy icon in item headers.
  * Copying now produces pretty-printed JSON where appropriate and uses a coroutine-friendly clipboard approach across platforms.

* **Documentation**
  * Add Code Style guidance: do not use @Suppress("DEPRECATION"); migrate to replacement APIs instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->