### PR TITLE
Exclude com.moneymanager.test package from Kover coverage reports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,6 +116,8 @@ kover {
                 classes("*Module$*")
                 // Exclude SQLDelight generated code
                 classes("com.moneymanager.database.*")
+                // Exclude test helper modules — they live in commonMain but are not production code
+                packages("com.moneymanager.test")
             }
         }
         total {

--- a/test/app/db/build.gradle.kts
+++ b/test/app/db/build.gradle.kts
@@ -3,10 +3,6 @@ plugins {
     id("moneymanager.android-convention")
 }
 
-kover {
-    disable()
-}
-
 kotlin {
     sourceSets {
         val commonMain by getting {


### PR DESCRIPTION
## Summary
- Removes the `kover { disable() }` added in #444 — disabling Kover on the submodule doesn't work because other modules' tests load `DbTest` from the classpath, so Kover still records it in their instrumentation and it surfaces in the aggregated report with 0% coverage
- Adds `packages("com.moneymanager.test")` to the root-level `excludes` filter, which strips the package from the merged report regardless of which module's instrumentation contributed the data

## Test plan
- [ ] Verify `DbTest.kt` no longer appears in Codecov after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to exclude test helper modules from reporting and adjusted coverage settings for the database test module.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NikolayMetchev/money-manager/pull/447)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->