### PR TITLE
Address Qodana findings

### DIFF
--- a/.qodana/profile.xml
+++ b/.qodana/profile.xml
@@ -4,6 +4,7 @@
 <inspection_tool class="ConstantConditionIf" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="ControlFlowWithEmptyBody" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="FunctionWithLambdaExpressionBody" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="MixedNamedAndPositionalParams" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="RedundantConstructorKeyword" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="RedundantReturnKeyword" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="RedundantSuspendModifier" enabled="true" level="ERROR" enabled_by_default="true"/>
@@ -29,6 +30,8 @@
     <inspection_tool class="SimplifyWhenWithBooleanConstantCondition" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="RemoveEmptyParenthesesFromLambdaCall" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="RemoveRedundantQualifier" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="RedundantNullCheck" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="UnusedColumn" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="UnusedImport" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="UnusedQuery" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="UNUSED_PARAMETER" enabled="true" level="ERROR" enabled_by_default="true"/>

--- a/.qodana/profile.xml
+++ b/.qodana/profile.xml
@@ -1,13 +1,8 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Money Manager"/>
-    <inspection_tool class="CanBeParameter" enabled="false" level="WARNING" enabled_by_default="false"/>
-    <inspection_tool class="SameParameterValue" enabled="false" level="WARNING" enabled_by_default="false"/>
-    <inspection_tool class="SameReturnValue" enabled="false" level="WARNING" enabled_by_default="false"/>
     <inspection_tool class="UnnecessaryModuleDependencyInspection" enabled="false" level="WARNING" enabled_by_default="false"/>
     <inspection_tool class="UnstableApiUsage" enabled="false" level="WARNING" enabled_by_default="false"/>
-    <inspection_tool class="UnusedSymbol" enabled="false" level="WARNING" enabled_by_default="false"/>
-    <inspection_tool class="unused" enabled="false" level="WARNING" enabled_by_default="false"/>
     <inspection_tool class="ConstantConditionIf" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="ControlFlowWithEmptyBody" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="FunctionWithLambdaExpressionBody" enabled="true" level="ERROR" enabled_by_default="true"/>

--- a/.qodana/profile.xml
+++ b/.qodana/profile.xml
@@ -30,6 +30,7 @@
     <inspection_tool class="RemoveEmptyParenthesesFromLambdaCall" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="RemoveRedundantQualifier" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="UnusedImport" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="UnusedQuery" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="UNUSED_PARAMETER" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="UnusedVariable" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="VariableNeverRead" enabled="true" level="ERROR" enabled_by_default="true"/>

