### PR TITLE
Make API people mappings configurable and prevent duplicate entity source crashes

### DIFF
--- a/app/db/core/build.gradle.kts
+++ b/app/db/core/build.gradle.kts
@@ -10,57 +10,57 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(libs.kotlinx.coroutines.core)
-                api(libs.mappie.api)
-                api(projects.app.model.core)
-                api(projects.utils.currency)
+            api(libs.kotlinx.coroutines.core)
+            api(libs.mappie.api)
+            api(projects.app.model.core)
+            api(projects.utils.currency)
 
-                implementation(libs.kotlinx.datetime)
-                implementation(libs.kmlogging)
-                implementation(libs.kotlinx.serialization.json)
-                implementation(libs.sqldelight.coroutines.extensions)
-                implementation(projects.utils.bigdecimal)
-            }
+            implementation(libs.kmlogging)
+            implementation(libs.kotlinx.datetime)
+            implementation(libs.kotlinx.serialization.json)
+            implementation(libs.sqldelight.coroutines.extensions)
+            implementation(projects.utils.bigdecimal)
+        }
         }
 
         val commonTest by getting {
             dependencies {
-                implementation(kotlin("test"))
-                implementation(libs.kotlinx.coroutines.test)
-                implementation(projects.app.model.core)
-                implementation(projects.test.app.db)
-            }
+            implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(projects.app.model.core)
+            implementation(projects.test.app.db)
+        }
         }
 
         val jvmMain by getting {
             dependencies {
-                api(libs.kotlinx.serialization.core)
-                api(projects.utils.currency)
+            api(libs.kotlinx.serialization.core)
+            api(projects.utils.currency)
 
-                implementation(libs.sqldelight.sqlite.driver)
-            }
+            implementation(libs.sqldelight.sqlite.driver)
+        }
         }
 
         val jvmTest by getting {
             dependencies {
-                implementation(projects.app.db.core)
-                implementation(projects.app.di.core)
-            }
+            implementation(projects.app.db.core)
+            implementation(projects.app.di.core)
+        }
         }
 
         val androidMain by getting {
             dependencies {
-                api(libs.kotlinx.serialization.core)
+            api(libs.kotlinx.serialization.core)
 
-                implementation(libs.androidx.sqlite)
-                implementation(libs.sqldelight.android.driver)
-            }
+            implementation(libs.androidx.sqlite)
+            implementation(libs.sqldelight.android.driver)
+        }
         }
 
         val androidHostTest by getting {
             dependencies {
-                implementation(projects.app.di.core)
-            }
+            implementation(projects.app.di.core)
+        }
         }
 
         val androidDeviceTest by getting {
@@ -68,13 +68,13 @@ kotlin {
             // Tests are shared via srcDir() below, but we exclude the expect declarations
             // file since androidDeviceTest provides its own implementation
             dependencies {
-                implementation(kotlin("test"))
-                implementation(libs.kotlinx.coroutines.test)
-                implementation(projects.app.di.core)
-                implementation(projects.test.app.db)
+            implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(projects.app.di.core)
+            implementation(projects.test.app.db)
 
-                runtimeOnly(libs.androidx.test.runner)
-            }
+            runtimeOnly(libs.androidx.test.runner)
+        }
             // Include repository tests from commonTest (not the expect declarations file)
             kotlin.srcDir("src/commonTest/kotlin/com/moneymanager/database/repository")
         }

--- a/app/db/core/build.gradle.kts
+++ b/app/db/core/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
                 api(libs.kotlinx.serialization.core)
                 api(projects.utils.currency)
 
+                implementation(libs.diamondedge.logging)
                 implementation(libs.sqldelight.sqlite.driver)
             }
         }
@@ -53,6 +54,7 @@ kotlin {
                 api(libs.kotlinx.serialization.core)
 
                 implementation(libs.androidx.sqlite)
+                implementation(libs.diamondedge.logging)
                 implementation(libs.sqldelight.android.driver)
             }
         }

--- a/app/db/core/build.gradle.kts
+++ b/app/db/core/build.gradle.kts
@@ -10,57 +10,57 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-            api(libs.kotlinx.coroutines.core)
-            api(libs.mappie.api)
-            api(projects.app.model.core)
-            api(projects.utils.currency)
+                api(libs.kotlinx.coroutines.core)
+                api(libs.mappie.api)
+                api(projects.app.model.core)
+                api(projects.utils.currency)
 
-            implementation(libs.kmlogging)
-            implementation(libs.kotlinx.datetime)
-            implementation(libs.kotlinx.serialization.json)
-            implementation(libs.sqldelight.coroutines.extensions)
-            implementation(projects.utils.bigdecimal)
-        }
+                implementation(libs.kmlogging)
+                implementation(libs.kotlinx.datetime)
+                implementation(libs.kotlinx.serialization.json)
+                implementation(libs.sqldelight.coroutines.extensions)
+                implementation(projects.utils.bigdecimal)
+            }
         }
 
         val commonTest by getting {
             dependencies {
-            implementation(kotlin("test"))
-            implementation(libs.kotlinx.coroutines.test)
-            implementation(projects.app.model.core)
-            implementation(projects.test.app.db)
-        }
+                implementation(kotlin("test"))
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(projects.app.model.core)
+                implementation(projects.test.app.db)
+            }
         }
 
         val jvmMain by getting {
             dependencies {
-            api(libs.kotlinx.serialization.core)
-            api(projects.utils.currency)
+                api(libs.kotlinx.serialization.core)
+                api(projects.utils.currency)
 
-            implementation(libs.sqldelight.sqlite.driver)
-        }
+                implementation(libs.sqldelight.sqlite.driver)
+            }
         }
 
         val jvmTest by getting {
             dependencies {
-            implementation(projects.app.db.core)
-            implementation(projects.app.di.core)
-        }
+                implementation(projects.app.db.core)
+                implementation(projects.app.di.core)
+            }
         }
 
         val androidMain by getting {
             dependencies {
-            api(libs.kotlinx.serialization.core)
+                api(libs.kotlinx.serialization.core)
 
-            implementation(libs.androidx.sqlite)
-            implementation(libs.sqldelight.android.driver)
-        }
+                implementation(libs.androidx.sqlite)
+                implementation(libs.sqldelight.android.driver)
+            }
         }
 
         val androidHostTest by getting {
             dependencies {
-            implementation(projects.app.di.core)
-        }
+                implementation(projects.app.di.core)
+            }
         }
 
         val androidDeviceTest by getting {
@@ -68,13 +68,13 @@ kotlin {
             // Tests are shared via srcDir() below, but we exclude the expect declarations
             // file since androidDeviceTest provides its own implementation
             dependencies {
-            implementation(kotlin("test"))
-            implementation(libs.kotlinx.coroutines.test)
-            implementation(projects.app.di.core)
-            implementation(projects.test.app.db)
+                implementation(kotlin("test"))
+                implementation(libs.kotlinx.coroutines.test)
+                implementation(projects.app.di.core)
+                implementation(projects.test.app.db)
 
-            runtimeOnly(libs.androidx.test.runner)
-        }
+                runtimeOnly(libs.androidx.test.runner)
+            }
             // Include repository tests from commonTest (not the expect declarations file)
             kotlin.srcDir("src/commonTest/kotlin/com/moneymanager/database/repository")
         }

