### PR TITLE
Remove session revoke functionality

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiSessionRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiSessionRepositoryImpl.kt
@@ -100,42 +100,9 @@ class ApiSessionRepositoryImpl(
             queries.selectByDeviceId(deviceId.id).executeAsList().map { it.toApiSession() }
         }
 
-    override suspend fun getActiveSessions(now: Instant): List<ApiSession> =
+    override suspend fun getSessions(now: Instant): List<ApiSession> =
         withContext(Dispatchers.Default) {
-            queries.selectActiveSessions(now.toEpochMilliseconds()).executeAsList().map { it.toApiSession() }
-        }
-
-    override suspend fun revokeSession(
-        id: ApiSessionId,
-        revokedAt: Instant,
-    ): Unit =
-        withContext(Dispatchers.Default) {
-            queries.revoke(
-                revoked_at = revokedAt.toEpochMilliseconds(),
-                id = id.id,
-            )
-        }
-
-    override suspend fun revokeSessionByToken(
-        token: String,
-        revokedAt: Instant,
-    ): Unit =
-        withContext(Dispatchers.Default) {
-            queries.revokeByToken(
-                revoked_at = revokedAt.toEpochMilliseconds(),
-                token = token,
-            )
-        }
-
-    override suspend fun revokeAllSessionsForDevice(
-        deviceId: DeviceId,
-        revokedAt: Instant,
-    ): Unit =
-        withContext(Dispatchers.Default) {
-            queries.revokeAllForDevice(
-                revoked_at = revokedAt.toEpochMilliseconds(),
-                device_id = deviceId.id,
-            )
+            queries.selectSessions(now.toEpochMilliseconds()).executeAsList().map { it.toApiSession() }
         }
 
     override suspend fun insertRequest(
@@ -326,7 +293,6 @@ class ApiSessionRepositoryImpl(
             deviceId = DeviceId(device_id),
             createdAt = Instant.fromEpochMilliseconds(created_at),
             expiresAt = expires_at?.let { Instant.fromEpochMilliseconds(it) },
-            revokedAt = revoked_at?.let { Instant.fromEpochMilliseconds(it) },
             credentialId = credential_id?.let { MonzoCredentialId(it) },
             kind = ApiSessionKind.fromValueOrNull(kind),
         )

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/ApiSession.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/ApiSession.sq
@@ -22,7 +22,6 @@ CREATE TABLE api_session (
     device_id INTEGER NOT NULL,
     created_at INTEGER NOT NULL,
     expires_at INTEGER,
-    revoked_at INTEGER,
     credential_id INTEGER,
     kind TEXT,
     imported_at INTEGER,
@@ -98,10 +97,9 @@ SELECT * FROM api_session WHERE device_id = ? ORDER BY created_at DESC;
 selectByCredentialId:
 SELECT * FROM api_session WHERE credential_id = ? ORDER BY created_at DESC;
 
-selectActiveSessions:
+selectSessions:
 SELECT * FROM api_session
-WHERE revoked_at IS NULL
-AND (expires_at IS NULL OR expires_at > ?)
+WHERE (expires_at IS NULL OR expires_at > ?)
 ORDER BY created_at DESC;
 
 insert:
@@ -110,15 +108,6 @@ VALUES (?, ?, ?, ?, ?, ?, ?);
 
 insertSessionType:
 INSERT INTO api_session_type(id, name) VALUES (?, ?);
-
-revoke:
-UPDATE api_session SET revoked_at = ? WHERE id = ?;
-
-revokeByToken:
-UPDATE api_session SET revoked_at = ? WHERE token = ?;
-
-revokeAllForDevice:
-UPDATE api_session SET revoked_at = ? WHERE device_id = ? AND revoked_at IS NULL;
 
 insertRequest:
 INSERT INTO api_request(session_id, method, url)

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/ApiSessionRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/ApiSessionRepositoryImplTest.kt
@@ -46,7 +46,6 @@ class ApiSessionRepositoryImplTest : DbTest() {
             assertEquals(deviceId, session.deviceId)
             assertEquals(now, session.createdAt)
             assertNull(session.expiresAt)
-            assertNull(session.revokedAt)
         }
 
     @Test
@@ -99,65 +98,7 @@ class ApiSessionRepositoryImplTest : DbTest() {
         }
 
     @Test
-    fun `revokeSession sets revokedAt`() =
-        runTest {
-            val deviceId = deviceId()
-            val id = repositories.apiSessionRepository.createSession(token, deviceId, now, null)
-
-            val revokedAt = now + 1.hours
-            repositories.apiSessionRepository.revokeSession(id, revokedAt)
-
-            val session = repositories.apiSessionRepository.getSessionById(id)
-            assertNotNull(session)
-            assertEquals(revokedAt, session.revokedAt)
-        }
-
-    @Test
-    fun `revokeSessionByToken sets revokedAt`() =
-        runTest {
-            val deviceId = deviceId()
-            val id = repositories.apiSessionRepository.createSession(token, deviceId, now, null)
-
-            val revokedAt = now + 1.hours
-            repositories.apiSessionRepository.revokeSessionByToken(token, revokedAt)
-
-            val session = repositories.apiSessionRepository.getSessionById(id)
-            assertNotNull(session)
-            assertEquals(revokedAt, session.revokedAt)
-        }
-
-    @Test
-    fun `revokeAllSessionsForDevice revokes all active sessions`() =
-        runTest {
-            val deviceId = deviceId()
-            val id1 = repositories.apiSessionRepository.createSession("token-1", deviceId, now, null)
-            val id2 = repositories.apiSessionRepository.createSession("token-2", deviceId, now, null)
-
-            val revokedAt = now + 1.hours
-            repositories.apiSessionRepository.revokeAllSessionsForDevice(deviceId, revokedAt)
-
-            val session1 = repositories.apiSessionRepository.getSessionById(id1)
-            val session2 = repositories.apiSessionRepository.getSessionById(id2)
-            assertNotNull(session1?.revokedAt)
-            assertNotNull(session2?.revokedAt)
-        }
-
-    @Test
-    fun `getActiveSessions excludes revoked sessions`() =
-        runTest {
-            val deviceId = deviceId()
-            val id1 = repositories.apiSessionRepository.createSession("token-1", deviceId, now, null)
-            repositories.apiSessionRepository.createSession("token-2", deviceId, now, null)
-
-            repositories.apiSessionRepository.revokeSession(id1, now + 1.hours)
-
-            val active = repositories.apiSessionRepository.getActiveSessions(now + 2.hours)
-            assertEquals(1, active.size)
-            assertEquals("token-2", active.first().token)
-        }
-
-    @Test
-    fun `getActiveSessions excludes expired sessions`() =
+    fun `getSessions excludes expired sessions`() =
         runTest {
             val deviceId = deviceId()
             // Session expires in 1 hour
@@ -165,7 +106,7 @@ class ApiSessionRepositoryImplTest : DbTest() {
             repositories.apiSessionRepository.createSession("valid-token", deviceId, now, now + 3.hours)
 
             // Check at now + 2 hours: first session is expired, second is not
-            val active = repositories.apiSessionRepository.getActiveSessions(now + 2.hours)
+            val active = repositories.apiSessionRepository.getSessions(now + 2.hours)
             assertEquals(1, active.size)
             assertEquals("valid-token", active.first().token)
         }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ApiSession.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ApiSession.kt
@@ -37,7 +37,6 @@ data class ApiSession(
     val deviceId: DeviceId,
     val createdAt: Instant,
     val expiresAt: Instant?,
-    val revokedAt: Instant?,
     val credentialId: MonzoCredentialId?,
     val kind: ApiSessionKind?,
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ApiSessionRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ApiSessionRepository.kt
@@ -78,44 +78,11 @@ interface ApiSessionRepository {
     suspend fun getSessionsByDevice(deviceId: DeviceId): List<ApiSession>
 
     /**
-     * Returns all sessions that are currently active (not revoked and not expired).
+     * Returns all sessions that are not expired.
      *
      * @param now The current timestamp used to check expiry
      */
-    suspend fun getActiveSessions(now: Instant): List<ApiSession>
-
-    /**
-     * Revokes the session with the given ID.
-     *
-     * @param id The session ID to revoke
-     * @param revokedAt The revocation timestamp
-     */
-    suspend fun revokeSession(
-        id: ApiSessionId,
-        revokedAt: Instant,
-    )
-
-    /**
-     * Revokes the session identified by the given token.
-     *
-     * @param token The session token to revoke
-     * @param revokedAt The revocation timestamp
-     */
-    suspend fun revokeSessionByToken(
-        token: String,
-        revokedAt: Instant,
-    )
-
-    /**
-     * Revokes all active sessions for the given device.
-     *
-     * @param deviceId The device whose sessions should be revoked
-     * @param revokedAt The revocation timestamp
-     */
-    suspend fun revokeAllSessionsForDevice(
-        deviceId: DeviceId,
-        revokedAt: Instant,
-    )
+    suspend fun getSessions(now: Instant): List<ApiSession>
 
     /**
      * Stores one API request payload and its headers for the given session.

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -88,11 +87,8 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import org.lighthousegames.logging.logging
 import kotlin.time.Clock
 import kotlin.time.Instant
-
-private val logger = logging()
 
 @Composable
 @Suppress("DEPRECATION")
@@ -119,8 +115,6 @@ fun ApiSessionsScreen(
     var sessionsByCredential by remember { mutableStateOf<Map<MonzoCredentialId, List<ApiSession>>>(emptyMap()) }
     var importedSessionIds by remember { mutableStateOf<Set<ApiSessionId>>(emptySet()) }
     var isLoading by remember { mutableStateOf(true) }
-    var sessionToRevoke by remember { mutableStateOf<ApiSession?>(null) }
-
     // Per-session import state
     var importResultBySession by remember { mutableStateOf<Map<ApiSessionId, MonzoImportResult>>(emptyMap()) }
     var importErrorBySession by remember { mutableStateOf<Map<ApiSessionId, String>>(emptyMap()) }
@@ -148,34 +142,6 @@ fun ApiSessionsScreen(
     }
 
     LaunchedEffect(Unit) { refresh() }
-
-    sessionToRevoke?.let { session ->
-        AlertDialog(
-            onDismissRequest = { sessionToRevoke = null },
-            title = { Text("Revoke Session?") },
-            text = {
-                Text("This will revoke the session created on ${session.createdAt.displayDateTime()}.")
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        sessionToRevoke = null
-                        scope.launch {
-                            try {
-                                apiSessionRepository.revokeSession(session.id, Clock.System.now())
-                                refresh()
-                            } catch (expected: Exception) {
-                                logger.error(expected) { "Failed to revoke session: ${expected.message}" }
-                            }
-                        }
-                    },
-                ) { Text("Revoke") }
-            },
-            dismissButton = {
-                TextButton(onClick = { sessionToRevoke = null }) { Text("Cancel") }
-            },
-        )
-    }
 
     Column(
         modifier = Modifier.fillMaxSize().padding(16.dp),
@@ -360,7 +326,6 @@ fun ApiSessionsScreen(
                                     }
                                 },
                                 onSessionClick = onSessionClick,
-                                onRevokeSession = { sessionToRevoke = it },
                                 onCopyError = { error -> clipboardManager.setText(AnnotatedString(error)) },
                             )
                         }
@@ -392,7 +357,6 @@ private fun CredentialCard(
     onDownloadTransactions: () -> Unit,
     onImport: (ApiSession) -> Unit,
     onSessionClick: (ApiSession) -> Unit,
-    onRevokeSession: (ApiSession) -> Unit,
     onCopyError: (String) -> Unit,
 ) {
     val displayToken =
@@ -480,7 +444,6 @@ private fun CredentialCard(
                         importError = importErrorBySession[session.id],
                         onImport = { onImport(session) },
                         onOpenTraffic = { onSessionClick(session) },
-                        onRevoke = { onRevokeSession(session) },
                         onCopyError = onCopyError,
                     )
                 }
@@ -498,12 +461,9 @@ private fun SessionRow(
     importError: String?,
     onImport: () -> Unit,
     onOpenTraffic: () -> Unit,
-    onRevoke: () -> Unit,
     onCopyError: (String) -> Unit,
 ) {
-    val isActive =
-        session.revokedAt == null &&
-            (session.expiresAt?.let { it > Clock.System.now() } ?: true)
+    val isActive = session.expiresAt?.let { it > Clock.System.now() } ?: true
 
     val containerColor =
         if (isActive) {
@@ -546,14 +506,6 @@ private fun SessionRow(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-
-        session.revokedAt?.let {
-            Text(
-                text = "Revoked: ${it.displayDateTime()}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.error,
-            )
-        }
 
         importResult?.let {
             Text(text = it.displaySummary(), color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.bodySmall)
@@ -601,7 +553,6 @@ private fun SessionRow(
                     }
                 }
                 OutlinedButton(onClick = onOpenTraffic) { Text("Traffic") }
-                OutlinedButton(onClick = onRevoke) { Text("Revoke") }
             }
         } else {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {


### PR DESCRIPTION
## Summary

- Removes `revoked_at` column from `api_session` table and all associated SQL queries
- Removes `revokeSession`, `revokeSessionByToken`, `revokeAllSessionsForDevice` from the repository interface and implementation
- Removes the Revoke button, confirmation dialog, and "Revoked:" label from the sessions UI
- Renames `selectActiveSessions` → `selectSessions` (no longer meaningful to call it "active" without revocation)

Sessions already have an expiry mechanism (`expires_at`), so revocation was redundant.

## Test plan

- [ ] `./gradlew build` passes (compiles, tests, coverage, dependency health)

🤖 Generated with [Claude Code](https://claude.com/claude-code)