### PR TITLE
Exclude test helper module from Kover coverage

### DIFF
--- a/test/app/db/build.gradle.kts
+++ b/test/app/db/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     id("moneymanager.android-convention")
 }
 
+kover {
+    disable()
+}
+
 kotlin {
     sourceSets {
         val commonMain by getting {


### PR DESCRIPTION
## Summary
- `DbTest` lives in `commonMain` of the `test/app/db` module, so Kover treats it as production code and reports it with 0% coverage in Codecov
- Adds `kover { disable() }` to the module's `build.gradle.kts` to exclude it from instrumentation entirely

## Test plan
- [ ] Verify Codecov no longer reports `DbTest.kt` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)