### PR TITLE
Fix API session highlight scope and audit deep-link scrolling

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="default.db" connection-mode="Multiple" uuid="9679d342-fbb4-4305-86df-60c13e34b0f0">
+    <data-source source="LOCAL" name="default.db" uuid="9679d342-fbb4-4305-86df-60c13e34b0f0">
       <driver-ref>sqlite.xerial</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
       <jdbc-url>jdbc:sqlite:$USER_HOME$/.dbmanager/default.db</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
-    <data-source source="LOCAL" name="money_manager.db" connection-mode="Multiple" uuid="42147222-7eb0-4849-9ee6-1b646251106e">
+    <data-source source="LOCAL" name="money_manager.db" uuid="42147222-7eb0-4849-9ee6-1b646251106e">
       <driver-ref>sqlite.xerial</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
       <jdbc-url>jdbc:sqlite:$USER_HOME$/.moneymanager/money_manager.db</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
-    <data-source source="LOCAL" name="money_manager-old - Copy.db" connection-mode="Multiple" uuid="95fe7662-5446-4f6e-af23-06425552765f">
+    <data-source source="LOCAL" name="money_manager-old - Copy.db" uuid="95fe7662-5446-4f6e-af23-06425552765f">
       <driver-ref>sqlite.xerial</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.sqlite.JDBC</jdbc-driver>

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="default.db" uuid="9679d342-fbb4-4305-86df-60c13e34b0f0">
+    <data-source source="LOCAL" name="default.db" connection-mode="Multiple" uuid="9679d342-fbb4-4305-86df-60c13e34b0f0">
       <driver-ref>sqlite.xerial</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
       <jdbc-url>jdbc:sqlite:$USER_HOME$/.dbmanager/default.db</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
-    <data-source source="LOCAL" name="money_manager.db" uuid="42147222-7eb0-4849-9ee6-1b646251106e">
+    <data-source source="LOCAL" name="money_manager.db" connection-mode="Multiple" uuid="42147222-7eb0-4849-9ee6-1b646251106e">
       <driver-ref>sqlite.xerial</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
       <jdbc-url>jdbc:sqlite:$USER_HOME$/.moneymanager/money_manager.db</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