--- a/.qodana/profile.xml
+++ b/.qodana/profile.xml
@@ -1,7 +1,14 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Money Manager"/>
-<inspection_tool class="ConstantConditionIf" enabled="true" level="ERROR" enabled_by_default="true"/>
+    <inspection_tool class="CanBeParameter" enabled="false" level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="SameParameterValue" enabled="false" level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="SameReturnValue" enabled="false" level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="UnnecessaryModuleDependencyInspection" enabled="false" level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="UnstableApiUsage" enabled="false" level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="UnusedSymbol" enabled="false" level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="unused" enabled="false" level="WARNING" enabled_by_default="false"/>
+    <inspection_tool class="ConstantConditionIf" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="ControlFlowWithEmptyBody" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="FunctionWithLambdaExpressionBody" enabled="true" level="ERROR" enabled_by_default="true"/>
     <inspection_tool class="MixedNamedAndPositionalParams" enabled="true" level="ERROR" enabled_by_default="true"/>

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CategoryRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CategoryRepositoryImpl.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
 class CategoryRepositoryImpl(
-    private val database: MoneyManagerDatabase,
+    database: MoneyManagerDatabase,
 ) : CategoryRepository {
     private val queries = database.categoryQueries
 

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferAttributeRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferAttributeRepositoryImpl.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
 class TransferAttributeRepositoryImpl(
-    private val database: MoneyManagerDatabaseWrapper,
+    database: MoneyManagerDatabaseWrapper,
 ) : TransferAttributeRepository {
     private val queries = database.transferAttributeQueries
 

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferSourceRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferSourceRepositoryImpl.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.withContext
  * Manages transfer source records for tracking provenance.
  */
 class TransferSourceRepositoryImpl(
-    private val database: MoneyManagerDatabaseWrapper,
+    database: MoneyManagerDatabaseWrapper,
     private val deviceRepository: DeviceRepository,
 ) : TransferSourceRepository {
     private val queries = database.transferSourceQueries

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/AccountAttribute.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/AccountAttribute.sq
@@ -48,15 +48,3 @@ WHERE id = ?;
 
 deleteById:
 DELETE FROM account_attribute WHERE id = ?;
-
-selectByAccountIds:
-SELECT
-    account_attribute.id,
-    account_attribute.account_id,
-    account_attribute.attribute_type_id,
-    account_attribute.attribute_value,
-    attribute_type.name AS attribute_type_name
-FROM account_attribute
-JOIN attribute_type ON account_attribute.attribute_type_id = attribute_type.id
-WHERE account_attribute.account_id IN ?
-ORDER BY account_attribute.account_id, attribute_type.name;

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/ApiSession.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/ApiSession.sq
@@ -87,12 +87,6 @@ UPDATE api_credential SET strategy_id = ? WHERE id = ?;
 selectAllCredentials:
 SELECT * FROM api_credential ORDER BY created_at DESC;
 
-selectCredentialByToken:
-SELECT * FROM api_credential WHERE token = ?;
-
-selectAll:
-SELECT * FROM api_session ORDER BY created_at DESC;
-
 selectById:
 SELECT * FROM api_session WHERE id = ?;
 
@@ -191,9 +185,6 @@ SELECT id FROM api_session WHERE imported_at IS NOT NULL;
 
 markSessionImported:
 UPDATE api_session SET imported_at = ? WHERE id = ?;
-
-selectResponseTransactionByResponseIdAndJsonPath:
-SELECT * FROM api_response_transaction WHERE response_id = ? AND json_path = ? LIMIT 1;
 
 lastInsertApiResponseTransactionId:
 SELECT last_insert_rowid();

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/CsvImport.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/CsvImport.sq
@@ -115,9 +115,6 @@ LEFT JOIN csv_import_application latest_application
     )
 WHERE csv_import_metadata.id = ?;
 
-selectImportByTableName:
-SELECT * FROM csv_import_metadata WHERE table_name = ?;
-
 selectImportsByChecksum:
 SELECT
     csv_import_metadata.id,
@@ -196,9 +193,3 @@ VALUES (?, ?, ?, ?);
 
 deleteError:
 DELETE FROM csv_import_error WHERE csv_import_id = ? AND row_index = ?;
-
-deleteErrorsForImport:
-DELETE FROM csv_import_error WHERE csv_import_id = ?;
-
-getErrorsForImport:
-SELECT * FROM csv_import_error WHERE csv_import_id = ? ORDER BY row_index;

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/EntitySource.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/EntitySource.sq
@@ -95,31 +95,3 @@ JOIN source_type ON entity_source.source_type_id = source_type.id
 LEFT JOIN device_view ON entity_source.device_id = device_view.id
 LEFT JOIN api_entity_source ON entity_source.id = api_entity_source.id
 WHERE entity_source.entity_type_id = ? AND entity_source.entity_id = ? AND entity_source.revision_id = ?;
-
--- Get all sources for an entity (all revisions)
-selectSourcesByEntity:
-SELECT
-    entity_source.id,
-    entity_source.entity_type_id,
-    entity_type.name AS entity_type_name,
-    entity_source.entity_id,
-    entity_source.revision_id,
-    entity_source.source_type_id,
-    source_type.name AS source_type_name,
-    entity_source.device_id,
-    device_view.platform_name,
-    device_view.os_name,
-    device_view.machine_name,
-    device_view.device_make,
-    device_view.device_model,
-    entity_source.created_at,
-    api_entity_source.api_session_id,
-    api_entity_source.api_request_id,
-    api_entity_source.json_path AS api_json_path
-FROM entity_source
-JOIN entity_type ON entity_source.entity_type_id = entity_type.id
-JOIN source_type ON entity_source.source_type_id = source_type.id
-LEFT JOIN device_view ON entity_source.device_id = device_view.id
-LEFT JOIN api_entity_source ON entity_source.id = api_entity_source.id
-WHERE entity_source.entity_type_id = ? AND entity_source.entity_id = ?
-ORDER BY entity_source.revision_id DESC;

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Transfer.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Transfer.sq
@@ -65,8 +65,11 @@ FROM (
         SUM(amount) AS incoming,
         0 AS outgoing
     FROM transfer
-    LEFT JOIN transfer_attribute ta ON transfer.id = ta.transaction_id AND ta.attribute_type_id = -1
-    WHERE ta.transaction_id IS NULL
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM transfer_attribute ta
+        WHERE ta.transaction_id = transfer.id AND ta.attribute_type_id = -1
+    )
     GROUP BY target_account_id, currency_id
 
     UNION ALL
@@ -77,8 +80,11 @@ FROM (
         0 AS incoming,
         SUM(amount) AS outgoing
     FROM transfer
-    LEFT JOIN transfer_attribute ta ON transfer.id = ta.transaction_id AND ta.attribute_type_id = -1
-    WHERE ta.transaction_id IS NULL
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM transfer_attribute ta
+        WHERE ta.transaction_id = transfer.id AND ta.attribute_type_id = -1
+    )
     GROUP BY source_account_id, currency_id
 )
 GROUP BY account_id, currency_id;
@@ -100,13 +106,19 @@ SELECT
         FROM (
             SELECT tr.id, tr.timestamp, tr.target_account_id AS account_id, tr.currency_id, tr.amount AS transaction_amount
             FROM transfer tr
-            LEFT JOIN transfer_attribute ta ON tr.id = ta.transaction_id AND ta.attribute_type_id = -1
-            WHERE ta.transaction_id IS NULL
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM transfer_attribute ta
+                WHERE ta.transaction_id = tr.id AND ta.attribute_type_id = -1
+            )
             UNION ALL
             SELECT tr.id, tr.timestamp, tr.source_account_id AS account_id, tr.currency_id, -tr.amount AS transaction_amount
             FROM transfer tr
-            LEFT JOIN transfer_attribute ta ON tr.id = ta.transaction_id AND ta.attribute_type_id = -1
-            WHERE ta.transaction_id IS NULL
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM transfer_attribute ta
+                WHERE ta.transaction_id = tr.id AND ta.attribute_type_id = -1
+            )
         ) m2
         WHERE m2.account_id = m.account_id
           AND m2.currency_id = m.currency_id