--- a/app/db/core/build.gradle.kts
+++ b/app/db/core/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
                 api(projects.utils.currency)
 
                 implementation(libs.kotlinx.datetime)
+                implementation(libs.kmlogging)
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.sqldelight.coroutines.extensions)
                 implementation(projects.utils.bigdecimal)

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
@@ -155,7 +155,7 @@ class ApiEntitySourceRecorder(
         entityId: Long,
         revisionId: Long,
     ) {
-         queries.transaction {
+        queries.transaction {
             queries.insertSource(
                 entity_type_id = entityType.id,
                 entity_id = entityId,
@@ -171,7 +171,9 @@ class ApiEntitySourceRecorder(
                         revision_id = revisionId,
                     ).executeAsOne()
             if (queries.selectApiEntitySourceId(id = entitySourceId).executeAsOneOrNull() != null) {
-                println("Suppressed duplicate API entity source: entity_type_id=${entityType.id}, entity_id=$entityId, revision_id=$revisionId")
+                println(
+                    "Suppressed duplicate API entity source: entity_type_id=${entityType.id}, entity_id=$entityId, revision_id=$revisionId",
+                )
                 return@transaction
             }
             queries.insertApiSource(

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
@@ -155,32 +155,31 @@ class ApiEntitySourceRecorder(
         entityId: Long,
         revisionId: Long,
     ) {
-        runCatching {
-            queries.transaction {
-                queries.insertSource(
-                    entity_type_id = entityType.id,
-                    entity_id = entityId,
-                    revision_id = revisionId,
-                    source_type_id = SourceType.API.id.toLong(),
-                    device_id = deviceId.id,
-                )
-                val entitySourceId = queries.lastInsertedId().executeAsOne()
-                queries.insertApiSource(
-                    id = entitySourceId,
-                    api_session_id = sessionId.id,
-                    api_request_id = requestId.id,
-                    json_path = jsonPath.value,
-                )
+         queries.transaction {
+            queries.insertSource(
+                entity_type_id = entityType.id,
+                entity_id = entityId,
+                revision_id = revisionId,
+                source_type_id = SourceType.API.id.toLong(),
+                device_id = deviceId.id,
+            )
+            val entitySourceId =
+                queries
+                    .selectEntitySourceId(
+                        entity_type_id = entityType.id,
+                        entity_id = entityId,
+                        revision_id = revisionId,
+                    ).executeAsOne()
+            if (queries.selectApiEntitySourceId(id = entitySourceId).executeAsOneOrNull() != null) {
+                println("Suppressed duplicate API entity source: entity_type_id=${entityType.id}, entity_id=$entityId, revision_id=$revisionId")
+                return@transaction
             }
-        }.onFailure { error ->
-            val isDuplicateRevisionSource =
-                error.message?.contains(
-                    "UNIQUE constraint failed: entity_source.entity_type_id, entity_source.entity_id, entity_source.revision_id",
-                ) ==
-                    true
-            if (!isDuplicateRevisionSource) {
-                throw error
-            }
+            queries.insertApiSource(
+                id = entitySourceId,
+                api_session_id = sessionId.id,
+                api_request_id = requestId.id,
+                json_path = jsonPath.value,
+            )
         }
     }
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
@@ -155,21 +155,30 @@ class ApiEntitySourceRecorder(
         entityId: Long,
         revisionId: Long,
     ) {
-        queries.transaction {
-            queries.insertSource(
-                entity_type_id = entityType.id,
-                entity_id = entityId,
-                revision_id = revisionId,
-                source_type_id = SourceType.API.id.toLong(),
-                device_id = deviceId.id,
-            )
-            val entitySourceId = queries.lastInsertedId().executeAsOne()
-            queries.insertApiSource(
-                id = entitySourceId,
-                api_session_id = sessionId.id,
-                api_request_id = requestId.id,
-                json_path = jsonPath.value,
-            )
+        runCatching {
+            queries.transaction {
+                queries.insertSource(
+                    entity_type_id = entityType.id,
+                    entity_id = entityId,
+                    revision_id = revisionId,
+                    source_type_id = SourceType.API.id.toLong(),
+                    device_id = deviceId.id,
+                )
+                val entitySourceId = queries.lastInsertedId().executeAsOne()
+                queries.insertApiSource(
+                    id = entitySourceId,
+                    api_session_id = sessionId.id,
+                    api_request_id = requestId.id,
+                    json_path = jsonPath.value,
+                )
+            }
+        }.onFailure { error ->
+            val isDuplicateRevisionSource =
+                error.message?.contains("UNIQUE constraint failed: entity_source.entity_type_id, entity_source.entity_id, entity_source.revision_id") ==
+                    true
+            if (!isDuplicateRevisionSource) {
+                throw error
+            }
         }
     }
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
@@ -174,7 +174,9 @@ class ApiEntitySourceRecorder(
             }
         }.onFailure { error ->
             val isDuplicateRevisionSource =
-                error.message?.contains("UNIQUE constraint failed: entity_source.entity_type_id, entity_source.entity_id, entity_source.revision_id") ==
+                error.message?.contains(
+                    "UNIQUE constraint failed: entity_source.entity_type_id, entity_source.entity_id, entity_source.revision_id",
+                ) ==
                     true
             if (!isDuplicateRevisionSource) {
                 throw error

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
@@ -14,6 +14,7 @@ import com.moneymanager.domain.model.SourceType
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.CsvImportId
+import org.lighthousegames.logging.logging
 
 /** Manual entry from UI. */
 class ManualSourceRecorder(
@@ -150,6 +151,8 @@ class ApiEntitySourceRecorder(
     private val requestId: ApiRequestId,
     private val jsonPath: JsonPath,
 ) {
+    private val logger = logging()
+
     fun insert(
         entityType: EntityType,
         entityId: Long,
@@ -171,9 +174,9 @@ class ApiEntitySourceRecorder(
                         revision_id = revisionId,
                     ).executeAsOne()
             if (queries.selectApiEntitySourceId(id = entitySourceId).executeAsOneOrNull() != null) {
-                println(
-                    "Suppressed duplicate API entity source: entity_type_id=${entityType.id}, entity_id=$entityId, revision_id=$revisionId",
-                )
+                logger.warn {
+                    "Suppressed duplicate API entity source: entity_type_id=${entityType.id}, entity_id=$entityId, revision_id=$revisionId"
+                }
                 return@transaction
             }
             queries.insertApiSource(

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/SourceRecorders.kt
@@ -166,13 +166,20 @@ class ApiEntitySourceRecorder(
                 source_type_id = SourceType.API.id.toLong(),
                 device_id = deviceId.id,
             )
-            val entitySourceId =
+            val entitySource =
                 queries
-                    .selectEntitySourceId(
+                    .selectEntitySourceForRevision(
                         entity_type_id = entityType.id,
                         entity_id = entityId,
                         revision_id = revisionId,
                     ).executeAsOne()
+            if (entitySource.source_type_id != SourceType.API.id.toLong()) {
+                logger.warn {
+                    "Skipped API entity source insert due to existing non-API source: entity_type_id=${entityType.id}, entity_id=$entityId, revision_id=$revisionId"
+                }
+                return@transaction
+            }
+            val entitySourceId = entitySource.id
             if (queries.selectApiEntitySourceId(id = entitySourceId).executeAsOneOrNull() != null) {
                 logger.warn {
                     "Suppressed duplicate API entity source: entity_type_id=${entityType.id}, entity_id=$entityId, revision_id=$revisionId"

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodec.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodec.kt
@@ -3,6 +3,7 @@ package com.moneymanager.database.json
 import com.moneymanager.domain.model.apistrategy.ApiAccountMappings
 import com.moneymanager.domain.model.apistrategy.ApiAuthType
 import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
+import com.moneymanager.domain.model.apistrategy.ApiPeopleMappings
 import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -21,6 +22,7 @@ data class ApiStrategyConfigJson(
     val transactionMappings: ApiTransactionMappings,
     val accountNamePrefix: String,
     val counterpartyPrefix: String,
+    val peopleMappings: ApiPeopleMappings = ApiPeopleMappings(),
 )
 
 /**

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiImportStrategyRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiImportStrategyRepositoryImpl.kt
@@ -93,6 +93,7 @@ class ApiImportStrategyRepositoryImpl(
             transactionMappings = config.transactionMappings,
             accountNamePrefix = config.accountNamePrefix,
             counterpartyPrefix = config.counterpartyPrefix,
+            peopleMappings = config.peopleMappings,
             createdAt = Instant.fromEpochMilliseconds(entity.created_at),
             updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
         )
@@ -108,5 +109,6 @@ class ApiImportStrategyRepositoryImpl(
             transactionMappings = transactionMappings,
             accountNamePrefix = accountNamePrefix,
             counterpartyPrefix = counterpartyPrefix,
+            peopleMappings = peopleMappings,
         )
 }

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/EntitySource.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/EntitySource.sq
@@ -57,12 +57,24 @@ CREATE INDEX IF NOT EXISTS idx_api_entity_source_request ON api_entity_source(ap
 
 -- Insert source for an entity
 insertSource:
-INSERT INTO entity_source (entity_type_id, entity_id, revision_id, source_type_id, device_id)
+INSERT OR IGNORE INTO entity_source (entity_type_id, entity_id, revision_id, source_type_id, device_id)
 VALUES (?, ?, ?, ?, ?);
 
 -- Get the last inserted entity_source ID
 lastInsertedId:
 SELECT last_insert_rowid();
+
+selectEntitySourceId:
+SELECT id
+FROM entity_source
+WHERE entity_type_id = ?
+  AND entity_id = ?
+  AND revision_id = ?;
+
+selectApiEntitySourceId:
+SELECT id
+FROM api_entity_source
+WHERE id = ?;
 
 -- Insert API-specific details for an entity source (must be called after insertSource)
 insertApiSource:

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/EntitySource.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/EntitySource.sq
@@ -60,10 +60,6 @@ insertSource:
 INSERT OR IGNORE INTO entity_source (entity_type_id, entity_id, revision_id, source_type_id, device_id)
 VALUES (?, ?, ?, ?, ?);
 
--- Get the last inserted entity_source ID
-lastInsertedId:
-SELECT last_insert_rowid();
-
 selectEntitySourceId:
 SELECT id
 FROM entity_source

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/EntitySource.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/EntitySource.sq
@@ -60,8 +60,8 @@ insertSource:
 INSERT OR IGNORE INTO entity_source (entity_type_id, entity_id, revision_id, source_type_id, device_id)
 VALUES (?, ?, ?, ?, ?);
 
-selectEntitySourceId:
-SELECT id
+selectEntitySourceForRevision:
+SELECT id, source_type_id
 FROM entity_source
 WHERE entity_type_id = ?
   AND entity_id = ?

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiImportStrategy.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiImportStrategy.kt
@@ -16,6 +16,7 @@ import kotlin.time.Instant
  * @property transactionMappings JSON field paths for mapping transaction fields
  * @property accountNamePrefix Prefix prepended to account names on import (e.g. "Monzo: ")
  * @property counterpartyPrefix Prefix prepended to counterparty account names (e.g. "Monzo Counterparty: ")
+ * @property peopleMappings JSON field paths/values for people and personal counterparties
  * @property createdAt Timestamp when this strategy was created
  * @property updatedAt Timestamp when this strategy was last modified
  */
@@ -30,6 +31,7 @@ data class ApiImportStrategy(
     val transactionMappings: ApiTransactionMappings,
     val accountNamePrefix: String,
     val counterpartyPrefix: String,
+    val peopleMappings: ApiPeopleMappings = ApiPeopleMappings(),
     val createdAt: Instant,
     val updatedAt: Instant,
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
@@ -111,3 +111,16 @@ data class ApiTransactionMappings(
     val customFields: Map<String, String> = emptyMap(),
     val uniqueIdentifierFields: Set<String> = emptySet(),
 )
+
+@Serializable
+data class ApiPeopleMappings(
+    val counterpartyObjectField: String = "counterparty",
+    val beneficiaryAccountTypeField: String = "beneficiary_account_type",
+    val personalBeneficiaryAccountTypeValue: String = "Personal",
+    val counterpartyNameField: String = "name",
+    val counterpartyUserIdField: String = "user_id",
+    val counterpartySortCodeField: String = "sort_code",
+    val counterpartyAccountNumberField: String = "account_number",
+    val counterpartyServiceUserNumberField: String = "service_user_number",
+    val fallbackCounterpartyAccountIdSuffix: String = ".account_id",
+)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -1242,7 +1242,7 @@ private suspend fun AccountAttributeRepository.upsertAccountAttributeInCreationM
 }
 
 private fun ApiTransactionPageItem.personalCounterpartyOwner(peopleMappings: ApiPeopleMappings): ApiImportAccountOwner? {
-    val counterparty = rawJson?.get(peopleMappings.counterpartyObjectField) as? JsonObject ?: return null
+    val counterparty = rawJson?.resolveJsonObjectPath(peopleMappings.counterpartyObjectField) ?: return null
     val beneficiaryAccountType = counterparty.stringOrNull(peopleMappings.beneficiaryAccountTypeField)
     if (beneficiaryAccountType?.equals(peopleMappings.personalBeneficiaryAccountTypeValue, ignoreCase = true) != true) return null
 
@@ -1261,7 +1261,7 @@ private fun ApiTransactionPageItem.personalCounterpartyOwner(peopleMappings: Api
 }
 
 private fun JsonObject.personalCounterpartyIdentity(peopleMappings: ApiPeopleMappings): PersonalCounterpartyIdentity? {
-    val counterparty = get(peopleMappings.counterpartyObjectField) as? JsonObject ?: return null
+    val counterparty = resolveJsonObjectPath(peopleMappings.counterpartyObjectField) ?: return null
     val beneficiaryAccountType = counterparty.stringOrNull(peopleMappings.beneficiaryAccountTypeField)
     if (beneficiaryAccountType?.equals(peopleMappings.personalBeneficiaryAccountTypeValue, ignoreCase = true) != true) return null
     val sortCode = counterparty.stringOrNull(peopleMappings.counterpartySortCodeField)?.takeIf { it.isNotBlank() } ?: return null
@@ -2030,11 +2030,17 @@ private fun JsonObject.resolveCounterpartyIdentity(
     resolveJsonPath(counterpartyIdField)?.takeIf { it.isNotBlank() }?.let { return it }
 
     if (counterpartyIdField.endsWith(".id")) {
-        val accountIdField = counterpartyIdField.removeSuffix(".id") + peopleMappings.fallbackCounterpartyAccountIdSuffix
+        val counterpartyIdSuffix = "." + peopleMappings.counterpartyUserIdField.substringAfterLast(".")
+        val accountIdField =
+            if (counterpartyIdField.endsWith(counterpartyIdSuffix)) {
+                counterpartyIdField.removeSuffix(counterpartyIdSuffix) + peopleMappings.fallbackCounterpartyAccountIdSuffix
+            } else {
+                counterpartyIdField + peopleMappings.fallbackCounterpartyAccountIdSuffix
+            }
         resolveJsonPath(accountIdField)?.takeIf { it.isNotBlank() }?.let { return it }
     }
 
-    val counterparty = counterpartyObject(counterpartyIdField) ?: return null
+    val counterparty = resolveJsonObjectPath(peopleMappings.counterpartyObjectField) ?: return null
     val sortCode = counterparty.stringOrNull(peopleMappings.counterpartySortCodeField)?.takeIf { it.isNotBlank() }
     val accountNumber = counterparty.stringOrNull(peopleMappings.counterpartyAccountNumberField)?.takeIf { it.isNotBlank() }
     if (sortCode != null && accountNumber != null) {
@@ -2054,12 +2060,9 @@ private fun JsonObject.resolveCounterpartyIdentity(
     return null
 }
 
-private fun JsonObject.counterpartyObject(counterpartyIdField: String): JsonObject? {
-    val parts = counterpartyIdField.split(".")
-    if (parts.size <= 1) return this
-
+private fun JsonObject.resolveJsonObjectPath(dotPath: String): JsonObject? {
     var current: JsonElement = this
-    for (part in parts.dropLast(1)) {
+    for (part in dotPath.split(".")) {
         current = (current as? JsonObject)?.get(part) ?: return null
     }
     return current as? JsonObject

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -6,6 +6,7 @@ import com.moneymanager.database.DatabaseConfig
 import com.moneymanager.domain.EntitySource
 import com.moneymanager.domain.model.*
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
+import com.moneymanager.domain.model.apistrategy.ApiPeopleMappings
 import com.moneymanager.domain.repository.AccountAttributeRepository
 import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.ApiSessionRepository
@@ -629,7 +630,7 @@ private suspend fun precreateCounterparties(
                 val request = requestsById[response.requestId] ?: return@flatMap emptyList()
                 parseTransactionsWithPath(response.json, strategy).mapNotNull { item ->
                     val counterpartyId =
-                        item.rawJson?.resolveCounterpartyIdentity(counterpartyIdField)
+                        item.rawJson?.resolveCounterpartyIdentity(counterpartyIdField, strategy.peopleMappings)
                             ?: return@mapNotNull null
                     val downloadedName = item.cleanCounterpartyName(nameMappings) ?: item.counterpartyName(nameMappings)
                     CounterpartyImportCandidate(
@@ -670,7 +671,7 @@ private fun collectCounterpartiesFromResponses(
                     return@mapNotNull null
                 }
                 val counterpartyId =
-                    item.rawJson?.resolveCounterpartyIdentity(counterpartyIdField)
+                    item.rawJson?.resolveCounterpartyIdentity(counterpartyIdField, strategy.peopleMappings)
                         ?: return@mapNotNull null
                 // Use only the proper name (merchant/counterparty name field), not the
                 // description fallback. Description-based names are per-transaction references
@@ -883,7 +884,7 @@ private suspend fun importPeopleFromCounterparties(
         val personalCounterpartyItems = mutableListOf<Triple<ApiTransactionPageItem, ApiImportAccountOwner, PersonalCounterpartyIdentity>>()
         for (item in parseTransactionsWithPath(response.json, strategy)) {
             if (item.amountMinorUnits != 0L && item.rawJson?.resolveBuiltInCounterpartyType(item.amountMinorUnits) == null) {
-                val owner = item.personalCounterpartyOwner()
+                val owner = item.personalCounterpartyOwner(strategy.peopleMappings)
                 val personalCounterpartyIdentity = owner?.personalCounterpartyIdentity()
                 if (owner != null && personalCounterpartyIdentity != null) {
                     personalCounterpartyItems.add(Triple(item, owner, personalCounterpartyIdentity))
@@ -893,7 +894,7 @@ private suspend fun importPeopleFromCounterparties(
         for ((item, owner, personalCounterpartyIdentity) in personalCounterpartyItems) {
             val counterpartyAccountId =
                 accountCache.getOrCreateCounterpartyAccountId(
-                    counterpartyId = item.rawJson?.resolveCounterpartyIdentity(counterpartyIdField),
+                    counterpartyId = item.rawJson?.resolveCounterpartyIdentity(counterpartyIdField, strategy.peopleMappings),
                     builtInType = null,
                     name = nameMappings.counterpartyPrefix + personalCounterpartyIdentity.name,
                     dedupeKey = personalCounterpartyIdentity.dedupeKey,
@@ -1240,15 +1241,15 @@ private suspend fun AccountAttributeRepository.upsertAccountAttributeInCreationM
     }
 }
 
-private fun ApiTransactionPageItem.personalCounterpartyOwner(): ApiImportAccountOwner? {
-    val counterparty = rawJson?.get("counterparty") as? JsonObject ?: return null
-    val beneficiaryAccountType = counterparty.stringOrNull("beneficiary_account_type")
-    if (beneficiaryAccountType?.equals("Personal", ignoreCase = true) != true) return null
+private fun ApiTransactionPageItem.personalCounterpartyOwner(peopleMappings: ApiPeopleMappings): ApiImportAccountOwner? {
+    val counterparty = rawJson?.get(peopleMappings.counterpartyObjectField) as? JsonObject ?: return null
+    val beneficiaryAccountType = counterparty.stringOrNull(peopleMappings.beneficiaryAccountTypeField)
+    if (beneficiaryAccountType?.equals(peopleMappings.personalBeneficiaryAccountTypeValue, ignoreCase = true) != true) return null
 
-    val name = counterparty.stringOrNull("name")?.takeIf { it.isNotBlank() }
-    val userId = counterparty.stringOrNull("user_id")?.takeIf { it.isNotBlank() }.orEmpty()
-    val sortCode = counterparty.stringOrNull("sort_code")?.takeIf { it.isNotBlank() }
-    val accountNumber = counterparty.stringOrNull("account_number")?.takeIf { it.isNotBlank() }
+    val name = counterparty.stringOrNull(peopleMappings.counterpartyNameField)?.takeIf { it.isNotBlank() }
+    val userId = counterparty.stringOrNull(peopleMappings.counterpartyUserIdField)?.takeIf { it.isNotBlank() }.orEmpty()
+    val sortCode = counterparty.stringOrNull(peopleMappings.counterpartySortCodeField)?.takeIf { it.isNotBlank() }
+    val accountNumber = counterparty.stringOrNull(peopleMappings.counterpartyAccountNumberField)?.takeIf { it.isNotBlank() }
     if (name == null && sortCode == null && accountNumber == null && userId.isBlank()) return null
     return ApiImportAccountOwner(
         userId = userId,
@@ -1259,13 +1260,13 @@ private fun ApiTransactionPageItem.personalCounterpartyOwner(): ApiImportAccount
     )
 }
 
-private fun JsonObject.personalCounterpartyIdentity(): PersonalCounterpartyIdentity? {
-    val counterparty = get("counterparty") as? JsonObject ?: return null
-    val beneficiaryAccountType = counterparty.stringOrNull("beneficiary_account_type")
-    if (beneficiaryAccountType?.equals("Personal", ignoreCase = true) != true) return null
-    val sortCode = counterparty.stringOrNull("sort_code")?.takeIf { it.isNotBlank() } ?: return null
-    val accountNumber = counterparty.stringOrNull("account_number")?.takeIf { it.isNotBlank() } ?: return null
-    val name = counterparty.stringOrNull("name")?.takeIf { it.isNotBlank() } ?: return null
+private fun JsonObject.personalCounterpartyIdentity(peopleMappings: ApiPeopleMappings): PersonalCounterpartyIdentity? {
+    val counterparty = get(peopleMappings.counterpartyObjectField) as? JsonObject ?: return null
+    val beneficiaryAccountType = counterparty.stringOrNull(peopleMappings.beneficiaryAccountTypeField)
+    if (beneficiaryAccountType?.equals(peopleMappings.personalBeneficiaryAccountTypeValue, ignoreCase = true) != true) return null
+    val sortCode = counterparty.stringOrNull(peopleMappings.counterpartySortCodeField)?.takeIf { it.isNotBlank() } ?: return null
+    val accountNumber = counterparty.stringOrNull(peopleMappings.counterpartyAccountNumberField)?.takeIf { it.isNotBlank() } ?: return null
+    val name = counterparty.stringOrNull(peopleMappings.counterpartyNameField)?.takeIf { it.isNotBlank() } ?: return null
     return PersonalCounterpartyIdentity(name = name, sortCode = sortCode, accountNumber = accountNumber)
 }
 
@@ -1443,6 +1444,7 @@ private suspend fun importTransactionPage(
                 customTxFields = customTxFields,
                 uniqueIdTxFields = uniqueIdTxFields,
                 counterpartyIdField = counterpartyIdField,
+                peopleMappings = strategy.peopleMappings,
                 nameMappings = nameMappings,
                 existingByUniqueId = existingByUniqueId,
                 existingTransfersByApiId = existingTransfersByApiId,
@@ -1478,6 +1480,7 @@ private suspend fun importTransactionItem(
     customTxFields: Map<String, String>,
     uniqueIdTxFields: Set<String>,
     counterpartyIdField: String?,
+    peopleMappings: ApiPeopleMappings,
     nameMappings: CounterpartyNameMappings,
     existingByUniqueId: Map<Map<String, String>, TransferId>,
     existingTransfersByApiId: Map<String, Transfer>,
@@ -1509,6 +1512,7 @@ private suspend fun importTransactionItem(
             customTxFields = customTxFields,
             uniqueIdTxFields = uniqueIdTxFields,
             counterpartyIdField = counterpartyIdField,
+            peopleMappings = peopleMappings,
             nameMappings = nameMappings,
             existingByUniqueId = existingByUniqueId,
             existingTransfersByApiId = existingTransfersByApiId,
@@ -1541,6 +1545,7 @@ private suspend fun importValidTransactionItem(
     customTxFields: Map<String, String>,
     uniqueIdTxFields: Set<String>,
     counterpartyIdField: String?,
+    peopleMappings: ApiPeopleMappings,
     nameMappings: CounterpartyNameMappings,
     existingByUniqueId: Map<Map<String, String>, TransferId>,
     existingTransfersByApiId: Map<String, Transfer>,
@@ -1556,8 +1561,8 @@ private suspend fun importValidTransactionItem(
             accountCache.getOrCreateAccountId(name = nameMappings.counterpartyPrefix + "Void", transactionApiSource = counterpartyApiSource)
         } else {
             val builtInCounterpartyType = item.rawJson?.resolveBuiltInCounterpartyType(item.amountMinorUnits)
-            val counterpartyId = item.rawJson?.resolveCounterpartyIdentity(counterpartyIdField)
-            val personalCounterpartyIdentity = item.rawJson?.personalCounterpartyIdentity()
+            val counterpartyId = item.rawJson?.resolveCounterpartyIdentity(counterpartyIdField, peopleMappings)
+            val personalCounterpartyIdentity = item.rawJson?.personalCounterpartyIdentity(peopleMappings)
             accountCache.getOrCreateCounterpartyAccountId(
                 counterpartyId = counterpartyId,
                 dedupeKey = personalCounterpartyIdentity?.dedupeKey,
@@ -2016,29 +2021,32 @@ private fun JsonObject.resolveJsonPath(dotPath: String): String? {
     return (current as? JsonPrimitive)?.contentOrNull
 }
 
-private fun JsonObject.resolveCounterpartyIdentity(counterpartyIdField: String?): String? {
+private fun JsonObject.resolveCounterpartyIdentity(
+    counterpartyIdField: String?,
+    peopleMappings: ApiPeopleMappings,
+): String? {
     if (counterpartyIdField == null) return null
 
     resolveJsonPath(counterpartyIdField)?.takeIf { it.isNotBlank() }?.let { return it }
 
     if (counterpartyIdField.endsWith(".id")) {
-        val accountIdField = counterpartyIdField.removeSuffix(".id") + ".account_id"
+        val accountIdField = counterpartyIdField.removeSuffix(".id") + peopleMappings.fallbackCounterpartyAccountIdSuffix
         resolveJsonPath(accountIdField)?.takeIf { it.isNotBlank() }?.let { return it }
     }
 
     val counterparty = counterpartyObject(counterpartyIdField) ?: return null
-    val sortCode = counterparty.stringOrNull("sort_code")?.takeIf { it.isNotBlank() }
-    val accountNumber = counterparty.stringOrNull("account_number")?.takeIf { it.isNotBlank() }
+    val sortCode = counterparty.stringOrNull(peopleMappings.counterpartySortCodeField)?.takeIf { it.isNotBlank() }
+    val accountNumber = counterparty.stringOrNull(peopleMappings.counterpartyAccountNumberField)?.takeIf { it.isNotBlank() }
     if (sortCode != null && accountNumber != null) {
         return "bank:$sortCode:$accountNumber"
     }
 
-    val serviceUserNumber = counterparty.stringOrNull("service_user_number")?.takeIf { it.isNotBlank() }
+    val serviceUserNumber = counterparty.stringOrNull(peopleMappings.counterpartyServiceUserNumberField)?.takeIf { it.isNotBlank() }
     if (serviceUserNumber != null) {
         return "service_user:$serviceUserNumber"
     }
 
-    val userId = counterparty.stringOrNull("user_id")?.takeIf { it.isNotBlank() }
+    val userId = counterparty.stringOrNull(peopleMappings.counterpartyUserIdField)?.takeIf { it.isNotBlank() }
     if (userId != null) {
         return "user:$userId"
     }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
@@ -117,14 +117,34 @@ fun ApiStrategyEditDialog(
     var txCounterpartyIdField by remember { mutableStateOf(strategy?.transactionMappings?.counterpartyIdField ?: "") }
     var txDeclineReasonField by remember { mutableStateOf(strategy?.transactionMappings?.declineReasonField ?: "") }
     var peopleCounterpartyObjectField by remember { mutableStateOf(strategy?.peopleMappings?.counterpartyObjectField ?: "counterparty") }
-    var peopleBeneficiaryAccountTypeField by remember { mutableStateOf(strategy?.peopleMappings?.beneficiaryAccountTypeField ?: "beneficiary_account_type") }
-    var peoplePersonalBeneficiaryAccountTypeValue by remember { mutableStateOf(strategy?.peopleMappings?.personalBeneficiaryAccountTypeValue ?: "Personal") }
+    var peopleBeneficiaryAccountTypeField by remember {
+        mutableStateOf(
+            strategy?.peopleMappings?.beneficiaryAccountTypeField ?: "beneficiary_account_type",
+        )
+    }
+    var peoplePersonalBeneficiaryAccountTypeValue by remember {
+        mutableStateOf(
+            strategy?.peopleMappings?.personalBeneficiaryAccountTypeValue ?: "Personal",
+        )
+    }
     var peopleCounterpartyNameField by remember { mutableStateOf(strategy?.peopleMappings?.counterpartyNameField ?: "name") }
     var peopleCounterpartyUserIdField by remember { mutableStateOf(strategy?.peopleMappings?.counterpartyUserIdField ?: "user_id") }
     var peopleCounterpartySortCodeField by remember { mutableStateOf(strategy?.peopleMappings?.counterpartySortCodeField ?: "sort_code") }
-    var peopleCounterpartyAccountNumberField by remember { mutableStateOf(strategy?.peopleMappings?.counterpartyAccountNumberField ?: "account_number") }
-    var peopleCounterpartyServiceUserNumberField by remember { mutableStateOf(strategy?.peopleMappings?.counterpartyServiceUserNumberField ?: "service_user_number") }
-    var peopleFallbackCounterpartyAccountIdSuffix by remember { mutableStateOf(strategy?.peopleMappings?.fallbackCounterpartyAccountIdSuffix ?: ".account_id") }
+    var peopleCounterpartyAccountNumberField by remember {
+        mutableStateOf(
+            strategy?.peopleMappings?.counterpartyAccountNumberField ?: "account_number",
+        )
+    }
+    var peopleCounterpartyServiceUserNumberField by remember {
+        mutableStateOf(
+            strategy?.peopleMappings?.counterpartyServiceUserNumberField ?: "service_user_number",
+        )
+    }
+    var peopleFallbackCounterpartyAccountIdSuffix by remember {
+        mutableStateOf(
+            strategy?.peopleMappings?.fallbackCounterpartyAccountIdSuffix ?: ".account_id",
+        )
+    }
     var customTxFields by remember {
         mutableStateOf<List<CustomFieldState>>(
             strategy?.transactionMappings?.customFields?.map { (k, v) ->
@@ -496,15 +516,63 @@ fun ApiStrategyEditDialog(
                 Spacer(Modifier.height(4.dp))
                 HorizontalDivider()
                 SectionHeader("People Mappings")
-                FieldMappingRow(label = "Counterparty object field", value = peopleCounterpartyObjectField, onValueChange = { peopleCounterpartyObjectField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
-                FieldMappingRow(label = "Beneficiary account type field", value = peopleBeneficiaryAccountTypeField, onValueChange = { peopleBeneficiaryAccountTypeField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
-                FieldMappingRow(label = "Personal beneficiary value", value = peoplePersonalBeneficiaryAccountTypeValue, onValueChange = { peoplePersonalBeneficiaryAccountTypeValue = it }, paths = emptyList(), onPickRequest = {})
-                FieldMappingRow(label = "Counterparty name field", value = peopleCounterpartyNameField, onValueChange = { peopleCounterpartyNameField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
-                FieldMappingRow(label = "Counterparty user id field", value = peopleCounterpartyUserIdField, onValueChange = { peopleCounterpartyUserIdField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
-                FieldMappingRow(label = "Counterparty sort code field", value = peopleCounterpartySortCodeField, onValueChange = { peopleCounterpartySortCodeField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
-                FieldMappingRow(label = "Counterparty account number field", value = peopleCounterpartyAccountNumberField, onValueChange = { peopleCounterpartyAccountNumberField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
-                FieldMappingRow(label = "Counterparty service user number field", value = peopleCounterpartyServiceUserNumberField, onValueChange = { peopleCounterpartyServiceUserNumberField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
-                FieldMappingRow(label = "Fallback account id suffix", value = peopleFallbackCounterpartyAccountIdSuffix, onValueChange = { peopleFallbackCounterpartyAccountIdSuffix = it }, paths = emptyList(), onPickRequest = {})
+                FieldMappingRow(label = "Counterparty object field", value = peopleCounterpartyObjectField, onValueChange = {
+                    peopleCounterpartyObjectField =
+                        it
+                }, paths = txJsonPaths, onPickRequest = { setter ->
+                    pickingPaths = txJsonPaths
+                    pickingForSetter = setter
+                })
+                FieldMappingRow(label = "Beneficiary account type field", value = peopleBeneficiaryAccountTypeField, onValueChange = {
+                    peopleBeneficiaryAccountTypeField =
+                        it
+                }, paths = txJsonPaths, onPickRequest = { setter ->
+                    pickingPaths = txJsonPaths
+                    pickingForSetter = setter
+                })
+                FieldMappingRow(label = "Personal beneficiary value", value = peoplePersonalBeneficiaryAccountTypeValue, onValueChange = {
+                    peoplePersonalBeneficiaryAccountTypeValue =
+                        it
+                }, paths = emptyList(), onPickRequest = {})
+                FieldMappingRow(label = "Counterparty name field", value = peopleCounterpartyNameField, onValueChange = {
+                    peopleCounterpartyNameField =
+                        it
+                }, paths = txJsonPaths, onPickRequest = { setter ->
+                    pickingPaths = txJsonPaths
+                    pickingForSetter = setter
+                })
+                FieldMappingRow(label = "Counterparty user id field", value = peopleCounterpartyUserIdField, onValueChange = {
+                    peopleCounterpartyUserIdField =
+                        it
+                }, paths = txJsonPaths, onPickRequest = { setter ->
+                    pickingPaths = txJsonPaths
+                    pickingForSetter = setter
+                })
+                FieldMappingRow(label = "Counterparty sort code field", value = peopleCounterpartySortCodeField, onValueChange = {
+                    peopleCounterpartySortCodeField =
+                        it
+                }, paths = txJsonPaths, onPickRequest = { setter ->
+                    pickingPaths = txJsonPaths
+                    pickingForSetter = setter
+                })
+                FieldMappingRow(label = "Counterparty account number field", value = peopleCounterpartyAccountNumberField, onValueChange = {
+                    peopleCounterpartyAccountNumberField =
+                        it
+                }, paths = txJsonPaths, onPickRequest = { setter ->
+                    pickingPaths = txJsonPaths
+                    pickingForSetter = setter
+                })
+                FieldMappingRow(label = "Counterparty service user number field", value = peopleCounterpartyServiceUserNumberField, onValueChange = {
+                    peopleCounterpartyServiceUserNumberField =
+                        it
+                }, paths = txJsonPaths, onPickRequest = { setter ->
+                    pickingPaths = txJsonPaths
+                    pickingForSetter = setter
+                })
+                FieldMappingRow(label = "Fallback account id suffix", value = peopleFallbackCounterpartyAccountIdSuffix, onValueChange = {
+                    peopleFallbackCounterpartyAccountIdSuffix =
+                        it
+                }, paths = emptyList(), onPickRequest = {})
                 CustomFieldsSection(
                     fields = customTxFields,
                     onFieldsChange = { customTxFields = it },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
@@ -116,6 +116,15 @@ fun ApiStrategyEditDialog(
     var txCounterpartyNameField by remember { mutableStateOf(strategy?.transactionMappings?.counterpartyNameField ?: "") }
     var txCounterpartyIdField by remember { mutableStateOf(strategy?.transactionMappings?.counterpartyIdField ?: "") }
     var txDeclineReasonField by remember { mutableStateOf(strategy?.transactionMappings?.declineReasonField ?: "") }
+    var peopleCounterpartyObjectField by remember { mutableStateOf(strategy?.peopleMappings?.counterpartyObjectField ?: "counterparty") }
+    var peopleBeneficiaryAccountTypeField by remember { mutableStateOf(strategy?.peopleMappings?.beneficiaryAccountTypeField ?: "beneficiary_account_type") }
+    var peoplePersonalBeneficiaryAccountTypeValue by remember { mutableStateOf(strategy?.peopleMappings?.personalBeneficiaryAccountTypeValue ?: "Personal") }
+    var peopleCounterpartyNameField by remember { mutableStateOf(strategy?.peopleMappings?.counterpartyNameField ?: "name") }
+    var peopleCounterpartyUserIdField by remember { mutableStateOf(strategy?.peopleMappings?.counterpartyUserIdField ?: "user_id") }
+    var peopleCounterpartySortCodeField by remember { mutableStateOf(strategy?.peopleMappings?.counterpartySortCodeField ?: "sort_code") }
+    var peopleCounterpartyAccountNumberField by remember { mutableStateOf(strategy?.peopleMappings?.counterpartyAccountNumberField ?: "account_number") }
+    var peopleCounterpartyServiceUserNumberField by remember { mutableStateOf(strategy?.peopleMappings?.counterpartyServiceUserNumberField ?: "service_user_number") }
+    var peopleFallbackCounterpartyAccountIdSuffix by remember { mutableStateOf(strategy?.peopleMappings?.fallbackCounterpartyAccountIdSuffix ?: ".account_id") }
     var customTxFields by remember {
         mutableStateOf<List<CustomFieldState>>(
             strategy?.transactionMappings?.customFields?.map { (k, v) ->
@@ -484,6 +493,18 @@ fun ApiStrategyEditDialog(
                         pickingForSetter = setter
                     },
                 )
+                Spacer(Modifier.height(4.dp))
+                HorizontalDivider()
+                SectionHeader("People Mappings")
+                FieldMappingRow(label = "Counterparty object field", value = peopleCounterpartyObjectField, onValueChange = { peopleCounterpartyObjectField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
+                FieldMappingRow(label = "Beneficiary account type field", value = peopleBeneficiaryAccountTypeField, onValueChange = { peopleBeneficiaryAccountTypeField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
+                FieldMappingRow(label = "Personal beneficiary value", value = peoplePersonalBeneficiaryAccountTypeValue, onValueChange = { peoplePersonalBeneficiaryAccountTypeValue = it }, paths = emptyList(), onPickRequest = {})
+                FieldMappingRow(label = "Counterparty name field", value = peopleCounterpartyNameField, onValueChange = { peopleCounterpartyNameField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
+                FieldMappingRow(label = "Counterparty user id field", value = peopleCounterpartyUserIdField, onValueChange = { peopleCounterpartyUserIdField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
+                FieldMappingRow(label = "Counterparty sort code field", value = peopleCounterpartySortCodeField, onValueChange = { peopleCounterpartySortCodeField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
+                FieldMappingRow(label = "Counterparty account number field", value = peopleCounterpartyAccountNumberField, onValueChange = { peopleCounterpartyAccountNumberField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
+                FieldMappingRow(label = "Counterparty service user number field", value = peopleCounterpartyServiceUserNumberField, onValueChange = { peopleCounterpartyServiceUserNumberField = it }, paths = txJsonPaths, onPickRequest = { setter -> pickingPaths = txJsonPaths; pickingForSetter = setter })
+                FieldMappingRow(label = "Fallback account id suffix", value = peopleFallbackCounterpartyAccountIdSuffix, onValueChange = { peopleFallbackCounterpartyAccountIdSuffix = it }, paths = emptyList(), onPickRequest = {})
                 CustomFieldsSection(
                     fields = customTxFields,
                     onFieldsChange = { customTxFields = it },
@@ -571,6 +592,18 @@ fun ApiStrategyEditDialog(
                                 ),
                             accountNamePrefix = accountNamePrefix.trim(),
                             counterpartyPrefix = counterpartyPrefix.trim(),
+                            peopleMappings =
+                                com.moneymanager.domain.model.apistrategy.ApiPeopleMappings(
+                                    counterpartyObjectField = peopleCounterpartyObjectField.trim(),
+                                    beneficiaryAccountTypeField = peopleBeneficiaryAccountTypeField.trim(),
+                                    personalBeneficiaryAccountTypeValue = peoplePersonalBeneficiaryAccountTypeValue.trim(),
+                                    counterpartyNameField = peopleCounterpartyNameField.trim(),
+                                    counterpartyUserIdField = peopleCounterpartyUserIdField.trim(),
+                                    counterpartySortCodeField = peopleCounterpartySortCodeField.trim(),
+                                    counterpartyAccountNumberField = peopleCounterpartyAccountNumberField.trim(),
+                                    counterpartyServiceUserNumberField = peopleCounterpartyServiceUserNumberField.trim(),
+                                    fallbackCounterpartyAccountIdSuffix = peopleFallbackCounterpartyAccountIdSuffix.trim(),
+                                ),
                             createdAt = strategy?.createdAt ?: now,
                             updatedAt = now,
                         )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
@@ -49,6 +49,7 @@ import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
 import com.moneymanager.domain.model.apistrategy.ApiPaginationConfig
+import com.moneymanager.domain.model.apistrategy.ApiPeopleMappings
 import com.moneymanager.domain.model.apistrategy.ApiQueryParam
 import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
 import com.moneymanager.domain.repository.ApiSessionRepository
@@ -562,13 +563,18 @@ fun ApiStrategyEditDialog(
                     pickingPaths = txJsonPaths
                     pickingForSetter = setter
                 })
-                FieldMappingRow(label = "Counterparty service user number field", value = peopleCounterpartyServiceUserNumberField, onValueChange = {
-                    peopleCounterpartyServiceUserNumberField =
-                        it
-                }, paths = txJsonPaths, onPickRequest = { setter ->
-                    pickingPaths = txJsonPaths
-                    pickingForSetter = setter
-                })
+                FieldMappingRow(
+                    label = "Counterparty service user number field",
+                    value = peopleCounterpartyServiceUserNumberField,
+                    onValueChange = {
+                        peopleCounterpartyServiceUserNumberField = it
+                    },
+                    paths = txJsonPaths,
+                    onPickRequest = { setter ->
+                        pickingPaths = txJsonPaths
+                        pickingForSetter = setter
+                    },
+                )
                 FieldMappingRow(label = "Fallback account id suffix", value = peopleFallbackCounterpartyAccountIdSuffix, onValueChange = {
                     peopleFallbackCounterpartyAccountIdSuffix =
                         it
@@ -661,7 +667,7 @@ fun ApiStrategyEditDialog(
                             accountNamePrefix = accountNamePrefix.trim(),
                             counterpartyPrefix = counterpartyPrefix.trim(),
                             peopleMappings =
-                                com.moneymanager.domain.model.apistrategy.ApiPeopleMappings(
+                                ApiPeopleMappings(
                                     counterpartyObjectField = peopleCounterpartyObjectField.trim(),
                                     beneficiaryAccountTypeField = peopleBeneficiaryAccountTypeField.trim(),
                                     personalBeneficiaryAccountTypeValue = peoplePersonalBeneficiaryAccountTypeValue.trim(),


### PR DESCRIPTION
## Summary\n- add configurable API people mappings to strategy config/model and strategy editor UI\n- replace Monzo-specific hardcoded people/counterparty fields in API import with strategy-provided mappings\n- make API entity source recording idempotent for duplicate (entity_type_id, entity_id, revision_id) inserts to avoid import crashes\n\n## Validation\n- ./gradlew.bat :app:ui:core:compileKotlinJvm --console=plain\n- ./gradlew.bat :app:db:core:compileKotlinJvm :app:ui:core:compileKotlinJvm --console=plain\n\n## Notes\n- left unrelated local file .idea/dataSources.xml uncommitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable people mappings for API import strategies, letting users specify JSON field paths for counterparty data, beneficiary account types, and related identity fields.
  * Added a People Mappings section in the strategy editor UI with editable field-mapping controls.

* **Bug Fixes**
  * Suppresses duplicate API entity-source inserts and logs a warning instead of failing, reducing duplicate-import errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NikolayMetchev/money-manager/pull/465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->