-    <data-source source="LOCAL" name="money_manager-old - Copy.db" uuid="95fe7662-5446-4f6e-af23-06425552765f">
+    <data-source source="LOCAL" name="money_manager-old - Copy.db" connection-mode="Multiple" uuid="95fe7662-5446-4f6e-af23-06425552765f">
       <driver-ref>sqlite.xerial</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.sqlite.JDBC</jdbc-driver>

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -94,7 +94,6 @@ import com.moneymanager.ui.util.ContentCopyIcon
 import com.moneymanager.ui.util.displayDateTime
 import com.moneymanager.ui.util.setPlainText
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -909,8 +908,7 @@ fun ApiSessionTrafficScreen(
                         // do a second scroll to center it vertically in the viewport.
                         val nodeY =
                             snapshotFlow { highlightNodeRootY }
-                                .filter { it >= 0f }
-                                .first()
+                                .first { it >= 0f }
                         val viewportHeight = lazyListState.layoutInfo.viewportSize.height
                         val listStartY = lazyListState.layoutInfo.viewportStartOffset.toFloat()
                         val nodeOffsetInViewport = nodeY - listStartY

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -251,7 +251,6 @@ fun ApiSessionsScreen(
             }
             else -> {
                 val lazyListState = rememberLazyListState()
-                var listRootY by remember { mutableFloatStateOf(0f) }
                 Box(modifier = Modifier.fillMaxSize()) {
                     LazyColumn(state = lazyListState, verticalArrangement = Arrangement.spacedBy(12.dp)) {
                         items(credentials) { credential ->

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -94,6 +94,7 @@ import com.moneymanager.ui.util.ContentCopyIcon
 import com.moneymanager.ui.util.displayDateTime
 import com.moneymanager.ui.util.setPlainText
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -906,16 +907,15 @@ fun ApiSessionTrafficScreen(
                         lazyListState.animateScrollToItem(highlightedPairIndex)
                         // Wait for the highlighted node's position to be reported, then
                         // do a second scroll to center it vertically in the viewport.
-                        snapshotFlow { highlightNodeRootY }
-                            .collect { nodeY ->
-                                if (nodeY >= 0f) {
-                                    val viewportHeight = lazyListState.layoutInfo.viewportSize.height
-                                    val listStartY = lazyListState.layoutInfo.viewportStartOffset.toFloat()
-                                    val nodeOffsetInViewport = nodeY - listStartY
-                                    val delta = nodeOffsetInViewport - viewportHeight / 2f
-                                    lazyListState.scroll { scrollBy(delta) }
-                                }
-                            }
+                        val nodeY =
+                            snapshotFlow { highlightNodeRootY }
+                                .filter { it >= 0f }
+                                .first()
+                        val viewportHeight = lazyListState.layoutInfo.viewportSize.height
+                        val listStartY = lazyListState.layoutInfo.viewportStartOffset.toFloat()
+                        val nodeOffsetInViewport = nodeY - listStartY
+                        val delta = nodeOffsetInViewport - viewportHeight / 2f
+                        lazyListState.scroll { scrollBy(delta) }
                     }
                 }
 
@@ -936,21 +936,21 @@ fun ApiSessionTrafficScreen(
                                 pair.response?.let { responseTransactionsByResponseId[it.id] }
                                     ?: emptyList()
                             val requestMatches = highlightRequestId == null || pair.request?.id == highlightRequestId
+                            val jsonPathMatches =
+                                highlightJsonPath != null &&
+                                    responseTransactions.any {
+                                        highlightJsonPath.startsWithJsonPath(it.jsonPath.value)
+                                    }
                             val isHighlighted =
                                 (highlightRequestId != null || highlightJsonPath != null) &&
                                     requestMatches &&
                                     (
                                         // Highlight by specific jsonPath when available (transaction sources).
                                         // Use prefix matching so sub-paths resolve to the containing response.
-                                        (
-                                            highlightJsonPath != null &&
-                                                responseTransactions.any {
-                                                    highlightJsonPath.startsWithJsonPath(it.jsonPath.value)
-                                                }
-                                        ) ||
+                                        jsonPathMatches ||
                                             // Highlight by requestId when jsonPath doesn't match any transaction
                                             // (e.g. main account sources stored at $.accounts[0], not transaction paths)
-                                            highlightRequestId != null
+                                            (highlightRequestId != null && highlightJsonPath == null)
                                     )
                             ApiTrafficPairCard(
                                 pair = pair,
@@ -1245,8 +1245,8 @@ private fun JsonTreeNode(
 ) {
     val childCount = element.childCount()
     val expandable = childCount > 0
-    // This node is the target if all highlight segments have been consumed
-    val isHighlightTarget = remainingHighlightSegments.isNullOrEmpty()
+    // This node is the target only when a highlight path exists and all segments are consumed.
+    val isHighlightTarget = remainingHighlightSegments != null && remainingHighlightSegments.isEmpty()
     // Force-expand the node if it's on the highlight path
     val forceExpandPath = !remainingHighlightSegments.isNullOrEmpty()
     val shouldForceExpand = forceExpandSubtree || forceExpandPath || isHighlightTarget
@@ -1271,7 +1271,6 @@ private fun JsonTreeNode(
         }
 
     val nodeTransaction = latestTransactionByJsonPath[jsonPath]
-    val isInHighlightedSubtree = highlightSubtree || isHighlightTarget
     val highlightBackground =
         when {
             isHighlightTarget -> MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.85f)
@@ -1280,7 +1279,7 @@ private fun JsonTreeNode(
             else -> Color.Transparent
         }
     val highlightTextColor =
-        if (isInHighlightedSubtree) {
+        if (isHighlightTarget) {
             MaterialTheme.colorScheme.onTertiaryContainer
         } else {
             MaterialTheme.colorScheme.onSurface
@@ -1355,7 +1354,7 @@ private fun JsonTreeNode(
                         latestTransactionByJsonPath = latestTransactionByJsonPath,
                         remainingHighlightSegments = nextSegments,
                         forceExpandSubtree = forceExpandSubtree || isHighlightTarget,
-                        highlightSubtree = isInHighlightedSubtree,
+                        highlightSubtree = highlightSubtree || isHighlightTarget,
                         onHighlightPositioned = onHighlightPositioned,
                     )
                 }
@@ -1380,7 +1379,7 @@ private fun JsonTreeNode(
                         latestTransactionByJsonPath = latestTransactionByJsonPath,
                         remainingHighlightSegments = nextSegments,
                         forceExpandSubtree = forceExpandSubtree || isHighlightTarget,
-                        highlightSubtree = isInHighlightedSubtree,
+                        highlightSubtree = highlightSubtree || isHighlightTarget,
                         onHighlightPositioned = onHighlightPositioned,
                     )
                 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -251,6 +251,7 @@ fun ApiSessionsScreen(
             }
             else -> {
                 val lazyListState = rememberLazyListState()
+                var listRootY by remember { mutableFloatStateOf(0f) }
                 Box(modifier = Modifier.fillMaxSize()) {
                     LazyColumn(state = lazyListState, verticalArrangement = Arrangement.spacedBy(12.dp)) {
                         items(credentials) { credential ->
@@ -863,6 +864,7 @@ fun ApiSessionTrafficScreen(
             }
             else -> {
                 val lazyListState = rememberLazyListState()
+                var listRootY by remember { mutableFloatStateOf(0f) }
                 // Absolute Y (in root coordinates) of the highlighted JSON node, reported
                 // by JsonTreeNode once it is laid out, so we can center it in the viewport.
                 var highlightNodeRootY by remember(highlightJsonPath) { mutableFloatStateOf(-1f) }
@@ -901,23 +903,30 @@ fun ApiSessionTrafficScreen(
                         }
                     }
 
-                LaunchedEffect(highlightedPairIndex) {
+                LaunchedEffect(highlightedPairIndex, highlightJsonPath) {
                     if (highlightedPairIndex >= 0) {
                         lazyListState.animateScrollToItem(highlightedPairIndex)
-                        // Wait for the highlighted node's position to be reported, then
-                        // do a second scroll to center it vertically in the viewport.
-                        val nodeY =
-                            snapshotFlow { highlightNodeRootY }
-                                .first { it >= 0f }
-                        val viewportHeight = lazyListState.layoutInfo.viewportSize.height
-                        val listStartY = lazyListState.layoutInfo.viewportStartOffset.toFloat()
-                        val nodeOffsetInViewport = nodeY - listStartY
-                        val delta = nodeOffsetInViewport - viewportHeight / 2f
-                        lazyListState.scroll { scrollBy(delta) }
+                        if (highlightJsonPath != null) {
+                            // Wait for the highlighted node's position to be reported, then
+                            // do a second scroll to center it vertically in the viewport.
+                            val nodeY =
+                                snapshotFlow { highlightNodeRootY }
+                                    .first { it >= 0f }
+                            val viewportHeight = lazyListState.layoutInfo.viewportSize.height
+                            val listStartY = lazyListState.layoutInfo.viewportStartOffset.toFloat()
+                            val nodeOffsetInViewport = nodeY - listRootY - listStartY
+                            val delta = nodeOffsetInViewport - viewportHeight / 2f
+                            lazyListState.scroll { scrollBy(delta) }
+                        }
                     }
                 }
 
-                Box(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .onGloballyPositioned { coords -> listRootY = coords.positionInRoot().y },
+                ) {
                     LazyColumn(
                         state = lazyListState,
                         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -943,8 +952,14 @@ fun ApiSessionTrafficScreen(
                             ApiTrafficPairCard(
                                 pair = pair,
                                 responseTransactions = responseTransactions,
+                                isHighlighted = isHighlighted,
                                 highlightJsonPath = if (isHighlighted) highlightJsonPath else null,
-                                onHighlightPositioned = if (isHighlighted) { y -> highlightNodeRootY = y } else null,
+                                onHighlightPositioned =
+                                    if (isHighlighted && highlightJsonPath != null) {
+                                        { y -> highlightNodeRootY = y }
+                                    } else {
+                                        null
+                                    },
                             )
                         }
                     }
@@ -962,10 +977,10 @@ fun ApiSessionTrafficScreen(
 private fun ApiTrafficPairCard(
     pair: ApiTrafficPair,
     responseTransactions: List<ApiResponseTransaction> = emptyList(),
+    isHighlighted: Boolean = false,
     highlightJsonPath: String? = null,
     onHighlightPositioned: ((Float) -> Unit)? = null,
 ) {
-    val isHighlighted = highlightJsonPath != null
     val cardContainerColor =
         if (isHighlighted) {
             MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f)
@@ -1225,7 +1240,10 @@ internal fun shouldHighlightPair(
     highlightRequestId: ApiRequestId?,
     highlightJsonPath: String?,
 ): Boolean {
-    val requestMatches = highlightRequestId == null || pair.request?.id == highlightRequestId
+    val requestMatches =
+        highlightRequestId == null ||
+            pair.request?.id == highlightRequestId ||
+            pair.response?.requestId == highlightRequestId
     val jsonPathMatches =
         highlightJsonPath != null &&
             responseTransactions.any {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -935,23 +935,13 @@ fun ApiSessionTrafficScreen(
                             val responseTransactions =
                                 pair.response?.let { responseTransactionsByResponseId[it.id] }
                                     ?: emptyList()
-                            val requestMatches = highlightRequestId == null || pair.request?.id == highlightRequestId
-                            val jsonPathMatches =
-                                highlightJsonPath != null &&
-                                    responseTransactions.any {
-                                        highlightJsonPath.startsWithJsonPath(it.jsonPath.value)
-                                    }
                             val isHighlighted =
-                                (highlightRequestId != null || highlightJsonPath != null) &&
-                                    requestMatches &&
-                                    (
-                                        // Highlight by specific jsonPath when available (transaction sources).
-                                        // Use prefix matching so sub-paths resolve to the containing response.
-                                        jsonPathMatches ||
-                                            // Highlight by requestId when jsonPath doesn't match any transaction
-                                            // (e.g. main account sources stored at $.accounts[0], not transaction paths)
-                                            (highlightRequestId != null && highlightJsonPath == null)
-                                    )
+                                shouldHighlightPair(
+                                    pair = pair,
+                                    responseTransactions = responseTransactions,
+                                    highlightRequestId = highlightRequestId,
+                                    highlightJsonPath = highlightJsonPath,
+                                )
                             ApiTrafficPairCard(
                                 pair = pair,
                                 responseTransactions = responseTransactions,
@@ -1197,7 +1187,7 @@ private fun JsonViewer(
  * Returns true if this path equals [prefix] or is a child of it
  * (e.g. "$.transactions[0].counterparty".startsWithJsonPath("$.transactions[0]") == true).
  */
-private fun String.startsWithJsonPath(prefix: String): Boolean =
+internal fun String.startsWithJsonPath(prefix: String): Boolean =
     this == prefix || this.startsWith("$prefix.") || this.startsWith("$prefix[")
 
 /**
@@ -1205,7 +1195,7 @@ private fun String.startsWithJsonPath(prefix: String): Boolean =
  * string segments (["transactions", "2"]) used to trace the highlight path
  * through the JSON tree.  Returns null when no highlight is needed.
  */
-private fun parseJsonPathSegments(jsonPath: String?): List<String>? {
+internal fun parseJsonPathSegments(jsonPath: String?): List<String>? {
     if (jsonPath == null) return null
     // Strip leading "$." prefix, then split on "." and "[…]"
     val stripped = jsonPath.removePrefix("$.").removePrefix("$")
@@ -1228,6 +1218,29 @@ private fun parseJsonPathSegments(jsonPath: String?): List<String>? {
     return segments.ifEmpty { null }
 }
 
+internal fun isHighlightTarget(remainingHighlightSegments: List<String>?): Boolean =
+    remainingHighlightSegments != null && remainingHighlightSegments.isEmpty()
+
+internal fun shouldHighlightPair(
+    pair: ApiTrafficPair,
+    responseTransactions: List<ApiResponseTransaction>,
+    highlightRequestId: ApiRequestId?,
+    highlightJsonPath: String?,
+): Boolean {
+    val requestMatches = highlightRequestId == null || pair.request?.id == highlightRequestId
+    val jsonPathMatches =
+        highlightJsonPath != null &&
+            responseTransactions.any {
+                highlightJsonPath.startsWithJsonPath(it.jsonPath.value)
+            }
+    return (highlightRequestId != null || highlightJsonPath != null) &&
+        requestMatches &&
+        (
+            jsonPathMatches ||
+                (highlightRequestId != null && highlightJsonPath == null)
+        )
+}
+
 @Composable
 private fun JsonTreeNode(
     label: String?,
@@ -1246,7 +1259,7 @@ private fun JsonTreeNode(
     val childCount = element.childCount()
     val expandable = childCount > 0
     // This node is the target only when a highlight path exists and all segments are consumed.
-    val isHighlightTarget = remainingHighlightSegments != null && remainingHighlightSegments.isEmpty()
+    val isHighlightTarget = isHighlightTarget(remainingHighlightSegments)
     // Force-expand the node if it's on the highlight path
     val forceExpandPath = !remainingHighlightSegments.isNullOrEmpty()
     val shouldForceExpand = forceExpandSubtree || forceExpandPath || isHighlightTarget
@@ -1425,7 +1438,7 @@ private fun jsonObjectChildPath(
         "$parentPath.$key"
     }
 
-private data class ApiTrafficPair(
+internal data class ApiTrafficPair(
     val request: ApiRequest?,
     val response: ApiResponse?,
 )

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
@@ -84,11 +84,12 @@ class ApiSessionsScreenLogicTest {
     private fun request(id: Long) =
         com.moneymanager.domain.model.ApiRequest(
             id = ApiRequestId(id),
-            sessionId = com.moneymanager.domain.model.ApiSessionId(1),
+            sessionId =
+                com.moneymanager.domain.model
+                    .ApiSessionId(1),
             requestedAt = kotlin.time.Instant.DISTANT_PAST,
             method = "GET",
             url = "https://example.com",
             headers = emptyList(),
         )
 }
-

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
@@ -63,7 +63,8 @@ class ApiSessionsScreenLogicTest {
 
     @Test
     fun shouldHighlightPair_matchesByJsonPathPrefix() {
-        val pair = ApiTrafficPair(request = request(43), response = null)
+        val requestId = 43L
+        val pair = ApiTrafficPair(request = request(requestId), response = null)
         val highlighted =
             shouldHighlightPair(
                 pair = pair,
@@ -78,7 +79,7 @@ class ApiSessionsScreenLogicTest {
                             errorMessage = null,
                         ),
                     ),
-                highlightRequestId = ApiRequestId(42),
+                highlightRequestId = ApiRequestId(requestId),
                 highlightJsonPath = "$.transactions[0].counterparty.name",
             )
         assertTrue(highlighted)

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
@@ -37,7 +37,7 @@ class ApiSessionsScreenLogicTest {
 
     @Test
     fun shouldHighlightPair_doesNotFallbackToRequestWhenJsonPathProvidedButUnmatched() {
-        val pair = ApiTrafficPair(request = request(41), response = null)
+        val pair = ApiTrafficPair(request = request(42), response = null)
         val highlighted =
             shouldHighlightPair(
                 pair = pair,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
@@ -1,0 +1,94 @@
+package com.moneymanager.ui.screens
+
+import com.moneymanager.domain.model.ApiRequestId
+import com.moneymanager.domain.model.ApiResponseId
+import com.moneymanager.domain.model.ApiResponseTransaction
+import com.moneymanager.domain.model.ApiResponseTransactionId
+import com.moneymanager.domain.model.ApiResponseTransactionState
+import com.moneymanager.domain.model.JsonPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ApiSessionsScreenLogicTest {
+    @Test
+    fun startsWithJsonPath_matchesExactAndNestedPaths() {
+        assertTrue("$.transactions[0].counterparty".startsWithJsonPath("$.transactions[0]"))
+        assertTrue("$.transactions[0]".startsWithJsonPath("$.transactions[0]"))
+        assertFalse("$.transactions[10]".startsWithJsonPath("$.transactions[1]"))
+    }
+
+    @Test
+    fun parseJsonPathSegments_parsesObjectAndArraySegments() {
+        assertEquals(listOf("transactions", "2", "counterparty"), parseJsonPathSegments("$.transactions[2].counterparty"))
+        assertEquals(listOf("accounts", "0"), parseJsonPathSegments("$.accounts[0]"))
+    }
+
+    @Test
+    fun isHighlightTarget_requiresNonNullEmptySegments() {
+        assertFalse(isHighlightTarget(null))
+        assertFalse(isHighlightTarget(listOf("transactions")))
+        assertTrue(isHighlightTarget(emptyList()))
+    }
+
+    @Test
+    fun shouldHighlightPair_doesNotFallbackToRequestWhenJsonPathProvidedButUnmatched() {
+        val pair = ApiTrafficPair(request = request(42), response = null)
+        val highlighted =
+            shouldHighlightPair(
+                pair = pair,
+                responseTransactions = emptyList(),
+                highlightRequestId = ApiRequestId(42),
+                highlightJsonPath = "$.transactions[0]",
+            )
+        assertFalse(highlighted)
+    }
+
+    @Test
+    fun shouldHighlightPair_allowsRequestFallbackWhenJsonPathMissing() {
+        val pair = ApiTrafficPair(request = request(42), response = null)
+        val highlighted =
+            shouldHighlightPair(
+                pair = pair,
+                responseTransactions = emptyList(),
+                highlightRequestId = ApiRequestId(42),
+                highlightJsonPath = null,
+            )
+        assertTrue(highlighted)
+    }
+
+    @Test
+    fun shouldHighlightPair_matchesByJsonPathPrefix() {
+        val pair = ApiTrafficPair(request = request(42), response = null)
+        val highlighted =
+            shouldHighlightPair(
+                pair = pair,
+                responseTransactions =
+                    listOf(
+                        ApiResponseTransaction(
+                            id = ApiResponseTransactionId(1),
+                            responseId = ApiResponseId(9),
+                            jsonPath = JsonPath("$.transactions[0]"),
+                            state = ApiResponseTransactionState.IMPORTED,
+                            transactionId = null,
+                            errorMessage = null,
+                        ),
+                    ),
+                highlightRequestId = ApiRequestId(42),
+                highlightJsonPath = "$.transactions[0].counterparty.name",
+            )
+        assertTrue(highlighted)
+    }
+
+    private fun request(id: Long) =
+        com.moneymanager.domain.model.ApiRequest(
+            id = ApiRequestId(id),
+            sessionId = com.moneymanager.domain.model.ApiSessionId(1),
+            requestedAt = kotlin.time.Instant.DISTANT_PAST,
+            method = "GET",
+            url = "https://example.com",
+            headers = emptyList(),
+        )
+}
+

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
@@ -1,15 +1,18 @@
 package com.moneymanager.ui.screens
 
+import com.moneymanager.domain.model.ApiRequest
 import com.moneymanager.domain.model.ApiRequestId
 import com.moneymanager.domain.model.ApiResponseId
 import com.moneymanager.domain.model.ApiResponseTransaction
 import com.moneymanager.domain.model.ApiResponseTransactionId
 import com.moneymanager.domain.model.ApiResponseTransactionState
+import com.moneymanager.domain.model.ApiSessionId
 import com.moneymanager.domain.model.JsonPath
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 
 class ApiSessionsScreenLogicTest {
     @Test
@@ -82,12 +85,10 @@ class ApiSessionsScreenLogicTest {
     }
 
     private fun request(id: Long) =
-        com.moneymanager.domain.model.ApiRequest(
+        ApiRequest(
             id = ApiRequestId(id),
-            sessionId =
-                com.moneymanager.domain.model
-                    .ApiSessionId(1),
-            requestedAt = kotlin.time.Instant.DISTANT_PAST,
+            sessionId = ApiSessionId(1),
+            requestedAt = Instant.DISTANT_PAST,
             method = "GET",
             url = "https://example.com",
             headers = emptyList(),

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
@@ -37,7 +37,7 @@ class ApiSessionsScreenLogicTest {
 
     @Test
     fun shouldHighlightPair_doesNotFallbackToRequestWhenJsonPathProvidedButUnmatched() {
-        val pair = ApiTrafficPair(request = request(42), response = null)
+        val pair = ApiTrafficPair(request = request(41), response = null)
         val highlighted =
             shouldHighlightPair(
                 pair = pair,
@@ -63,7 +63,7 @@ class ApiSessionsScreenLogicTest {
 
     @Test
     fun shouldHighlightPair_matchesByJsonPathPrefix() {
-        val pair = ApiTrafficPair(request = request(42), response = null)
+        val pair = ApiTrafficPair(request = request(43), response = null)
         val highlighted =
             shouldHighlightPair(
                 pair = pair,


### PR DESCRIPTION
## Summary
- fix API session traffic deep-link scrolling from audit references so centering runs once instead of continuously scrolling
- fix highlight target detection so null/empty path does not tint the entire JSON view
- restore section-level highlighting for the matched JSON subtree only
- tighten card-level highlight fallback so request-id fallback is used only when no jsonPath is provided

## Validation
- ./gradlew.bat :app:ui:core:compileKotlinJvm --console=plain

## Notes
- left unrelated local change in .idea/dataSources.xml uncommitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced scrolling and auto-centering behavior for highlighted JSON nodes in API session details
  * Improved JSON path matching logic for more accurate highlighting of API traffic data across requests and responses

* **Tests**
  * Added unit tests for JSON path parsing and highlight targeting functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NikolayMetchev/money-manager/pull/475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->