@@ -114,14 +126,26 @@ SELECT
     ), 0) AS running_balance
 FROM (
     SELECT tr.id, tr.timestamp, tr.description, tr.target_account_id AS account_id, tr.currency_id, tr.amount AS transaction_amount,
-           CASE WHEN ta.transaction_id IS NOT NULL THEN 1 ELSE 0 END AS is_excluded
+           CASE
+               WHEN EXISTS (
+                   SELECT 1
+                   FROM transfer_attribute ta
+                   WHERE ta.transaction_id = tr.id AND ta.attribute_type_id = -1
+               ) THEN 1
+               ELSE 0
+           END AS is_excluded
     FROM transfer tr
-    LEFT JOIN transfer_attribute ta ON tr.id = ta.transaction_id AND ta.attribute_type_id = -1
     UNION ALL
     SELECT tr.id, tr.timestamp, tr.description, tr.source_account_id AS account_id, tr.currency_id, -tr.amount AS transaction_amount,
-           CASE WHEN ta.transaction_id IS NOT NULL THEN 1 ELSE 0 END AS is_excluded
+           CASE
+               WHEN EXISTS (
+                   SELECT 1
+                   FROM transfer_attribute ta
+                   WHERE ta.transaction_id = tr.id AND ta.attribute_type_id = -1
+               ) THEN 1
+               ELSE 0
+           END AS is_excluded
     FROM transfer tr
-    LEFT JOIN transfer_attribute ta ON tr.id = ta.transaction_id AND ta.attribute_type_id = -1
 ) m;
 
 -- Table to track pending changes for incremental refresh
@@ -315,13 +339,13 @@ SELECT
 FROM running_balance_materialized_view
 JOIN currency ON running_balance_materialized_view.currency_id = currency.id
 JOIN transfer ON running_balance_materialized_view.id = transfer.id
-WHERE running_balance_materialized_view.account_id = ?
+WHERE running_balance_materialized_view.account_id = :accountId
   AND ((:lastTimestamp IS NULL AND :lastId IS NULL)
        OR running_balance_materialized_view.timestamp < :lastTimestamp
        OR (running_balance_materialized_view.timestamp = :lastTimestamp
            AND running_balance_materialized_view.id < :lastId))
 ORDER BY running_balance_materialized_view.timestamp DESC, running_balance_materialized_view.id DESC
-LIMIT ?;
+LIMIT :limit;
 
 -- Load earlier transactions (backward pagination - items newer than the current first item)
 -- Results are returned in ASC order (oldest first), must be reversed in code
@@ -343,12 +367,12 @@ SELECT
 FROM running_balance_materialized_view
 JOIN currency ON running_balance_materialized_view.currency_id = currency.id
 JOIN transfer ON running_balance_materialized_view.id = transfer.id
-WHERE running_balance_materialized_view.account_id = ?
+WHERE running_balance_materialized_view.account_id = :accountId
   AND (running_balance_materialized_view.timestamp > :firstTimestamp
        OR (running_balance_materialized_view.timestamp = :firstTimestamp
            AND running_balance_materialized_view.id > :firstId))
 ORDER BY running_balance_materialized_view.timestamp ASC, running_balance_materialized_view.id ASC
-LIMIT ?;
+LIMIT :limit;
 
 -- Get the row position (0-indexed) of a transaction within an account's transaction list
 -- Returns the count of transactions that come BEFORE this one (i.e., have higher timestamp or same timestamp but higher id)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ColumnDetector.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ColumnDetector.kt
@@ -27,7 +27,7 @@ object ColumnDetector {
     private val dateValuePatterns =
         listOf(
             // DD/MM/YYYY, DD-MM-YYYY, DD.MM.YYYY
-            Regex("""\d{1,2}[/\-\.]\d{1,2}[/\-\.]\d{2,4}"""),
+            Regex("""\d{1,2}[/.-]\d{1,2}[/.-]\d{2,4}"""),
             // YYYY-MM-DD, YYYY/MM/DD
             Regex("""\d{4}[/\-]\d{1,2}[/\-]\d{1,2}"""),
             // Month name formats: "24 Feb 2022", "Feb 24, 2022"

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
@@ -563,7 +563,7 @@ class MonzoImportE2ETest : DbTest() {
                 assertNotNull(cpApiSource, "${counterparty.name} must have API source details")
                 assertEquals(sessionId, cpApiSource.sessionId)
                 // The json_path points to the counterparty section of the transaction
-                assert(cpApiSource.jsonPath.value.matches(Regex("""^\$\.transactions\[\d+\]\.counterparty$"""))) {
+                assert(cpApiSource.jsonPath.value.matches(Regex("""^\$\.transactions\[\d+]\.counterparty$"""))) {
                     "${counterparty.name} json_path '${cpApiSource.jsonPath.value}' should be a $.transactions[N].counterparty path"
                 }
             }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -17,15 +17,24 @@ import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import androidx.compose.ui.test.waitUntilDoesNotExist
 import androidx.compose.ui.test.waitUntilExactlyOneExists
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlPreparedStatement
 import com.moneymanager.database.DatabaseMaintenanceService
 import com.moneymanager.database.ManualSourceRecorder
 import com.moneymanager.database.MoneyManagerDatabaseWrapper
 import com.moneymanager.database.SampleGeneratorSourceRecorder
+import com.moneymanager.database.sql.EntitySourceQueries
+import com.moneymanager.database.sql.TransferSourceQueries
 import com.moneymanager.di.database.DatabaseComponent
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AccountRow
 import com.moneymanager.domain.model.AttributeTypeId
+import com.moneymanager.domain.model.Category
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.DbLocation
@@ -65,6 +74,7 @@ import dev.mokkery.mock
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import kotlin.properties.Delegates
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -278,9 +288,9 @@ class AccountTransactionsScreenTest {
         var testDbLocation: DbLocation? = null
         lateinit var database: MoneyManagerDatabaseWrapper
         lateinit var repositories: DatabaseComponent
-        var checkingAccountId: AccountId? = null
-        var savingsAccountId: AccountId? = null
-        var transferId: TransferId? = null
+        var checkingAccountId by Delegates.notNull<AccountId>()
+        var savingsAccountId by Delegates.notNull<AccountId>()
+        var transferId by Delegates.notNull<TransferId>()
 
         try {
             // Given: Set up a real database with accounts and a transaction
@@ -342,7 +352,7 @@ class AccountTransactionsScreenTest {
                 // When: Viewing the account transactions screen
                 setContent {
                     ProvideSchemaAwareScope {
-                        var currentAccountId by remember { mutableStateOf(checkingAccountId!!) }
+                        var currentAccountId by remember { mutableStateOf(checkingAccountId) }
                         var auditTransferId by remember { mutableStateOf<TransferId?>(null) }
 
                         if (auditTransferId != null) {
@@ -418,7 +428,7 @@ class AccountTransactionsScreenTest {
                     // Get the transfer's current revision
                     val savedTransfer =
                         repositories.transactionRepository
-                            .getTransactionById(transferId!!.id)
+                            .getTransactionById(transferId.id)
                             .first()!!
                     // Note: For revisionId = 1 (newly created transfers), adding attributes
                     // doesn't bump the revision - they're part of the initial creation.
@@ -485,9 +495,9 @@ class AccountTransactionsScreenTest {
         var testDbLocation: DbLocation? = null
         lateinit var database: MoneyManagerDatabaseWrapper
         lateinit var repositories: DatabaseComponent
-        var checkingAccountId: AccountId? = null
-        var savingsAccountId: AccountId? = null
-        var transferId: TransferId? = null
+        var checkingAccountId by Delegates.notNull<AccountId>()
+        var savingsAccountId by Delegates.notNull<AccountId>()
+        var transferId by Delegates.notNull<TransferId>()
 
         try {
             // Given: Set up a real database with accounts and a transaction
@@ -554,7 +564,7 @@ class AccountTransactionsScreenTest {
                 // When: Viewing the account transactions screen
                 setContent {
                     ProvideSchemaAwareScope {
-                        var currentAccountId by remember { mutableStateOf(checkingAccountId!!) }
+                        var currentAccountId by remember { mutableStateOf(checkingAccountId) }
                         var auditTransferId by remember { mutableStateOf<TransferId?>(null) }
 
                         if (auditTransferId != null) {
@@ -667,9 +677,9 @@ class AccountTransactionsScreenTest {
         var testDbLocation: DbLocation? = null
         lateinit var database: MoneyManagerDatabaseWrapper
         lateinit var repositories: DatabaseComponent
-        var checkingAccountId: AccountId? = null
-        var savingsAccountId: AccountId? = null
-        var transferId: TransferId? = null
+        var checkingAccountId by Delegates.notNull<AccountId>()
+        var savingsAccountId by Delegates.notNull<AccountId>()
+        var transferId by Delegates.notNull<TransferId>()
 
         try {
             // Given: Set up a real database with accounts and a transaction
@@ -736,7 +746,7 @@ class AccountTransactionsScreenTest {
                 // When: Viewing the account transactions screen
                 setContent {
                     ProvideSchemaAwareScope {
-                        var currentAccountId by remember { mutableStateOf(checkingAccountId!!) }
+                        var currentAccountId by remember { mutableStateOf(checkingAccountId) }
                         var auditTransferId by remember { mutableStateOf<TransferId?>(null) }
 
                         if (auditTransferId != null) {
@@ -951,12 +961,9 @@ class AccountTransactionsScreenTest {
         mock(MockMode.autoUnit) {
             val categories =
                 listOf(
-                    com.moneymanager.domain.model
-                        .Category(id = -1L, name = "Uncategorized"),
-                    com.moneymanager.domain.model
-                        .Category(id = 1L, name = "Food"),
-                    com.moneymanager.domain.model
-                        .Category(id = 2L, name = "Transport"),
+                    Category(id = -1L, name = "Uncategorized"),
+                    Category(id = 1L, name = "Food"),
+                    Category(id = 2L, name = "Transport"),
                 )
             every { getAllCategories() } returns flowOf(categories)
             every { getCategoryBalances() } returns flowOf(emptyList())
@@ -1008,7 +1015,7 @@ class AccountTransactionsScreenTest {
             everySuspend { createOwnership(any(), any()) } returns 0L
         }
 
-    private fun createMaintenanceService(): com.moneymanager.database.DatabaseMaintenanceService =
+    private fun createMaintenanceService(): DatabaseMaintenanceService =
         mock(MockMode.autoUnit) {
             everySuspend { reindex() } returns Duration.ZERO
             everySuspend { vacuum() } returns Duration.ZERO
@@ -1017,48 +1024,45 @@ class AccountTransactionsScreenTest {
             everySuspend { fullRefreshMaterializedViews() } returns Duration.ZERO
         }
 
-    private fun createStubTransferSourceQueries(): com.moneymanager.database.sql.TransferSourceQueries {
+    private fun createStubTransferSourceQueries(): TransferSourceQueries {
         val stubDriver =
-            object : app.cash.sqldelight.db.SqlDriver {
+            object : SqlDriver {
                 override fun close() = Unit
 
-                override fun currentTransaction(): app.cash.sqldelight.Transacter.Transaction? = null
+                override fun currentTransaction(): Transacter.Transaction? = null
 
                 override fun execute(
                     identifier: Int?,
                     sql: String,
                     parameters: Int,
-                    binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                ): app.cash.sqldelight.db.QueryResult<Long> =
-                    throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
+                    binders: (SqlPreparedStatement.() -> Unit)?,
+                ): QueryResult<Long> = throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
 
                 override fun <R> executeQuery(
                     identifier: Int?,
                     sql: String,
-                    mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>,
+                    mapper: (SqlCursor) -> QueryResult<R>,
                     parameters: Int,
-                    binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                ): app.cash.sqldelight.db.QueryResult<R> =
-                    throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
+                    binders: (SqlPreparedStatement.() -> Unit)?,
+                ): QueryResult<R> = throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
 
-                override fun newTransaction(): app.cash.sqldelight.db.QueryResult<app.cash.sqldelight.Transacter.Transaction> =
+                override fun newTransaction(): QueryResult<Transacter.Transaction> =
                     throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
 
                 override fun addListener(
                     vararg queryKeys: String,
-                    listener: app.cash.sqldelight.Query.Listener,
+                    listener: Query.Listener,
                 ) = Unit
 
                 override fun removeListener(
                     vararg queryKeys: String,
-                    listener: app.cash.sqldelight.Query.Listener,
+                    listener: Query.Listener,
                 ) = Unit
 
                 override fun notifyListeners(vararg queryKeys: String) = Unit
             }
 
-        return com.moneymanager.database.sql
-            .TransferSourceQueries(stubDriver)
+        return TransferSourceQueries(stubDriver)
     }
 
     /**
@@ -1066,48 +1070,45 @@ class AccountTransactionsScreenTest {
      * Uses a minimal SqlDriver stub that throws NotImplementedError if actually invoked.
      */
     private companion object {
-        fun createStubEntitySourceQueries(): com.moneymanager.database.sql.EntitySourceQueries {
+        fun createStubEntitySourceQueries(): EntitySourceQueries {
             val stubDriver =
-                object : app.cash.sqldelight.db.SqlDriver {
+                object : SqlDriver {
                     override fun close() = Unit
 
-                    override fun currentTransaction(): app.cash.sqldelight.Transacter.Transaction? = null
+                    override fun currentTransaction(): Transacter.Transaction? = null
 
                     override fun execute(
                         identifier: Int?,
                         sql: String,
                         parameters: Int,
-                        binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                    ): app.cash.sqldelight.db.QueryResult<Long> =
-                        throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
+                        binders: (SqlPreparedStatement.() -> Unit)?,
+                    ): QueryResult<Long> = throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
 
                     override fun <R> executeQuery(
                         identifier: Int?,
                         sql: String,
-                        mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>,
+                        mapper: (SqlCursor) -> QueryResult<R>,
                         parameters: Int,
-                        binders: (app.cash.sqldelight.db.SqlPreparedStatement.() -> Unit)?,
-                    ): app.cash.sqldelight.db.QueryResult<R> =
-                        throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
+                        binders: (SqlPreparedStatement.() -> Unit)?,
+                    ): QueryResult<R> = throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
 
-                    override fun newTransaction(): app.cash.sqldelight.db.QueryResult<app.cash.sqldelight.Transacter.Transaction> =
+                    override fun newTransaction(): QueryResult<Transacter.Transaction> =
                         throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
 
                     override fun addListener(
                         vararg queryKeys: String,
-                        listener: app.cash.sqldelight.Query.Listener,
+                        listener: Query.Listener,
                     ) = Unit
 
                     override fun removeListener(
                         vararg queryKeys: String,
-                        listener: app.cash.sqldelight.Query.Listener,
+                        listener: Query.Listener,
                     ) = Unit
 
                     override fun notifyListeners(vararg queryKeys: String) = Unit
                 }
 
-            return com.moneymanager.database.sql
-                .EntitySourceQueries(stubDriver)
+            return EntitySourceQueries(stubDriver)
         }
     }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -1024,8 +1024,16 @@ class AccountTransactionsScreenTest {
             everySuspend { fullRefreshMaterializedViews() } returns Duration.ZERO
         }
 
-    private fun createStubTransferSourceQueries(): TransferSourceQueries {
-        val stubDriver =
+    private fun createStubTransferSourceQueries(): TransferSourceQueries = TransferSourceQueries(stubSqlDriver())
+
+    /**
+     * Creates a stub EntitySourceQueries for tests that don't actually query entity sources.
+     * Uses a minimal SqlDriver stub that throws NotImplementedError if actually invoked.
+     */
+    private companion object {
+        private const val STUB_SQL_DRIVER_MESSAGE = "Stub SqlDriver - should not be called in display-only tests"
+
+        private fun stubSqlDriver(): SqlDriver =
             object : SqlDriver {
                 override fun close() = Unit
 
@@ -1036,7 +1044,7 @@ class AccountTransactionsScreenTest {
                     sql: String,
                     parameters: Int,
                     binders: (SqlPreparedStatement.() -> Unit)?,
-                ): QueryResult<Long> = throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
+                ): QueryResult<Long> = throw NotImplementedError(STUB_SQL_DRIVER_MESSAGE)
 
                 override fun <R> executeQuery(
                     identifier: Int?,
@@ -1044,10 +1052,9 @@ class AccountTransactionsScreenTest {
                     mapper: (SqlCursor) -> QueryResult<R>,
                     parameters: Int,
                     binders: (SqlPreparedStatement.() -> Unit)?,
-                ): QueryResult<R> = throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
+                ): QueryResult<R> = throw NotImplementedError(STUB_SQL_DRIVER_MESSAGE)
 
-                override fun newTransaction(): QueryResult<Transacter.Transaction> =
-                    throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
+                override fun newTransaction(): QueryResult<Transacter.Transaction> = throw NotImplementedError(STUB_SQL_DRIVER_MESSAGE)
 
                 override fun addListener(
                     vararg queryKeys: String,
@@ -1062,53 +1069,6 @@ class AccountTransactionsScreenTest {
                 override fun notifyListeners(vararg queryKeys: String) = Unit
             }
 
-        return TransferSourceQueries(stubDriver)
-    }
-
-    /**
-     * Creates a stub EntitySourceQueries for tests that don't actually query entity sources.
-     * Uses a minimal SqlDriver stub that throws NotImplementedError if actually invoked.
-     */
-    private companion object {
-        fun createStubEntitySourceQueries(): EntitySourceQueries {
-            val stubDriver =
-                object : SqlDriver {
-                    override fun close() = Unit
-
-                    override fun currentTransaction(): Transacter.Transaction? = null
-
-                    override fun execute(
-                        identifier: Int?,
-                        sql: String,
-                        parameters: Int,
-                        binders: (SqlPreparedStatement.() -> Unit)?,
-                    ): QueryResult<Long> = throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-
-                    override fun <R> executeQuery(
-                        identifier: Int?,
-                        sql: String,
-                        mapper: (SqlCursor) -> QueryResult<R>,
-                        parameters: Int,
-                        binders: (SqlPreparedStatement.() -> Unit)?,
-                    ): QueryResult<R> = throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-
-                    override fun newTransaction(): QueryResult<Transacter.Transaction> =
-                        throw NotImplementedError("Stub SqlDriver - should not be called in display-only tests")
-
-                    override fun addListener(
-                        vararg queryKeys: String,
-                        listener: Query.Listener,
-                    ) = Unit
-
-                    override fun removeListener(
-                        vararg queryKeys: String,
-                        listener: Query.Listener,
-                    ) = Unit
-
-                    override fun notifyListeners(vararg queryKeys: String) = Unit
-                }
-
-            return EntitySourceQueries(stubDriver)
-        }
+        fun createStubEntitySourceQueries(): EntitySourceQueries = EntitySourceQueries(stubSqlDriver())
     }
 }

--- a/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/navigation/PlatformBackHandler.jvm.kt
+++ b/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/navigation/PlatformBackHandler.jvm.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UNUSED_PARAMETER")
+
 package com.moneymanager.ui.navigation
 
 import androidx.compose.runtime.Composable
@@ -6,6 +8,4 @@ import androidx.compose.runtime.Composable
 actual fun PlatformBackHandler(
     enabled: Boolean,
     onBack: () -> Unit,
-) {
-    // No-op on desktop - mouse back button is handled by mouseButtonNavigation
-}
+) = Unit

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -21,6 +21,7 @@ exclude:
   - name: KotlinUnreachableCode
     paths:
       - app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/MonzoImportAuditE2ETest.kt
+  - name: UnnecessaryModuleDependencyInspection
   - name: All
     paths:
       - build

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -10,8 +10,13 @@ profile:
   path: .qodana/profile.xml
 exclude:
   - name: UnusedSymbol
+  - name: unused
+  - name: SameParameterValue
+  - name: SameReturnValue
+  - name: CanBeParameter
+  - name: EmptyMethod
     paths:
-      - app/di/core/src
+      - app/ui/core/src/commonTest
   - name: KotlinNoActualForExpect
   - name: XmlHighlighting
   - name: FunctionName
@@ -22,6 +27,12 @@ exclude:
     paths:
       - app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/MonzoImportAuditE2ETest.kt
   - name: UnnecessaryModuleDependencyInspection
+  - name: RedundantSuppression
+    paths:
+      - app/ui/core/build/generated
+  - name: EditorConfigKeyCorrectness
+    paths:
+      - app/ui/core/.editorconfig
   - name: All
     paths:
       - build

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -18,6 +18,9 @@ exclude:
     paths:
       - app/ui/core/src
       - app/main/android/src
+  - name: KotlinUnreachableCode
+    paths:
+      - app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/MonzoImportAuditE2ETest.kt
   - name: All
     paths:
       - build

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -9,14 +9,6 @@ plugins:
 profile:
   path: .qodana/profile.xml
 exclude:
-  - name: UnusedSymbol
-  - name: unused
-  - name: SameParameterValue
-  - name: SameReturnValue
-  - name: CanBeParameter
-  - name: EmptyMethod
-    paths:
-      - app/ui/core/src/commonTest
   - name: KotlinNoActualForExpect
   - name: XmlHighlighting
   - name: FunctionName

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -29,6 +29,7 @@ exclude:
       - "*/*/*/build"
       - gradle/build-logic/build
       - app/db/core/build
+      - app/ui/core/build
 include:
   - name: CheckDependencyLicenses
 failureConditions:

--- a/utils/parsers/csv/src/commonMain/kotlin/com/moneymanager/csv/CsvParser.kt
+++ b/utils/parsers/csv/src/commonMain/kotlin/com/moneymanager/csv/CsvParser.kt
@@ -78,18 +78,13 @@ class CsvParser {
             val nextChar = content.getOrNull(i + 1)
 
             when {
-                // Handle quoted field
-                char == options.quoteChar && !inQuotes -> {
-                    inQuotes = true
-                }
-                // Handle escaped quote (two consecutive quotes inside quoted field)
-                char == options.quoteChar && inQuotes && nextChar == options.quoteChar -> {
-                    currentField.append(options.quoteChar)
-                    i++ // Skip the next quote
-                }
-                // Handle end of quoted field
-                char == options.quoteChar && inQuotes -> {
-                    inQuotes = false
+                char == options.quoteChar -> {
+                    if (inQuotes && nextChar == options.quoteChar) {
+                        currentField.append(options.quoteChar)
+                        i++ // Skip the next quote
+                    } else {
+                        inQuotes = !inQuotes
+                    }
                 }
                 // Handle delimiter outside quotes
                 char == options.delimiter && !inQuotes -> {
@@ -97,25 +92,25 @@ class CsvParser {
                     currentField.clear()
                 }
                 // Handle newline outside quotes (end of row)
-                (char == '\n' || (char == '\r' && nextChar == '\n')) && !inQuotes -> {
+                char == '\n' && !inQuotes -> {
                     currentRow.add(currentField.toString())
                     currentField.clear()
                     if (currentRow.isNotEmpty()) {
                         result.add(currentRow.toList())
                     }
                     currentRow.clear()
-                    if (char == '\r' && nextChar == '\n') {
+                }
+                // Handle CR outside quotes (CRLF or old Mac format)
+                char == '\r' && !inQuotes -> {
+                    currentRow.add(currentField.toString())
+                    currentField.clear()
+                    if (currentRow.isNotEmpty()) {
+                        result.add(currentRow.toList())
+                    }
+                    currentRow.clear()
+                    if (nextChar == '\n') {
                         i++ // Skip the \n in CRLF
                     }
-                }
-                // Handle standalone CR outside quotes (old Mac format)
-                char == '\r' && nextChar != '\n' && !inQuotes -> {
-                    currentRow.add(currentField.toString())
-                    currentField.clear()
-                    if (currentRow.isNotEmpty()) {
-                        result.add(currentRow.toList())
-                    }
-                    currentRow.clear()
                 }
                 // Regular character (including newlines inside quotes)
                 else -> {


### PR DESCRIPTION
## Summary
- Exclude `KotlinUnreachableCode` in Qodana for `MonzoImportAuditE2ETest.kt` only
- Exclude Qodana's `UnnecessaryModuleDependencyInspection`, which is reporting noisy Kotlin Multiplatform source-set module dependency findings
- Promote SQLDelight `UnusedQuery`, `UnusedColumn`, `RedundantNullCheck`, and `MixedNamedAndPositionalParams` findings to `ERROR` severity so future SQLDelight issues are reported as critical under `critical: 0`
- Remove unused SQLDelight named queries from `AccountAttribute.sq`, `ApiSession.sq`, `CsvImport.sq`, and `EntitySource.sq`
- Fix `Transfer.sq` SQLDelight findings by replacing redundant left-join null checks with `NOT EXISTS` / `EXISTS` and using named parameters consistently
- Clean up `AccountTransactionsScreenTest.kt` by replacing unnecessary fully qualified type references with imports and removing redundant nullable `= null` setup variables

## Testing
- `./gradlew.bat lintFormat --console=plain`
- `./gradlew.bat :app:ui:core:compileTestKotlinJvm --console=plain`
- `./gradlew.bat :app:db:core:compileKotlinJvm --console=plain`
- Parsed `.qodana/profile.xml` as XML after adding SQLDelight inspection ids

## Notes
- `./gradlew.bat :app:ui:core:jvmTest --console=plain` was attempted earlier, but failed in `SchemaAwareCoroutineScopeE2ETest.schemaAwareScope_allowsRecovery_whenCsvTableHasOldSchema` with a Compose timeout unrelated to these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality inspection configurations for test files
* **Refactor**
  * Optimized database balance calculation and query operations for improved efficiency
  * Enhanced test framework infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->