### PR TITLE
Add Wise API import by generalizing the generic API import layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,12 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 
 **SQLDelight** schema files: `app/db/core/src/commonMain/sqldelight/com/moneymanager/database/`
 
+**BETA — no DB versioning yet**: The app is in BETA and database versioning/migrations are not
+implemented (tracked in [issue #426](https://github.com/NikolayMetchev/money-manager/issues/426)).
+Until that lands, **do not make backward-compatible DB changes or write migration code**. The
+database is recreated from scratch on schema changes (seeding runs only on fresh-database creation),
+so existing local databases are expected to be deleted/recreated rather than migrated.
+
 **Important**: Store booleans as INTEGER (0/1). Don't use `AS Boolean` in .sq files.
 
 **Mappie** generates type-safe mappers from database entities to domain models. Annotate mapper interfaces with `@Mapper`.

--- a/app/db/core/src/androidMain/kotlin/com/moneymanager/database/AndroidDatabaseManager.kt
+++ b/app/db/core/src/androidMain/kotlin/com/moneymanager/database/AndroidDatabaseManager.kt
@@ -88,9 +88,6 @@ class AndroidDatabaseManager(
                 onProgress(DatabaseInitializationProgress("Preparing repositories...", 5, 6))
             }
 
-            // Idempotent: adds any built-in API strategies missing from existing databases.
-            DatabaseConfig.ensureBuiltInApiStrategies(database)
-
             onProgress(DatabaseInitializationProgress("Finishing database startup...", 6, 6))
             database
         }

--- a/app/db/core/src/androidMain/kotlin/com/moneymanager/database/AndroidDatabaseManager.kt
+++ b/app/db/core/src/androidMain/kotlin/com/moneymanager/database/AndroidDatabaseManager.kt
@@ -88,6 +88,9 @@ class AndroidDatabaseManager(
                 onProgress(DatabaseInitializationProgress("Preparing repositories...", 5, 6))
             }
 
+            // Idempotent: adds any built-in API strategies missing from existing databases.
+            DatabaseConfig.ensureBuiltInApiStrategies(database)
+
             onProgress(DatabaseInitializationProgress("Finishing database startup...", 6, 6))
             database
         }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -8,11 +8,18 @@ import com.moneymanager.database.json.ApiStrategyJsonCodec
 import com.moneymanager.domain.model.EntityType
 import com.moneymanager.domain.model.SourceType
 import com.moneymanager.domain.model.apistrategy.ApiAccountMappings
+import com.moneymanager.domain.model.apistrategy.ApiAmountFormat
 import com.moneymanager.domain.model.apistrategy.ApiAuthType
 import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiPaginationConfig
 import com.moneymanager.domain.model.apistrategy.ApiQueryParam
+import com.moneymanager.domain.model.apistrategy.ApiSignSource
 import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
+import com.moneymanager.domain.model.apistrategy.BuiltInCounterpartyRule
+import com.moneymanager.domain.model.apistrategy.PaginationMode
+import com.moneymanager.domain.model.apistrategy.PredicateOp
+import com.moneymanager.domain.model.apistrategy.RulePredicate
+import com.moneymanager.domain.model.apistrategy.RuleSign
 import com.moneymanager.domain.repository.CurrencyRepository
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
@@ -793,9 +800,10 @@ object DatabaseConfig {
             attributeTypeQueries.insertWithId(id = ACCOUNT_SORT_CODE_ATTR_TYPE_ID, name = "account-sort-code")
             attributeTypeQueries.insertWithId(id = ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID, name = "account-account-number")
 
-            // Seed the built-in Monzo API import strategy (after triggers and system device are
-            // created so the INSERT trigger records the initial audit entry and source is attributed)
+            // Seed the built-in Monzo and Wise API import strategies (after triggers and system
+            // device are created so the INSERT trigger records the initial audit entry and source)
             seedMonzoStrategy(systemDeviceId)
+            seedWiseStrategy(systemDeviceId)
 
             // Seed currencies with source tracking
             allCurrencies.forEach { currency ->
@@ -853,6 +861,7 @@ object DatabaseConfig {
                     ),
                 accountNamePrefix = "Monzo: ",
                 counterpartyPrefix = "Monzo Counterparty: ",
+                builtInCounterpartyRules = monzoAtmRules,
             )
         val now = Clock.System.now().toEpochMilliseconds()
         apiImportStrategyQueries.insert(
@@ -864,6 +873,120 @@ object DatabaseConfig {
         )
         apiImportStrategyQueries.insertSource(
             strategy_id = monzoStrategyId.toString(),
+            revision_id = 1,
+            source_type_id = SourceType.SYSTEM.id.toLong(),
+            device_id = systemDeviceId,
+        )
+    }
+
+    /**
+     * Monzo ATM-detection expressed declaratively (moved out of the import engine). Each rule routes
+     * matching outgoing transactions to a single consolidated "ATM" counterparty account.
+     */
+    private val monzoAtmRules: List<BuiltInCounterpartyRule> =
+        listOf(
+            BuiltInCounterpartyRule(
+                name = "ATM",
+                onlyWhenSign = RuleSign.NEGATIVE,
+                predicates = listOf(RulePredicate(path = "atm_fees_detailed", op = PredicateOp.EXISTS)),
+            ),
+            BuiltInCounterpartyRule(
+                name = "ATM",
+                onlyWhenSign = RuleSign.NEGATIVE,
+                predicates = listOf(RulePredicate(path = "labels", op = PredicateOp.ARRAY_ANY_STARTS_WITH, value = "withdrawal.atm")),
+            ),
+            BuiltInCounterpartyRule(
+                name = "ATM",
+                onlyWhenSign = RuleSign.NEGATIVE,
+                predicates = listOf(RulePredicate(path = "metadata.mcc", op = PredicateOp.EQUALS, value = "6011")),
+            ),
+            BuiltInCounterpartyRule(
+                name = "ATM",
+                onlyWhenSign = RuleSign.NEGATIVE,
+                predicates =
+                    listOf(
+                        RulePredicate(path = "category", op = PredicateOp.EQUALS_IGNORE_CASE, value = "cash"),
+                        RulePredicate(path = "merchant", op = PredicateOp.OBJECT_EMPTY),
+                        RulePredicate(path = "counterparty", op = PredicateOp.OBJECT_EMPTY),
+                    ),
+            ),
+        )
+
+    /** Fixed UUID for the built-in Wise strategy so it can be referenced reliably. */
+    private val wiseStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-000000000002")
+
+    /**
+     * Seeds the built-in Wise API import strategy. Wise has a three-level hierarchy
+     * (profiles → balances → statements): profiles are fetched as an ancestor endpoint and their id
+     * is templated into the balances and statement paths; amounts are decimal with the direction in
+     * a separate `type` field; statements are fetched in date windows.
+     */
+    private fun MoneyManagerDatabaseWrapper.seedWiseStrategy(systemDeviceId: Long) {
+        val config =
+            ApiStrategyConfigJson(
+                baseUrl = "https://api.transferwise.com",
+                authType = ApiAuthType.BEARER_TOKEN,
+                ancestorEndpoints =
+                    listOf(
+                        ApiEndpointConfig(path = "/v1/profiles", responseArrayKey = ""),
+                    ),
+                accountsEndpoint =
+                    ApiEndpointConfig(
+                        path = "/v4/profiles/{ancestor[0].id}/balances",
+                        responseArrayKey = "",
+                        queryParams = listOf(ApiQueryParam(name = "types", value = "STANDARD")),
+                    ),
+                transactionsEndpoint =
+                    ApiEndpointConfig(
+                        path = "/v1/profiles/{ancestor[0].id}/balance-statements/{account.id}/statement.json",
+                        responseArrayKey = "transactions",
+                        queryParams =
+                            listOf(
+                                ApiQueryParam(name = "currency", dynamicSource = "account.currency"),
+                                ApiQueryParam(name = "type", value = "FLAT"),
+                            ),
+                        pagination =
+                            ApiPaginationConfig(
+                                mode = PaginationMode.DATE_WINDOW,
+                                startParam = "intervalStart",
+                                endParam = "intervalEnd",
+                                windowDays = 469,
+                            ),
+                    ),
+                accountMappings =
+                    ApiAccountMappings(
+                        idField = "id",
+                        descriptionField = "name",
+                        ownersArrayField = null,
+                        currencyField = "currency",
+                    ),
+                transactionMappings =
+                    ApiTransactionMappings(
+                        amountField = "amount.value",
+                        currencyField = "amount.currency",
+                        timestampField = "date",
+                        descriptionField = "details.description",
+                        amountFormat = ApiAmountFormat.DECIMAL_MAJOR_UNITS,
+                        signSource = ApiSignSource.FIELD,
+                        signField = "type",
+                        creditValues = setOf("CREDIT"),
+                        idField = "referenceNumber",
+                        merchantNameField = "details.merchant.name",
+                        counterpartyNameField = "details.senderName",
+                    ),
+                accountNamePrefix = "Wise: ",
+                counterpartyPrefix = "Wise Counterparty: ",
+            )
+        val now = Clock.System.now().toEpochMilliseconds()
+        apiImportStrategyQueries.insert(
+            id = wiseStrategyId.toString(),
+            name = "Wise",
+            config_json = ApiStrategyJsonCodec.encode(config),
+            created_at = now,
+            updated_at = now,
+        )
+        apiImportStrategyQueries.insertSource(
+            strategy_id = wiseStrategyId.toString(),
             revision_id = 1,
             source_type_id = SourceType.SYSTEM.id.toLong(),
             device_id = systemDeviceId,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -802,8 +802,7 @@ object DatabaseConfig {
 
             // Seed the built-in Monzo and Wise API import strategies (after triggers and system
             // device are created so the INSERT trigger records the initial audit entry and source)
-            seedMonzoStrategy(systemDeviceId)
-            seedWiseStrategy(systemDeviceId)
+            ensureBuiltInApiStrategies(systemDeviceId)
 
             // Seed currencies with source tracking
             allCurrencies.forEach { currency ->
@@ -819,14 +818,32 @@ object DatabaseConfig {
         }
     }
 
+    /**
+     * Inserts any missing built-in API import strategies (Monzo, Wise). Idempotent and safe to run
+     * on every database open, so databases created before a built-in strategy was added pick it up
+     * on the next launch. Skips silently if the system device is missing.
+     */
+    suspend fun ensureBuiltInApiStrategies(database: MoneyManagerDatabaseWrapper) {
+        with(database) {
+            val systemDeviceId =
+                deviceQueries.selectSystemDevice(platform_id = 0).executeAsOneOrNull() ?: return
+            ensureBuiltInApiStrategies(systemDeviceId)
+        }
+    }
+
+    private fun MoneyManagerDatabaseWrapper.ensureBuiltInApiStrategies(systemDeviceId: Long) {
+        seedMonzoStrategy(systemDeviceId)
+        seedWiseStrategy(systemDeviceId)
+    }
+
     /** Fixed UUID for the built-in Monzo strategy so it can be referenced reliably. */
     private val monzoStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-000000000001")
 
     /**
-     * Seeds the built-in Monzo API import strategy.
-     * Called once during new-database initialisation.
+     * Inserts the built-in Monzo API import strategy if it is not already present (idempotent).
      */
     private fun MoneyManagerDatabaseWrapper.seedMonzoStrategy(systemDeviceId: Long) {
+        if (apiImportStrategyQueries.selectById(monzoStrategyId.toString()).executeAsOneOrNull() != null) return
         val config =
             ApiStrategyConfigJson(
                 baseUrl = "https://api.monzo.com",
@@ -919,9 +936,10 @@ object DatabaseConfig {
      * Seeds the built-in Wise API import strategy. Wise has a three-level hierarchy
      * (profiles → balances → statements): profiles are fetched as an ancestor endpoint and their id
      * is templated into the balances and statement paths; amounts are decimal with the direction in
-     * a separate `type` field; statements are fetched in date windows.
+     * a separate `type` field; statements are fetched in date windows. Idempotent.
      */
     private fun MoneyManagerDatabaseWrapper.seedWiseStrategy(systemDeviceId: Long) {
+        if (apiImportStrategyQueries.selectById(wiseStrategyId.toString()).executeAsOneOrNull() != null) return
         val config =
             ApiStrategyConfigJson(
                 baseUrl = "https://api.transferwise.com",

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -941,17 +941,12 @@ object DatabaseConfig {
                                 ApiQueryParam(name = "currency", dynamicSource = "account.currency"),
                                 ApiQueryParam(name = "type", value = "FLAT"),
                             ),
-                        pagination =
-                            ApiPaginationConfig(
-                                mode = PaginationMode.DATE_WINDOW,
-                                startParam = "intervalStart",
-                                endParam = "intervalEnd",
-                                windowDays = 469,
-                            ),
+                        // startParam/endParam/windowDays default to Wise's values (intervalStart,
+                        // intervalEnd, 469).
+                        pagination = ApiPaginationConfig(mode = PaginationMode.DATE_WINDOW),
                     ),
                 accountMappings =
                     ApiAccountMappings(
-                        idField = "id",
                         descriptionField = "name",
                         ownersArrayField = null,
                         currencyField = "currency",
@@ -984,7 +979,6 @@ object DatabaseConfig {
                 peopleDownload =
                     ApiPersonImportConfig(
                         endpoint = ApiEndpointConfig(path = "/v1/profiles", responseArrayKey = ""),
-                        externalIdField = "id",
                         firstNameField = "details.firstName",
                         lastNameField = "details.lastName",
                         preferredNameField = "details.preferredName",

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -40,9 +40,6 @@ object DatabaseConfig {
     /** Stable ID for the "built-in type" attribute type used by built-in counterparty accounts. */
     const val BUILT_IN_COUNTERPARTY_TYPE_ATTR_TYPE_ID: Long = -3
 
-    /** Stable ID for the "person-external-id" attribute type (e.g. Monzo userId value). */
-    const val PERSON_EXTERNAL_ID_ATTR_TYPE_ID: Long = -4
-
     /** Stable ID for the "sort code" account attribute type used for personal counterparties. */
     const val ACCOUNT_SORT_CODE_ATTR_TYPE_ID: Long = -5
 
@@ -798,7 +795,6 @@ object DatabaseConfig {
             attributeTypeQueries.insertWithId(id = EXCLUDED_ATTR_TYPE_ID, name = "excluded")
             attributeTypeQueries.insertWithId(id = ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID, name = "account-external-id")
             attributeTypeQueries.insertWithId(id = BUILT_IN_COUNTERPARTY_TYPE_ATTR_TYPE_ID, name = "built-in type")
-            attributeTypeQueries.insertWithId(id = PERSON_EXTERNAL_ID_ATTR_TYPE_ID, name = "person-external-id")
             attributeTypeQueries.insertWithId(id = ACCOUNT_SORT_CODE_ATTR_TYPE_ID, name = "account-sort-code")
             attributeTypeQueries.insertWithId(id = ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID, name = "account-account-number")
 
@@ -861,6 +857,7 @@ object DatabaseConfig {
                 accountNamePrefix = "Monzo: ",
                 counterpartyPrefix = "Monzo Counterparty: ",
                 builtInCounterpartyRules = monzoAtmRules,
+                personExternalIdAttribute = "monzo-external-id",
             )
         val now = Clock.System.now().toEpochMilliseconds()
         apiImportStrategyQueries.insert(
@@ -994,6 +991,7 @@ object DatabaseConfig {
                         fallbackNameField = "details.name",
                         accountOwnerAncestorExpr = "ancestor[0].id",
                     ),
+                personExternalIdAttribute = "wise-external-id",
             )
         val now = Clock.System.now().toEpochMilliseconds()
         apiImportStrategyQueries.insert(

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -12,6 +12,7 @@ import com.moneymanager.domain.model.apistrategy.ApiAmountFormat
 import com.moneymanager.domain.model.apistrategy.ApiAuthType
 import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiPaginationConfig
+import com.moneymanager.domain.model.apistrategy.ApiPersonImportConfig
 import com.moneymanager.domain.model.apistrategy.ApiQueryParam
 import com.moneymanager.domain.model.apistrategy.ApiSignSource
 import com.moneymanager.domain.model.apistrategy.ApiSigningConfig
@@ -980,6 +981,18 @@ object DatabaseConfig {
                 signing =
                     ApiSigningConfig(
                         statementCountries = setOf("US", "CA", "AU", "NZ", "SG", "MY"),
+                    ),
+                // The account holder lives on the profile (the ancestor), not the balance, so people
+                // are downloaded/imported separately from the /v1/profiles endpoint.
+                peopleDownload =
+                    ApiPersonImportConfig(
+                        endpoint = ApiEndpointConfig(path = "/v1/profiles", responseArrayKey = ""),
+                        externalIdField = "id",
+                        firstNameField = "details.firstName",
+                        lastNameField = "details.lastName",
+                        preferredNameField = "details.preferredName",
+                        fallbackNameField = "details.name",
+                        accountOwnerAncestorExpr = "ancestor[0].id",
                     ),
             )
         val now = Clock.System.now().toEpochMilliseconds()

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -802,7 +802,8 @@ object DatabaseConfig {
 
             // Seed the built-in Monzo and Wise API import strategies (after triggers and system
             // device are created so the INSERT trigger records the initial audit entry and source)
-            ensureBuiltInApiStrategies(systemDeviceId)
+            seedMonzoStrategy(systemDeviceId)
+            seedWiseStrategy(systemDeviceId)
 
             // Seed currencies with source tracking
             allCurrencies.forEach { currency ->
@@ -818,32 +819,11 @@ object DatabaseConfig {
         }
     }
 
-    /**
-     * Inserts any missing built-in API import strategies (Monzo, Wise). Idempotent and safe to run
-     * on every database open, so databases created before a built-in strategy was added pick it up
-     * on the next launch. Skips silently if the system device is missing.
-     */
-    suspend fun ensureBuiltInApiStrategies(database: MoneyManagerDatabaseWrapper) {
-        with(database) {
-            val systemDeviceId =
-                deviceQueries.selectSystemDevice(platform_id = 0).executeAsOneOrNull() ?: return
-            ensureBuiltInApiStrategies(systemDeviceId)
-        }
-    }
-
-    private fun MoneyManagerDatabaseWrapper.ensureBuiltInApiStrategies(systemDeviceId: Long) {
-        seedMonzoStrategy(systemDeviceId)
-        seedWiseStrategy(systemDeviceId)
-    }
-
     /** Fixed UUID for the built-in Monzo strategy so it can be referenced reliably. */
     private val monzoStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-000000000001")
 
-    /**
-     * Inserts the built-in Monzo API import strategy if it is not already present (idempotent).
-     */
+    /** Seeds the built-in Monzo API import strategy during new-database initialisation. */
     private fun MoneyManagerDatabaseWrapper.seedMonzoStrategy(systemDeviceId: Long) {
-        if (apiImportStrategyQueries.selectById(monzoStrategyId.toString()).executeAsOneOrNull() != null) return
         val config =
             ApiStrategyConfigJson(
                 baseUrl = "https://api.monzo.com",
@@ -936,13 +916,12 @@ object DatabaseConfig {
      * Seeds the built-in Wise API import strategy. Wise has a three-level hierarchy
      * (profiles → balances → statements): profiles are fetched as an ancestor endpoint and their id
      * is templated into the balances and statement paths; amounts are decimal with the direction in
-     * a separate `type` field; statements are fetched in date windows. Idempotent.
+     * a separate `type` field; statements are fetched in date windows.
      */
     private fun MoneyManagerDatabaseWrapper.seedWiseStrategy(systemDeviceId: Long) {
-        if (apiImportStrategyQueries.selectById(wiseStrategyId.toString()).executeAsOneOrNull() != null) return
         val config =
             ApiStrategyConfigJson(
-                baseUrl = "https://api.transferwise.com",
+                baseUrl = "https://api.wise.com",
                 authType = ApiAuthType.BEARER_TOKEN,
                 ancestorEndpoints =
                     listOf(

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -14,6 +14,7 @@ import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiPaginationConfig
 import com.moneymanager.domain.model.apistrategy.ApiQueryParam
 import com.moneymanager.domain.model.apistrategy.ApiSignSource
+import com.moneymanager.domain.model.apistrategy.ApiSigningConfig
 import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
 import com.moneymanager.domain.model.apistrategy.BuiltInCounterpartyRule
 import com.moneymanager.domain.model.apistrategy.PaginationMode
@@ -973,6 +974,9 @@ object DatabaseConfig {
                     ),
                 accountNamePrefix = "Wise: ",
                 counterpartyPrefix = "Wise Counterparty: ",
+                // Wise balance statements are SCA-protected: a 403 returns an x-2fa-approval one-time
+                // token that must be signed with the credential's private key and replayed.
+                signing = ApiSigningConfig(),
             )
         val now = Clock.System.now().toEpochMilliseconds()
         apiImportStrategyQueries.insert(

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -975,8 +975,12 @@ object DatabaseConfig {
                 accountNamePrefix = "Wise: ",
                 counterpartyPrefix = "Wise Counterparty: ",
                 // Wise balance statements are SCA-protected: a 403 returns an x-2fa-approval one-time
-                // token that must be signed with the credential's private key and replayed.
-                signing = ApiSigningConfig(),
+                // token that must be signed with the credential's private key and replayed. Statements
+                // are only available via the API for accounts based in these countries.
+                signing =
+                    ApiSigningConfig(
+                        statementCountries = setOf("US", "CA", "AU", "NZ", "SG", "MY"),
+                    ),
             )
         val now = Clock.System.now().toEpochMilliseconds()
         apiImportStrategyQueries.insert(

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodec.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodec.kt
@@ -4,6 +4,7 @@ import com.moneymanager.domain.model.apistrategy.ApiAccountMappings
 import com.moneymanager.domain.model.apistrategy.ApiAuthType
 import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiPeopleMappings
+import com.moneymanager.domain.model.apistrategy.ApiSigningConfig
 import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
 import com.moneymanager.domain.model.apistrategy.BuiltInCounterpartyRule
 import kotlinx.serialization.Serializable
@@ -26,6 +27,7 @@ data class ApiStrategyConfigJson(
     val peopleMappings: ApiPeopleMappings = ApiPeopleMappings(),
     val ancestorEndpoints: List<ApiEndpointConfig> = emptyList(),
     val builtInCounterpartyRules: List<BuiltInCounterpartyRule> = emptyList(),
+    val signing: ApiSigningConfig? = null,
 )
 
 /**

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodec.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodec.kt
@@ -4,6 +4,7 @@ import com.moneymanager.domain.model.apistrategy.ApiAccountMappings
 import com.moneymanager.domain.model.apistrategy.ApiAuthType
 import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiPeopleMappings
+import com.moneymanager.domain.model.apistrategy.ApiPersonImportConfig
 import com.moneymanager.domain.model.apistrategy.ApiSigningConfig
 import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
 import com.moneymanager.domain.model.apistrategy.BuiltInCounterpartyRule
@@ -28,6 +29,7 @@ data class ApiStrategyConfigJson(
     val ancestorEndpoints: List<ApiEndpointConfig> = emptyList(),
     val builtInCounterpartyRules: List<BuiltInCounterpartyRule> = emptyList(),
     val signing: ApiSigningConfig? = null,
+    val peopleDownload: ApiPersonImportConfig? = null,
 )
 
 /**

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodec.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodec.kt
@@ -30,6 +30,7 @@ data class ApiStrategyConfigJson(
     val builtInCounterpartyRules: List<BuiltInCounterpartyRule> = emptyList(),
     val signing: ApiSigningConfig? = null,
     val peopleDownload: ApiPersonImportConfig? = null,
+    val personExternalIdAttribute: String? = null,
 )
 
 /**

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodec.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodec.kt
@@ -5,6 +5,7 @@ import com.moneymanager.domain.model.apistrategy.ApiAuthType
 import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiPeopleMappings
 import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
+import com.moneymanager.domain.model.apistrategy.BuiltInCounterpartyRule
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -23,6 +24,8 @@ data class ApiStrategyConfigJson(
     val accountNamePrefix: String,
     val counterpartyPrefix: String,
     val peopleMappings: ApiPeopleMappings = ApiPeopleMappings(),
+    val ancestorEndpoints: List<ApiEndpointConfig> = emptyList(),
+    val builtInCounterpartyRules: List<BuiltInCounterpartyRule> = emptyList(),
 )
 
 /**

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/ApiImportStrategyAuditEntryMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/ApiImportStrategyAuditEntryMapper.kt
@@ -45,6 +45,8 @@ object ApiImportStrategyAuditEntryMapper {
                 accountNamePrefix = raw.accountNamePrefix,
                 counterpartyPrefix = raw.counterpartyPrefix,
                 peopleMappings = raw.peopleMappings,
+                ancestorEndpoints = raw.ancestorEndpoints,
+                builtInCounterpartyRules = raw.builtInCounterpartyRules,
             )
         return ApiImportStrategyAuditEntry(
             id = from.id,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/ApiImportStrategyAuditEntryMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/ApiImportStrategyAuditEntryMapper.kt
@@ -47,6 +47,7 @@ object ApiImportStrategyAuditEntryMapper {
                 peopleMappings = raw.peopleMappings,
                 ancestorEndpoints = raw.ancestorEndpoints,
                 builtInCounterpartyRules = raw.builtInCounterpartyRules,
+                signing = raw.signing,
             )
         return ApiImportStrategyAuditEntry(
             id = from.id,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/ApiImportStrategyAuditEntryMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/ApiImportStrategyAuditEntryMapper.kt
@@ -48,6 +48,7 @@ object ApiImportStrategyAuditEntryMapper {
                 ancestorEndpoints = raw.ancestorEndpoints,
                 builtInCounterpartyRules = raw.builtInCounterpartyRules,
                 signing = raw.signing,
+                peopleDownload = raw.peopleDownload,
             )
         return ApiImportStrategyAuditEntry(
             id = from.id,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/ApiImportStrategyAuditEntryMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/ApiImportStrategyAuditEntryMapper.kt
@@ -49,6 +49,7 @@ object ApiImportStrategyAuditEntryMapper {
                 builtInCounterpartyRules = raw.builtInCounterpartyRules,
                 signing = raw.signing,
                 peopleDownload = raw.peopleDownload,
+                personExternalIdAttribute = raw.personExternalIdAttribute,
             )
         return ApiImportStrategyAuditEntry(
             id = from.id,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiImportStrategyRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiImportStrategyRepositoryImpl.kt
@@ -119,6 +119,8 @@ class ApiImportStrategyRepositoryImpl(
             accountNamePrefix = config.accountNamePrefix,
             counterpartyPrefix = config.counterpartyPrefix,
             peopleMappings = config.peopleMappings,
+            ancestorEndpoints = config.ancestorEndpoints,
+            builtInCounterpartyRules = config.builtInCounterpartyRules,
             createdAt = Instant.fromEpochMilliseconds(entity.created_at),
             updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
             revisionId = entity.revision_id,
@@ -137,5 +139,7 @@ class ApiImportStrategyRepositoryImpl(
             accountNamePrefix = accountNamePrefix,
             counterpartyPrefix = counterpartyPrefix,
             peopleMappings = peopleMappings,
+            ancestorEndpoints = ancestorEndpoints,
+            builtInCounterpartyRules = builtInCounterpartyRules,
         )
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiImportStrategyRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiImportStrategyRepositoryImpl.kt
@@ -121,6 +121,7 @@ class ApiImportStrategyRepositoryImpl(
             peopleMappings = config.peopleMappings,
             ancestorEndpoints = config.ancestorEndpoints,
             builtInCounterpartyRules = config.builtInCounterpartyRules,
+            signing = config.signing,
             createdAt = Instant.fromEpochMilliseconds(entity.created_at),
             updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
             revisionId = entity.revision_id,
@@ -141,5 +142,6 @@ class ApiImportStrategyRepositoryImpl(
             peopleMappings = peopleMappings,
             ancestorEndpoints = ancestorEndpoints,
             builtInCounterpartyRules = builtInCounterpartyRules,
+            signing = signing,
         )
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiImportStrategyRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiImportStrategyRepositoryImpl.kt
@@ -122,6 +122,7 @@ class ApiImportStrategyRepositoryImpl(
             ancestorEndpoints = config.ancestorEndpoints,
             builtInCounterpartyRules = config.builtInCounterpartyRules,
             signing = config.signing,
+            peopleDownload = config.peopleDownload,
             createdAt = Instant.fromEpochMilliseconds(entity.created_at),
             updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
             revisionId = entity.revision_id,
@@ -143,5 +144,6 @@ class ApiImportStrategyRepositoryImpl(
             ancestorEndpoints = ancestorEndpoints,
             builtInCounterpartyRules = builtInCounterpartyRules,
             signing = signing,
+            peopleDownload = peopleDownload,
         )
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiImportStrategyRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiImportStrategyRepositoryImpl.kt
@@ -123,6 +123,7 @@ class ApiImportStrategyRepositoryImpl(
             builtInCounterpartyRules = config.builtInCounterpartyRules,
             signing = config.signing,
             peopleDownload = config.peopleDownload,
+            personExternalIdAttribute = config.personExternalIdAttribute,
             createdAt = Instant.fromEpochMilliseconds(entity.created_at),
             updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
             revisionId = entity.revision_id,
@@ -145,5 +146,6 @@ class ApiImportStrategyRepositoryImpl(
             builtInCounterpartyRules = builtInCounterpartyRules,
             signing = signing,
             peopleDownload = peopleDownload,
+            personExternalIdAttribute = personExternalIdAttribute,
         )
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiSessionRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiSessionRepositoryImpl.kt
@@ -40,6 +40,8 @@ class ApiSessionRepositoryImpl(
         createdAt: Instant,
         type: ApiSessionType,
         strategyId: ApiImportStrategyId?,
+        privateKey: String?,
+        publicKey: String?,
     ): MonzoCredentialId =
         withContext(Dispatchers.Default) {
             val id =
@@ -49,6 +51,8 @@ class ApiSessionRepositoryImpl(
                         token = token,
                         created_at = createdAt.toEpochMilliseconds(),
                         strategy_id = strategyId?.id?.toString(),
+                        private_key = privateKey,
+                        public_key = publicKey,
                     )
                     queries.lastInsertCredentialRowId().executeAsOne()
                 }
@@ -62,6 +66,19 @@ class ApiSessionRepositoryImpl(
         withContext(Dispatchers.Default) {
             queries.updateCredentialStrategy(
                 strategy_id = strategyId?.id?.toString(),
+                id = credentialId.id,
+            )
+        }
+
+    override suspend fun updateCredentialKeys(
+        credentialId: MonzoCredentialId,
+        privateKey: String?,
+        publicKey: String?,
+    ): Unit =
+        withContext(Dispatchers.Default) {
+            queries.updateCredentialKeys(
+                private_key = privateKey,
+                public_key = publicKey,
                 id = credentialId.id,
             )
         }
@@ -326,6 +343,8 @@ class ApiSessionRepositoryImpl(
             token = token,
             createdAt = Instant.fromEpochMilliseconds(created_at),
             strategyId = strategy_id?.let { ApiImportStrategyId(Uuid.parse(it)) },
+            privateKey = private_key,
+            publicKey = public_key,
         )
 
     private fun com.moneymanager.database.sql.Api_session_with_latest_import.toApiSession(): ApiSession =

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiSessionRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiSessionRepositoryImpl.kt
@@ -64,10 +64,13 @@ class ApiSessionRepositoryImpl(
         strategyId: ApiImportStrategyId?,
     ): Unit =
         withContext(Dispatchers.Default) {
-            queries.updateCredentialStrategy(
-                strategy_id = strategyId?.id?.toString(),
-                id = credentialId.id,
-            )
+            val affected =
+                queries
+                    .updateCredentialStrategy(
+                        strategy_id = strategyId?.id?.toString(),
+                        id = credentialId.id,
+                    ).await()
+            check(affected == 1L) { "Expected to update one credential ($credentialId) strategy, but $affected rows matched" }
         }
 
     override suspend fun updateCredentialKeys(
@@ -76,11 +79,14 @@ class ApiSessionRepositoryImpl(
         publicKey: String?,
     ): Unit =
         withContext(Dispatchers.Default) {
-            queries.updateCredentialKeys(
-                private_key = privateKey,
-                public_key = publicKey,
-                id = credentialId.id,
-            )
+            val affected =
+                queries
+                    .updateCredentialKeys(
+                        private_key = privateKey,
+                        public_key = publicKey,
+                        id = credentialId.id,
+                    ).await()
+            check(affected == 1L) { "Expected to update one credential ($credentialId) keys, but $affected rows matched" }
         }
 
     override suspend fun getAllCredentials(): List<MonzoCredential> =

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/ApiSession.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/ApiSession.sq
@@ -12,6 +12,9 @@ CREATE TABLE api_credential (
     token TEXT NOT NULL UNIQUE CHECK(length(trim(token)) > 0),
     created_at INTEGER NOT NULL,
     strategy_id TEXT,
+    -- PEM-encoded RSA key pair for request signing (e.g. Wise SCA); null when not configured.
+    private_key TEXT,
+    public_key TEXT,
     FOREIGN KEY (type_id) REFERENCES api_session_type(id),
     FOREIGN KEY (strategy_id) REFERENCES api_import_strategy(id) ON DELETE SET NULL
 );
@@ -101,14 +104,17 @@ CREATE INDEX idx_api_response_session ON api_response(session_id);
 CREATE INDEX idx_api_response_responded_at ON api_response(responded_at);
 
 insertCredential:
-INSERT INTO api_credential(type_id, token, created_at, strategy_id)
-VALUES (?, ?, ?, ?);
+INSERT INTO api_credential(type_id, token, created_at, strategy_id, private_key, public_key)
+VALUES (?, ?, ?, ?, ?, ?);
 
 lastInsertCredentialRowId:
 SELECT last_insert_rowid();
 
 updateCredentialStrategy:
 UPDATE api_credential SET strategy_id = ? WHERE id = ?;
+
+updateCredentialKeys:
+UPDATE api_credential SET private_key = ?, public_key = ? WHERE id = ?;
 
 selectAllCredentials:
 SELECT * FROM api_credential ORDER BY created_at DESC;

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/ApiSession.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/ApiSession.sq
@@ -13,8 +13,10 @@ CREATE TABLE api_credential (
     created_at INTEGER NOT NULL,
     strategy_id TEXT,
     -- PEM-encoded RSA key pair for request signing (e.g. Wise SCA); null when not configured.
+    -- A signing key is only meaningful as a pair, so enforce both-null or both-present.
     private_key TEXT,
     public_key TEXT,
+    CHECK ((private_key IS NULL) = (public_key IS NULL)),
     FOREIGN KEY (type_id) REFERENCES api_session_type(id),
     FOREIGN KEY (strategy_id) REFERENCES api_import_strategy(id) ON DELETE SET NULL
 );

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BuiltInApiStrategySeedTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BuiltInApiStrategySeedTest.kt
@@ -7,33 +7,15 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class BuiltInApiStrategySeedTest : DbTest() {
-    private suspend fun strategies() =
-        repositories.apiImportStrategyRepository
-            .getAllStrategies()
-            .first()
-
-    private suspend fun strategyNames(): Set<String> = strategies().map { it.name }.toSet()
-
     @Test
-    fun `a fresh database has both built-in strategies`() =
+    fun `a fresh database seeds both built-in strategies`() =
         runTest {
-            assertEquals(setOf("Monzo", "Wise"), strategyNames())
-        }
-
-    @Test
-    fun `ensureBuiltInApiStrategies re-adds a missing strategy and is idempotent`() =
-        runTest {
-            // Simulate a database created before Wise existed.
-            val wise = strategies().single { it.name == "Wise" }
-            repositories.apiImportStrategyRepository.deleteStrategy(wise.id)
-            assertEquals(setOf("Monzo"), strategyNames(), "Wise should be gone after delete")
-
-            // The migration path: opening the database restores the missing built-in.
-            DatabaseConfig.ensureBuiltInApiStrategies(database)
-            assertEquals(setOf("Monzo", "Wise"), strategyNames(), "Wise should be restored")
-
-            // Running again must not create duplicates.
-            DatabaseConfig.ensureBuiltInApiStrategies(database)
-            assertEquals(2, strategies().size, "Seeding must be idempotent")
+            val names =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .map { it.name }
+                    .toSet()
+            assertEquals(setOf("Monzo", "Wise"), names)
         }
 }

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BuiltInApiStrategySeedTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BuiltInApiStrategySeedTest.kt
@@ -1,0 +1,39 @@
+package com.moneymanager.database
+
+import com.moneymanager.test.database.DbTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BuiltInApiStrategySeedTest : DbTest() {
+    private suspend fun strategies() =
+        repositories.apiImportStrategyRepository
+            .getAllStrategies()
+            .first()
+
+    private suspend fun strategyNames(): Set<String> = strategies().map { it.name }.toSet()
+
+    @Test
+    fun `a fresh database has both built-in strategies`() =
+        runTest {
+            assertEquals(setOf("Monzo", "Wise"), strategyNames())
+        }
+
+    @Test
+    fun `ensureBuiltInApiStrategies re-adds a missing strategy and is idempotent`() =
+        runTest {
+            // Simulate a database created before Wise existed.
+            val wise = strategies().single { it.name == "Wise" }
+            repositories.apiImportStrategyRepository.deleteStrategy(wise.id)
+            assertEquals(setOf("Monzo"), strategyNames(), "Wise should be gone after delete")
+
+            // The migration path: opening the database restores the missing built-in.
+            DatabaseConfig.ensureBuiltInApiStrategies(database)
+            assertEquals(setOf("Monzo", "Wise"), strategyNames(), "Wise should be restored")
+
+            // Running again must not create duplicates.
+            DatabaseConfig.ensureBuiltInApiStrategies(database)
+            assertEquals(2, strategies().size, "Seeding must be idempotent")
+        }
+}

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodecTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodecTest.kt
@@ -43,9 +43,6 @@ class ApiStrategyJsonCodecTest {
             config(
                 ApiPaginationConfig(
                     mode = PaginationMode.DATE_WINDOW,
-                    startParam = "intervalStart",
-                    endParam = "intervalEnd",
-                    windowDays = 469,
                     extraParams = listOf(ApiQueryParam(name = "type", value = "FLAT")),
                 ),
             )

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodecTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/json/ApiStrategyJsonCodecTest.kt
@@ -1,0 +1,86 @@
+package com.moneymanager.database.json
+
+import com.moneymanager.domain.model.apistrategy.ApiAccountMappings
+import com.moneymanager.domain.model.apistrategy.ApiAuthType
+import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
+import com.moneymanager.domain.model.apistrategy.ApiPaginationConfig
+import com.moneymanager.domain.model.apistrategy.ApiQueryParam
+import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
+import com.moneymanager.domain.model.apistrategy.PaginationMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ApiStrategyJsonCodecTest {
+    private fun config(pagination: ApiPaginationConfig?) =
+        ApiStrategyConfigJson(
+            baseUrl = "https://example.com",
+            authType = ApiAuthType.BEARER_TOKEN,
+            accountsEndpoint = ApiEndpointConfig(path = "/accounts", responseArrayKey = "accounts"),
+            transactionsEndpoint =
+                ApiEndpointConfig(
+                    path = "/transactions",
+                    responseArrayKey = "transactions",
+                    queryParams = listOf(ApiQueryParam(name = "account_id", dynamicSource = "account.id")),
+                    pagination = pagination,
+                ),
+            accountMappings = ApiAccountMappings(),
+            transactionMappings = ApiTransactionMappings(),
+            accountNamePrefix = "X: ",
+            counterpartyPrefix = "X CP: ",
+        )
+
+    @Test
+    fun `cursor pagination round-trips`() {
+        val original = config(ApiPaginationConfig())
+        val decoded = ApiStrategyJsonCodec.decode(ApiStrategyJsonCodec.encode(original))
+        assertEquals(original, decoded)
+        assertEquals(PaginationMode.CURSOR, decoded.transactionsEndpoint.pagination?.mode)
+    }
+
+    @Test
+    fun `date-window pagination round-trips`() {
+        val original =
+            config(
+                ApiPaginationConfig(
+                    mode = PaginationMode.DATE_WINDOW,
+                    startParam = "intervalStart",
+                    endParam = "intervalEnd",
+                    windowDays = 469,
+                    extraParams = listOf(ApiQueryParam(name = "type", value = "FLAT")),
+                ),
+            )
+        val decoded = ApiStrategyJsonCodec.decode(ApiStrategyJsonCodec.encode(original))
+        assertEquals(original, decoded)
+        assertEquals(PaginationMode.DATE_WINDOW, decoded.transactionsEndpoint.pagination?.mode)
+    }
+
+    @Test
+    fun `legacy pagination without a mode discriminator decodes as cursor`() {
+        // Pagination JSON persisted before the `mode` field existed: a flat cursor object.
+        val legacyJson =
+            """
+            {
+              "baseUrl": "https://example.com",
+              "authType": "BEARER_TOKEN",
+              "accountsEndpoint": { "path": "/accounts", "responseArrayKey": "accounts" },
+              "transactionsEndpoint": {
+                "path": "/transactions",
+                "responseArrayKey": "transactions",
+                "queryParams": [ { "name": "account_id", "dynamicSource": "account.id" } ],
+                "pagination": { "limitParam": "limit", "limitValue": 100, "cursorParam": "before", "cursorResponseField": "created" }
+              },
+              "accountMappings": {},
+              "transactionMappings": {},
+              "accountNamePrefix": "X: ",
+              "counterpartyPrefix": "X CP: "
+            }
+            """.trimIndent()
+
+        val decoded = ApiStrategyJsonCodec.decode(legacyJson)
+        val pagination = decoded.transactionsEndpoint.pagination
+        assertEquals(PaginationMode.CURSOR, pagination?.mode)
+        assertEquals("before", pagination?.cursorParam)
+        assertEquals("created", pagination?.cursorResponseField)
+        assertEquals(100, pagination?.limitValue)
+    }
+}

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/PersonAttributeRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/PersonAttributeRepositoryImplTest.kt
@@ -2,8 +2,6 @@
 
 package com.moneymanager.database.repository
 
-import com.moneymanager.database.DatabaseConfig
-import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.AuditType
 import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.PersonId
@@ -28,9 +26,10 @@ class PersonAttributeRepositoryImplTest : DbTest() {
                     ),
                 )
 
+            val attributeTypeId = repositories.attributeTypeRepository.getOrCreate("monzo-external-id")
             repositories.personAttributeRepository.insertInCreationMode(
                 personId = personId,
-                attributeTypeId = AttributeTypeId(DatabaseConfig.PERSON_EXTERNAL_ID_ATTR_TYPE_ID),
+                attributeTypeId = attributeTypeId,
                 value = "user_001",
             )
 
@@ -39,7 +38,7 @@ class PersonAttributeRepositoryImplTest : DbTest() {
 
             val attrs = repositories.personAttributeRepository.getByPerson(personId).first()
             assertEquals(1, attrs.size)
-            assertEquals("person-external-id", attrs.single().attributeType.name)
+            assertEquals("monzo-external-id", attrs.single().attributeType.name)
             assertEquals("user_001", attrs.single().value)
 
             val auditEntries = repositories.auditRepository.getAttributeAuditByPerson(personId)

--- a/app/db/core/src/jvmMain/kotlin/com/moneymanager/database/JvmDatabaseManager.kt
+++ b/app/db/core/src/jvmMain/kotlin/com/moneymanager/database/JvmDatabaseManager.kt
@@ -77,9 +77,6 @@ class JvmDatabaseManager : DatabaseManager {
                 onProgress(DatabaseInitializationProgress("Preparing repositories...", 6, 7))
             }
 
-            // Idempotent: adds any built-in API strategies missing from existing databases.
-            DatabaseConfig.ensureBuiltInApiStrategies(database)
-
             onProgress(DatabaseInitializationProgress("Finishing database startup...", 7, 7))
             database
         }

--- a/app/db/core/src/jvmMain/kotlin/com/moneymanager/database/JvmDatabaseManager.kt
+++ b/app/db/core/src/jvmMain/kotlin/com/moneymanager/database/JvmDatabaseManager.kt
@@ -77,6 +77,9 @@ class JvmDatabaseManager : DatabaseManager {
                 onProgress(DatabaseInitializationProgress("Preparing repositories...", 6, 7))
             }
 
+            // Idempotent: adds any built-in API strategies missing from existing databases.
+            DatabaseConfig.ensureBuiltInApiStrategies(database)
+
             onProgress(DatabaseInitializationProgress("Finishing database startup...", 7, 7))
             database
         }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ApiSession.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ApiSession.kt
@@ -13,6 +13,9 @@ data class MonzoCredential(
     val token: String,
     val createdAt: Instant,
     val strategyId: ApiImportStrategyId? = null,
+    /** PEM-encoded RSA keys for request signing (e.g. Wise SCA); null when not configured. */
+    val privateKey: String? = null,
+    val publicKey: String? = null,
 )
 
 @JvmInline

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ApiSession.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ApiSession.kt
@@ -16,7 +16,12 @@ data class MonzoCredential(
     /** PEM-encoded RSA keys for request signing (e.g. Wise SCA); null when not configured. */
     val privateKey: String? = null,
     val publicKey: String? = null,
-)
+) {
+    override fun toString(): String =
+        "MonzoCredential(id=$id, type=$type, token=<redacted>, createdAt=$createdAt, " +
+            "strategyId=$strategyId, privateKey=${if (privateKey != null) "<redacted>" else "null"}, " +
+            "publicKey=${if (publicKey != null) "<redacted>" else "null"})"
+}
 
 @JvmInline
 value class MonzoCredentialId(

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ApiSession.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ApiSession.kt
@@ -30,6 +30,7 @@ enum class ApiSessionKind(
 ) {
     ACCOUNTS("ACCOUNTS"),
     TRANSACTIONS("TRANSACTIONS"),
+    PEOPLE("PEOPLE"),
     ;
 
     companion object {

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiImportStrategy.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiImportStrategy.kt
@@ -38,6 +38,7 @@ data class ApiImportStrategy(
     val peopleMappings: ApiPeopleMappings = ApiPeopleMappings(),
     val ancestorEndpoints: List<ApiEndpointConfig> = emptyList(),
     val builtInCounterpartyRules: List<BuiltInCounterpartyRule> = emptyList(),
+    val signing: ApiSigningConfig? = null,
     val createdAt: Instant,
     val updatedAt: Instant,
     val revisionId: Long = 1,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiImportStrategy.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiImportStrategy.kt
@@ -17,6 +17,10 @@ import kotlin.time.Instant
  * @property accountNamePrefix Prefix prepended to account names on import (e.g. "Monzo: ")
  * @property counterpartyPrefix Prefix prepended to counterparty account names (e.g. "Monzo Counterparty: ")
  * @property peopleMappings JSON field paths/values for people and personal counterparties
+ * @property ancestorEndpoints Resource endpoints fetched before accounts whose items supply context
+ *                             for templating descendant endpoint paths/params (e.g. Wise "profiles")
+ * @property builtInCounterpartyRules Declarative rules routing matching transactions to a single
+ *                                    consolidated built-in counterparty account (e.g. ATM)
  * @property createdAt Timestamp when this strategy was created
  * @property updatedAt Timestamp when this strategy was last modified
  */
@@ -32,6 +36,8 @@ data class ApiImportStrategy(
     val accountNamePrefix: String,
     val counterpartyPrefix: String,
     val peopleMappings: ApiPeopleMappings = ApiPeopleMappings(),
+    val ancestorEndpoints: List<ApiEndpointConfig> = emptyList(),
+    val builtInCounterpartyRules: List<BuiltInCounterpartyRule> = emptyList(),
     val createdAt: Instant,
     val updatedAt: Instant,
     val revisionId: Long = 1,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiImportStrategy.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiImportStrategy.kt
@@ -40,6 +40,7 @@ data class ApiImportStrategy(
     val builtInCounterpartyRules: List<BuiltInCounterpartyRule> = emptyList(),
     val signing: ApiSigningConfig? = null,
     val peopleDownload: ApiPersonImportConfig? = null,
+    val personExternalIdAttribute: String? = null,
     val createdAt: Instant,
     val updatedAt: Instant,
     val revisionId: Long = 1,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiImportStrategy.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiImportStrategy.kt
@@ -39,6 +39,7 @@ data class ApiImportStrategy(
     val ancestorEndpoints: List<ApiEndpointConfig> = emptyList(),
     val builtInCounterpartyRules: List<BuiltInCounterpartyRule> = emptyList(),
     val signing: ApiSigningConfig? = null,
+    val peopleDownload: ApiPersonImportConfig? = null,
     val createdAt: Instant,
     val updatedAt: Instant,
     val revisionId: Long = 1,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
@@ -256,6 +256,23 @@ data class BuiltInCounterpartyRule(
 )
 
 /**
+ * Strong Customer Authentication (request-signing) parameters for a provider that protects some
+ * endpoints behind a challenge-response signature (e.g. Wise balance statements). When a request is
+ * rejected with [triggerStatus] and returns a one-time token in [challengeHeader], the importer signs
+ * the token with the credential's private key and retries with the signature in [signatureHeader].
+ *
+ * @property challengeHeader Response header carrying the one-time token (e.g. "x-2fa-approval")
+ * @property signatureHeader Request header for the Base64 signature on retry (e.g. "X-Signature")
+ * @property triggerStatus HTTP status that signals a signing challenge (e.g. 403)
+ */
+@Serializable
+data class ApiSigningConfig(
+    val challengeHeader: String = "x-2fa-approval",
+    val signatureHeader: String = "X-Signature",
+    val triggerStatus: Int = 403,
+)
+
+/**
  * Decoded, domain-level view of an API import strategy's full configuration.
  * Stored as JSON in the database; decoded by the db layer for use across all layers.
  *
@@ -277,4 +294,5 @@ data class ApiStrategyConfig(
     val peopleMappings: ApiPeopleMappings,
     val ancestorEndpoints: List<ApiEndpointConfig> = emptyList(),
     val builtInCounterpartyRules: List<BuiltInCounterpartyRule> = emptyList(),
+    val signing: ApiSigningConfig? = null,
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
@@ -328,4 +328,11 @@ data class ApiStrategyConfig(
     val builtInCounterpartyRules: List<BuiltInCounterpartyRule> = emptyList(),
     val signing: ApiSigningConfig? = null,
     val peopleDownload: ApiPersonImportConfig? = null,
+    /**
+     * Name of the person-attribute type that stores this provider's external id for an imported
+     * person (e.g. "monzo-external-id", "wise-external-id"). Per-provider so the same person can carry
+     * a distinct id from each provider; people are matched across providers by name, with the missing
+     * provider id backfilled. Null disables external-id storage.
+     */
+    val personExternalIdAttribute: String? = null,
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
@@ -278,6 +278,33 @@ data class ApiSigningConfig(
 )
 
 /**
+ * Configuration for downloading and importing the account holder(s) — the person whose credentials
+ * are used — from a dedicated endpoint (e.g. Wise `/v1/profiles`). Present only for providers that
+ * expose owner identity separately from the accounts; null disables the "Download People" feature.
+ *
+ * @property endpoint The people/profiles endpoint to fetch
+ * @property externalIdField Dot-path to the person's stable external id (e.g. "id")
+ * @property firstNameField Dot-path to the first name (e.g. "details.firstName")
+ * @property lastNameField Optional dot-path to the last name (e.g. "details.lastName")
+ * @property preferredNameField Optional dot-path to a preferred name
+ * @property fallbackNameField Optional dot-path to a single display name used when the name fields
+ *                             are blank (e.g. business profiles: "details.name")
+ * @property accountOwnerAncestorExpr When set, links each imported person to the accounts fetched
+ *                                    under the matching ancestor value (e.g. "ancestor[0].id" links a
+ *                                    profile to the balances fetched under that profile id).
+ */
+@Serializable
+data class ApiPersonImportConfig(
+    val endpoint: ApiEndpointConfig,
+    val externalIdField: String = "id",
+    val firstNameField: String,
+    val lastNameField: String? = null,
+    val preferredNameField: String? = null,
+    val fallbackNameField: String? = null,
+    val accountOwnerAncestorExpr: String? = null,
+)
+
+/**
  * Decoded, domain-level view of an API import strategy's full configuration.
  * Stored as JSON in the database; decoded by the db layer for use across all layers.
  *
@@ -300,4 +327,5 @@ data class ApiStrategyConfig(
     val ancestorEndpoints: List<ApiEndpointConfig> = emptyList(),
     val builtInCounterpartyRules: List<BuiltInCounterpartyRule> = emptyList(),
     val signing: ApiSigningConfig? = null,
+    val peopleDownload: ApiPersonImportConfig? = null,
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
@@ -14,10 +14,17 @@ enum class ApiAuthType {
 /**
  * A single query parameter for an API endpoint.
  *
- * @property name Parameter name (e.g. "account_id", "limit")
+ * @property name Parameter name (e.g. "account_id", "limit", "currency")
  * @property value Static value; null when the value is derived at runtime via [dynamicSource]
- * @property dynamicSource Identifies the runtime source for the parameter value.
- *                         Use "account.id" to inject the current account's external API ID.
+ * @property dynamicSource Identifies the runtime source for the parameter value, resolved against
+ *                         the import context. Supported expressions:
+ *                         - "account.id" — the current account's external API id
+ *                         - "account.<field>" — a dot-path field on the current account's raw JSON
+ *                           (e.g. "account.currency")
+ *                         - "ancestor[N].<field>" — a field on the N-th ancestor resource item
+ *                           (e.g. "ancestor[0].id"); "parent.id" aliases the last ancestor's id
+ *                         - "window.start" / "window.end" — the ISO-8601 bounds of the current
+ *                           date window (see [ApiPaginationConfig.DateWindow])
  */
 @Serializable
 data class ApiQueryParam(
@@ -26,36 +33,54 @@ data class ApiQueryParam(
     val dynamicSource: String? = null,
 )
 
+/** Selects which pagination scheme an endpoint uses. */
+@Serializable
+enum class PaginationMode {
+    /** Before-cursor paging (cursor extracted from the earliest item of each page). */
+    CURSOR,
+
+    /** Fixed-length date windows, one request per window. */
+    DATE_WINDOW,
+}
+
 /**
- * Pagination strategy for an API endpoint that uses a before-cursor scheme.
+ * Pagination strategy for an API endpoint. A single flat shape carries the parameters for both
+ * schemes; [mode] selects which set applies. A flat (rather than sealed) shape keeps this model
+ * module free of the serialization-json artifact and stays backward compatible: legacy configs
+ * persisted before [mode] existed decode with the default [PaginationMode.CURSOR] and their
+ * original cursor fields.
  *
- * The cursor is extracted from the earliest item in each page (identified by [cursorResponseField])
- * and passed as the [cursorParam] query parameter on the next request.
+ * Cursor fields: the cursor is the minimum [cursorResponseField] across a page, sent as [cursorParam].
  *
- * @property limitParam Name of the query parameter that controls page size (e.g. "limit")
- * @property limitValue Maximum number of items to request per page (e.g. 100)
- * @property cursorParam Name of the query parameter used for the before-cursor (e.g. "before")
- * @property cursorResponseField Field name within each item used to extract the next cursor value
- *                               (e.g. "created"). The minimum value across all items in the page
- *                               is used as the cursor for the next page.
+ * Date-window fields: history is fetched in [windowDays]-long windows back to [lookbackDays] ago,
+ * each request bounded by [startParam]/[endParam] (also exposed to templating as window.start/end),
+ * with [extraParams] appended. Windows are anchored to fixed boundaries so earlier windows produce
+ * stable, cacheable URLs; only the final window (ending "now") shifts across re-imports.
  */
 @Serializable
 data class ApiPaginationConfig(
+    val mode: PaginationMode = PaginationMode.CURSOR,
     val limitParam: String = "limit",
     val limitValue: Int = 100,
     val cursorParam: String = "before",
     val cursorResponseField: String = "created",
+    val startParam: String = "intervalStart",
+    val endParam: String = "intervalEnd",
+    val windowDays: Int = 469,
+    val lookbackDays: Int = 365 * 6,
+    val extraParams: List<ApiQueryParam> = emptyList(),
 )
 
 /**
  * Configuration for a single API endpoint.
  *
- * @property path URL path relative to the strategy's [ApiImportStrategy.baseUrl]
- *               (e.g. "/accounts" or "/transactions")
- * @property responseArrayKey Top-level JSON object key that holds the items array
- *                            (e.g. "accounts" or "transactions")
+ * @property path URL path relative to the strategy's base URL. May contain `{expression}`
+ *               placeholders resolved against the import context using the same vocabulary as
+ *               [ApiQueryParam.dynamicSource] (e.g. "/v4/profiles/{ancestor[0].id}/balances").
+ * @property responseArrayKey Top-level JSON object key holding the items array (e.g. "accounts").
+ *                            Blank means the response body itself is the array (a bare JSON array).
  * @property queryParams Static and dynamic query parameters appended to every request
- * @property pagination Optional before-cursor pagination; null means only one page is fetched
+ * @property pagination Optional pagination strategy; null means only one page is fetched
  */
 @Serializable
 data class ApiEndpointConfig(
@@ -66,43 +91,75 @@ data class ApiEndpointConfig(
 )
 
 /**
- * JSON field names used to extract account data from an API response item.
+ * JSON field names used to extract account data from an API response item. Defaults match the
+ * Monzo response shape so existing strategies behave identically.
  *
  * @property idField Field containing the external account identifier (e.g. "id")
  * @property descriptionField Field containing the account description or name (e.g. "description")
- * @property ownerNameField Nested field path (dot-notation) to owner names; when set the names are
- *                          extracted from an "owners" array at this sub-path and joined with ", "
- *                          as a fallback when [descriptionField] is blank.
- *                          Example: "preferred_name" extracts `owners[*].preferred_name`.
+ * @property ownerNameField Nested field path to owner names; when set the names are extracted from
+ *                          the owners array at this sub-path and used as a fallback for blank
+ *                          descriptions. Example: "preferred_name".
+ * @property ownersArrayField Field holding the owners array; null when the API has no owners array.
+ * @property ownerUserIdField Field within an owner object holding its stable external id.
+ * @property ownerNameFallbackField Field within an owner object holding a display name fallback.
+ * @property sortCodeField Account/owner field holding a bank sort code.
+ * @property accountNumberField Account/owner field holding a bank account number.
+ * @property currencyField Optional account-level currency field (e.g. Wise "currency"); exposed to
+ *                         templating as account.currency.
  */
 @Serializable
 data class ApiAccountMappings(
     val idField: String = "id",
     val descriptionField: String = "description",
     val ownerNameField: String? = null,
+    val ownersArrayField: String? = "owners",
+    val ownerUserIdField: String = "user_id",
+    val ownerNameFallbackField: String = "name",
+    val sortCodeField: String = "sort_code",
+    val accountNumberField: String = "account_number",
+    val currencyField: String? = null,
     val customFields: Map<String, String> = emptyMap(),
     val uniqueIdentifierFields: Set<String> = emptySet(),
 )
 
+/** How a transaction amount value is encoded in the API response. */
+@Serializable
+enum class ApiAmountFormat {
+    /** Integer amount already expressed in minor currency units (e.g. Monzo: 1234 == 12.34). */
+    MINOR_UNITS_INTEGER,
+
+    /** Decimal amount in major currency units (e.g. Wise: "12.34"); converted via Money. */
+    DECIMAL_MAJOR_UNITS,
+}
+
+/** Where the sign (incoming vs outgoing) of a transaction comes from. */
+@Serializable
+enum class ApiSignSource {
+    /** The amount value itself is signed (negative == outgoing). */
+    EMBEDDED,
+
+    /** A separate field (see [ApiTransactionMappings.signField]) carries the direction. */
+    FIELD,
+}
+
 /**
- * JSON field names used to extract transaction data from an API response item.
+ * JSON field names used to extract transaction data from an API response item. Defaults match the
+ * Monzo response shape so existing strategies behave identically.
  *
- * @property amountField Field containing the amount in minor currency units (e.g. "amount")
- * @property timestampField Field containing the ISO-8601 timestamp (e.g. "created")
- * @property currencyField Field containing the ISO-4217 currency code (e.g. "currency")
- * @property descriptionField Field containing the transaction description (e.g. "description")
- * @property merchantNameField Optional dot-notation path to a merchant name
- *                             (e.g. "merchant.name"); used as the counterparty name when present
- * @property counterpartyNameField Optional dot-notation path to a counterparty name
- *                                 (e.g. "counterparty.name"); fallback when merchant is absent
- * @property declineReasonField Optional field containing the decline reason for declined
- *                               transactions (e.g. "decline_reason")
- * @property localAmountField Optional field containing the local/original amount in minor units
- *                            (e.g. "local_amount"). When set together with [localCurrencyField],
- *                            the local amount and currency are used when the local currency differs
- *                            from the account currency (i.e. for foreign-currency transactions).
- * @property localCurrencyField Optional field containing the local/original ISO-4217 currency code
- *                              (e.g. "local_currency"). See [localAmountField].
+ * @property amountField Dot-path to the amount value (e.g. "amount" or "amount.value")
+ * @property timestampField Dot-path to the ISO-8601 timestamp (e.g. "created", "date")
+ * @property currencyField Dot-path to the ISO-4217 currency code (e.g. "currency", "amount.currency")
+ * @property descriptionField Dot-path to the transaction description
+ * @property amountFormat How [amountField] is encoded; see [ApiAmountFormat]
+ * @property signSource Where the transaction direction comes from; see [ApiSignSource]
+ * @property signField Dot-path to the direction field when [signSource] is [ApiSignSource.FIELD]
+ * @property creditValues Values of [signField] that mean "incoming/positive" (e.g. {"CREDIT"})
+ * @property idField Dot-path to the transaction's stable id, used for de-duplication
+ * @property merchantNameField Optional dot-path to a merchant name; preferred counterparty name
+ * @property counterpartyNameField Optional dot-path to a counterparty name; fallback for merchant
+ * @property declineReasonField Optional dot-path to a decline reason for declined transactions
+ * @property localAmountField Optional dot-path to a local/original amount (foreign transactions)
+ * @property localCurrencyField Optional dot-path to a local/original currency code
  */
 @Serializable
 data class ApiTransactionMappings(
@@ -110,6 +167,11 @@ data class ApiTransactionMappings(
     val timestampField: String = "created",
     val currencyField: String = "currency",
     val descriptionField: String = "description",
+    val amountFormat: ApiAmountFormat = ApiAmountFormat.MINOR_UNITS_INTEGER,
+    val signSource: ApiSignSource = ApiSignSource.EMBEDDED,
+    val signField: String? = null,
+    val creditValues: Set<String> = emptySet(),
+    val idField: String = "id",
     val merchantNameField: String? = null,
     val counterpartyNameField: String? = null,
     val counterpartyIdField: String? = null,
@@ -133,9 +195,75 @@ data class ApiPeopleMappings(
     val fallbackCounterpartyAccountIdSuffix: String = ".account_id",
 )
 
+/** Sign gate for a [BuiltInCounterpartyRule]; restricts the rule to incoming or outgoing transactions. */
+@Serializable
+enum class RuleSign { ANY, NEGATIVE, POSITIVE }
+
+/** Comparison operator for a [RulePredicate]. */
+@Serializable
+enum class PredicateOp {
+    /** The path resolves to any present value. */
+    EXISTS,
+
+    /** The resolved string equals [RulePredicate.value]. */
+    EQUALS,
+
+    /** The resolved string equals [RulePredicate.value], ignoring case. */
+    EQUALS_IGNORE_CASE,
+
+    /** The resolved string starts with [RulePredicate.value]. */
+    STARTS_WITH,
+
+    /** The path resolves to an array with any element starting with [RulePredicate.value]. */
+    ARRAY_ANY_STARTS_WITH,
+
+    /** The path resolves to an object that is empty (or absent). */
+    OBJECT_EMPTY,
+
+    /** The path resolves to a non-empty object. */
+    OBJECT_NON_EMPTY,
+}
+
+/**
+ * A single condition evaluated against a transaction's raw JSON.
+ *
+ * @property path Dot-path into the transaction object (e.g. "metadata.mcc")
+ * @property op The comparison to apply
+ * @property value Comparison operand for ops that need one (EQUALS, STARTS_WITH, …)
+ */
+@Serializable
+data class RulePredicate(
+    val path: String,
+    val op: PredicateOp,
+    val value: String? = null,
+)
+
+/**
+ * A declarative rule that classifies a transaction as a well-known built-in counterparty (e.g.
+ * "ATM"), so such transactions consolidate into a single account regardless of merchant details.
+ * All [predicates] must match (logical AND) and the [onlyWhenSign] gate must hold.
+ *
+ * @property name Built-in type name; stored as the account's built-in-type attribute and used as
+ *                the default counterparty account name.
+ * @property onlyWhenSign Restricts the rule to incoming/outgoing transactions; ANY disables the gate.
+ * @property predicates Conditions that must all hold for the rule to match.
+ */
+@Serializable
+data class BuiltInCounterpartyRule(
+    val name: String,
+    val onlyWhenSign: RuleSign = RuleSign.ANY,
+    val predicates: List<RulePredicate> = emptyList(),
+)
+
 /**
  * Decoded, domain-level view of an API import strategy's full configuration.
  * Stored as JSON in the database; decoded by the db layer for use across all layers.
+ *
+ * @property ancestorEndpoints Resource endpoints fetched before accounts whose items supply context
+ *                             ids/fields for templating descendant endpoint paths and params
+ *                             (e.g. Wise "profiles"). Empty for flat two-level APIs like Monzo.
+ * @property builtInCounterpartyRules Declarative rules routing matching transactions to a single
+ *                                    consolidated built-in counterparty account (e.g. ATM).
  */
 data class ApiStrategyConfig(
     val baseUrl: String,
@@ -147,4 +275,6 @@ data class ApiStrategyConfig(
     val accountNamePrefix: String,
     val counterpartyPrefix: String,
     val peopleMappings: ApiPeopleMappings,
+    val ancestorEndpoints: List<ApiEndpointConfig> = emptyList(),
+    val builtInCounterpartyRules: List<BuiltInCounterpartyRule> = emptyList(),
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
@@ -264,12 +264,17 @@ data class BuiltInCounterpartyRule(
  * @property challengeHeader Response header carrying the one-time token (e.g. "x-2fa-approval")
  * @property signatureHeader Request header for the Base64 signature on retry (e.g. "X-Signature")
  * @property triggerStatus HTTP status that signals a signing challenge (e.g. 403)
+ * @property statementCountries ISO 3166-1 alpha-2 country codes whose accounts can retrieve
+ *                             statements/transactions via the API. Empty means no restriction; when
+ *                             non-empty the UI disables transaction download for other locales (Wise
+ *                             only supports statements for US/CA/AU/NZ/SG/MY).
  */
 @Serializable
 data class ApiSigningConfig(
     val challengeHeader: String = "x-2fa-approval",
     val signatureHeader: String = "X-Signature",
     val triggerStatus: Int = 403,
+    val statementCountries: Set<String> = emptySet(),
 )
 
 /**

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ApiSessionRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ApiSessionRepository.kt
@@ -36,8 +36,10 @@ data class ApiSessionImportRevision(
 
 interface ApiSessionRepository {
     /**
-     * Creates a new credential (saved token). Returns the existing credential ID if the token
-     * is already saved.
+     * Creates a new credential (saved token), carrying its own [strategyId] and optional signing
+     * keys, and returns its generated ID. A credential's identity is this generated ID, not the raw
+     * token; the token column is globally unique, so attempting to save the same token twice fails
+     * rather than merging into — or silently overwriting the strategy/keys of — an existing row.
      *
      * @param strategyId Optional link to the API import strategy this credential uses.
      */

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ApiSessionRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ApiSessionRepository.kt
@@ -46,6 +46,8 @@ interface ApiSessionRepository {
         createdAt: Instant,
         type: ApiSessionType = ApiSessionType.MONZO,
         strategyId: ApiImportStrategyId? = null,
+        privateKey: String? = null,
+        publicKey: String? = null,
     ): MonzoCredentialId
 
     /**
@@ -54,6 +56,15 @@ interface ApiSessionRepository {
     suspend fun updateCredentialStrategy(
         credentialId: MonzoCredentialId,
         strategyId: ApiImportStrategyId?,
+    )
+
+    /**
+     * Stores (or replaces) the PEM-encoded RSA signing key pair on a credential.
+     */
+    suspend fun updateCredentialKeys(
+        credentialId: MonzoCredentialId,
+        privateKey: String?,
+        publicKey: String?,
     )
 
     /**

--- a/app/ui/core/build.gradle.kts
+++ b/app/ui/core/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
             dependencies {
                 api(libs.kotlinx.coroutines.core)
                 api(libs.kotlinx.datetime)
+                api(libs.kotlinx.serialization.json)
                 api(projects.app.db.core)
                 api(projects.app.model.core)
                 api(projects.utils.bigdecimal)
@@ -21,7 +22,6 @@ kotlin {
 
                 implementation(libs.human.readable)
                 implementation(libs.kmlogging)
-                implementation(libs.kotlinx.serialization.json)
                 implementation(projects.utils.compose.filePicker)
                 implementation(projects.utils.compose.scrollbar)
                 implementation(projects.utils.currency)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -288,6 +288,7 @@ fun MoneyManagerApp(
                                         personRepository = services.people.personRepository,
                                         personAttributeRepository = services.people.personAttributeRepository,
                                         personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
+                                        attributeTypeRepository = services.transactions.attributeTypeRepository,
                                         entitySource = services.transactions.entitySource,
                                         scrollToPersonId = (screen as? Screen.PeopleScroll)?.personId,
                                         onAuditClick = { person ->

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -45,6 +45,7 @@ import com.moneymanager.ui.navigation.Screen
 import com.moneymanager.ui.navigation.mouseButtonNavigation
 import com.moneymanager.ui.screens.AccountAuditScreen
 import com.moneymanager.ui.screens.AccountsScreen
+import com.moneymanager.ui.screens.ApiConnectScreen
 import com.moneymanager.ui.screens.ApiSessionTrafficScreen
 import com.moneymanager.ui.screens.CategoriesScreen
 import com.moneymanager.ui.screens.CategoryAuditScreen
@@ -52,7 +53,6 @@ import com.moneymanager.ui.screens.CsvImportDetailScreen
 import com.moneymanager.ui.screens.CurrenciesScreen
 import com.moneymanager.ui.screens.CurrencyAuditScreen
 import com.moneymanager.ui.screens.ImportsScreen
-import com.moneymanager.ui.screens.MonzoAuthScreen
 import com.moneymanager.ui.screens.PeopleScreen
 import com.moneymanager.ui.screens.PersonAuditScreen
 import com.moneymanager.ui.screens.SettingsScreen
@@ -175,12 +175,12 @@ fun MoneyManagerApp(
                                         currentScreen is Screen.ApiStrategies ||
                                         currentScreen is Screen.ApiStrategyAuditHistory ||
                                         currentScreen is Screen.ApiSessionTraffic ||
-                                        currentScreen is Screen.MonzoConnect,
+                                        currentScreen is Screen.ConnectApi,
                                 onClick = {
                                     navigationHistory.navigateTo(
                                         Screen.Imports(
                                             when (currentScreen) {
-                                                is Screen.ApiSessionTraffic, is Screen.MonzoConnect,
+                                                is Screen.ApiSessionTraffic, is Screen.ConnectApi,
                                                 is Screen.ApiStrategies, is Screen.ApiStrategyAuditHistory,
                                                 -> ImportTab.API
                                                 is Screen.Imports -> currentScreen.tab
@@ -386,7 +386,7 @@ fun MoneyManagerApp(
                                             navigationHistory.navigateTo(Screen.CsvStrategies)
                                         },
                                         onAddCredentialClick = {
-                                            navigationHistory.navigateTo(Screen.MonzoConnect)
+                                            navigationHistory.navigateTo(Screen.ConnectApi)
                                         },
                                         onApiStrategiesClick = {
                                             navigationHistory.navigateTo(Screen.ApiStrategies)
@@ -581,13 +581,14 @@ fun MoneyManagerApp(
                                         onBack = { navigationHistory.navigateBack() },
                                     )
                                 }
-                                is Screen.MonzoConnect -> {
+                                is Screen.ConnectApi -> {
                                     LaunchedEffect(Unit) {
                                         currentlyViewedAccountId = null
                                         currentlyViewedCurrencyId = null
                                     }
-                                    MonzoAuthScreen(
+                                    ApiConnectScreen(
                                         apiSessionRepository = services.imports.apiSessionRepository,
+                                        apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
                                         onCredentialSaved = {
                                             navigationHistory.navigateBack()
                                         },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -2,12 +2,24 @@
 
 package com.moneymanager.ui.api
 
+import com.moneymanager.bigdecimal.BigDecimal
 import com.moneymanager.database.DatabaseConfig
 import com.moneymanager.domain.ApiEntitySourceRecord
 import com.moneymanager.domain.EntitySource
 import com.moneymanager.domain.model.*
+import com.moneymanager.domain.model.apistrategy.ApiAmountFormat
+import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
+import com.moneymanager.domain.model.apistrategy.ApiPaginationConfig
 import com.moneymanager.domain.model.apistrategy.ApiPeopleMappings
+import com.moneymanager.domain.model.apistrategy.ApiQueryParam
+import com.moneymanager.domain.model.apistrategy.ApiSignSource
+import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
+import com.moneymanager.domain.model.apistrategy.BuiltInCounterpartyRule
+import com.moneymanager.domain.model.apistrategy.PaginationMode
+import com.moneymanager.domain.model.apistrategy.PredicateOp
+import com.moneymanager.domain.model.apistrategy.RulePredicate
+import com.moneymanager.domain.model.apistrategy.RuleSign
 import com.moneymanager.domain.repository.AccountAttributeCreateInput
 import com.moneymanager.domain.repository.AccountAttributeRepository
 import com.moneymanager.domain.repository.AccountRepository
@@ -92,25 +104,60 @@ suspend fun downloadApiSessionAccounts(
     sessionId: ApiSessionId,
     strategy: ApiImportStrategy,
 ): ApiAccountsDownloadResult {
-    val accountsUrl = buildEndpointUrl(strategy.baseUrl, strategy.accountsEndpoint.path)
     val existingRequests = apiSessionRepository.getRequestsBySession(sessionId)
+    val existingResponses = apiSessionRepository.getResponsesBySession(sessionId)
+    val existingResponsesByRequestId = existingResponses.associateBy { it.requestId }
+    val existingRequestsByUrl = existingRequests.associateBy { it.url }
 
-    // Incremental: skip only when both the request and its response are already stored.
-    // If the request exists but has no response (interrupted prior run), fall through and re-fetch.
-    val existingAccountsRequest = existingRequests.firstOrNull { it.url == accountsUrl }
-    if (existingAccountsRequest != null) {
-        val existingResponse =
-            apiSessionRepository
-                .getResponsesBySession(sessionId)
-                .firstOrNull { it.requestId == existingAccountsRequest.id }
-        if (existingResponse != null) {
-            return ApiAccountsDownloadResult(accountCount = parseAccounts(existingResponse.json, strategy).size, skipped = true)
-        }
+    // Resolve ancestor resources (e.g. Wise profiles) first; for a flat API (Monzo) this is a
+    // single empty context so the accounts endpoint is fetched exactly once.
+    val ancestorContexts =
+        fetchAncestorContexts(token, apiClient, strategy, existingRequestsByUrl, existingResponsesByRequestId)
+
+    var totalAccounts = 0
+    var anyFetched = false
+    for (ancestors in ancestorContexts) {
+        val url = buildAccountsUrl(strategy, ImportUrlContext(ancestorItems = ancestors))
+        // Incremental: reuse a stored response only when both request and response are present.
+        val existingResponse = existingRequestsByUrl[url]?.let { existingResponsesByRequestId[it.id] }
+        val json =
+            if (existingResponse != null) {
+                existingResponse.json
+            } else {
+                anyFetched = true
+                fetchResponse(url = url, token = token, apiClient = apiClient).body
+            }
+        totalAccounts += parseAccounts(json, strategy).size
     }
+    return ApiAccountsDownloadResult(accountCount = totalAccounts, skipped = !anyFetched)
+}
 
-    val response = fetchResponse(url = accountsUrl, token = token, apiClient = apiClient)
-    val accounts = parseAccounts(response.body, strategy)
-    return ApiAccountsDownloadResult(accountCount = accounts.size)
+/**
+ * Fetches each configured ancestor endpoint in order, expanding the context tree so every leaf is
+ * a full chain of ancestor items used to template the accounts/transactions endpoints. Returns a
+ * single empty chain when the strategy has no ancestor endpoints.
+ */
+private suspend fun fetchAncestorContexts(
+    token: String,
+    apiClient: ApiClient,
+    strategy: ApiImportStrategy,
+    existingRequestsByUrl: Map<String, ApiRequest>,
+    existingResponsesByRequestId: Map<ApiRequestId, ApiResponse>,
+): List<List<JsonObject>> {
+    var contexts: List<List<JsonObject>> = listOf(emptyList())
+    strategy.ancestorEndpoints.forEach { endpoint ->
+        val next = mutableListOf<List<JsonObject>>()
+        for (ancestors in contexts) {
+            val url = buildEndpointRequestUrl(strategy.baseUrl, endpoint, ImportUrlContext(ancestorItems = ancestors))
+            val existingResponse = existingRequestsByUrl[url]?.let { existingResponsesByRequestId[it.id] }
+            val json = existingResponse?.json ?: fetchResponse(url = url, token = token, apiClient = apiClient).body
+            for (item in responseItemsArray(json, endpoint.responseArrayKey).orEmpty()) {
+                (item as? JsonObject)?.let { next += ancestors + it }
+            }
+        }
+        contexts = next
+    }
+    return contexts
 }
 
 /**
@@ -133,8 +180,7 @@ suspend fun downloadApiSessionTransactions(
     val existingResponsesByRequestId = existingResponses.associateBy { it.requestId }
     val existingRequestsByUrl = existingRequests.associateBy { it.url }
 
-    // Read accounts from a separate accounts session if provided, otherwise from this session
-    val accountsUrl = buildEndpointUrl(strategy.baseUrl, strategy.accountsEndpoint.path)
+    // Read accounts from a separate accounts session if provided, otherwise from this session.
     val resolvedAccountsSessionId = accountsSessionId ?: sessionId
     val accountsRequests =
         if (accountsSessionId != null && accountsSessionId != sessionId) {
@@ -148,58 +194,85 @@ suspend fun downloadApiSessionTransactions(
         } else {
             existingResponses
         }
-    val accountsRequestIds = accountsRequests.filter { it.url == accountsUrl }.map { it.id }.toSet()
-    val apiAccounts =
-        accountsResponses
-            .filter { it.requestId in accountsRequestIds }
-            .flatMap { response -> parseAccounts(response.json, strategy) }
+    val accountsRequestsById = accountsRequests.associateBy { it.id }
+
+    // Each account is paired with the ancestor context (e.g. profile id) recovered from the path of
+    // the accounts request that produced it, so its transaction URLs can be templated.
+    val accountEntries: List<Pair<ApiImportAccount, Map<String, String>>> =
+        accountsResponses.flatMap { response ->
+            val request = accountsRequestsById[response.requestId] ?: return@flatMap emptyList()
+            if (!request.isAccountsRequest(strategy)) return@flatMap emptyList()
+            val ancestorVars = request.ancestorVars(strategy)
+            parseAccounts(response.json, strategy).map { it to ancestorVars }
+        }
 
     var transactionResponseCount = 0
+    val pagination = strategy.transactionsEndpoint.pagination
+    val now = Clock.System.now()
 
-    for ((index, account) in apiAccounts.withIndex()) {
-        var before: Instant? = null
-        var page = 1
-        var hasTransactions: Boolean
-        do {
-            onProgress(
-                ApiTransactionsDownloadProgress(
-                    accountIndex = index + 1,
-                    accountCount = apiAccounts.size,
-                    page = page,
-                    downloadedResponsePageCount = transactionResponseCount,
-                ),
-            )
-            val url = buildTransactionUrl(strategy, account.id, before)
-
-            // Incremental: reuse a stored response only when both request and response are present.
-            // An orphan request (response missing from an interrupted prior run) is treated as a
-            // cache miss so pagination can make progress on retry.
-            val existingResponse = existingRequestsByUrl[url]?.let { existingResponsesByRequestId[it.id] }
-            val transactions: List<ApiTransactionPageItem> =
-                if (existingResponse != null) {
-                    parseTransactionsWithPath(existingResponse.json, strategy)
-                } else {
-                    val response = fetchResponse(url = url, token = token, apiClient = apiClient)
+    accountEntries.forEachIndexed { index, (account, ancestorVars) ->
+        if (pagination?.mode == PaginationMode.DATE_WINDOW) {
+            dateWindows(pagination, now).forEachIndexed { windowIndex, window ->
+                val ctx =
+                    ImportUrlContext(
+                        account = account,
+                        ancestorVars = ancestorVars,
+                        windowStart = window.start.toString(),
+                        windowEnd = window.end.toString(),
+                    )
+                val url = buildDateWindowTransactionUrl(strategy, pagination, ctx, window)
+                onProgress(
+                    ApiTransactionsDownloadProgress(
+                        accountIndex = index + 1,
+                        accountCount = accountEntries.size,
+                        page = windowIndex + 1,
+                        downloadedResponsePageCount = transactionResponseCount,
+                    ),
+                )
+                val existingResponse = existingRequestsByUrl[url]?.let { existingResponsesByRequestId[it.id] }
+                if (existingResponse == null) {
+                    fetchResponse(url = url, token = token, apiClient = apiClient)
                     transactionResponseCount += 1
-                    parseTransactionsWithPath(response.body, strategy)
                 }
+            }
+        } else {
+            var before: Instant? = null
+            var page = 1
+            var hasTransactions: Boolean
+            do {
+                val ctx = ImportUrlContext(account = account, ancestorVars = ancestorVars)
+                onProgress(
+                    ApiTransactionsDownloadProgress(
+                        accountIndex = index + 1,
+                        accountCount = accountEntries.size,
+                        page = page,
+                        downloadedResponsePageCount = transactionResponseCount,
+                    ),
+                )
+                val url = buildCursorTransactionUrl(strategy, ctx, before)
 
-            before = transactions.minOfOrNull { it.created }
-            hasTransactions = transactions.isNotEmpty()
-            onProgress(
-                ApiTransactionsDownloadProgress(
-                    accountIndex = index + 1,
-                    accountCount = apiAccounts.size,
-                    page = page,
-                    downloadedResponsePageCount = transactionResponseCount,
-                ),
-            )
-            page += 1
-        } while (hasTransactions)
+                // Incremental: reuse a stored response only when both request and response are present.
+                // An orphan request (response missing from an interrupted prior run) is treated as a
+                // cache miss so pagination can make progress on retry.
+                val existingResponse = existingRequestsByUrl[url]?.let { existingResponsesByRequestId[it.id] }
+                val transactions: List<ApiTransactionPageItem> =
+                    if (existingResponse != null) {
+                        parseTransactionsWithPath(existingResponse.json, strategy)
+                    } else {
+                        val response = fetchResponse(url = url, token = token, apiClient = apiClient)
+                        transactionResponseCount += 1
+                        parseTransactionsWithPath(response.body, strategy)
+                    }
+
+                before = transactions.minOfOrNull { it.created }
+                hasTransactions = transactions.isNotEmpty()
+                page += 1
+            } while (hasTransactions)
+        }
     }
 
     return ApiTransactionsDownloadResult(
-        accountCount = apiAccounts.size,
+        accountCount = accountEntries.size,
         transactionResponseCount = transactionResponseCount,
     )
 }
@@ -359,10 +432,15 @@ private suspend fun setupImportSession(
             responses
         }
 
+    // Only responses produced by the accounts endpoint are parsed as accounts; ancestor responses
+    // (e.g. Wise profiles) and transaction responses are excluded.
+    val accountOnlyResponses =
+        accountsResponses.filter { accountsRequestsById[it.requestId]?.isAccountsRequest(strategy) == true }
+
     // Build a map from external account ID to the accounts-list source (request + jsonPath)
     // so newly created accounts can be linked back to their API origin.
     val accountApiSourceByExternalId =
-        accountsResponses
+        accountOnlyResponses
             .flatMap { response ->
                 val requestId = accountsRequestsById[response.requestId]?.id ?: return@flatMap emptyList()
                 parseAccountsWithPaths(response.json, strategy).map { (account, jsonPath) ->
@@ -371,10 +449,10 @@ private suspend fun setupImportSession(
             }.toMap()
 
     val accountsById =
-        accountsResponses
+        accountOnlyResponses
             .flatMap { response -> parseAccounts(response.json, strategy) }
             .associateBy { it.id }
-    val transactionResponses = responses.filter { requestsById[it.requestId]?.accountIdParameter(strategy) != null }
+    val transactionResponses = responses.filter { requestsById[it.requestId]?.resolveAccountExternalId(strategy) != null }
 
     val currencyCache = CurrencyCache(currencyRepository)
     val attributeTypeCache = AttributeTypeCache(attributeTypeRepository)
@@ -404,7 +482,7 @@ private suspend fun setupImportSession(
             accountRepository = accountRepository,
             accountAttributeRepository = accountAttributeRepository,
         ).toMutableMap()
-    val builtInTypeIndex: MutableMap<BuiltInCounterpartyType, AccountId> =
+    val builtInTypeIndex: MutableMap<String, AccountId> =
         loadBuiltInTypeIndex(
             accountRepository = accountRepository,
             accountAttributeRepository = accountAttributeRepository,
@@ -492,7 +570,7 @@ private suspend fun importTransactionsConcurrently(setup: ImportSetup) {
     val pageContexts = mutableListOf<ApiImportPageContext>()
     setup.transactionResponses.forEachIndexed { index, response ->
         val request = setup.requestsById[response.requestId] ?: return@forEachIndexed
-        val account = setup.accountsById[request.accountIdParameter(setup.strategy)] ?: return@forEachIndexed
+        val account = setup.accountsById[request.resolveAccountExternalId(setup.strategy)] ?: return@forEachIndexed
         val ownAccountId = setup.accountCache.getOrCreateAccountId(account.id, account.displayName(setup.strategy))
         pageContexts +=
             ApiImportPageContext(
@@ -621,7 +699,7 @@ suspend fun discoverApiCounterpartiesToCreate(
     val transactionResponses =
         apiSessionRepository
             .getResponsesBySession(sessionId)
-            .filter { requestsById[it.requestId]?.accountIdParameter(strategy) != null }
+            .filter { requestsById[it.requestId]?.resolveAccountExternalId(strategy) != null }
 
     return collectCounterpartiesFromResponses(
         responses = transactionResponses,
@@ -657,7 +735,7 @@ private suspend fun precreateCounterparties(
                     async {
                         val request = requestsById[response.requestId] ?: return@async emptyList()
                         parseTransactionsWithPath(response.json, strategy).mapNotNull { item ->
-                            if (item.rawJson?.resolveBuiltInCounterpartyType(item.amountMinorUnits) != null) {
+                            if (item.rawJson?.resolveBuiltInCounterpartyType(strategy.builtInCounterpartyRules, item.amountSign) != null) {
                                 return@mapNotNull null
                             }
                             val counterpartyId =
@@ -705,7 +783,7 @@ private fun collectCounterpartiesFromResponses(
             parseTransactionsWithPath(response.json, strategy).mapNotNull { item ->
                 // Skip transactions handled by built-in type logic — their counterpartyId is
                 // irrelevant because they all route to a single built-in account.
-                if (item.rawJson?.resolveBuiltInCounterpartyType(item.amountMinorUnits) != null) {
+                if (item.rawJson?.resolveBuiltInCounterpartyType(strategy.builtInCounterpartyRules, item.amountSign) != null) {
                     return@mapNotNull null
                 }
                 val counterpartyId =
@@ -745,15 +823,15 @@ private suspend fun loadAccountExternalIdIndex(
 private suspend fun loadBuiltInTypeIndex(
     accountRepository: AccountRepository,
     accountAttributeRepository: AccountAttributeRepository,
-): Map<BuiltInCounterpartyType, AccountId> {
-    val index = mutableMapOf<BuiltInCounterpartyType, AccountId>()
+): Map<String, AccountId> {
+    val index = mutableMapOf<String, AccountId>()
     for (account in accountRepository.getAllAccounts().first()) {
         accountAttributeRepository
             .getByAccount(account.id)
             .first()
             .firstOrNull { it.attributeType.id == BUILT_IN_COUNTERPARTY_TYPE_ATTR_TYPE_ID }
             ?.let { attribute ->
-                BuiltInCounterpartyType.fromAttributeValue(attribute.value)?.let { index[it] = account.id }
+                index[attribute.value] = account.id
             }
     }
     return index
@@ -811,14 +889,14 @@ private suspend fun flushPendingBuiltInTypeAttributes(
     accountAttributeRepository: AccountAttributeRepository,
 ) {
     val pending = accountCache.drainPendingBuiltInTypeAttributes()
-    val seen = mutableSetOf<BuiltInCounterpartyType>()
+    val seen = mutableSetOf<String>()
     for ((accountId, builtInType) in pending) {
         if (seen.add(builtInType)) {
             runCatching {
                 accountAttributeRepository.insertInCreationMode(
                     accountId = accountId,
                     attributeTypeId = BUILT_IN_COUNTERPARTY_TYPE_ATTR_TYPE_ID,
-                    value = builtInType.attributeValue,
+                    value = builtInType,
                 )
             }
         }
@@ -866,10 +944,10 @@ private suspend fun importPeopleFromAccounts(
 
         val accountId = accountCache.getOrCreateAccountId(account.id, account.displayName(strategy))
         val sortCode =
-            account.rawJson?.stringOrNull("sort_code")?.takeIf { it.isNotBlank() }
+            account.rawJson?.stringOrNull(strategy.accountMappings.sortCodeField)?.takeIf { it.isNotBlank() }
                 ?: account.owners.firstOrNull { !it.sortCode.isNullOrBlank() }?.sortCode
         val accountNumber =
-            account.rawJson?.stringOrNull("account_number")?.takeIf { it.isNotBlank() }
+            account.rawJson?.stringOrNull(strategy.accountMappings.accountNumberField)?.takeIf { it.isNotBlank() }
                 ?: account.owners.firstOrNull { !it.accountNumber.isNullOrBlank() }?.accountNumber
         if (sortCode != null || accountNumber != null) {
             accountAttributeRepository.ensureCounterpartyPersonalAttributesInCreationMode(
@@ -917,7 +995,8 @@ private suspend fun importPeopleFromCounterparties(
         val request = requestsById[response.requestId] ?: continue
         val personalCounterpartyItems = mutableListOf<Triple<ApiTransactionPageItem, ApiImportAccountOwner, PersonalCounterpartyIdentity>>()
         for (item in parseTransactionsWithPath(response.json, strategy)) {
-            if (item.amountMinorUnits != 0L && item.rawJson?.resolveBuiltInCounterpartyType(item.amountMinorUnits) == null) {
+            val isBuiltIn = item.rawJson?.resolveBuiltInCounterpartyType(strategy.builtInCounterpartyRules, item.amountSign) != null
+            if (!item.isZeroAmount && !isBuiltIn) {
                 val owner = item.personalCounterpartyOwner(strategy.peopleMappings)
                 val personalCounterpartyIdentity = owner?.personalCounterpartyIdentity()
                 if (owner != null && personalCounterpartyIdentity != null) {
@@ -1313,21 +1392,10 @@ private fun parseAccounts(
     strategy: ApiImportStrategy,
 ): List<ApiImportAccount> =
     try {
-        Json
-            .parseToJsonElement(json)
-            .jsonObject[strategy.accountsEndpoint.responseArrayKey]
-            ?.jsonArray
+        responseItemsArray(json, strategy.accountsEndpoint.responseArrayKey)
             ?.mapIndexedNotNull { index, element ->
-                val account = element.jsonObject
-                val id = account.resolveJsonPath(strategy.accountMappings.idField) ?: return@mapIndexedNotNull null
-                ApiImportAccount(
-                    id = id,
-                    description = account.resolveJsonPath(strategy.accountMappings.descriptionField).orEmpty(),
-                    owners = parseAccountOwners(account, strategy, JsonPath("$.${strategy.accountsEndpoint.responseArrayKey}[$index]")),
-                    sortCode = account.stringOrNull("sort_code"),
-                    accountNumber = account.stringOrNull("account_number"),
-                    rawJson = account,
-                )
+                val account = element as? JsonObject ?: return@mapIndexedNotNull null
+                parseAccount(account, strategy, accountsItemJsonPath(strategy, index))
             }
             ?: emptyList()
     } catch (e: SerializationException) {
@@ -1335,62 +1403,83 @@ private fun parseAccounts(
         emptyList()
     }
 
+private fun accountsItemJsonPath(
+    strategy: ApiImportStrategy,
+    index: Int,
+): JsonPath = arrayItemJsonPath(strategy.accountsEndpoint.responseArrayKey, index)
+
+private fun parseAccount(
+    account: JsonObject,
+    strategy: ApiImportStrategy,
+    accountJsonPath: JsonPath,
+): ApiImportAccount? {
+    val mappings = strategy.accountMappings
+    val id = account.resolveJsonPath(mappings.idField) ?: return null
+    return ApiImportAccount(
+        id = id,
+        description = account.resolveJsonPath(mappings.descriptionField).orEmpty(),
+        owners = parseAccountOwners(account, strategy, accountJsonPath),
+        sortCode = account.stringOrNull(mappings.sortCodeField),
+        accountNumber = account.stringOrNull(mappings.accountNumberField),
+        rawJson = account,
+    )
+}
+
 private fun parseAccountOwners(
     account: JsonObject,
     strategy: ApiImportStrategy,
     accountJsonPath: JsonPath,
-): List<ApiImportAccountOwner> =
-    account["owners"]
+): List<ApiImportAccountOwner> {
+    val mappings = strategy.accountMappings
+    val ownersField = mappings.ownersArrayField ?: return emptyList()
+    return account[ownersField]
         ?.jsonArray
         ?.mapNotNull { element ->
             val owner = element as? JsonObject ?: return@mapNotNull null
-            val userId = owner["user_id"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+            val userId = owner.stringOrNull(mappings.ownerUserIdField) ?: return@mapNotNull null
             val preferredName =
-                strategy.accountMappings.ownerNameField
+                mappings.ownerNameField
                     ?.let { owner.resolveJsonPath(it) }
                     ?.takeIf { it.isNotBlank() }
-                    ?: owner.stringOrNull("name")?.takeIf { it.isNotBlank() }
+                    ?: owner.stringOrNull(mappings.ownerNameFallbackField)?.takeIf { it.isNotBlank() }
             val sortCode =
-                owner.stringOrNull("sort_code")?.takeIf { it.isNotBlank() }
-                    ?: account.stringOrNull("sort_code")?.takeIf { it.isNotBlank() }
+                owner.stringOrNull(mappings.sortCodeField)?.takeIf { it.isNotBlank() }
+                    ?: account.stringOrNull(mappings.sortCodeField)?.takeIf { it.isNotBlank() }
             val accountNumber =
-                owner.stringOrNull("account_number")?.takeIf { it.isNotBlank() }
-                    ?: account.stringOrNull("account_number")?.takeIf { it.isNotBlank() }
+                owner.stringOrNull(mappings.accountNumberField)?.takeIf { it.isNotBlank() }
+                    ?: account.stringOrNull(mappings.accountNumberField)?.takeIf { it.isNotBlank() }
             ApiImportAccountOwner(
                 userId = userId,
                 preferredName = preferredName,
                 sortCode = sortCode,
                 accountNumber = accountNumber,
-                jsonPath = JsonPath("${accountJsonPath.value}.owners"),
+                jsonPath = JsonPath("${accountJsonPath.value}.$ownersField"),
             )
         }
         ?: emptyList()
+}
 
 private fun parseAccountsWithPaths(
     json: String,
     strategy: ApiImportStrategy,
 ): List<Pair<ApiImportAccount, JsonPath>> =
-    Json
-        .parseToJsonElement(json)
-        .jsonObject[strategy.accountsEndpoint.responseArrayKey]
-        ?.jsonArray
+    responseItemsArray(json, strategy.accountsEndpoint.responseArrayKey)
         ?.mapIndexedNotNull { index, element ->
-            val account = element.jsonObject
-            val id = account.resolveJsonPath(strategy.accountMappings.idField) ?: return@mapIndexedNotNull null
-            val jsonPath = JsonPath("$.${strategy.accountsEndpoint.responseArrayKey}[$index]")
-            ApiImportAccount(
-                id = id,
-                description = account.resolveJsonPath(strategy.accountMappings.descriptionField).orEmpty(),
-                owners = parseAccountOwners(account, strategy, jsonPath),
-                sortCode = account.stringOrNull("sort_code"),
-                accountNumber = account.stringOrNull("account_number"),
-                rawJson = account,
-            ) to jsonPath
+            val account = element as? JsonObject ?: return@mapIndexedNotNull null
+            val jsonPath = accountsItemJsonPath(strategy, index)
+            parseAccount(account, strategy, jsonPath)?.let { it to jsonPath }
         }
         ?: emptyList()
 
+/**
+ * A parsed transaction page item. The amount is normalized into exactly one of [amountMinorUnits]
+ * (integer minor-units format) or [amountDecimalMajor] (decimal major-units format, magnitude only),
+ * with [amountSign] (-1/0/1) carrying the direction independently of how the amount was encoded.
+ */
 private data class ApiTransactionPageItem(
-    val amountMinorUnits: Long,
+    val amountMinorUnits: Long?,
+    val amountDecimalMajor: BigDecimal?,
+    val amountSign: Int,
     val created: Instant,
     val currencyCode: String,
     val description: String,
@@ -1401,7 +1490,10 @@ private data class ApiTransactionPageItem(
     val rawJson: JsonObject? = null,
     val localAmountMinorUnits: Long? = null,
     val localCurrencyCode: String? = null,
-)
+) {
+    val isZeroAmount: Boolean get() = amountSign == 0
+    val isIncoming: Boolean get() = amountSign > 0
+}
 
 private data class CounterpartyNameMappings(
     val merchantNameField: String?,
@@ -1703,13 +1795,14 @@ private suspend fun prepareValidTransactionItem(
             jsonPath = JsonPath("${item.jsonPath.value}.counterparty"),
         )
     val counterpartyAccountId =
-        if (item.amountMinorUnits == 0L) {
+        if (item.isZeroAmount) {
             setup.accountCache.getOrCreateAccountId(
                 name = setup.nameMappings.counterpartyPrefix + "Void",
                 transactionApiSource = counterpartyApiSource,
             )
         } else {
-            val builtInCounterpartyType = item.rawJson?.resolveBuiltInCounterpartyType(item.amountMinorUnits)
+            val builtInCounterpartyType =
+                item.rawJson?.resolveBuiltInCounterpartyType(setup.strategy.builtInCounterpartyRules, item.amountSign)
             val counterpartyId = item.rawJson?.resolveCounterpartyIdentity(setup.counterpartyIdField, setup.strategy.peopleMappings)
             val personalCounterpartyIdentity = item.rawJson?.personalCounterpartyIdentity(setup.strategy.peopleMappings)
             setup.accountCache.getOrCreateCounterpartyAccountId(
@@ -1718,13 +1811,13 @@ private suspend fun prepareValidTransactionItem(
                 builtInType = builtInCounterpartyType,
                 name =
                     setup.nameMappings.counterpartyPrefix +
-                        (builtInCounterpartyType?.defaultCounterpartyName ?: item.counterpartyName(setup.nameMappings)),
+                        (builtInCounterpartyType ?: item.counterpartyName(setup.nameMappings)),
                 apiSource = counterpartyApiSource,
                 personalIdentity = personalCounterpartyIdentity,
             )
         }
     val transfer = item.toTransfer(context.ownAccountId, counterpartyAccountId, currency)
-    val transactionApiId = item.rawJson?.resolveJsonPath("id")?.takeIf { it.isNotBlank() }
+    val transactionApiId = item.rawJson?.resolveJsonPath(setup.strategy.transactionMappings.idField)?.takeIf { it.isNotBlank() }
     val uniqueKey =
         if (setup.uniqueIdTxFields.isNotEmpty() && item.rawJson != null) {
             setup.uniqueIdTxFields.associateWith { fieldName ->
@@ -1846,25 +1939,24 @@ private fun parseTransactionsWithPath(
 ): List<ApiTransactionPageItem> =
     try {
         val mappings = strategy.transactionMappings
-        Json
-            .parseToJsonElement(json)
-            .jsonObject[strategy.transactionsEndpoint.responseArrayKey]
-            ?.jsonArray
+        responseItemsArray(json, strategy.transactionsEndpoint.responseArrayKey)
             ?.mapIndexedNotNull { index, element ->
-                val obj = element.jsonObject
+                val obj = element as? JsonObject ?: return@mapIndexedNotNull null
                 val created = obj.resolveJsonPath(mappings.timestampField)?.let { Instant.parse(it) }
-                val amount = obj.resolveJsonPath(mappings.amountField)?.toLongOrNull()
+                val amount = parseAmount(obj, mappings)
                 val currency = obj.resolveJsonPath(mappings.currencyField)
                 val declineReason = mappings.declineReasonField?.let { obj.resolveJsonPath(it) }
                 val localAmount = mappings.localAmountField?.let { obj.resolveJsonPath(it) }?.toLongOrNull()
                 val localCurrency = mappings.localCurrencyField?.let { obj.resolveJsonPath(it) }
                 if (created != null && amount != null && currency != null) {
                     ApiTransactionPageItem(
-                        amountMinorUnits = amount,
+                        amountMinorUnits = amount.minorUnits,
+                        amountDecimalMajor = amount.decimalMajor,
+                        amountSign = amount.sign,
                         created = created,
                         currencyCode = currency.uppercase(),
                         description = obj.resolveJsonPath(mappings.descriptionField).orEmpty(),
-                        jsonPath = JsonPath("$.${strategy.transactionsEndpoint.responseArrayKey}[$index]"),
+                        jsonPath = arrayItemJsonPath(strategy.transactionsEndpoint.responseArrayKey, index),
                         merchantName = mappings.merchantNameField?.let { obj.resolveJsonPath(it) },
                         counterpartyName = mappings.counterpartyNameField?.let { obj.resolveJsonPath(it) },
                         declineReason = declineReason,
@@ -1874,7 +1966,8 @@ private fun parseTransactionsWithPath(
                     )
                 } else {
                     logger.error {
-                        "Skipping API transaction at index $index: missing required fields (created=$created, amount=$amount, currency=$currency)"
+                        "Skipping API transaction at index $index: missing required fields " +
+                            "(created=$created, amount=$amount, currency=$currency)"
                     }
                     null
                 }
@@ -1885,31 +1978,224 @@ private fun parseTransactionsWithPath(
         emptyList()
     }
 
-private fun buildTransactionUrl(
+/** Normalized amount: exactly one of [minorUnits]/[decimalMajor] is set; [sign] is the direction. */
+private data class ParsedAmount(
+    val minorUnits: Long?,
+    val decimalMajor: BigDecimal?,
+    val sign: Int,
+)
+
+/** Parses a transaction amount per the strategy's amount format and sign source. */
+private fun parseAmount(
+    obj: JsonObject,
+    mappings: ApiTransactionMappings,
+): ParsedAmount? {
+    val raw = obj.resolveJsonPath(mappings.amountField) ?: return null
+    return when (mappings.amountFormat) {
+        ApiAmountFormat.MINOR_UNITS_INTEGER -> {
+            val value = raw.toLongOrNull() ?: return null
+            val magnitudeSign = value.compareTo(0L).coerceIn(-1, 1)
+            ParsedAmount(minorUnits = value, decimalMajor = null, sign = resolveSign(obj, mappings, magnitudeSign))
+        }
+        ApiAmountFormat.DECIMAL_MAJOR_UNITS -> {
+            val decimal = runCatching { BigDecimal(raw) }.getOrNull() ?: return null
+            val magnitudeSign = decimal.compareTo(BigDecimal.ZERO).coerceIn(-1, 1)
+            ParsedAmount(minorUnits = null, decimalMajor = decimal.abs(), sign = resolveSign(obj, mappings, magnitudeSign))
+        }
+    }
+}
+
+/** Resolves the transaction sign (-1/0/1) from either the amount magnitude or a dedicated field. */
+private fun resolveSign(
+    obj: JsonObject,
+    mappings: ApiTransactionMappings,
+    magnitudeSign: Int,
+): Int =
+    when (mappings.signSource) {
+        ApiSignSource.EMBEDDED -> magnitudeSign
+        ApiSignSource.FIELD -> {
+            if (magnitudeSign == 0) {
+                0
+            } else {
+                val signValue = mappings.signField?.let { obj.resolveJsonPath(it) }
+                if (signValue != null && signValue in mappings.creditValues) 1 else -1
+            }
+        }
+    }
+
+/** JSON path for the [index]-th item of a response array, accounting for a blank (root-array) key. */
+private fun arrayItemJsonPath(
+    responseArrayKey: String,
+    index: Int,
+): JsonPath = if (responseArrayKey.isBlank()) JsonPath("$[$index]") else JsonPath("$.$responseArrayKey[$index]")
+
+/** Extracts the items array from a response body; a blank [responseArrayKey] means the body is the array. */
+private fun responseItemsArray(
+    json: String,
+    responseArrayKey: String,
+): JsonArray? =
+    try {
+        val root = Json.parseToJsonElement(json)
+        if (responseArrayKey.isBlank()) {
+            root as? JsonArray
+        } else {
+            (root as? JsonObject)?.get(responseArrayKey)?.jsonArray
+        }
+    } catch (e: SerializationException) {
+        logger.error(e) { "Failed to parse API response array (key='$responseArrayKey')" }
+        null
+    }
+
+private const val MILLIS_PER_DAY = 86_400_000L
+private val PATH_TEMPLATE_REGEX = Regex("\\{([^}]+)}")
+
+/**
+ * Resolves [ApiQueryParam.dynamicSource] / path-template expressions against the data available
+ * while building a request URL. Supported expressions are documented on [ApiQueryParam.dynamicSource].
+ */
+private class ImportUrlContext(
+    private val account: ApiImportAccount? = null,
+    private val ancestorItems: List<JsonObject>? = null,
+    private val ancestorVars: Map<String, String> = emptyMap(),
+    private val windowStart: String? = null,
+    private val windowEnd: String? = null,
+) {
+    fun resolve(expr: String): String? =
+        when {
+            expr == "account.id" -> account?.id
+            expr.startsWith("account.") -> account?.rawJson?.resolveJsonPath(expr.removePrefix("account."))
+            expr == "window.start" -> windowStart
+            expr == "window.end" -> windowEnd
+            expr == "parent.id" ->
+                ancestorVars.entries.lastOrNull { it.key.endsWith(".id") }?.value
+                    ?: ancestorItems?.lastOrNull()?.resolveJsonPath("id")
+            expr.startsWith("ancestor[") -> resolveAncestor(expr)
+            else -> ancestorVars[expr]
+        }
+
+    private fun resolveAncestor(expr: String): String? {
+        ancestorVars[expr]?.let { return it }
+        val index = expr.substringAfter('[').substringBefore(']').toIntOrNull() ?: return null
+        val field = expr.substringAfter("].", missingDelimiterValue = "id")
+        return ancestorItems?.getOrNull(index)?.resolveJsonPath(field)
+    }
+}
+
+/** Substitutes `{expression}` placeholders in [path] using [ctx]; unresolved placeholders are kept. */
+private fun applyPathTemplate(
+    path: String,
+    ctx: ImportUrlContext,
+): String = PATH_TEMPLATE_REGEX.replace(path) { match -> ctx.resolve(match.groupValues[1]) ?: match.value }
+
+/**
+ * Inverse of [applyPathTemplate]: matches a concrete [actualPath] against a [template] and returns
+ * each placeholder expression mapped to its captured value, or null when the path does not match.
+ */
+private fun extractPathVariables(
+    template: String,
+    actualPath: String,
+): Map<String, String>? {
+    val exprs = mutableListOf<String>()
+    val pattern =
+        buildString {
+            append('^')
+            var last = 0
+            for (match in PATH_TEMPLATE_REGEX.findAll(template)) {
+                append(Regex.escape(template.substring(last, match.range.first)))
+                append("([^/]+)")
+                exprs += match.groupValues[1]
+                last = match.range.last + 1
+            }
+            append(Regex.escape(template.substring(last)))
+            append('$')
+        }
+    val match = Regex(pattern).matchEntire(actualPath) ?: return null
+    return exprs.mapIndexed { index, expr -> expr to match.groupValues[index + 1] }.toMap()
+}
+
+/** Appends static and dynamic [queryParams] to this URL builder, resolving each against [ctx]. */
+private fun URLBuilder.appendQueryParams(
+    queryParams: List<ApiQueryParam>,
+    ctx: ImportUrlContext,
+) {
+    for (queryParam in queryParams) {
+        val value = queryParam.value ?: queryParam.dynamicSource?.let { ctx.resolve(it) }
+        if (value != null) parameters.append(queryParam.name, value)
+    }
+}
+
+/** Builds a fully-templated URL for [endpoint] (path placeholders + query params) using [ctx]. */
+private fun buildEndpointRequestUrl(
+    baseUrl: String,
+    endpoint: ApiEndpointConfig,
+    ctx: ImportUrlContext,
+): String =
+    URLBuilder(buildEndpointUrl(baseUrl, applyPathTemplate(endpoint.path, ctx)))
+        .apply { appendQueryParams(endpoint.queryParams, ctx) }
+        .buildString()
+
+/** Builds the accounts-endpoint URL for the given ancestor [ctx]. */
+private fun buildAccountsUrl(
     strategy: ApiImportStrategy,
-    accountId: String,
+    ctx: ImportUrlContext,
+): String = buildEndpointRequestUrl(strategy.baseUrl, strategy.accountsEndpoint, ctx)
+
+/** Builds a before-cursor transaction page URL (Monzo-style). */
+private fun buildCursorTransactionUrl(
+    strategy: ApiImportStrategy,
+    ctx: ImportUrlContext,
     before: Instant?,
 ): String =
-    URLBuilder(buildEndpointUrl(strategy.baseUrl, strategy.transactionsEndpoint.path))
+    URLBuilder(buildEndpointUrl(strategy.baseUrl, applyPathTemplate(strategy.transactionsEndpoint.path, ctx)))
         .apply {
-            for (queryParam in strategy.transactionsEndpoint.queryParams) {
-                val value =
-                    when (queryParam.dynamicSource) {
-                        "account.id" -> accountId
-                        null -> queryParam.value
-                        else -> null
-                    }
-                if (value != null) {
-                    parameters.append(queryParam.name, value)
-                }
-            }
+            appendQueryParams(strategy.transactionsEndpoint.queryParams, ctx)
             strategy.transactionsEndpoint.pagination?.let { pagination ->
                 parameters.append(pagination.limitParam, pagination.limitValue.toString())
-                if (before != null) {
-                    parameters.append(pagination.cursorParam, before.toString())
-                }
+                if (before != null) parameters.append(pagination.cursorParam, before.toString())
             }
         }.buildString()
+
+/** Builds a date-window transaction URL bounded by the window carried in [ctx]. */
+private fun buildDateWindowTransactionUrl(
+    strategy: ApiImportStrategy,
+    pagination: ApiPaginationConfig,
+    ctx: ImportUrlContext,
+    window: ApiDateWindow,
+): String =
+    URLBuilder(buildEndpointUrl(strategy.baseUrl, applyPathTemplate(strategy.transactionsEndpoint.path, ctx)))
+        .apply {
+            appendQueryParams(strategy.transactionsEndpoint.queryParams, ctx)
+            appendQueryParams(pagination.extraParams, ctx)
+            parameters.append(pagination.startParam, window.start.toString())
+            parameters.append(pagination.endParam, window.end.toString())
+        }.buildString()
+
+private data class ApiDateWindow(
+    val start: Instant,
+    val end: Instant,
+)
+
+/**
+ * Produces the date windows to fetch, anchored to fixed epoch boundaries so earlier windows yield
+ * stable, cacheable URLs across re-imports; only the final window (ending [now]) shifts.
+ */
+private fun dateWindows(
+    pagination: ApiPaginationConfig,
+    now: Instant,
+): List<ApiDateWindow> {
+    val windowMillis = pagination.windowDays.toLong() * MILLIS_PER_DAY
+    if (windowMillis <= 0L) return emptyList()
+    val nowMillis = now.toEpochMilliseconds()
+    val rawStart = nowMillis - pagination.lookbackDays.toLong() * MILLIS_PER_DAY
+    var start = (rawStart / windowMillis) * windowMillis
+    val windows = mutableListOf<ApiDateWindow>()
+    while (start < nowMillis) {
+        val end = minOf(start + windowMillis, nowMillis)
+        windows += ApiDateWindow(Instant.fromEpochMilliseconds(start), Instant.fromEpochMilliseconds(end))
+        start += windowMillis
+    }
+    return windows
+}
 
 private fun buildEndpointUrl(
     baseUrl: String,
@@ -1924,14 +2210,33 @@ private fun ApiResponse.toApiHttpResponse(): ApiHttpResponse =
         requestId = requestId.id,
     )
 
-private fun ApiRequest.accountIdParameter(strategy: ApiImportStrategy): String? {
+private fun ApiRequest.encodedPath(): String = runCatching { URLBuilder(url).encodedPath }.getOrNull().orEmpty()
+
+/**
+ * Recovers the current account's external id from a stored transaction request. Uses the
+ * `account.id` query parameter when the strategy injects the id that way (Monzo); otherwise matches
+ * the request path against the transactions-endpoint path template and captures the `{account.id}`
+ * segment (Wise). Returns null for requests that are not transaction requests.
+ */
+private fun ApiRequest.resolveAccountExternalId(strategy: ApiImportStrategy): String? {
     val accountIdParamName =
         strategy.transactionsEndpoint.queryParams
             .firstOrNull { it.dynamicSource == "account.id" }
             ?.name
-            ?: return null
-    return runCatching { URLBuilder(url).parameters[accountIdParamName] }.getOrNull()
+    if (accountIdParamName != null) {
+        return runCatching { URLBuilder(url).parameters[accountIdParamName] }.getOrNull()
+    }
+    return extractPathVariables(strategy.transactionsEndpoint.path, encodedPath())?.get("account.id")
 }
+
+/** True when this request targets the accounts endpoint (path matches the accounts path template). */
+private fun ApiRequest.isAccountsRequest(strategy: ApiImportStrategy): Boolean =
+    extractPathVariables(strategy.accountsEndpoint.path, encodedPath()) != null &&
+        resolveAccountExternalId(strategy) == null
+
+/** Ancestor placeholder values substituted into this accounts request's path (e.g. profile id). */
+private fun ApiRequest.ancestorVars(strategy: ApiImportStrategy): Map<String, String> =
+    extractPathVariables(strategy.accountsEndpoint.path, encodedPath()).orEmpty()
 
 private data class AccountApiSource(
     val sessionId: ApiSessionId,
@@ -1948,7 +2253,7 @@ private class AccountCache(
     // Pre-built by the caller in the serial section before concurrent import starts
     private val counterpartyIdIndex: MutableMap<String, AccountId>,
     private val personalCounterpartyKeyIndex: MutableMap<String, AccountId>,
-    private val builtInTypeIndex: MutableMap<BuiltInCounterpartyType, AccountId>,
+    private val builtInTypeIndex: MutableMap<String, AccountId>,
     private val onAccountCreated: suspend (isSourceAccount: Boolean) -> Unit = {},
 ) {
     private val mutex = Mutex()
@@ -1961,7 +2266,7 @@ private class AccountCache(
      */
     private val pendingCounterpartyAttributes: MutableList<Pair<AccountId, String>> = mutableListOf()
     private val pendingPersonalCounterpartyAttributes: MutableList<Pair<AccountId, PersonalCounterpartyIdentity>> = mutableListOf()
-    private val pendingBuiltInTypeAttributes: MutableList<Pair<AccountId, BuiltInCounterpartyType>> = mutableListOf()
+    private val pendingBuiltInTypeAttributes: MutableList<Pair<AccountId, String>> = mutableListOf()
 
     suspend fun drainPendingCounterpartyAttributes(): List<Pair<AccountId, String>> =
         mutex.withLock {
@@ -1973,7 +2278,7 @@ private class AccountCache(
             pendingPersonalCounterpartyAttributes.toList().also { pendingPersonalCounterpartyAttributes.clear() }
         }
 
-    suspend fun drainPendingBuiltInTypeAttributes(): List<Pair<AccountId, BuiltInCounterpartyType>> =
+    suspend fun drainPendingBuiltInTypeAttributes(): List<Pair<AccountId, String>> =
         mutex.withLock {
             pendingBuiltInTypeAttributes.toList().also { pendingBuiltInTypeAttributes.clear() }
         }
@@ -2003,7 +2308,7 @@ private class AccountCache(
     suspend fun getOrCreateCounterpartyAccountId(
         counterpartyId: String?,
         dedupeKey: String? = null,
-        builtInType: BuiltInCounterpartyType?,
+        builtInType: String?,
         name: String,
         apiSource: AccountApiSource,
         personalIdentity: PersonalCounterpartyIdentity? = null,
@@ -2127,14 +2432,14 @@ private class AccountCache(
         repeat(createdCount) { onAccountCreated(false) }
     }
 
-    private suspend fun findBuiltInTypeAccountId(builtInType: BuiltInCounterpartyType): AccountId? {
+    private suspend fun findBuiltInTypeAccountId(builtInType: String): AccountId? {
         val accounts = accountRepository.getAllAccounts().first()
         for (account in accounts) {
             val attributes = accountAttributeRepository.getByAccount(account.id).first()
             if (
                 attributes.any {
                     it.attributeType.id == BUILT_IN_COUNTERPARTY_TYPE_ATTR_TYPE_ID &&
-                        it.value == builtInType.attributeValue
+                        it.value == builtInType
                 }
             ) {
                 return account.id
@@ -2237,8 +2542,13 @@ private fun ApiTransactionPageItem.toTransfer(
     counterpartyAccountId: AccountId,
     currency: Currency,
 ): Transfer {
-    val money = Money(amountMinorUnits.absoluteValue, currency)
-    val isIncoming = amountMinorUnits > 0
+    val money =
+        when {
+            amountMinorUnits != null -> Money(amountMinorUnits.absoluteValue, currency)
+            amountDecimalMajor != null -> Money.fromDisplayValue(amountDecimalMajor, currency)
+            else -> Money(0L, currency)
+        }
+    val isIncoming = this.isIncoming
     return Transfer(
         id = TransferId(0L),
         timestamp = created,
@@ -2324,44 +2634,52 @@ private fun JsonObject.resolveJsonObjectPath(dotPath: String): JsonObject? {
     return current as? JsonObject
 }
 
-private enum class BuiltInCounterpartyType(
-    val attributeValue: String,
-    val defaultCounterpartyName: String,
-) {
-    ATM(
-        attributeValue = "ATM",
-        defaultCounterpartyName = "ATM",
-    ),
-    ;
+/**
+ * Evaluates the strategy's declarative [rules] against this transaction's raw JSON, returning the
+ * name of the first matching built-in counterparty type (e.g. "ATM"), or null when none match.
+ * [amountSign] (-1/0/1) drives each rule's sign gate.
+ */
+private fun JsonObject.resolveBuiltInCounterpartyType(
+    rules: List<BuiltInCounterpartyRule>,
+    amountSign: Int,
+): String? {
+    for (rule in rules) {
+        if (!rule.onlyWhenSign.matches(amountSign)) continue
+        if (rule.predicates.all { evaluatePredicate(it) }) return rule.name
+    }
+    return null
+}
 
-    companion object {
-        fun fromAttributeValue(value: String): BuiltInCounterpartyType? = entries.firstOrNull { it.attributeValue == value }
+private fun RuleSign.matches(sign: Int): Boolean =
+    when (this) {
+        RuleSign.ANY -> true
+        RuleSign.NEGATIVE -> sign < 0
+        RuleSign.POSITIVE -> sign > 0
+    }
+
+private fun JsonObject.evaluatePredicate(predicate: RulePredicate): Boolean {
+    val operand = predicate.value.orEmpty()
+    return when (predicate.op) {
+        PredicateOp.EXISTS -> resolveJsonElementPath(predicate.path) != null
+        PredicateOp.EQUALS -> resolveJsonPath(predicate.path) == predicate.value
+        PredicateOp.EQUALS_IGNORE_CASE -> resolveJsonPath(predicate.path)?.equals(predicate.value, ignoreCase = true) == true
+        PredicateOp.STARTS_WITH -> resolveJsonPath(predicate.path)?.startsWith(operand) == true
+        PredicateOp.ARRAY_ANY_STARTS_WITH ->
+            (resolveJsonElementPath(predicate.path) as? JsonArray)?.any { element ->
+                element.jsonPrimitive.contentOrNull?.startsWith(operand, ignoreCase = true) == true
+            } == true
+        PredicateOp.OBJECT_EMPTY -> resolveJsonObjectPath(predicate.path).let { it == null || it.isEmpty() }
+        PredicateOp.OBJECT_NON_EMPTY -> resolveJsonObjectPath(predicate.path)?.isNotEmpty() == true
     }
 }
 
-private fun JsonObject.resolveBuiltInCounterpartyType(amountMinorUnits: Long): BuiltInCounterpartyType? {
-    if (amountMinorUnits >= 0L) return null
-    if (this["atm_fees_detailed"] is JsonObject) return BuiltInCounterpartyType.ATM
-    val hasAtmLabel =
-        this["labels"]
-            ?.let { it as? JsonArray }
-            ?.any { label ->
-                label
-                    .jsonPrimitive
-                    .contentOrNull
-                    ?.startsWith("withdrawal.atm", ignoreCase = true) == true
-            } == true
-    if (hasAtmLabel) return BuiltInCounterpartyType.ATM
-    val mcc = (this["metadata"] as? JsonObject)?.stringOrNull("mcc")
-    if (mcc == "6011") return BuiltInCounterpartyType.ATM
-    if (stringOrNull("category")?.equals("cash", ignoreCase = true) == true) {
-        val hasMerchant = (this["merchant"] as? JsonObject)?.isNotEmpty() == true
-        val hasCounterpartyDetails = (this["counterparty"] as? JsonObject)?.isNotEmpty() == true
-        if (!hasMerchant && !hasCounterpartyDetails) {
-            return BuiltInCounterpartyType.ATM
-        }
+/** Resolves a dot-notation path to its [JsonElement] (object, array, or primitive), or null. */
+private fun JsonObject.resolveJsonElementPath(dotPath: String): JsonElement? {
+    var current: JsonElement = this
+    for (part in dotPath.split(".")) {
+        current = (current as? JsonObject)?.get(part) ?: return null
     }
-    return null
+    return current
 }
 
 private class AttributeTypeCache(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -425,8 +425,9 @@ private fun JsonObject.toPersonOwner(
     index: Int,
 ): ApiImportAccountOwner? {
     val externalId = resolveJsonPath(config.externalIdField)?.takeIf { it.isNotBlank() }
-    val first = config.preferredNameField?.let { resolveJsonPath(it) }?.takeIf { it.isNotBlank() }
-        ?: resolveJsonPath(config.firstNameField)?.takeIf { it.isNotBlank() }
+    val first =
+        config.preferredNameField?.let { resolveJsonPath(it) }?.takeIf { it.isNotBlank() }
+            ?: resolveJsonPath(config.firstNameField)?.takeIf { it.isNotBlank() }
     val last = config.lastNameField?.let { resolveJsonPath(it) }?.takeIf { it.isNotBlank() }
     val fallback = config.fallbackNameField?.let { resolveJsonPath(it) }?.takeIf { it.isNotBlank() }
     val name = listOfNotNull(first, last).joinToString(" ").ifBlank { fallback ?: return null }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -2243,7 +2243,8 @@ private fun responseItemsArray(
     }
 
 private const val MILLIS_PER_DAY = 86_400_000L
-private val PATH_TEMPLATE_REGEX = Regex("\\{([^}]+)}")
+// The closing brace is escaped because Android's regex engine rejects a bare '}'.
+private val PATH_TEMPLATE_REGEX = Regex("\\{([^}]+)\\}")
 
 /**
  * Resolves [ApiQueryParam.dynamicSource] / path-template expressions against the data available

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -318,6 +318,7 @@ suspend fun importApiSessionTransactions(
             onProgress,
         )
     onProgress(ApiSessionImportProgress(detail = "Preparing import session...", progress = 0.05f))
+    ensureSourceAccounts(setup)
     precreateAndFlushCounterparties(setup, counterpartyAccountNames)
     onProgress(ApiSessionImportProgress(detail = "Counterparties prepared.", progress = 0.2f))
     importTransactionsConcurrently(setup)
@@ -335,6 +336,17 @@ suspend fun importApiSessionTransactions(
         errorCount = setup.counts.totalErrors,
         excludedCount = setup.counts.totalExcluded,
     )
+}
+
+/**
+ * Materialises an [com.moneymanager.domain.model.Account] for every downloaded account up front, so
+ * accounts exist even when they have no owners and no transactions (e.g. Wise balances). Account
+ * creation is otherwise only a side effect of importing transactions or owners. Idempotent.
+ */
+private suspend fun ensureSourceAccounts(setup: ImportSetup) {
+    for (account in setup.accountsById.values) {
+        setup.accountCache.getOrCreateAccountId(account.id, account.displayName(setup.strategy))
+    }
 }
 
 /** Mutable progress counters shared between the setup, parallel import, and progress callback. */

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -33,6 +33,7 @@ import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.TransactionRepository
 import com.moneymanager.rest.ApiClient
 import com.moneymanager.rest.ApiHttpResponse
+import com.moneymanager.rest.ScaParams
 import com.moneymanager.ui.screens.transactions.logger
 import io.ktor.http.*
 import kotlinx.coroutines.CancellationException
@@ -103,6 +104,7 @@ suspend fun downloadApiSessionAccounts(
     apiSessionRepository: ApiSessionRepository,
     sessionId: ApiSessionId,
     strategy: ApiImportStrategy,
+    sca: ScaParams? = null,
 ): ApiAccountsDownloadResult {
     val existingRequests = apiSessionRepository.getRequestsBySession(sessionId)
     val existingResponses = apiSessionRepository.getResponsesBySession(sessionId)
@@ -112,7 +114,7 @@ suspend fun downloadApiSessionAccounts(
     // Resolve ancestor resources (e.g. Wise profiles) first; for a flat API (Monzo) this is a
     // single empty context so the accounts endpoint is fetched exactly once.
     val ancestorContexts =
-        fetchAncestorContexts(token, apiClient, strategy, existingRequestsByUrl, existingResponsesByRequestId)
+        fetchAncestorContexts(token, apiClient, strategy, existingRequestsByUrl, existingResponsesByRequestId, sca)
 
     var totalAccounts = 0
     var anyFetched = false
@@ -125,7 +127,7 @@ suspend fun downloadApiSessionAccounts(
                 existingResponse.json
             } else {
                 anyFetched = true
-                fetchResponse(url = url, token = token, apiClient = apiClient).body
+                fetchResponse(url = url, token = token, apiClient = apiClient, sca = sca).body
             }
         totalAccounts += parseAccounts(json, strategy).size
     }
@@ -143,6 +145,7 @@ private suspend fun fetchAncestorContexts(
     strategy: ApiImportStrategy,
     existingRequestsByUrl: Map<String, ApiRequest>,
     existingResponsesByRequestId: Map<ApiRequestId, ApiResponse>,
+    sca: ScaParams?,
 ): List<List<JsonObject>> {
     var contexts: List<List<JsonObject>> = listOf(emptyList())
     strategy.ancestorEndpoints.forEach { endpoint ->
@@ -150,7 +153,7 @@ private suspend fun fetchAncestorContexts(
         for (ancestors in contexts) {
             val url = buildEndpointRequestUrl(strategy.baseUrl, endpoint, ImportUrlContext(ancestorItems = ancestors))
             val existingResponse = existingRequestsByUrl[url]?.let { existingResponsesByRequestId[it.id] }
-            val json = existingResponse?.json ?: fetchResponse(url = url, token = token, apiClient = apiClient).body
+            val json = existingResponse?.json ?: fetchResponse(url = url, token = token, apiClient = apiClient, sca = sca).body
             for (item in responseItemsArray(json, endpoint.responseArrayKey).orEmpty()) {
                 (item as? JsonObject)?.let { next += ancestors + it }
             }
@@ -173,6 +176,7 @@ suspend fun downloadApiSessionTransactions(
     sessionId: ApiSessionId,
     strategy: ApiImportStrategy,
     accountsSessionId: ApiSessionId? = null,
+    sca: ScaParams? = null,
     onProgress: (ApiTransactionsDownloadProgress) -> Unit = {},
 ): ApiTransactionsDownloadResult {
     val existingRequests = apiSessionRepository.getRequestsBySession(sessionId)
@@ -231,7 +235,7 @@ suspend fun downloadApiSessionTransactions(
                 )
                 val existingResponse = existingRequestsByUrl[url]?.let { existingResponsesByRequestId[it.id] }
                 if (existingResponse == null) {
-                    fetchResponse(url = url, token = token, apiClient = apiClient)
+                    fetchResponse(url = url, token = token, apiClient = apiClient, sca = sca)
                     transactionResponseCount += 1
                 }
             }
@@ -259,7 +263,7 @@ suspend fun downloadApiSessionTransactions(
                     if (existingResponse != null) {
                         parseTransactionsWithPath(existingResponse.json, strategy)
                     } else {
-                        val response = fetchResponse(url = url, token = token, apiClient = apiClient)
+                        val response = fetchResponse(url = url, token = token, apiClient = apiClient, sca = sca)
                         transactionResponseCount += 1
                         parseTransactionsWithPath(response.body, strategy)
                     }
@@ -1258,8 +1262,9 @@ private suspend fun fetchResponse(
     url: String,
     token: String,
     apiClient: ApiClient,
+    sca: ScaParams? = null,
 ): ApiHttpResponse {
-    val response = apiClient.get(url = url, bearerToken = token)
+    val response = apiClient.get(url = url, bearerToken = token, sca = sca)
     if (response.statusCode != 200) {
         throw ApiSessionImportException("HTTP ${response.statusCode}: ${response.body}")
     }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -52,7 +52,6 @@ import kotlin.time.Instant
 
 private val ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID = AttributeTypeId(DatabaseConfig.ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID)
 private val BUILT_IN_COUNTERPARTY_TYPE_ATTR_TYPE_ID = AttributeTypeId(DatabaseConfig.BUILT_IN_COUNTERPARTY_TYPE_ATTR_TYPE_ID)
-private val PERSON_EXTERNAL_ID_ATTR_TYPE_ID = AttributeTypeId(DatabaseConfig.PERSON_EXTERNAL_ID_ATTR_TYPE_ID)
 private val ACCOUNT_SORT_CODE_ATTR_TYPE_ID = AttributeTypeId(DatabaseConfig.ACCOUNT_SORT_CODE_ATTR_TYPE_ID)
 private val ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID = AttributeTypeId(DatabaseConfig.ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID)
 private const val API_IMPORT_TRANSACTION_WRITE_BATCH_SIZE = 100
@@ -333,12 +332,14 @@ suspend fun importApiSessionPeople(
     personRepository: PersonRepository,
     personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     personAttributeRepository: PersonAttributeRepository,
+    attributeTypeRepository: AttributeTypeRepository,
     entitySource: EntitySource,
     sessionId: ApiSessionId,
     strategy: ApiImportStrategy,
     accountsSessionId: ApiSessionId? = null,
 ): ApiPeopleImportResult {
     val config = strategy.peopleDownload ?: return ApiPeopleImportResult(personCount = 0, ownershipCount = 0)
+    val externalIdAttributeTypeId = strategy.personExternalIdAttribute?.let { attributeTypeRepository.getOrCreate(it) }
     val requestsById = apiSessionRepository.getRequestsBySession(sessionId).associateBy { it.id }
     val peopleResponses =
         apiSessionRepository.getResponsesBySession(sessionId).filter { response ->
@@ -347,7 +348,7 @@ suspend fun importApiSessionPeople(
         }
     val ownedAccountsByProfile =
         buildProfileAccountMap(apiSessionRepository, accountRepository, accountAttributeRepository, accountsSessionId, strategy, config)
-    val peopleIndex = loadPeopleIndex(personRepository, personAttributeRepository)
+    val peopleIndex = loadPeopleIndex(personRepository, personAttributeRepository, externalIdAttributeTypeId)
 
     var personCount = 0
     var ownershipCount = 0
@@ -365,6 +366,7 @@ suspend fun importApiSessionPeople(
                             peopleIndex = peopleIndex,
                             personRepository = personRepository,
                             personAttributeRepository = personAttributeRepository,
+                            externalIdAttributeTypeId = externalIdAttributeTypeId,
                             entitySource = entitySource,
                             sessionId = sessionId,
                             requestId = requestId,
@@ -380,6 +382,7 @@ suspend fun importApiSessionPeople(
                                 personRepository = personRepository,
                                 personAccountOwnershipRepository = personAccountOwnershipRepository,
                                 personAttributeRepository = personAttributeRepository,
+                                externalIdAttributeTypeId = externalIdAttributeTypeId,
                                 entitySource = entitySource,
                                 sessionId = sessionId,
                                 requestId = requestId,
@@ -773,8 +776,10 @@ private suspend fun importTransactionsConcurrently(setup: ImportSetup) {
     }
 }
 
-private suspend fun importPeopleFromSession(setup: ImportSetup): Int =
-    importPeopleFromAccounts(
+private suspend fun importPeopleFromSession(setup: ImportSetup): Int {
+    val externalIdAttributeTypeId =
+        setup.strategy.personExternalIdAttribute?.let { setup.attributeTypeCache.getOrCreate(it) }
+    return importPeopleFromAccounts(
         accountsById = setup.accountsById,
         accountCache = setup.accountCache,
         strategy = setup.strategy,
@@ -785,6 +790,7 @@ private suspend fun importPeopleFromSession(setup: ImportSetup): Int =
         entitySource = setup.entitySource,
         accountApiSourceByExternalId = setup.accountCache.accountApiSourceByExternalId,
         sessionId = setup.sessionId,
+        externalIdAttributeTypeId = externalIdAttributeTypeId,
     ) +
         importPeopleFromCounterparties(
             transactionResponses = setup.transactionResponses,
@@ -799,7 +805,9 @@ private suspend fun importPeopleFromSession(setup: ImportSetup): Int =
             personRepository = setup.personRepository,
             personAccountOwnershipRepository = setup.personAccountOwnershipRepository,
             personAttributeRepository = setup.personAttributeRepository,
+            externalIdAttributeTypeId = externalIdAttributeTypeId,
         )
+}
 
 private suspend fun flushPostTransactionAttributes(setup: ImportSetup) {
     if (setup.counterpartyIdField != null) {
@@ -1107,8 +1115,9 @@ private suspend fun importPeopleFromAccounts(
     entitySource: EntitySource? = null,
     accountApiSourceByExternalId: Map<String, AccountApiSource> = emptyMap(),
     sessionId: ApiSessionId? = null,
+    externalIdAttributeTypeId: AttributeTypeId? = null,
 ): Int {
-    val peopleIndex = loadPeopleIndex(personRepository, personAttributeRepository)
+    val peopleIndex = loadPeopleIndex(personRepository, personAttributeRepository, externalIdAttributeTypeId)
     var newPeopleCount = 0
 
     for (account in accountsById.values) {
@@ -1136,6 +1145,7 @@ private suspend fun importPeopleFromAccounts(
                 personRepository = personRepository,
                 personAccountOwnershipRepository = personAccountOwnershipRepository,
                 personAttributeRepository = personAttributeRepository,
+                externalIdAttributeTypeId = externalIdAttributeTypeId,
                 entitySource = entitySource,
                 sessionId = sessionId,
                 requestId = accountApiSourceByExternalId[account.id]?.requestId,
@@ -1159,8 +1169,9 @@ private suspend fun importPeopleFromCounterparties(
     personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     personAttributeRepository: PersonAttributeRepository,
     entitySource: EntitySource,
+    externalIdAttributeTypeId: AttributeTypeId?,
 ): Int {
-    val peopleIndex = loadPeopleIndex(personRepository, personAttributeRepository)
+    val peopleIndex = loadPeopleIndex(personRepository, personAttributeRepository, externalIdAttributeTypeId)
     var newPeopleCount = 0
 
     for (response in transactionResponses) {
@@ -1199,6 +1210,7 @@ private suspend fun importPeopleFromCounterparties(
                     personRepository = personRepository,
                     personAccountOwnershipRepository = personAccountOwnershipRepository,
                     personAttributeRepository = personAttributeRepository,
+                    externalIdAttributeTypeId = externalIdAttributeTypeId,
                     entitySource = entitySource,
                     sessionId = sessionId,
                     requestId = request.id,
@@ -1216,6 +1228,7 @@ private suspend fun importOwnersForAccount(
     personRepository: PersonRepository,
     personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     personAttributeRepository: PersonAttributeRepository,
+    externalIdAttributeTypeId: AttributeTypeId?,
     entitySource: EntitySource? = null,
     sessionId: ApiSessionId? = null,
     requestId: ApiRequestId? = null,
@@ -1235,6 +1248,7 @@ private suspend fun importOwnersForAccount(
                 peopleIndex = peopleIndex,
                 personRepository = personRepository,
                 personAttributeRepository = personAttributeRepository,
+                externalIdAttributeTypeId = externalIdAttributeTypeId,
                 entitySource = entitySource,
                 sessionId = sessionId,
                 requestId = requestId,
@@ -1273,20 +1287,24 @@ private suspend fun resolveOrCreatePerson(
     peopleIndex: MutablePeopleIndex,
     personRepository: PersonRepository,
     personAttributeRepository: PersonAttributeRepository,
+    externalIdAttributeTypeId: AttributeTypeId?,
     entitySource: EntitySource? = null,
     sessionId: ApiSessionId? = null,
     requestId: ApiRequestId? = null,
 ): Pair<Person, Boolean>? {
-    val externalId = owner.userId.trim().ifBlank { null }
     val bankKey = owner.bankKey()
     val name = owner.preferredName?.trim().orEmpty()
-    val displayName = name.ifBlank { bankKey ?: externalId ?: return null }
+    val rawExternalId = owner.userId.trim().ifBlank { null }
+    val displayName = name.ifBlank { bankKey ?: rawExternalId ?: return null }
+    // Only match/store the provider id when this provider declares an attribute for it.
+    val externalId = if (externalIdAttributeTypeId != null) rawExternalId else null
 
     peopleIndex.find(externalId = externalId, bankKey = bankKey, fullName = displayName)?.let { existing ->
-        if (externalId != null && existing.externalId == null) {
+        // Matched (typically by name across providers): backfill this provider's external id if absent.
+        if (externalIdAttributeTypeId != null && externalId != null && existing.externalId == null) {
             logger.info { "Backfilling external id for imported person '${existing.fullName}'" }
             runCatching {
-                personAttributeRepository.insert(existing.person.id, PERSON_EXTERNAL_ID_ATTR_TYPE_ID, externalId)
+                personAttributeRepository.insert(existing.person.id, externalIdAttributeTypeId, externalId)
             }
             peopleIndex.replace(existing.person, externalId)
             return existing.person to false
@@ -1304,8 +1322,8 @@ private suspend fun resolveOrCreatePerson(
         )
     val newId = personRepository.createPerson(person)
     val createdPerson = person.copy(id = newId)
-    if (externalId != null) {
-        personAttributeRepository.insertInCreationMode(createdPerson.id, PERSON_EXTERNAL_ID_ATTR_TYPE_ID, externalId)
+    if (externalIdAttributeTypeId != null && externalId != null) {
+        personAttributeRepository.insertInCreationMode(createdPerson.id, externalIdAttributeTypeId, externalId)
     }
     if (entitySource != null && sessionId != null && requestId != null) {
         entitySource.recordFromApi(
@@ -1326,16 +1344,21 @@ private suspend fun resolveOrCreatePerson(
 private suspend fun loadPeopleIndex(
     personRepository: PersonRepository,
     personAttributeRepository: PersonAttributeRepository,
+    externalIdAttributeTypeId: AttributeTypeId?,
 ): MutablePeopleIndex {
     val people = personRepository.getAllPeople().first()
+    // External ids are loaded for the current provider only, so cross-provider matches fall through
+    // to name matching and the missing provider id is backfilled.
     val externalIdsByPersonId =
         people.associate { person ->
             person.id to
-                personAttributeRepository
-                    .getByPerson(person.id)
-                    .first()
-                    .firstOrNull { it.attributeType.id == PERSON_EXTERNAL_ID_ATTR_TYPE_ID }
-                    ?.value
+                externalIdAttributeTypeId?.let { typeId ->
+                    personAttributeRepository
+                        .getByPerson(person.id)
+                        .first()
+                        .firstOrNull { it.attributeType.id == typeId }
+                        ?.value
+                }
         }
     return MutablePeopleIndex.from(people, externalIdsByPersonId)
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -1246,7 +1246,7 @@ private suspend fun importOwnersForAccount(
         personAccountOwnershipRepository
             .getOwnershipsByAccount(accountId)
             .first()
-            .associateBy { it.personId }
+            .mapTo(mutableSetOf()) { it.personId }
     var newPeopleCount = 0
     var newOwnershipCount = 0
 
@@ -1263,9 +1263,10 @@ private suspend fun importOwnersForAccount(
                 requestId = requestId,
             ) ?: continue
 
-        val existingOwnership = existingOwnerPersonIds[person.id]
-        if (existingOwnership == null) {
+        if (person.id !in existingOwnerPersonIds) {
             val ownershipId = personAccountOwnershipRepository.createOwnership(person.id, accountId)
+            // Track the new link so duplicate owner entries in the same payload don't re-insert it.
+            existingOwnerPersonIds += person.id
             newOwnershipCount++
             if (entitySource != null && sessionId != null && requestId != null) {
                 entitySource.recordFromApi(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -310,12 +310,7 @@ suspend fun downloadApiSessionPeople(
 
     val url = buildEndpointRequestUrl(strategy.baseUrl, config.endpoint, ImportUrlContext())
     val existingResponse = existingRequestsByUrl[url]?.let { existingResponsesByRequestId[it.id] }
-    val json =
-        if (existingResponse != null) {
-            existingResponse.json
-        } else {
-            fetchResponse(url = url, token = token, apiClient = apiClient, sca = sca).body
-        }
+    val json = existingResponse?.json ?: fetchResponse(url = url, token = token, apiClient = apiClient, sca = sca).body
     val count = responseItemsArray(json, config.endpoint.responseArrayKey)?.count { it is JsonObject } ?: 0
     return ApiPeopleDownloadResult(personCount = count, skipped = existingResponse != null)
 }
@@ -2864,7 +2859,7 @@ private fun JsonObject.evaluatePredicate(predicate: RulePredicate): Boolean {
             (resolveJsonElementPath(predicate.path) as? JsonArray)?.any { element ->
                 element.jsonPrimitive.contentOrNull?.startsWith(operand, ignoreCase = true) == true
             } == true
-        PredicateOp.OBJECT_EMPTY -> resolveJsonObjectPath(predicate.path).let { it == null || it.isEmpty() }
+        PredicateOp.OBJECT_EMPTY -> resolveJsonObjectPath(predicate.path).isNullOrEmpty()
         PredicateOp.OBJECT_NON_EMPTY -> resolveJsonObjectPath(predicate.path)?.isNotEmpty() == true
     }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -12,6 +12,7 @@ import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
 import com.moneymanager.domain.model.apistrategy.ApiPaginationConfig
 import com.moneymanager.domain.model.apistrategy.ApiPeopleMappings
+import com.moneymanager.domain.model.apistrategy.ApiPersonImportConfig
 import com.moneymanager.domain.model.apistrategy.ApiQueryParam
 import com.moneymanager.domain.model.apistrategy.ApiSignSource
 import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
@@ -84,6 +85,16 @@ data class ApiAccountsDownloadResult(
 data class ApiTransactionsDownloadResult(
     val accountCount: Int,
     val transactionResponseCount: Int,
+)
+
+data class ApiPeopleDownloadResult(
+    val personCount: Int,
+    val skipped: Boolean = false,
+)
+
+data class ApiPeopleImportResult(
+    val personCount: Int,
+    val ownershipCount: Int,
 )
 
 data class ApiTransactionsDownloadProgress(
@@ -278,6 +289,151 @@ suspend fun downloadApiSessionTransactions(
     return ApiTransactionsDownloadResult(
         accountCount = accountEntries.size,
         transactionResponseCount = transactionResponseCount,
+    )
+}
+
+/**
+ * Downloads the people/profiles endpoint (the account holder identity) into [sessionId]. Only
+ * applies to strategies with [com.moneymanager.domain.model.apistrategy.ApiPersonImportConfig]
+ * configured (e.g. Wise); a no-op otherwise.
+ */
+suspend fun downloadApiSessionPeople(
+    token: String,
+    apiClient: ApiClient,
+    apiSessionRepository: ApiSessionRepository,
+    sessionId: ApiSessionId,
+    strategy: ApiImportStrategy,
+    sca: ScaParams? = null,
+): ApiPeopleDownloadResult {
+    val config = strategy.peopleDownload ?: return ApiPeopleDownloadResult(personCount = 0, skipped = true)
+    val existingRequestsByUrl = apiSessionRepository.getRequestsBySession(sessionId).associateBy { it.url }
+    val existingResponsesByRequestId = apiSessionRepository.getResponsesBySession(sessionId).associateBy { it.requestId }
+
+    val url = buildEndpointRequestUrl(strategy.baseUrl, config.endpoint, ImportUrlContext())
+    val existingResponse = existingRequestsByUrl[url]?.let { existingResponsesByRequestId[it.id] }
+    val json =
+        if (existingResponse != null) {
+            existingResponse.json
+        } else {
+            fetchResponse(url = url, token = token, apiClient = apiClient, sca = sca).body
+        }
+    val count = responseItemsArray(json, config.endpoint.responseArrayKey)?.count { it is JsonObject } ?: 0
+    return ApiPeopleDownloadResult(personCount = count, skipped = existingResponse != null)
+}
+
+/**
+ * Imports people from a people-download session: creates a [Person] for each profile holder and, when
+ * [accountsSessionId] is provided, links each person as an owner of the accounts fetched under their
+ * profile (via [ApiPersonImportConfig.accountOwnerAncestorExpr]).
+ */
+suspend fun importApiSessionPeople(
+    apiSessionRepository: ApiSessionRepository,
+    accountRepository: AccountRepository,
+    accountAttributeRepository: AccountAttributeRepository,
+    personRepository: PersonRepository,
+    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
+    personAttributeRepository: PersonAttributeRepository,
+    entitySource: EntitySource,
+    sessionId: ApiSessionId,
+    strategy: ApiImportStrategy,
+    accountsSessionId: ApiSessionId? = null,
+): ApiPeopleImportResult {
+    val config = strategy.peopleDownload ?: return ApiPeopleImportResult(personCount = 0, ownershipCount = 0)
+    val requestsById = apiSessionRepository.getRequestsBySession(sessionId).associateBy { it.id }
+    val peopleResponses =
+        apiSessionRepository.getResponsesBySession(sessionId).filter { response ->
+            val path = requestsById[response.requestId]?.encodedPath() ?: return@filter false
+            extractPathVariables(config.endpoint.path, path) != null
+        }
+    val ownedAccountsByProfile =
+        buildProfileAccountMap(apiSessionRepository, accountRepository, accountAttributeRepository, accountsSessionId, strategy, config)
+    val peopleIndex = loadPeopleIndex(personRepository, personAttributeRepository)
+
+    var personCount = 0
+    var ownershipCount = 0
+    for (response in peopleResponses) {
+        val requestId = requestsById[response.requestId]?.id
+        responseItemsArray(response.json, config.endpoint.responseArrayKey)
+            ?.forEachIndexed { index, element ->
+                val obj = element as? JsonObject ?: return@forEachIndexed
+                val owner = obj.toPersonOwner(config, index) ?: return@forEachIndexed
+                val ownedAccounts = ownedAccountsByProfile[owner.userId].orEmpty()
+                if (ownedAccounts.isEmpty()) {
+                    val created =
+                        resolveOrCreatePerson(
+                            owner = owner,
+                            peopleIndex = peopleIndex,
+                            personRepository = personRepository,
+                            personAttributeRepository = personAttributeRepository,
+                            entitySource = entitySource,
+                            sessionId = sessionId,
+                            requestId = requestId,
+                        )?.second == true
+                    if (created) personCount++
+                } else {
+                    for (accountId in ownedAccounts) {
+                        personCount +=
+                            importOwnersForAccount(
+                                owners = listOf(owner),
+                                accountId = accountId,
+                                peopleIndex = peopleIndex,
+                                personRepository = personRepository,
+                                personAccountOwnershipRepository = personAccountOwnershipRepository,
+                                personAttributeRepository = personAttributeRepository,
+                                entitySource = entitySource,
+                                sessionId = sessionId,
+                                requestId = requestId,
+                            )
+                        ownershipCount++
+                    }
+                }
+            }
+    }
+    return ApiPeopleImportResult(personCount = personCount, ownershipCount = ownershipCount)
+}
+
+/** Builds a map of profile external id → the [AccountId]s fetched under that profile. */
+private suspend fun buildProfileAccountMap(
+    apiSessionRepository: ApiSessionRepository,
+    accountRepository: AccountRepository,
+    accountAttributeRepository: AccountAttributeRepository,
+    accountsSessionId: ApiSessionId?,
+    strategy: ApiImportStrategy,
+    config: ApiPersonImportConfig,
+): Map<String, List<AccountId>> {
+    val ancestorExpr = config.accountOwnerAncestorExpr ?: return emptyMap()
+    if (accountsSessionId == null) return emptyMap()
+    val accountIdByExternalId = loadAccountExternalIdIndex(accountRepository, accountAttributeRepository)
+    val requestsById = apiSessionRepository.getRequestsBySession(accountsSessionId).associateBy { it.id }
+    val result = mutableMapOf<String, MutableList<AccountId>>()
+    for (response in apiSessionRepository.getResponsesBySession(accountsSessionId)) {
+        val request = requestsById[response.requestId] ?: continue
+        if (!request.isAccountsRequest(strategy)) continue
+        val profileId = request.ancestorVars(strategy)[ancestorExpr] ?: continue
+        for (account in parseAccounts(response.json, strategy)) {
+            accountIdByExternalId[account.id]?.let { result.getOrPut(profileId) { mutableListOf() }.add(it) }
+        }
+    }
+    return result
+}
+
+/** Maps a profile object to an owner; returns null when no usable name can be derived. */
+private fun JsonObject.toPersonOwner(
+    config: ApiPersonImportConfig,
+    index: Int,
+): ApiImportAccountOwner? {
+    val externalId = resolveJsonPath(config.externalIdField)?.takeIf { it.isNotBlank() }
+    val first = config.preferredNameField?.let { resolveJsonPath(it) }?.takeIf { it.isNotBlank() }
+        ?: resolveJsonPath(config.firstNameField)?.takeIf { it.isNotBlank() }
+    val last = config.lastNameField?.let { resolveJsonPath(it) }?.takeIf { it.isNotBlank() }
+    val fallback = config.fallbackNameField?.let { resolveJsonPath(it) }?.takeIf { it.isNotBlank() }
+    val name = listOfNotNull(first, last).joinToString(" ").ifBlank { fallback ?: return null }
+    return ApiImportAccountOwner(
+        userId = externalId.orEmpty(),
+        preferredName = name,
+        sortCode = null,
+        accountNumber = null,
+        jsonPath = arrayItemJsonPath(config.endpoint.responseArrayKey, index),
     )
 }
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -405,11 +405,15 @@ private suspend fun buildProfileAccountMap(
     val requestsById = apiSessionRepository.getRequestsBySession(accountsSessionId).associateBy { it.id }
     val result = mutableMapOf<String, MutableList<AccountId>>()
     for (response in apiSessionRepository.getResponsesBySession(accountsSessionId)) {
-        val request = requestsById[response.requestId] ?: continue
-        if (!request.isAccountsRequest(strategy)) continue
-        val profileId = request.ancestorVars(strategy)[ancestorExpr] ?: continue
-        for (account in parseAccounts(response.json, strategy)) {
-            accountIdByExternalId[account.id]?.let { result.getOrPut(profileId) { mutableListOf() }.add(it) }
+        val profileId =
+            requestsById[response.requestId]
+                ?.takeIf { it.isAccountsRequest(strategy) }
+                ?.ancestorVars(strategy)
+                ?.get(ancestorExpr)
+        if (profileId != null) {
+            for (account in parseAccounts(response.json, strategy)) {
+                accountIdByExternalId[account.id]?.let { result.getOrPut(profileId) { mutableListOf() }.add(it) }
+            }
         }
     }
     return result

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -343,6 +343,13 @@ suspend fun importApiSessionPeople(
         }
     val ownedAccountsByProfile =
         buildProfileAccountMap(apiSessionRepository, accountRepository, accountAttributeRepository, accountsSessionId, strategy, config)
+    // Ownership links can only be created against accounts that already exist. When people are
+    // imported before their accounts (no accounts session, or accounts not yet imported), the
+    // profile→account map is empty and people are created without ownerships; flag that so the
+    // empty-ownership outcome isn't mistaken for a successful link.
+    if (config.accountOwnerAncestorExpr != null && ownedAccountsByProfile.isEmpty()) {
+        logger.warn { "Importing people with no imported accounts to link; ownerships will not be created. Import accounts first." }
+    }
     val peopleIndex = loadPeopleIndex(personRepository, personAttributeRepository, externalIdAttributeTypeId)
 
     var personCount = 0
@@ -369,7 +376,7 @@ suspend fun importApiSessionPeople(
                     if (created) personCount++
                 } else {
                     for (accountId in ownedAccounts) {
-                        personCount +=
+                        val counts =
                             importOwnersForAccount(
                                 owners = listOf(owner),
                                 accountId = accountId,
@@ -382,7 +389,8 @@ suspend fun importApiSessionPeople(
                                 sessionId = sessionId,
                                 requestId = requestId,
                             )
-                        ownershipCount++
+                        personCount += counts.newPeople
+                        ownershipCount += counts.newOwnerships
                     }
                 }
             }
@@ -1150,7 +1158,7 @@ private suspend fun importPeopleFromAccounts(
                 sessionId = sessionId,
                 requestId = accountApiSourceByExternalId[account.id]?.requestId,
                 jsonPath = accountApiSourceByExternalId[account.id]?.jsonPath,
-            )
+            ).newPeople
     }
 
     return newPeopleCount
@@ -1214,7 +1222,7 @@ private suspend fun importPeopleFromCounterparties(
                     entitySource = entitySource,
                     sessionId = sessionId,
                     requestId = request.id,
-                )
+                ).newPeople
         }
     }
 
@@ -1233,13 +1241,14 @@ private suspend fun importOwnersForAccount(
     sessionId: ApiSessionId? = null,
     requestId: ApiRequestId? = null,
     jsonPath: JsonPath? = null,
-): Int {
+): OwnerImportCounts {
     val existingOwnerPersonIds =
         personAccountOwnershipRepository
             .getOwnershipsByAccount(accountId)
             .first()
             .associateBy { it.personId }
     var newPeopleCount = 0
+    var newOwnershipCount = 0
 
     for (owner in owners) {
         val (person, wasCreated) =
@@ -1257,6 +1266,7 @@ private suspend fun importOwnersForAccount(
         val existingOwnership = existingOwnerPersonIds[person.id]
         if (existingOwnership == null) {
             val ownershipId = personAccountOwnershipRepository.createOwnership(person.id, accountId)
+            newOwnershipCount++
             if (entitySource != null && sessionId != null && requestId != null) {
                 entitySource.recordFromApi(
                     ApiEntitySourceRecord(
@@ -1279,8 +1289,14 @@ private suspend fun importOwnersForAccount(
         }
     }
 
-    return newPeopleCount
+    return OwnerImportCounts(newPeople = newPeopleCount, newOwnerships = newOwnershipCount)
 }
+
+/** Counts of newly created people and account ownerships produced by [importOwnersForAccount]. */
+private data class OwnerImportCounts(
+    val newPeople: Int,
+    val newOwnerships: Int,
+)
 
 private suspend fun resolveOrCreatePerson(
     owner: ApiImportAccountOwner,
@@ -1388,7 +1404,21 @@ private class MutablePeopleIndex private constructor(
         val nameKey = fullName.importNameKey()
         return externalId?.let { peopleByExternalId[it] }
             ?: bankKey?.let { peopleByBankKey[it] }
-            ?: nameKey?.let { peopleByImportNameKey[it]?.firstOrNull() }
+            // Name matching is a heuristic across providers, so only accept it when it's
+            // unambiguous. If two distinct people share a first+last name, picking one arbitrarily
+            // would merge them and backfill the wrong provider id, so treat it as no match and let
+            // the caller create a fresh person instead.
+            ?: nameKey?.let { key ->
+                val candidates = peopleByImportNameKey[key]
+                when {
+                    candidates.isNullOrEmpty() -> null
+                    candidates.size == 1 -> candidates.single()
+                    else -> {
+                        logger.warn { "Ambiguous name match for '$fullName' (${candidates.size} people); not merging" }
+                        null
+                    }
+                }
+            }
     }
 
     fun add(
@@ -2191,22 +2221,29 @@ private fun parseAmount(
         ApiAmountFormat.MINOR_UNITS_INTEGER -> {
             val value = raw.toLongOrNull() ?: return null
             val magnitudeSign = value.compareTo(0L).coerceIn(-1, 1)
-            ParsedAmount(minorUnits = value, decimalMajor = null, sign = resolveSign(obj, mappings, magnitudeSign))
+            val sign = resolveSign(obj, mappings, magnitudeSign) ?: return null
+            ParsedAmount(minorUnits = value, decimalMajor = null, sign = sign)
         }
         ApiAmountFormat.DECIMAL_MAJOR_UNITS -> {
             val decimal = runCatching { BigDecimal(raw) }.getOrNull() ?: return null
             val magnitudeSign = decimal.compareTo(BigDecimal.ZERO).coerceIn(-1, 1)
-            ParsedAmount(minorUnits = null, decimalMajor = decimal.abs(), sign = resolveSign(obj, mappings, magnitudeSign))
+            val sign = resolveSign(obj, mappings, magnitudeSign) ?: return null
+            ParsedAmount(minorUnits = null, decimalMajor = decimal.abs(), sign = sign)
         }
     }
 }
 
-/** Resolves the transaction sign (-1/0/1) from either the amount magnitude or a dedicated field. */
+/**
+ * Resolves the transaction sign (-1/0/1) from either the amount magnitude or a dedicated field.
+ * Returns null when [ApiSignSource.FIELD] is configured but the sign field is absent: a missing
+ * direction indicator is unexpected data, so the caller skips the item rather than silently
+ * defaulting it to a debit. A present value that is simply not in [creditValues] is a debit.
+ */
 private fun resolveSign(
     obj: JsonObject,
     mappings: ApiTransactionMappings,
     magnitudeSign: Int,
-): Int =
+): Int? =
     when (mappings.signSource) {
         ApiSignSource.EMBEDDED -> magnitudeSign
         ApiSignSource.FIELD -> {
@@ -2214,7 +2251,14 @@ private fun resolveSign(
                 0
             } else {
                 val signValue = mappings.signField?.let { obj.resolveJsonPath(it) }
-                if (signValue != null && signValue in mappings.creditValues) 1 else -1
+                when {
+                    signValue == null -> {
+                        logger.warn { "Sign field '${mappings.signField}' missing from transaction; skipping item" }
+                        null
+                    }
+                    signValue in mappings.creditValues -> 1
+                    else -> -1
+                }
             }
         }
     }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -2243,8 +2243,10 @@ private fun responseItemsArray(
     }
 
 private const val MILLIS_PER_DAY = 86_400_000L
-// The closing brace is escaped because Android's regex engine rejects a bare '}'.
-private val PATH_TEMPLATE_REGEX = Regex("\\{([^}]+)\\}")
+
+// '}' is matched via a character class because Android's regex engine rejects a bare '}'
+// while the JVM flags an escaped '\}' as redundant.
+private val PATH_TEMPLATE_REGEX = Regex("\\{([^}]+)[}]")
 
 /**
  * Resolves [ApiQueryParam.dynamicSource] / path-template expressions against the data available

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -2250,13 +2250,12 @@ private fun resolveSign(
             if (magnitudeSign == 0) {
                 0
             } else {
-                val signValue = mappings.signField?.let { obj.resolveJsonPath(it) }
-                when {
-                    signValue == null -> {
+                when (val signValue = mappings.signField?.let { obj.resolveJsonPath(it) }) {
+                    null -> {
                         logger.warn { "Sign field '${mappings.signField}' missing from transaction; skipping item" }
                         null
                     }
-                    signValue in mappings.creditValues -> 1
+                    in mappings.creditValues -> 1
                     else -> -1
                 }
             }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/sca/ScaCrypto.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/sca/ScaCrypto.kt
@@ -1,0 +1,19 @@
+package com.moneymanager.ui.api.sca
+
+/** A PEM-encoded RSA key pair used for API request signing (e.g. Wise Strong Customer Authentication). */
+data class ScaKeyPair(
+    val privateKeyPem: String,
+    val publicKeyPem: String,
+)
+
+/** Generates a fresh RSA-2048 key pair, PEM-encoded (PKCS#8 private, X.509 public). */
+expect fun generateScaKeyPair(): ScaKeyPair
+
+/**
+ * Signs [oneTimeToken] with the PKCS#8 PEM [privateKeyPem] using SHA-256 with RSA and returns the
+ * Base64-encoded signature — the value an SCA-protected API expects in its signature header.
+ */
+expect fun signScaChallenge(
+    privateKeyPem: String,
+    oneTimeToken: String,
+): String

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/sca/ScaCrypto.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/sca/ScaCrypto.kt
@@ -1,11 +1,5 @@
 package com.moneymanager.ui.api.sca
 
-/** A PEM-encoded RSA key pair used for API request signing (e.g. Wise Strong Customer Authentication). */
-data class ScaKeyPair(
-    val privateKeyPem: String,
-    val publicKeyPem: String,
-)
-
 /** Generates a fresh RSA-2048 key pair, PEM-encoded (PKCS#8 private, X.509 public). */
 expect fun generateScaKeyPair(): ScaKeyPair
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/sca/ScaKeyPair.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/sca/ScaKeyPair.kt
@@ -4,4 +4,6 @@ package com.moneymanager.ui.api.sca
 data class ScaKeyPair(
     val privateKeyPem: String,
     val publicKeyPem: String,
-)
+) {
+    override fun toString(): String = "ScaKeyPair(privateKeyPem=<redacted>, publicKeyPem=<redacted>)"
+}

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/sca/ScaKeyPair.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/sca/ScaKeyPair.kt
@@ -1,0 +1,7 @@
+package com.moneymanager.ui.api.sca
+
+/** A PEM-encoded RSA key pair used for API request signing (e.g. Wise Strong Customer Authentication). */
+data class ScaKeyPair(
+    val privateKeyPem: String,
+    val publicKeyPem: String,
+)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
@@ -227,7 +227,6 @@ fun CreateAccountDialog(
         EditPersonDialog(
             personToEdit = null,
             personRepository = personRepository,
-            personAttributeRepository = personAttributeRepository,
             entitySource = entitySource,
             onPersonCreated = { personId ->
                 selectedOwnerIdForAddition = personId.id

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
@@ -29,6 +29,7 @@ import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.EntityType
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.repository.AccountRepository
+import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
@@ -52,6 +53,7 @@ fun CreateAccountDialog(
     categoryRepository: CategoryRepository,
     personRepository: PersonRepository,
     personAttributeRepository: PersonAttributeRepository? = null,
+    attributeTypeRepository: AttributeTypeRepository? = null,
     personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     entitySource: EntitySource,
     onDismiss: () -> Unit,
@@ -233,6 +235,7 @@ fun CreateAccountDialog(
             },
             onDismiss = { accountState.showCreatePersonDialog = false },
             personAttributeRepository = personAttributeRepository,
+            attributeTypeRepository = attributeTypeRepository,
         )
     }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
@@ -232,6 +232,7 @@ fun CreateAccountDialog(
                 selectedOwnerIdForAddition = personId.id
             },
             onDismiss = { accountState.showCreatePersonDialog = false },
+            personAttributeRepository = personAttributeRepository,
         )
     }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
@@ -282,7 +282,6 @@ fun EditAccountDialog(
         EditPersonDialog(
             personToEdit = null,
             personRepository = personRepository,
-            personAttributeRepository = personAttributeRepository,
             entitySource = entitySource,
             onDismiss = { accountState.showCreatePersonDialog = false },
         )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
@@ -284,6 +284,7 @@ fun EditAccountDialog(
             personRepository = personRepository,
             entitySource = entitySource,
             onDismiss = { accountState.showCreatePersonDialog = false },
+            personAttributeRepository = personAttributeRepository,
         )
     }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
@@ -285,6 +285,7 @@ fun EditAccountDialog(
             entitySource = entitySource,
             onDismiss = { accountState.showCreatePersonDialog = false },
             personAttributeRepository = personAttributeRepository,
+            attributeTypeRepository = attributeTypeRepository,
         )
     }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
@@ -9,10 +9,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,9 +24,12 @@ import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.EntitySource
 import com.moneymanager.domain.model.EntityType
 import com.moneymanager.domain.model.Person
+import com.moneymanager.domain.model.PersonAttribute
 import com.moneymanager.domain.model.PersonId
+import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.lighthousegames.logging.logging
 
@@ -37,13 +42,24 @@ fun EditPersonDialog(
     entitySource: EntitySource,
     onDismiss: () -> Unit,
     onPersonCreated: ((PersonId) -> Unit)? = null,
+    personAttributeRepository: PersonAttributeRepository? = null,
 ) {
     var firstName by remember { mutableStateOf(personToEdit?.firstName.orEmpty()) }
     var middleName by remember { mutableStateOf(personToEdit?.middleName.orEmpty()) }
     var lastName by remember { mutableStateOf(personToEdit?.lastName.orEmpty()) }
+    var attributes by remember { mutableStateOf<List<PersonAttribute>>(emptyList()) }
     val saveState = rememberDialogSaveState()
 
     val scope = rememberSchemaAwareCoroutineScope()
+
+    LaunchedEffect(personToEdit?.id) {
+        attributes =
+            if (personAttributeRepository != null && personToEdit != null) {
+                personAttributeRepository.getByPerson(personToEdit.id).first()
+            } else {
+                emptyList()
+            }
+    }
 
     AlertDialog(
         onDismissRequest = { if (!saveState.isSaving) onDismiss() },
@@ -82,6 +98,17 @@ fun EditPersonDialog(
                     singleLine = true,
                     enabled = !saveState.isSaving,
                 )
+
+                if (attributes.isNotEmpty()) {
+                    Text(text = "Identifiers", style = MaterialTheme.typography.labelLarge)
+                    attributes.sortedBy { it.attributeType.name }.forEach { attribute ->
+                        Text(
+                            text = "${attribute.attributeType.name}: ${attribute.value}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
 
                 saveState.errorMessage?.let { error -> ErrorMessageText(error) }
             }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -22,13 +21,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.EntitySource
+import com.moneymanager.domain.model.AttributeType
 import com.moneymanager.domain.model.EntityType
 import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.PersonAttribute
 import com.moneymanager.domain.model.PersonId
+import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import com.moneymanager.ui.screens.transactions.EditableAttributesSection
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.lighthousegames.logging.logging
@@ -43,22 +45,34 @@ fun EditPersonDialog(
     onDismiss: () -> Unit,
     onPersonCreated: ((PersonId) -> Unit)? = null,
     personAttributeRepository: PersonAttributeRepository? = null,
+    attributeTypeRepository: AttributeTypeRepository? = null,
 ) {
     var firstName by remember { mutableStateOf(personToEdit?.firstName.orEmpty()) }
     var middleName by remember { mutableStateOf(personToEdit?.middleName.orEmpty()) }
     var lastName by remember { mutableStateOf(personToEdit?.lastName.orEmpty()) }
-    var attributes by remember { mutableStateOf<List<PersonAttribute>>(emptyList()) }
     val saveState = rememberDialogSaveState()
+
+    // Attribute editing (e.g. provider external ids) is available when both repositories are provided.
+    val attributesEditable = personAttributeRepository != null && attributeTypeRepository != null
+    var existingAttributeTypes by remember { mutableStateOf<List<AttributeType>>(emptyList()) }
+    var editableAttributes by remember { mutableStateOf<Map<Long, Pair<String, String>>>(emptyMap()) }
+    var originalAttributeList by remember { mutableStateOf<List<PersonAttribute>>(emptyList()) }
+    var nextTempId by remember { mutableStateOf(-1L) }
+    var attributesLoaded by remember { mutableStateOf(false) }
 
     val scope = rememberSchemaAwareCoroutineScope()
 
+    LaunchedEffect(Unit) {
+        attributeTypeRepository?.getAll()?.collect { types -> existingAttributeTypes = types }
+    }
+
     LaunchedEffect(personToEdit?.id) {
-        attributes =
-            if (personAttributeRepository != null && personToEdit != null) {
-                personAttributeRepository.getByPerson(personToEdit.id).first()
-            } else {
-                emptyList()
-            }
+        if (personAttributeRepository != null && personToEdit != null && !attributesLoaded) {
+            val attrs = personAttributeRepository.getByPerson(personToEdit.id).first()
+            originalAttributeList = attrs
+            editableAttributes = attrs.associate { it.id to Pair(it.attributeType.name, it.value) }
+            attributesLoaded = true
+        }
     }
 
     AlertDialog(
@@ -99,15 +113,17 @@ fun EditPersonDialog(
                     enabled = !saveState.isSaving,
                 )
 
-                if (attributes.isNotEmpty()) {
-                    Text(text = "Identifiers", style = MaterialTheme.typography.labelLarge)
-                    attributes.sortedBy { it.attributeType.name }.forEach { attribute ->
-                        Text(
-                            text = "${attribute.attributeType.name}: ${attribute.value}",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
+                if (attributesEditable) {
+                    EditableAttributesSection(
+                        editableAttributes = editableAttributes,
+                        existingAttributeTypes = existingAttributeTypes,
+                        isSaving = saveState.isSaving,
+                        onAttributesChange = { editableAttributes = it },
+                        onAddAttribute = {
+                            editableAttributes = editableAttributes + (nextTempId to Pair("", ""))
+                            nextTempId--
+                        },
+                    )
                 }
 
                 saveState.errorMessage?.let { error -> ErrorMessageText(error) }
@@ -123,26 +139,38 @@ fun EditPersonDialog(
                         saveState.errorMessage = null
                         scope.launch {
                             try {
-                                if (personToEdit != null) {
-                                    val updatedPerson =
-                                        personToEdit.copy(
-                                            firstName = firstName.trim(),
-                                            middleName = middleName.trim().ifBlank { null },
-                                            lastName = lastName.trim().ifBlank { null },
+                                val personId =
+                                    if (personToEdit != null) {
+                                        personRepository.updatePerson(
+                                            personToEdit.copy(
+                                                firstName = firstName.trim(),
+                                                middleName = middleName.trim().ifBlank { null },
+                                                lastName = lastName.trim().ifBlank { null },
+                                            ),
                                         )
-                                    personRepository.updatePerson(updatedPerson)
-                                } else {
-                                    val newPerson =
-                                        Person(
-                                            id = PersonId(0),
-                                            firstName = firstName.trim(),
-                                            middleName = middleName.trim().ifBlank { null },
-                                            lastName = lastName.trim().ifBlank { null },
-                                        )
-                                    val personId = personRepository.createPerson(newPerson)
-                                    // Record source for audit trail
-                                    entitySource.record(EntityType.PERSON, personId.id, 1L)
-                                    onPersonCreated?.invoke(personId)
+                                        personToEdit.id
+                                    } else {
+                                        val newId =
+                                            personRepository.createPerson(
+                                                Person(
+                                                    id = PersonId(0),
+                                                    firstName = firstName.trim(),
+                                                    middleName = middleName.trim().ifBlank { null },
+                                                    lastName = lastName.trim().ifBlank { null },
+                                                ),
+                                            )
+                                        entitySource.record(EntityType.PERSON, newId.id, 1L)
+                                        onPersonCreated?.invoke(newId)
+                                        newId
+                                    }
+                                if (personAttributeRepository != null && attributeTypeRepository != null) {
+                                    savePersonAttributes(
+                                        personId = personId,
+                                        editableAttributes = editableAttributes,
+                                        originalAttributeList = originalAttributeList,
+                                        personAttributeRepository = personAttributeRepository,
+                                        attributeTypeRepository = attributeTypeRepository,
+                                    )
                                 }
                                 onDismiss()
                             } catch (expected: Exception) {
@@ -175,4 +203,38 @@ fun EditPersonDialog(
             }
         },
     )
+}
+
+/** Persists the dialog's attribute edits: deletes removed rows, updates changed ones, inserts new ones. */
+private suspend fun savePersonAttributes(
+    personId: PersonId,
+    editableAttributes: Map<Long, Pair<String, String>>,
+    originalAttributeList: List<PersonAttribute>,
+    personAttributeRepository: PersonAttributeRepository,
+    attributeTypeRepository: AttributeTypeRepository,
+) {
+    val keptIds = editableAttributes.keys.filter { it > 0 }.toSet()
+    originalAttributeList.map { it.id }.toSet().minus(keptIds).forEach { personAttributeRepository.delete(it) }
+
+    editableAttributes.filterKeys { it > 0 }.forEach { (id, pair) ->
+        val typeName = pair.first.trim()
+        val value = pair.second.trim()
+        val original = originalAttributeList.find { it.id == id } ?: return@forEach
+        when {
+            typeName.isBlank() || value.isBlank() -> personAttributeRepository.delete(id)
+            original.attributeType.name != typeName -> {
+                personAttributeRepository.delete(id)
+                personAttributeRepository.insert(personId, attributeTypeRepository.getOrCreate(typeName), value)
+            }
+            original.value != value -> personAttributeRepository.updateValue(id, value)
+        }
+    }
+
+    editableAttributes.filterKeys { it < 0 }.forEach { (_, pair) ->
+        val typeName = pair.first.trim()
+        val value = pair.second.trim()
+        if (typeName.isNotEmpty() && value.isNotEmpty()) {
+            personAttributeRepository.insert(personId, attributeTypeRepository.getOrCreate(typeName), value)
+        }
+    }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
@@ -139,7 +139,7 @@ fun EditPersonDialog(
                         saveState.errorMessage = null
                         scope.launch {
                             try {
-                                val personId =
+                                val newPersonId =
                                     if (personToEdit != null) {
                                         personRepository.updatePerson(
                                             personToEdit.copy(
@@ -148,21 +148,18 @@ fun EditPersonDialog(
                                                 lastName = lastName.trim().ifBlank { null },
                                             ),
                                         )
-                                        personToEdit.id
+                                        null
                                     } else {
-                                        val newId =
-                                            personRepository.createPerson(
-                                                Person(
-                                                    id = PersonId(0),
-                                                    firstName = firstName.trim(),
-                                                    middleName = middleName.trim().ifBlank { null },
-                                                    lastName = lastName.trim().ifBlank { null },
-                                                ),
-                                            )
-                                        entitySource.record(EntityType.PERSON, newId.id, 1L)
-                                        onPersonCreated?.invoke(newId)
-                                        newId
+                                        personRepository.createPerson(
+                                            Person(
+                                                id = PersonId(0),
+                                                firstName = firstName.trim(),
+                                                middleName = middleName.trim().ifBlank { null },
+                                                lastName = lastName.trim().ifBlank { null },
+                                            ),
+                                        )
                                     }
+                                val personId = newPersonId ?: personToEdit!!.id
                                 if (personAttributeRepository != null && attributeTypeRepository != null) {
                                     savePersonAttributes(
                                         personId = personId,
@@ -171,6 +168,12 @@ fun EditPersonDialog(
                                         personAttributeRepository = personAttributeRepository,
                                         attributeTypeRepository = attributeTypeRepository,
                                     )
+                                }
+                                // Only announce the new person once the full save (row + attributes)
+                                // has succeeded, so the parent never selects a half-saved person.
+                                if (newPersonId != null) {
+                                    entitySource.record(EntityType.PERSON, newPersonId.id, 1L)
+                                    onPersonCreated?.invoke(newPersonId)
                                 }
                                 onDismiss()
                             } catch (expected: Exception) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
@@ -13,23 +13,18 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.moneymanager.database.DatabaseConfig
 import com.moneymanager.domain.EntitySource
-import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.EntityType
 import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.PersonId
-import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.lighthousegames.logging.logging
 
@@ -39,7 +34,6 @@ private val logger = logging()
 fun EditPersonDialog(
     personToEdit: Person?,
     personRepository: PersonRepository,
-    personAttributeRepository: PersonAttributeRepository? = null,
     entitySource: EntitySource,
     onDismiss: () -> Unit,
     onPersonCreated: ((PersonId) -> Unit)? = null,
@@ -47,27 +41,9 @@ fun EditPersonDialog(
     var firstName by remember { mutableStateOf(personToEdit?.firstName.orEmpty()) }
     var middleName by remember { mutableStateOf(personToEdit?.middleName.orEmpty()) }
     var lastName by remember { mutableStateOf(personToEdit?.lastName.orEmpty()) }
-    var externalId by remember { mutableStateOf("") }
     val saveState = rememberDialogSaveState()
 
     val scope = rememberSchemaAwareCoroutineScope()
-
-    LaunchedEffect(personToEdit?.id) {
-        externalId =
-            if (personAttributeRepository != null) {
-                personToEdit
-                    ?.let { person ->
-                        personAttributeRepository
-                            .getByPerson(person.id)
-                            .first()
-                            .firstOrNull { it.attributeType.id.id == DatabaseConfig.PERSON_EXTERNAL_ID_ATTR_TYPE_ID }
-                            ?.value
-                            .orEmpty()
-                    }.orEmpty()
-            } else {
-                ""
-            }
-    }
 
     AlertDialog(
         onDismissRequest = { if (!saveState.isSaving) onDismiss() },
@@ -107,17 +83,6 @@ fun EditPersonDialog(
                     enabled = !saveState.isSaving,
                 )
 
-                if (personAttributeRepository != null) {
-                    OutlinedTextField(
-                        value = externalId,
-                        onValueChange = { externalId = it },
-                        label = { Text("External ID") },
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                        enabled = !saveState.isSaving,
-                    )
-                }
-
                 saveState.errorMessage?.let { error -> ErrorMessageText(error) }
             }
         },
@@ -131,7 +96,6 @@ fun EditPersonDialog(
                         saveState.errorMessage = null
                         scope.launch {
                             try {
-                                val resolvedExternalId = externalId.trim().ifBlank { null }
                                 if (personToEdit != null) {
                                     val updatedPerson =
                                         personToEdit.copy(
@@ -140,9 +104,6 @@ fun EditPersonDialog(
                                             lastName = lastName.trim().ifBlank { null },
                                         )
                                     personRepository.updatePerson(updatedPerson)
-                                    if (personAttributeRepository != null) {
-                                        upsertPersonExternalId(personToEdit.id, resolvedExternalId, personAttributeRepository)
-                                    }
                                 } else {
                                     val newPerson =
                                         Person(
@@ -152,9 +113,6 @@ fun EditPersonDialog(
                                             lastName = lastName.trim().ifBlank { null },
                                         )
                                     val personId = personRepository.createPerson(newPerson)
-                                    if (personAttributeRepository != null) {
-                                        upsertPersonExternalId(personId, resolvedExternalId, personAttributeRepository)
-                                    }
                                     // Record source for audit trail
                                     entitySource.record(EntityType.PERSON, personId.id, 1L)
                                     onPersonCreated?.invoke(personId)
@@ -190,33 +148,4 @@ fun EditPersonDialog(
             }
         },
     )
-}
-
-private suspend fun upsertPersonExternalId(
-    personId: PersonId,
-    externalId: String?,
-    personAttributeRepository: PersonAttributeRepository,
-) {
-    val attributeTypeId = AttributeTypeId(DatabaseConfig.PERSON_EXTERNAL_ID_ATTR_TYPE_ID)
-    val existingAttributes =
-        personAttributeRepository
-            .getByPerson(personId)
-            .first()
-            .filter { it.attributeType.id == attributeTypeId }
-
-    when {
-        externalId == null && existingAttributes.isNotEmpty() ->
-            existingAttributes.forEach { personAttributeRepository.delete(it.id) }
-        externalId != null && existingAttributes.isEmpty() ->
-            personAttributeRepository.insert(personId, attributeTypeId, externalId)
-        externalId != null && existingAttributes.size == 1 && existingAttributes.first().value != externalId ->
-            personAttributeRepository.updateValue(existingAttributes.first().id, externalId)
-        externalId != null && existingAttributes.size > 1 -> {
-            existingAttributes.drop(1).forEach { personAttributeRepository.delete(it.id) }
-            val first = existingAttributes.first()
-            if (first.value != externalId) {
-                personAttributeRepository.updateValue(first.id, externalId)
-            }
-        }
-    }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
@@ -214,7 +214,11 @@ private suspend fun savePersonAttributes(
     attributeTypeRepository: AttributeTypeRepository,
 ) {
     val keptIds = editableAttributes.keys.filter { it > 0 }.toSet()
-    originalAttributeList.map { it.id }.toSet().minus(keptIds).forEach { personAttributeRepository.delete(it) }
+    originalAttributeList
+        .map { it.id }
+        .toSet()
+        .minus(keptIds)
+        .forEach { personAttributeRepository.delete(it) }
 
     editableAttributes.filterKeys { it > 0 }.forEach { (id, pair) ->
         val typeName = pair.first.trim()

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
@@ -81,7 +81,7 @@ sealed class Screen(
         val strategyName: String,
     ) : Screen("API Strategy Audit: $strategyName")
 
-    data object MonzoConnect : Screen("Monzo Connection")
+    data object ConnectApi : Screen("Connect API Account")
 
     data class ApiSessionTraffic(
         val sessionId: ApiSessionId,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiConnectScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiConnectScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
@@ -179,8 +180,8 @@ fun ApiConnectScreen(
                     label = { Text("Access Token") },
                     placeholder = { Text("Paste your ${selectedStrategy?.name ?: "API"} access token here") },
                     modifier = Modifier.fillMaxWidth(),
-                    singleLine = false,
-                    maxLines = 4,
+                    singleLine = true,
+                    visualTransformation = PasswordVisualTransformation(),
                     isError = errorMessage != null,
                 )
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiConnectScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiConnectScreen.kt
@@ -139,6 +139,27 @@ fun ApiConnectScreen(
             }
         }
 
+        val instructions = connectInstructions(selectedStrategy)
+        if (instructions.isNotEmpty()) {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = "How to connect your ${selectedStrategy?.name} account",
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    instructions.forEachIndexed { index, step ->
+                        Text(text = "${index + 1}. $step", style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+            }
+        }
+
         Card(modifier = Modifier.fillMaxWidth()) {
             Column(
                 modifier =
@@ -217,12 +238,45 @@ fun ApiConnectScreen(
 }
 
 /** Convenience deep-link to a known provider's API-token page, derived from the strategy base URL. */
-private fun providerTokenPageUrl(strategy: ApiImportStrategy?): String? {
+private fun providerTokenPageUrl(strategy: ApiImportStrategy?): String? =
+    when (providerKind(strategy)) {
+        ProviderKind.MONZO -> "https://developers.monzo.com/"
+        ProviderKind.WISE -> "https://wise.com/your-account/integrations-and-tools/api-tokens"
+        null -> null
+    }
+
+/** Step-by-step instructions for obtaining an access token from a known provider. */
+private fun connectInstructions(strategy: ApiImportStrategy?): List<String> =
+    when (providerKind(strategy)) {
+        ProviderKind.MONZO ->
+            listOf(
+                "Open the Monzo Developer Playground in your browser.",
+                "Log in with your Monzo account credentials.",
+                "Monzo will send a magic link to your email or app. Approve the login.",
+                "Copy the access token shown on the playground page.",
+                "Paste the token below and tap \"Save Token\".",
+                "In the Monzo app, approve the API access notification so transactions can be read.",
+            )
+        ProviderKind.WISE ->
+            listOf(
+                "Open the Wise API tokens page in your browser and sign in.",
+                "Create a new API token (read access is sufficient) and copy it.",
+                "Paste the token below and tap \"Save Token\".",
+                "Statements are protected by Strong Customer Authentication: generate a signing key on the " +
+                    "credential and register its public key in Wise (Settings → API tokens → Manage public keys).",
+                "Note: retrieving statements via the API is only supported for accounts based in the US, Canada, " +
+                    "Australia, New Zealand, Singapore, and Malaysia.",
+            )
+        null -> emptyList()
+    }
+
+private enum class ProviderKind { MONZO, WISE }
+
+private fun providerKind(strategy: ApiImportStrategy?): ProviderKind? {
     val baseUrl = strategy?.baseUrl?.lowercase() ?: return null
     return when {
-        "monzo" in baseUrl -> "https://developers.monzo.com/"
-        "wise" in baseUrl || "transferwise" in baseUrl ->
-            "https://wise.com/your-account/integrations-and-tools/api-tokens"
+        "monzo" in baseUrl -> ProviderKind.MONZO
+        "wise" in baseUrl || "transferwise" in baseUrl -> ProviderKind.WISE
         else -> null
     }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiConnectScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiConnectScreen.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class)
+@file:OptIn(kotlin.time.ExperimentalTime::class, androidx.compose.material3.ExperimentalMaterial3Api::class)
 
 package com.moneymanager.ui.screens
 
@@ -15,10 +15,15 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -26,21 +31,43 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
+import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
+import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
+import com.moneymanager.domain.repository.ApiImportStrategyRepository
 import com.moneymanager.domain.repository.ApiSessionRepository
+import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 
-private const val MONZO_DEVELOPER_PORTAL_URL = "https://developers.monzo.com/"
-
+/**
+ * Generic "connect an API account" screen. Lists the available import strategies (Monzo, Wise, and
+ * any user-defined ones), lets the user pick one and paste a bearer token, then stores a credential
+ * linked to that strategy. No provider-specific behaviour lives here beyond an optional convenience
+ * link to a known provider's token page.
+ */
 @Composable
-fun MonzoAuthScreen(
+fun ApiConnectScreen(
     apiSessionRepository: ApiSessionRepository,
+    apiImportStrategyRepository: ApiImportStrategyRepository,
     onCredentialSaved: () -> Unit = {},
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
     val uriHandler = LocalUriHandler.current
 
+    val strategies by apiImportStrategyRepository
+        .getAllStrategies()
+        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+
+    var selectedStrategyId by remember { mutableStateOf<ApiImportStrategyId?>(null) }
+    LaunchedEffect(strategies) {
+        if (selectedStrategyId == null || strategies.none { it.id == selectedStrategyId }) {
+            selectedStrategyId = strategies.firstOrNull()?.id
+        }
+    }
+    val selectedStrategy = strategies.find { it.id == selectedStrategyId }
+
+    var strategyMenuExpanded by remember { mutableStateOf(false) }
     var tokenInput by remember { mutableStateOf("") }
     var isSaving by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
@@ -54,7 +81,7 @@ fun MonzoAuthScreen(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Text(
-            text = "Monzo Connection",
+            text = "Connect API Account",
             style = MaterialTheme.typography.headlineMedium,
         )
 
@@ -66,23 +93,48 @@ fun MonzoAuthScreen(
                         .padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                Text(
-                    text = "How to connect your Monzo account",
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(text = "1. Open the Monzo Developer Playground in your browser.", style = MaterialTheme.typography.bodyMedium)
-                Text(text = "2. Log in with your Monzo account credentials.", style = MaterialTheme.typography.bodyMedium)
-                Text(
-                    text = "3. Monzo will send a magic link to your email or app. Approve the login.",
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                Text(text = "4. Copy the access token shown on the playground page.", style = MaterialTheme.typography.bodyMedium)
-                Text(text = "5. Paste the token below and tap \"Save Token\".", style = MaterialTheme.typography.bodyMedium)
-                Button(
-                    onClick = { uriHandler.openUri(MONZO_DEVELOPER_PORTAL_URL) },
-                    modifier = Modifier.fillMaxWidth(),
+                Text(text = "Choose a provider", style = MaterialTheme.typography.titleMedium)
+
+                ExposedDropdownMenuBox(
+                    expanded = strategyMenuExpanded,
+                    onExpandedChange = { strategyMenuExpanded = it },
                 ) {
-                    Text("Open Monzo Developer Playground")
+                    OutlinedTextField(
+                        value = selectedStrategy?.name.orEmpty(),
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Provider") },
+                        placeholder = { Text("Select a provider") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = strategyMenuExpanded) },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+                        singleLine = true,
+                    )
+                    ExposedDropdownMenu(
+                        expanded = strategyMenuExpanded,
+                        onDismissRequest = { strategyMenuExpanded = false },
+                    ) {
+                        strategies.forEach { strategy ->
+                            DropdownMenuItem(
+                                text = { Text(strategy.name) },
+                                onClick = {
+                                    selectedStrategyId = strategy.id
+                                    strategyMenuExpanded = false
+                                },
+                            )
+                        }
+                    }
+                }
+
+                providerTokenPageUrl(selectedStrategy)?.let { url ->
+                    Button(
+                        onClick = { uriHandler.openUri(url) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text("Open ${selectedStrategy?.name} token page")
+                    }
                 }
             }
         }
@@ -104,7 +156,7 @@ fun MonzoAuthScreen(
                         errorMessage = null
                     },
                     label = { Text("Access Token") },
-                    placeholder = { Text("Paste your Monzo access token here") },
+                    placeholder = { Text("Paste your ${selectedStrategy?.name ?: "API"} access token here") },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = false,
                     maxLines = 4,
@@ -122,8 +174,13 @@ fun MonzoAuthScreen(
                 Button(
                     onClick = {
                         val trimmedToken = tokenInput.trim()
+                        val strategyId = selectedStrategyId
                         if (trimmedToken.isBlank()) {
                             errorMessage = "Token cannot be empty."
+                            return@Button
+                        }
+                        if (strategyId == null) {
+                            errorMessage = "Select a provider first."
                             return@Button
                         }
                         isSaving = true
@@ -133,6 +190,7 @@ fun MonzoAuthScreen(
                                 apiSessionRepository.createCredential(
                                     token = trimmedToken,
                                     createdAt = Clock.System.now(),
+                                    strategyId = strategyId,
                                 )
                                 onCredentialSaved()
                             } catch (expected: Exception) {
@@ -142,7 +200,7 @@ fun MonzoAuthScreen(
                             }
                         }
                     },
-                    enabled = !isSaving && tokenInput.isNotBlank(),
+                    enabled = !isSaving && tokenInput.isNotBlank() && selectedStrategyId != null,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     if (isSaving) {
@@ -155,5 +213,16 @@ fun MonzoAuthScreen(
         }
 
         Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+/** Convenience deep-link to a known provider's API-token page, derived from the strategy base URL. */
+private fun providerTokenPageUrl(strategy: ApiImportStrategy?): String? {
+    val baseUrl = strategy?.baseUrl?.lowercase() ?: return null
+    return when {
+        "monzo" in baseUrl -> "https://developers.monzo.com/"
+        "wise" in baseUrl || "transferwise" in baseUrl ->
+            "https://wise.com/your-account/integrations-and-tools/api-tokens"
+        else -> null
     }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -274,6 +274,7 @@ fun ApiSessionsScreen(
                             personRepository = personRepository,
                             personAccountOwnershipRepository = personAccountOwnershipRepository,
                             personAttributeRepository = personAttributeRepository,
+                            attributeTypeRepository = attributeTypeRepository,
                             entitySource = entitySource,
                             sessionId = session.id,
                             strategy = strategy,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -90,21 +90,21 @@ import com.moneymanager.ui.api.ApiTransactionsDownloadResult
 import com.moneymanager.ui.api.discoverApiCounterpartiesToCreate
 import com.moneymanager.ui.api.downloadApiSessionAccounts
 import com.moneymanager.ui.api.downloadApiSessionPeople
-import com.moneymanager.ui.api.importApiSessionPeople
 import com.moneymanager.ui.api.downloadApiSessionTransactions
+import com.moneymanager.ui.api.importApiSessionPeople
 import com.moneymanager.ui.api.importApiSessionTransactions
 import com.moneymanager.ui.api.sca.generateScaKeyPair
 import com.moneymanager.ui.api.sca.signScaChallenge
 import com.moneymanager.ui.background.LocalBackgroundTaskManager
 import com.moneymanager.ui.background.formatElapsedTime
-import com.moneymanager.ui.util.currentCountryCode
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.util.ContentCopyIcon
+import com.moneymanager.ui.util.currentCountryCode
 import com.moneymanager.ui.util.displayDateTime
 import com.moneymanager.ui.util.setPlainText
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -207,12 +207,13 @@ fun ApiSessionsScreen(
                 // session type which is always "Monzo".
                 val fallbackStrategy = allStrategies.firstOrNull()
                 strategyNameByCredential =
-                    allCredentials.mapNotNull { credential ->
-                        val name =
-                            credential.strategyId?.let { strategyById[it]?.name }
-                                ?: fallbackStrategy?.name
-                        name?.let { credential.id to it }
-                    }.toMap()
+                    allCredentials
+                        .mapNotNull { credential ->
+                            val name =
+                                credential.strategyId?.let { strategyById[it]?.name }
+                                    ?: fallbackStrategy?.name
+                            name?.let { credential.id to it }
+                        }.toMap()
                 requiresSigningByCredential =
                     allCredentials.associate { credential ->
                         val strategy = credential.strategyId?.let { strategyById[it] } ?: fallbackStrategy
@@ -225,19 +226,20 @@ fun ApiSessionsScreen(
                     }
                 val country = currentCountryCode()
                 transactionsBlockReasonByCredential =
-                    allCredentials.mapNotNull { credential ->
-                        val strategy = credential.strategyId?.let { strategyById[it] } ?: fallbackStrategy
-                        val countries = strategy?.signing?.statementCountries.orEmpty()
-                        if (countries.isNotEmpty() && (country == null || country !in countries)) {
-                            credential.id to
-                                "Transaction download isn't available for your region" +
-                                (country?.let { " ($it)" } ?: "") +
-                                ". ${strategy?.name ?: "This provider"} only supports statements for: " +
-                                countries.sorted().joinToString(", ") + "."
-                        } else {
-                            null
-                        }
-                    }.toMap()
+                    allCredentials
+                        .mapNotNull { credential ->
+                            val strategy = credential.strategyId?.let { strategyById[it] } ?: fallbackStrategy
+                            val countries = strategy?.signing?.statementCountries.orEmpty()
+                            if (countries.isNotEmpty() && (country == null || country !in countries)) {
+                                credential.id to
+                                    "Transaction download isn't available for your region" +
+                                    (country?.let { " ($it)" } ?: "") +
+                                    ". ${strategy?.name ?: "This provider"} only supports statements for: " +
+                                    countries.sorted().joinToString(", ") + "."
+                            } else {
+                                null
+                            }
+                        }.toMap()
                 importedSessionRevisions = apiSessionRepository.getImportedSessionRevisions()
             } finally {
                 isLoading = false
@@ -696,7 +698,9 @@ private fun SigningKeySection(
             Button(onClick = onGenerateSigningKey) { Text("Generate signing key") }
         } else {
             Text(
-                text = "Public key generated. Register it in your provider account (e.g. Wise → Settings → API tokens → Manage public keys).",
+                text =
+                    "Public key generated. Register it in your provider account " +
+                        "(e.g. Wise → Settings → API tokens → Manage public keys).",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -137,6 +137,7 @@ fun ApiSessionsScreen(
     var sessionsByCredential by remember { mutableStateOf<Map<MonzoCredentialId, List<ApiSession>>>(emptyMap()) }
     var importedSessionRevisions by remember { mutableStateOf<Set<ApiSessionImportRevision>>(emptySet()) }
     var currentStrategyRevisionByCredential by remember { mutableStateOf<Map<MonzoCredentialId, Long?>>(emptyMap()) }
+    var strategyNameByCredential by remember { mutableStateOf<Map<MonzoCredentialId, String>>(emptyMap()) }
     var isLoading by remember { mutableStateOf(true) }
     // Per-session import state
     var importResultBySession by remember { mutableStateOf<Map<ApiSessionId, ApiSessionImportResult>>(emptyMap()) }
@@ -175,6 +176,16 @@ fun ApiSessionsScreen(
                                 ?: fallbackStrategyRevision
                         )
                     }
+                // Label each credential by its linked strategy (the actual provider), not the legacy
+                // session type which is always "Monzo".
+                val fallbackStrategyName = allStrategies.firstOrNull()?.name
+                strategyNameByCredential =
+                    allCredentials.mapNotNull { credential ->
+                        val name =
+                            credential.strategyId?.let { strategyById[it]?.name }
+                                ?: fallbackStrategyName
+                        name?.let { credential.id to it }
+                    }.toMap()
                 importedSessionRevisions = apiSessionRepository.getImportedSessionRevisions()
             } finally {
                 isLoading = false
@@ -284,6 +295,7 @@ fun ApiSessionsScreen(
                             val isDownloadingTransactions = backgroundTasks.isRunning(monzoTransactionsDownloadTaskKey(credential.id))
                             CredentialCard(
                                 credential = credential,
+                                providerLabel = strategyNameByCredential[credential.id],
                                 sessions = credentialSessions,
                                 isDownloadingAccounts = isDownloadingAccounts,
                                 isDownloadingTransactions = isDownloadingTransactions,
@@ -537,6 +549,7 @@ private fun CounterpartyConfirmationDialog(
 @Composable
 private fun CredentialCard(
     credential: MonzoCredential,
+    providerLabel: String?,
     sessions: List<ApiSession>,
     isDownloadingAccounts: Boolean,
     isDownloadingTransactions: Boolean,
@@ -568,9 +581,12 @@ private fun CredentialCard(
             Text(
                 text =
                     "Credential · " +
-                        credential.type.name
-                            .lowercase()
-                            .replaceFirstChar { it.uppercase() },
+                        (
+                            providerLabel
+                                ?: credential.type.name
+                                    .lowercase()
+                                    .replaceFirstChar { it.uppercase() }
+                        ),
                 style = MaterialTheme.typography.titleMedium,
             )
             Text(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -88,7 +88,10 @@ import com.moneymanager.ui.api.ApiSessionImportResult
 import com.moneymanager.ui.api.ApiTransactionsDownloadProgress
 import com.moneymanager.ui.api.ApiTransactionsDownloadResult
 import com.moneymanager.ui.api.discoverApiCounterpartiesToCreate
+import com.moneymanager.ui.api.ApiPeopleDownloadResult
 import com.moneymanager.ui.api.downloadApiSessionAccounts
+import com.moneymanager.ui.api.downloadApiSessionPeople
+import com.moneymanager.ui.api.importApiSessionPeople
 import com.moneymanager.ui.api.downloadApiSessionTransactions
 import com.moneymanager.ui.api.importApiSessionTransactions
 import com.moneymanager.ui.api.sca.generateScaKeyPair
@@ -146,6 +149,7 @@ fun ApiSessionsScreen(
     var strategyNameByCredential by remember { mutableStateOf<Map<MonzoCredentialId, String>>(emptyMap()) }
     var requiresSigningByCredential by remember { mutableStateOf<Map<MonzoCredentialId, Boolean>>(emptyMap()) }
     var transactionsBlockReasonByCredential by remember { mutableStateOf<Map<MonzoCredentialId, String>>(emptyMap()) }
+    var peopleDownloadSupportedByCredential by remember { mutableStateOf<Map<MonzoCredentialId, Boolean>>(emptyMap()) }
     var isLoading by remember { mutableStateOf(true) }
     // Per-session import state
     var importResultBySession by remember { mutableStateOf<Map<ApiSessionId, ApiSessionImportResult>>(emptyMap()) }
@@ -215,6 +219,11 @@ fun ApiSessionsScreen(
                         val strategy = credential.strategyId?.let { strategyById[it] } ?: fallbackStrategy
                         credential.id to (strategy?.signing != null)
                     }
+                peopleDownloadSupportedByCredential =
+                    allCredentials.associate { credential ->
+                        val strategy = credential.strategyId?.let { strategyById[it] } ?: fallbackStrategy
+                        credential.id to (strategy?.peopleDownload != null)
+                    }
                 val country = currentCountryCode()
                 transactionsBlockReasonByCredential =
                     allCredentials.mapNotNull { credential ->
@@ -244,10 +253,10 @@ fun ApiSessionsScreen(
         counterpartyAccountNames: Map<String, String>,
     ) {
         val importLabel =
-            if (session.kind == ApiSessionKind.ACCOUNTS) {
-                "Import Accounts"
-            } else {
-                "Import Transactions"
+            when (session.kind) {
+                ApiSessionKind.ACCOUNTS -> "Import Accounts"
+                ApiSessionKind.PEOPLE -> "Import People"
+                else -> "Import Transactions"
             }
         backgroundTasks.startTask(
             key = monzoImportTaskKey(session.id),
@@ -256,29 +265,46 @@ fun ApiSessionsScreen(
         ) {
             val importStartedAt = System.currentTimeMillis()
             val result =
-                importApiSessionTransactions(
-                    apiSessionRepository = apiSessionRepository,
-                    accountRepository = accountRepository,
-                    currencyRepository = currencyRepository,
-                    transactionRepository = transactionRepository,
-                    entitySource = entitySource,
-                    personRepository = personRepository,
-                    personAccountOwnershipRepository = personAccountOwnershipRepository,
-                    personAttributeRepository = personAttributeRepository,
-                    attributeTypeRepository = attributeTypeRepository,
-                    accountAttributeRepository = accountAttributeRepository,
-                    deviceId = deviceId,
-                    sessionId = session.id,
-                    accountsSessionId = accountsSession?.id,
-                    strategy = strategy,
-                    counterpartyAccountNames = counterpartyAccountNames,
-                    onProgress = { progress ->
-                        scope.launch {
-                            importProgressBySession = importProgressBySession + (session.id to progress)
-                        }
-                        update(progress.detail, progress.progress)
-                    },
-                )
+                if (session.kind == ApiSessionKind.PEOPLE) {
+                    val peopleResult =
+                        importApiSessionPeople(
+                            apiSessionRepository = apiSessionRepository,
+                            accountRepository = accountRepository,
+                            accountAttributeRepository = accountAttributeRepository,
+                            personRepository = personRepository,
+                            personAccountOwnershipRepository = personAccountOwnershipRepository,
+                            personAttributeRepository = personAttributeRepository,
+                            entitySource = entitySource,
+                            sessionId = session.id,
+                            strategy = strategy,
+                            accountsSessionId = accountsSession?.id,
+                        )
+                    ApiSessionImportResult(accountCount = 0, transactionCount = 0, personCount = peopleResult.personCount)
+                } else {
+                    importApiSessionTransactions(
+                        apiSessionRepository = apiSessionRepository,
+                        accountRepository = accountRepository,
+                        currencyRepository = currencyRepository,
+                        transactionRepository = transactionRepository,
+                        entitySource = entitySource,
+                        personRepository = personRepository,
+                        personAccountOwnershipRepository = personAccountOwnershipRepository,
+                        personAttributeRepository = personAttributeRepository,
+                        attributeTypeRepository = attributeTypeRepository,
+                        accountAttributeRepository = accountAttributeRepository,
+                        deviceId = deviceId,
+                        sessionId = session.id,
+                        accountsSessionId = accountsSession?.id,
+                        strategy = strategy,
+                        counterpartyAccountNames = counterpartyAccountNames,
+                        onProgress = { progress ->
+                            scope.launch {
+                                importProgressBySession = importProgressBySession + (session.id to progress)
+                            }
+                            update(progress.detail, progress.progress)
+                        },
+                    )
+                }
             val importDurationMillis = System.currentTimeMillis() - importStartedAt
             apiSessionRepository.markSessionImported(
                 id = session.id,
@@ -337,11 +363,14 @@ fun ApiSessionsScreen(
                             val credentialSessions = sessionsByCredential[credential.id].orEmpty()
                             val isDownloadingAccounts = backgroundTasks.isRunning(monzoAccountsDownloadTaskKey(credential.id))
                             val isDownloadingTransactions = backgroundTasks.isRunning(monzoTransactionsDownloadTaskKey(credential.id))
+                            val isDownloadingPeople = backgroundTasks.isRunning(monzoPeopleDownloadTaskKey(credential.id))
                             CredentialCard(
                                 credential = credential,
                                 providerLabel = strategyNameByCredential[credential.id],
                                 requiresSigning = requiresSigningByCredential[credential.id] == true,
                                 transactionsBlockReason = transactionsBlockReasonByCredential[credential.id],
+                                peopleDownloadSupported = peopleDownloadSupportedByCredential[credential.id] == true,
+                                isDownloadingPeople = isDownloadingPeople,
                                 onGenerateSigningKey = {
                                     scope.launch {
                                         val keyPair = withContext(Dispatchers.Default) { generateScaKeyPair() }
@@ -405,6 +434,46 @@ fun ApiSessionsScreen(
                                             accountsDownloadResultByCredential =
                                                 accountsDownloadResultByCredential + (credential.id to result)
                                             result.displaySummary()
+                                        }
+                                    }
+                                },
+                                onDownloadPeople = {
+                                    scope.launch {
+                                        val strategy = resolveStrategy(credential) ?: return@launch
+                                        val newSessionId =
+                                            apiSessionRepository.createSession(
+                                                token = credential.token,
+                                                deviceId = deviceId,
+                                                createdAt = Clock.System.now(),
+                                                expiresAt = null,
+                                                credentialId = credential.id,
+                                                kind = ApiSessionKind.PEOPLE,
+                                            )
+                                        refresh()
+                                        backgroundTasks.startTask(
+                                            key = monzoPeopleDownloadTaskKey(credential.id),
+                                            title = "Download People",
+                                            initialDetail = "Starting people download for session #$newSessionId.",
+                                        ) {
+                                            val result =
+                                                downloadApiSessionPeople(
+                                                    token = credential.token,
+                                                    apiClient =
+                                                        createApiClient(
+                                                            trafficRecorder =
+                                                                ApiSessionTrafficRecorder(
+                                                                    sessionId = newSessionId,
+                                                                    apiSessionRepository = apiSessionRepository,
+                                                                ),
+                                                            engine = null,
+                                                        ),
+                                                    apiSessionRepository = apiSessionRepository,
+                                                    sessionId = newSessionId,
+                                                    strategy = strategy,
+                                                    sca = scaParamsFor(strategy, credential),
+                                                )
+                                            refresh()
+                                            "Downloaded ${result.personCount} ${if (result.personCount == 1) "person" else "people"}."
                                         }
                                     }
                                 },
@@ -649,8 +718,11 @@ private fun CredentialCard(
     providerLabel: String?,
     requiresSigning: Boolean,
     transactionsBlockReason: String?,
+    peopleDownloadSupported: Boolean,
+    isDownloadingPeople: Boolean,
     onGenerateSigningKey: () -> Unit,
     onCopyText: (String) -> Unit,
+    onDownloadPeople: () -> Unit,
     sessions: List<ApiSession>,
     isDownloadingAccounts: Boolean,
     isDownloadingTransactions: Boolean,
@@ -675,7 +747,7 @@ private fun CredentialCard(
         } else {
             credential.token
         }
-    val isCredentialBusy = isDownloadingAccounts || isDownloadingTransactions
+    val isCredentialBusy = isDownloadingAccounts || isDownloadingTransactions || isDownloadingPeople
 
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -764,6 +836,19 @@ private fun CredentialCard(
                     color = MaterialTheme.colorScheme.error,
                 )
             }
+            if (peopleDownloadSupported) {
+                OutlinedButton(
+                    onClick = onDownloadPeople,
+                    enabled = !isCredentialBusy,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    if (isDownloadingPeople) {
+                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                    } else {
+                        Text("Download People")
+                    }
+                }
+            }
 
             if (sessions.isNotEmpty()) {
                 HorizontalDivider()
@@ -827,6 +912,7 @@ private fun SessionRow(
                 when (session.kind) {
                     ApiSessionKind.ACCOUNTS -> "Accounts session"
                     ApiSessionKind.TRANSACTIONS -> "Transactions session"
+                    ApiSessionKind.PEOPLE -> "People session"
                     null -> "Session"
                 }
             Text(text = kindLabel, style = MaterialTheme.typography.labelLarge)
@@ -861,6 +947,7 @@ private fun SessionRow(
                 when (session.kind) {
                     ApiSessionKind.ACCOUNTS -> "Importing accounts..."
                     ApiSessionKind.TRANSACTIONS -> "Importing transactions..."
+                    ApiSessionKind.PEOPLE -> "Importing people..."
                     null -> "Importing..."
                 }
             Text(text = importLabel, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
@@ -891,6 +978,7 @@ private fun SessionRow(
                 when (session.kind) {
                     ApiSessionKind.ACCOUNTS -> "Import Accounts"
                     ApiSessionKind.TRANSACTIONS -> "Import Transactions"
+                    ApiSessionKind.PEOPLE -> "Import People"
                     null -> "Import Transactions"
                 }
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -1712,6 +1800,8 @@ private fun monzoAccountsDownloadTaskKey(credentialId: MonzoCredentialId): Strin
 
 private fun monzoTransactionsDownloadTaskKey(credentialId: MonzoCredentialId): String =
     "monzo-transactions-download-cred-${credentialId.id}"
+
+private fun monzoPeopleDownloadTaskKey(credentialId: MonzoCredentialId): String = "monzo-people-download-cred-${credentialId.id}"
 
 private fun monzoImportTaskKey(sessionId: ApiSessionId): String = "monzo-import-${sessionId.id}"
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -88,7 +88,6 @@ import com.moneymanager.ui.api.ApiSessionImportResult
 import com.moneymanager.ui.api.ApiTransactionsDownloadProgress
 import com.moneymanager.ui.api.ApiTransactionsDownloadResult
 import com.moneymanager.ui.api.discoverApiCounterpartiesToCreate
-import com.moneymanager.ui.api.ApiPeopleDownloadResult
 import com.moneymanager.ui.api.downloadApiSessionAccounts
 import com.moneymanager.ui.api.downloadApiSessionPeople
 import com.moneymanager.ui.api.importApiSessionPeople

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -95,6 +95,7 @@ import com.moneymanager.ui.api.sca.generateScaKeyPair
 import com.moneymanager.ui.api.sca.signScaChallenge
 import com.moneymanager.ui.background.LocalBackgroundTaskManager
 import com.moneymanager.ui.background.formatElapsedTime
+import com.moneymanager.ui.util.currentCountryCode
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.util.ContentCopyIcon
 import com.moneymanager.ui.util.displayDateTime
@@ -144,6 +145,7 @@ fun ApiSessionsScreen(
     var currentStrategyRevisionByCredential by remember { mutableStateOf<Map<MonzoCredentialId, Long?>>(emptyMap()) }
     var strategyNameByCredential by remember { mutableStateOf<Map<MonzoCredentialId, String>>(emptyMap()) }
     var requiresSigningByCredential by remember { mutableStateOf<Map<MonzoCredentialId, Boolean>>(emptyMap()) }
+    var transactionsBlockReasonByCredential by remember { mutableStateOf<Map<MonzoCredentialId, String>>(emptyMap()) }
     var isLoading by remember { mutableStateOf(true) }
     // Per-session import state
     var importResultBySession by remember { mutableStateOf<Map<ApiSessionId, ApiSessionImportResult>>(emptyMap()) }
@@ -213,6 +215,21 @@ fun ApiSessionsScreen(
                         val strategy = credential.strategyId?.let { strategyById[it] } ?: fallbackStrategy
                         credential.id to (strategy?.signing != null)
                     }
+                val country = currentCountryCode()
+                transactionsBlockReasonByCredential =
+                    allCredentials.mapNotNull { credential ->
+                        val strategy = credential.strategyId?.let { strategyById[it] } ?: fallbackStrategy
+                        val countries = strategy?.signing?.statementCountries.orEmpty()
+                        if (countries.isNotEmpty() && (country == null || country !in countries)) {
+                            credential.id to
+                                "Transaction download isn't available for your region" +
+                                (country?.let { " ($it)" } ?: "") +
+                                ". ${strategy?.name ?: "This provider"} only supports statements for: " +
+                                countries.sorted().joinToString(", ") + "."
+                        } else {
+                            null
+                        }
+                    }.toMap()
                 importedSessionRevisions = apiSessionRepository.getImportedSessionRevisions()
             } finally {
                 isLoading = false
@@ -324,6 +341,7 @@ fun ApiSessionsScreen(
                                 credential = credential,
                                 providerLabel = strategyNameByCredential[credential.id],
                                 requiresSigning = requiresSigningByCredential[credential.id] == true,
+                                transactionsBlockReason = transactionsBlockReasonByCredential[credential.id],
                                 onGenerateSigningKey = {
                                     scope.launch {
                                         val keyPair = withContext(Dispatchers.Default) { generateScaKeyPair() }
@@ -630,6 +648,7 @@ private fun CredentialCard(
     credential: MonzoCredential,
     providerLabel: String?,
     requiresSigning: Boolean,
+    transactionsBlockReason: String?,
     onGenerateSigningKey: () -> Unit,
     onCopyText: (String) -> Unit,
     sessions: List<ApiSession>,
@@ -726,13 +745,24 @@ private fun CredentialCard(
                         Text("Download Accounts")
                     }
                 }
-                Button(onClick = onDownloadTransactions, enabled = !isCredentialBusy, modifier = Modifier.weight(1f)) {
+                Button(
+                    onClick = onDownloadTransactions,
+                    enabled = !isCredentialBusy && transactionsBlockReason == null,
+                    modifier = Modifier.weight(1f),
+                ) {
                     if (isDownloadingTransactions) {
                         CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
                     } else {
                         Text("Download Transactions")
                     }
                 }
+            }
+            transactionsBlockReason?.let { reason ->
+                Text(
+                    text = reason,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
             }
 
             if (sessions.isNotEmpty()) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -164,7 +164,7 @@ fun ApiSessionsScreen(
     suspend fun resolveStrategy(credential: MonzoCredential): ApiImportStrategy? =
         credential.strategyId
             ?.let { apiImportStrategyRepository.getStrategyById(it).first() }
-            ?: apiImportStrategyRepository.getAllStrategies().first().firstOrNull()
+            ?: legacyDefaultStrategy(apiImportStrategyRepository.getAllStrategies().first())
 
     // Builds the SCA request-signing params when the strategy is SCA-protected and the credential
     // has a signing key (e.g. Wise statements). Null disables signing (e.g. Monzo).
@@ -194,7 +194,11 @@ fun ApiSessionsScreen(
                         .groupBy { it.credentialId!! }
                 val allStrategies = apiImportStrategyRepository.getAllStrategies().first()
                 val strategyById = allStrategies.associateBy { it.id }
-                val fallbackStrategyRevision = allStrategies.firstOrNull()?.revisionId
+                // Credentials created before strategy linking are, by definition, Monzo. Resolve them
+                // to the Monzo strategy by name rather than relying on repository ordering, which can
+                // change once additional providers (e.g. Wise) are seeded.
+                val fallbackStrategy = legacyDefaultStrategy(allStrategies)
+                val fallbackStrategyRevision = fallbackStrategy?.revisionId
                 currentStrategyRevisionByCredential =
                     allCredentials.associate { credential ->
                         credential.id to (
@@ -205,7 +209,6 @@ fun ApiSessionsScreen(
                     }
                 // Label each credential by its linked strategy (the actual provider), not the legacy
                 // session type which is always "Monzo".
-                val fallbackStrategy = allStrategies.firstOrNull()
                 strategyNameByCredential =
                     allCredentials
                         .mapNotNull { credential ->
@@ -1801,6 +1804,17 @@ private fun ApiSessionImportResult.displaySummary(): String =
         }
         append(".")
     }
+
+/** Legacy provider name for credentials created before strategy linking existed. */
+private const val LEGACY_DEFAULT_STRATEGY_NAME = "Monzo"
+
+/**
+ * Resolves the strategy for credentials with no linked [MonzoCredential.strategyId]. These predate
+ * strategy linking and are always Monzo, so match by name rather than relying on repository ordering,
+ * which is not stable once additional providers are seeded.
+ */
+private fun legacyDefaultStrategy(strategies: List<ApiImportStrategy>): ApiImportStrategy? =
+    strategies.firstOrNull { it.name == LEGACY_DEFAULT_STRATEGY_NAME }
 
 private fun monzoAccountsDownloadTaskKey(credentialId: MonzoCredentialId): String = "monzo-accounts-download-cred-${credentialId.id}"
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -530,8 +530,10 @@ fun ApiSessionsScreen(
                                 onImport = { session ->
                                     importResultBySession = importResultBySession - session.id
                                     importErrorBySession = importErrorBySession - session.id
+                                    // Transactions and People imports both correlate against the
+                                    // accounts session (to attach transactions / link owners to accounts).
                                     val accountsSession =
-                                        if (session.kind == ApiSessionKind.TRANSACTIONS) {
+                                        if (session.kind == ApiSessionKind.TRANSACTIONS || session.kind == ApiSessionKind.PEOPLE) {
                                             credentialSessions.firstOrNull { it.kind == ApiSessionKind.ACCOUNTS }
                                         } else {
                                             null

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -79,6 +79,7 @@ import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.TransactionRepository
 import com.moneymanager.rest.ApiSessionTrafficRecorder
+import com.moneymanager.rest.ScaParams
 import com.moneymanager.rest.createApiClient
 import com.moneymanager.ui.api.ApiAccountsDownloadResult
 import com.moneymanager.ui.api.ApiCounterpartySuggestion
@@ -90,6 +91,8 @@ import com.moneymanager.ui.api.discoverApiCounterpartiesToCreate
 import com.moneymanager.ui.api.downloadApiSessionAccounts
 import com.moneymanager.ui.api.downloadApiSessionTransactions
 import com.moneymanager.ui.api.importApiSessionTransactions
+import com.moneymanager.ui.api.sca.generateScaKeyPair
+import com.moneymanager.ui.api.sca.signScaChallenge
 import com.moneymanager.ui.background.LocalBackgroundTaskManager
 import com.moneymanager.ui.background.formatElapsedTime
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -98,7 +101,9 @@ import com.moneymanager.ui.util.displayDateTime
 import com.moneymanager.ui.util.setPlainText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -138,6 +143,7 @@ fun ApiSessionsScreen(
     var importedSessionRevisions by remember { mutableStateOf<Set<ApiSessionImportRevision>>(emptySet()) }
     var currentStrategyRevisionByCredential by remember { mutableStateOf<Map<MonzoCredentialId, Long?>>(emptyMap()) }
     var strategyNameByCredential by remember { mutableStateOf<Map<MonzoCredentialId, String>>(emptyMap()) }
+    var requiresSigningByCredential by remember { mutableStateOf<Map<MonzoCredentialId, Boolean>>(emptyMap()) }
     var isLoading by remember { mutableStateOf(true) }
     // Per-session import state
     var importResultBySession by remember { mutableStateOf<Map<ApiSessionId, ApiSessionImportResult>>(emptyMap()) }
@@ -154,6 +160,22 @@ fun ApiSessionsScreen(
         credential.strategyId
             ?.let { apiImportStrategyRepository.getStrategyById(it).first() }
             ?: apiImportStrategyRepository.getAllStrategies().first().firstOrNull()
+
+    // Builds the SCA request-signing params when the strategy is SCA-protected and the credential
+    // has a signing key (e.g. Wise statements). Null disables signing (e.g. Monzo).
+    fun scaParamsFor(
+        strategy: ApiImportStrategy,
+        credential: MonzoCredential,
+    ): ScaParams? {
+        val signing = strategy.signing ?: return null
+        val privateKey = credential.privateKey ?: return null
+        return ScaParams(
+            challengeHeader = signing.challengeHeader,
+            signatureHeader = signing.signatureHeader,
+            triggerStatus = signing.triggerStatus,
+            sign = { oneTimeToken -> signScaChallenge(privateKey, oneTimeToken) },
+        )
+    }
 
     fun refresh() {
         scope.launch {
@@ -178,14 +200,19 @@ fun ApiSessionsScreen(
                     }
                 // Label each credential by its linked strategy (the actual provider), not the legacy
                 // session type which is always "Monzo".
-                val fallbackStrategyName = allStrategies.firstOrNull()?.name
+                val fallbackStrategy = allStrategies.firstOrNull()
                 strategyNameByCredential =
                     allCredentials.mapNotNull { credential ->
                         val name =
                             credential.strategyId?.let { strategyById[it]?.name }
-                                ?: fallbackStrategyName
+                                ?: fallbackStrategy?.name
                         name?.let { credential.id to it }
                     }.toMap()
+                requiresSigningByCredential =
+                    allCredentials.associate { credential ->
+                        val strategy = credential.strategyId?.let { strategyById[it] } ?: fallbackStrategy
+                        credential.id to (strategy?.signing != null)
+                    }
                 importedSessionRevisions = apiSessionRepository.getImportedSessionRevisions()
             } finally {
                 isLoading = false
@@ -296,6 +323,19 @@ fun ApiSessionsScreen(
                             CredentialCard(
                                 credential = credential,
                                 providerLabel = strategyNameByCredential[credential.id],
+                                requiresSigning = requiresSigningByCredential[credential.id] == true,
+                                onGenerateSigningKey = {
+                                    scope.launch {
+                                        val keyPair = withContext(Dispatchers.Default) { generateScaKeyPair() }
+                                        apiSessionRepository.updateCredentialKeys(
+                                            credentialId = credential.id,
+                                            privateKey = keyPair.privateKeyPem,
+                                            publicKey = keyPair.publicKeyPem,
+                                        )
+                                        refresh()
+                                    }
+                                },
+                                onCopyText = { text -> scope.launch { clipboard.setPlainText(text) } },
                                 sessions = credentialSessions,
                                 isDownloadingAccounts = isDownloadingAccounts,
                                 isDownloadingTransactions = isDownloadingTransactions,
@@ -342,6 +382,7 @@ fun ApiSessionsScreen(
                                                     apiSessionRepository = apiSessionRepository,
                                                     sessionId = newSessionId,
                                                     strategy = strategy,
+                                                    sca = scaParamsFor(strategy, credential),
                                                 )
                                             accountsDownloadResultByCredential =
                                                 accountsDownloadResultByCredential + (credential.id to result)
@@ -386,6 +427,7 @@ fun ApiSessionsScreen(
                                                     sessionId = newSessionId,
                                                     strategy = strategy,
                                                     accountsSessionId = accountsSession?.id,
+                                                    sca = scaParamsFor(strategy, credential),
                                                     onProgress = { progress ->
                                                         downloadProgressByCredential =
                                                             downloadProgressByCredential + (credential.id to progress)
@@ -547,9 +589,49 @@ private fun CounterpartyConfirmationDialog(
 }
 
 @Composable
+private fun SigningKeySection(
+    publicKey: String?,
+    onGenerateSigningKey: () -> Unit,
+    onCopyText: (String) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(text = "Request signing (SCA)", style = MaterialTheme.typography.labelLarge)
+        if (publicKey == null) {
+            Text(
+                text =
+                    "This provider protects statements with Strong Customer Authentication. Generate a " +
+                        "signing key, then register its public key in your provider account.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Button(onClick = onGenerateSigningKey) { Text("Generate signing key") }
+        } else {
+            Text(
+                text = "Public key generated. Register it in your provider account (e.g. Wise → Settings → API tokens → Manage public keys).",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = publicKey,
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(onClick = { onCopyText(publicKey) }) { Text("Copy public key") }
+                TextButton(onClick = onGenerateSigningKey) { Text("Regenerate") }
+            }
+        }
+    }
+}
+
+@Composable
 private fun CredentialCard(
     credential: MonzoCredential,
     providerLabel: String?,
+    requiresSigning: Boolean,
+    onGenerateSigningKey: () -> Unit,
+    onCopyText: (String) -> Unit,
     sessions: List<ApiSession>,
     isDownloadingAccounts: Boolean,
     isDownloadingTransactions: Boolean,
@@ -599,6 +681,14 @@ private fun CredentialCard(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+
+            if (requiresSigning) {
+                SigningKeySection(
+                    publicKey = credential.publicKey,
+                    onGenerateSigningKey = onGenerateSigningKey,
+                    onCopyText = onCopyText,
+                )
+            }
 
             accountsDownloadResult?.let {
                 Text(text = it.displaySummary(), color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.bodySmall)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
@@ -42,6 +42,7 @@ import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.PersonAccountOwnership
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
+import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.ui.components.DeletePersonConfirmationDialog
@@ -53,6 +54,7 @@ fun PeopleScreen(
     personRepository: PersonRepository,
     personAttributeRepository: PersonAttributeRepository,
     personAccountOwnershipRepository: PersonAccountOwnershipRepository,
+    attributeTypeRepository: AttributeTypeRepository,
     entitySource: EntitySource,
     scrollToPersonId: PersonId? = null,
     onAuditClick: (Person) -> Unit = {},
@@ -137,6 +139,7 @@ fun PeopleScreen(
             entitySource = entitySource,
             onDismiss = { showCreateDialog = false },
             personAttributeRepository = personAttributeRepository,
+            attributeTypeRepository = attributeTypeRepository,
         )
     }
 
@@ -148,6 +151,7 @@ fun PeopleScreen(
             entitySource = entitySource,
             onDismiss = { personToEdit = null },
             personAttributeRepository = personAttributeRepository,
+            attributeTypeRepository = attributeTypeRepository,
         )
     }
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
@@ -41,8 +41,8 @@ import com.moneymanager.domain.EntitySource
 import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.PersonAccountOwnership
 import com.moneymanager.domain.model.PersonId
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.AttributeTypeRepository
+import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.ui.components.DeletePersonConfirmationDialog

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
@@ -134,7 +134,6 @@ fun PeopleScreen(
         EditPersonDialog(
             personToEdit = null,
             personRepository = personRepository,
-            personAttributeRepository = personAttributeRepository,
             entitySource = entitySource,
             onDismiss = { showCreateDialog = false },
         )
@@ -145,7 +144,6 @@ fun PeopleScreen(
         EditPersonDialog(
             personToEdit = currentPersonToEdit,
             personRepository = personRepository,
-            personAttributeRepository = personAttributeRepository,
             entitySource = entitySource,
             onDismiss = { personToEdit = null },
         )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
@@ -136,6 +136,7 @@ fun PeopleScreen(
             personRepository = personRepository,
             entitySource = entitySource,
             onDismiss = { showCreateDialog = false },
+            personAttributeRepository = personAttributeRepository,
         )
     }
 
@@ -146,6 +147,7 @@ fun PeopleScreen(
             personRepository = personRepository,
             entitySource = entitySource,
             onDismiss = { personToEdit = null },
+            personAttributeRepository = personAttributeRepository,
         )
     }
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiImportStrategyAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiImportStrategyAuditScreen.kt
@@ -10,6 +10,7 @@ import com.moneymanager.domain.model.AuditType
 import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
 import com.moneymanager.domain.model.apistrategy.ApiStrategyConfig
+import com.moneymanager.domain.model.apistrategy.PaginationMode
 import com.moneymanager.domain.repository.ApiImportStrategyRepository
 import com.moneymanager.domain.repository.AuditRepository
 import com.moneymanager.ui.audit.AuditDiffCard
@@ -225,10 +226,21 @@ private fun flattenEndpoint(
             }
     }
     endpoint.pagination?.let { pag ->
-        map["$prefix pagination limit param"] = pag.limitParam
-        map["$prefix pagination limit"] = pag.limitValue.toString()
-        map["$prefix pagination cursor param"] = pag.cursorParam
-        map["$prefix pagination cursor field"] = pag.cursorResponseField
+        map["$prefix pagination mode"] = pag.mode.name
+        when (pag.mode) {
+            PaginationMode.CURSOR -> {
+                map["$prefix pagination limit param"] = pag.limitParam
+                map["$prefix pagination limit"] = pag.limitValue.toString()
+                map["$prefix pagination cursor param"] = pag.cursorParam
+                map["$prefix pagination cursor field"] = pag.cursorResponseField
+            }
+            PaginationMode.DATE_WINDOW -> {
+                map["$prefix pagination start param"] = pag.startParam
+                map["$prefix pagination end param"] = pag.endParam
+                map["$prefix pagination window days"] = pag.windowDays.toString()
+                map["$prefix pagination lookback days"] = pag.lookbackDays.toString()
+            }
+        }
     }
 }
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
@@ -620,19 +620,20 @@ fun ApiStrategyEditDialog(
                     val originalPagination = strategy?.transactionsEndpoint?.pagination
                     val pagination =
                         when {
+                            // The toggle always wins: switching pagination off clears any config.
+                            !paginationEnabled -> null
                             // This dialog only exposes cursor-mode fields. For other modes (e.g. Wise's
                             // DATE_WINDOW) preserve the original config verbatim so saving doesn't
                             // silently downgrade it to cursor pagination and lose its settings.
                             originalPagination != null && originalPagination.mode != PaginationMode.CURSOR ->
                                 originalPagination
-                            paginationEnabled ->
+                            else ->
                                 ApiPaginationConfig(
                                     limitParam = paginationLimitParam,
                                     limitValue = paginationLimitValue.toIntOrNull() ?: 100,
                                     cursorParam = paginationCursorParam,
                                     cursorResponseField = paginationCursorField,
                                 )
-                            else -> null
                         }
                     val accountIdQueryParam =
                         if (transactionsAccountIdParam.isNotBlank()) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
@@ -88,7 +88,7 @@ fun ApiStrategyEditDialog(
         )
     }
 
-    // Pagination
+    // Pagination — this dialog edits before-cursor pagination only.
     var paginationEnabled by remember { mutableStateOf(strategy?.transactionsEndpoint?.pagination != null) }
     val defaultPagination = strategy?.transactionsEndpoint?.pagination ?: ApiPaginationConfig()
     var paginationLimitParam by remember { mutableStateOf(defaultPagination.limitParam) }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
@@ -52,6 +52,7 @@ import com.moneymanager.domain.model.apistrategy.ApiPaginationConfig
 import com.moneymanager.domain.model.apistrategy.ApiPeopleMappings
 import com.moneymanager.domain.model.apistrategy.ApiQueryParam
 import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
+import com.moneymanager.domain.model.apistrategy.PaginationMode
 import com.moneymanager.domain.repository.ApiSessionRepository
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
@@ -616,16 +617,22 @@ fun ApiStrategyEditDialog(
             TextButton(
                 onClick = {
                     val now = Clock.System.now()
+                    val originalPagination = strategy?.transactionsEndpoint?.pagination
                     val pagination =
-                        if (paginationEnabled) {
-                            ApiPaginationConfig(
-                                limitParam = paginationLimitParam,
-                                limitValue = paginationLimitValue.toIntOrNull() ?: 100,
-                                cursorParam = paginationCursorParam,
-                                cursorResponseField = paginationCursorField,
-                            )
-                        } else {
-                            null
+                        when {
+                            // This dialog only exposes cursor-mode fields. For other modes (e.g. Wise's
+                            // DATE_WINDOW) preserve the original config verbatim so saving doesn't
+                            // silently downgrade it to cursor pagination and lose its settings.
+                            originalPagination != null && originalPagination.mode != PaginationMode.CURSOR ->
+                                originalPagination
+                            paginationEnabled ->
+                                ApiPaginationConfig(
+                                    limitParam = paginationLimitParam,
+                                    limitValue = paginationLimitValue.toIntOrNull() ?: 100,
+                                    cursorParam = paginationCursorParam,
+                                    cursorResponseField = paginationCursorField,
+                                )
+                            else -> null
                         }
                     val accountIdQueryParam =
                         if (transactionsAccountIdParam.isNotBlank()) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/CurrentCountry.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/CurrentCountry.kt
@@ -1,0 +1,4 @@
+package com.moneymanager.ui.util
+
+/** The current device country as an ISO 3166-1 alpha-2 code (e.g. "GB"), or null if unknown. */
+expect fun currentCountryCode(): String?

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoBalanceFixtureE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoBalanceFixtureE2ETest.kt
@@ -118,7 +118,7 @@ class MonzoBalanceFixtureE2ETest : DbTest() {
                 repositories.apiImportStrategyRepository
                     .getAllStrategies()
                     .first()
-                    .first()
+                    .single { it.name == "Monzo" }
 
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
@@ -502,7 +502,7 @@ class MonzoImportE2ETest : DbTest() {
                 repositories.apiImportStrategyRepository
                     .getAllStrategies()
                     .first()
-                    .single()
+                    .single { it.name == "Monzo" }
 
             // WHEN — download then import
             downloadApiSessionAccounts(
@@ -692,7 +692,7 @@ class MonzoImportE2ETest : DbTest() {
                 repositories.apiImportStrategyRepository
                     .getAllStrategies()
                     .first()
-                    .single()
+                    .single { it.name == "Monzo" }
 
             downloadApiSessionAccounts(
                 token = "test-monzo-token",
@@ -783,7 +783,7 @@ class MonzoImportE2ETest : DbTest() {
                 repositories.apiImportStrategyRepository
                     .getAllStrategies()
                     .first()
-                    .single()
+                    .single { it.name == "Monzo" }
                     .let { strategy ->
                         strategy.copy(
                             transactionMappings =
@@ -876,7 +876,7 @@ class MonzoImportE2ETest : DbTest() {
                 repositories.apiImportStrategyRepository
                     .getAllStrategies()
                     .first()
-                    .single()
+                    .single { it.name == "Monzo" }
 
             downloadApiSessionAccounts(
                 token = "test-monzo-token",
@@ -967,7 +967,7 @@ class MonzoImportE2ETest : DbTest() {
                 repositories.apiImportStrategyRepository
                     .getAllStrategies()
                     .first()
-                    .single()
+                    .single { it.name == "Monzo" }
                     .let { strategy ->
                         strategy.copy(
                             transactionMappings =
@@ -1058,7 +1058,7 @@ class MonzoImportE2ETest : DbTest() {
                 repositories.apiImportStrategyRepository
                     .getAllStrategies()
                     .first()
-                    .single()
+                    .single { it.name == "Monzo" }
                     .let { strategy ->
                         strategy.copy(
                             transactionMappings =
@@ -1212,7 +1212,7 @@ class MonzoImportE2ETest : DbTest() {
                 repositories.apiImportStrategyRepository
                     .getAllStrategies()
                     .first()
-                    .single()
+                    .single { it.name == "Monzo" }
                     .let { strategy ->
                         strategy.copy(
                             transactionMappings =
@@ -1271,7 +1271,7 @@ class MonzoImportE2ETest : DbTest() {
                 repositories.apiImportStrategyRepository
                     .getAllStrategies()
                     .first()
-                    .single()
+                    .single { it.name == "Monzo" }
                     .let { strategy ->
                         strategy.copy(
                             transactionMappings =
@@ -1373,7 +1373,7 @@ class MonzoImportE2ETest : DbTest() {
                 repositories.apiImportStrategyRepository
                     .getAllStrategies()
                     .first()
-                    .single()
+                    .single { it.name == "Monzo" }
 
             suspend fun importAtmTransactions(
                 sessionToken: String,
@@ -1530,7 +1530,7 @@ class MonzoImportE2ETest : DbTest() {
                 repositories.apiImportStrategyRepository
                     .getAllStrategies()
                     .first()
-                    .single()
+                    .single { it.name == "Monzo" }
                     .let { baseStrategy ->
                         baseStrategy.copy(
                             transactionMappings =

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
@@ -839,7 +839,7 @@ class MonzoImportE2ETest : DbTest() {
         }
 
     @Test
-    fun `account owners with same external user id create one person with person-external-id attribute`() =
+    fun `account owners with same external user id create one person with monzo-external-id attribute`() =
         runTest {
             val deviceId =
                 repositories.deviceRepository.getOrCreateDevice(
@@ -918,7 +918,7 @@ class MonzoImportE2ETest : DbTest() {
                 repositories.personAttributeRepository
                     .getByPerson(allPeople.single().id)
                     .first()
-                    .single { it.attributeType.name == "person-external-id" }
+                    .single { it.attributeType.name == "monzo-external-id" }
             assertEquals("user_shared_001", personExternalIdAttr.value)
 
             val ownerships =
@@ -1109,7 +1109,7 @@ class MonzoImportE2ETest : DbTest() {
                     repositories.personAttributeRepository
                         .getByPerson(person.id)
                         .first()
-                        .any { it.attributeType.name == "person-external-id" && it.value == "anonuser_95515c2ea95c19a58aad7b" }
+                        .any { it.attributeType.name == "monzo-external-id" && it.value == "anonuser_95515c2ea95c19a58aad7b" }
                 }
             assertTrue(matchingPeople.isNotEmpty())
             val person = matchingPeople.first()
@@ -1118,8 +1118,8 @@ class MonzoImportE2ETest : DbTest() {
                 repositories.personAttributeRepository
                     .getByPerson(person.id)
                     .first()
-                    .singleOrNull { it.attributeType.name == "person-external-id" }
-                    ?: error("Expected person-external-id on imported person, but found none")
+                    .singleOrNull { it.attributeType.name == "monzo-external-id" }
+                    ?: error("Expected monzo-external-id on imported person, but found none")
             assertEquals("anonuser_95515c2ea95c19a58aad7b", personExternalId.value)
 
             val ownerships =

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
@@ -178,4 +178,73 @@ class WiseImportE2ETest : DbTest() {
 
             assertTrue(credit.amount.amount > 0 && debit.amount.amount > 0, "Stored magnitudes are positive")
         }
+
+    @Test
+    fun `importing an accounts-only session creates accounts without any transactions`() =
+        runTest {
+            val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+            val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+            val sessionId =
+                repositories.apiSessionRepository.createSession(
+                    token = "test-wise-token",
+                    deviceId = deviceId,
+                    createdAt = now,
+                    expiresAt = null,
+                )
+
+            // Only profiles + balances are served; statements are never requested for this session.
+            val mockEngine =
+                MockEngine { request ->
+                    val url = request.url.toString()
+                    val json =
+                        when {
+                            url.contains("/balances") -> BALANCES_JSON
+                            url.contains("/v1/profiles") -> PROFILES_JSON
+                            else -> error("Unexpected request: $url")
+                        }
+                    respond(content = json, status = HttpStatusCode.OK, headers = headersOf(HttpHeaders.ContentType, "application/json"))
+                }
+            val apiClient =
+                createApiClient(
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                    engine = mockEngine,
+                )
+            val strategy =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .single { it.name == "Wise" }
+
+            downloadApiSessionAccounts(
+                token = "test-wise-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+
+            val importResult =
+                importApiSessionTransactions(
+                    apiSessionRepository = repositories.apiSessionRepository,
+                    accountRepository = repositories.accountRepository,
+                    currencyRepository = repositories.currencyRepository,
+                    transactionRepository = repositories.transactionRepository,
+                    entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                    personRepository = repositories.personRepository,
+                    personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                    personAttributeRepository = repositories.personAttributeRepository,
+                    attributeTypeRepository = repositories.attributeTypeRepository,
+                    accountAttributeRepository = repositories.accountAttributeRepository,
+                    deviceId = deviceId,
+                    sessionId = sessionId,
+                    strategy = strategy,
+                )
+
+            assertEquals(0, importResult.transactionCount, "No transactions are downloaded for an accounts-only session")
+            val accounts = repositories.accountRepository.getAllAccounts().first()
+            assertNotNull(
+                accounts.singleOrNull { it.name == "Wise: GBP" },
+                "The Wise balance must be created as an account even with no owners and no transactions",
+            )
+        }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
@@ -1,0 +1,181 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.ui.wise
+
+import com.moneymanager.database.port.DbEntitySource
+import com.moneymanager.domain.model.DeviceInfo
+import com.moneymanager.rest.ApiSessionTrafficRecorder
+import com.moneymanager.rest.createApiClient
+import com.moneymanager.test.database.DbTest
+import com.moneymanager.ui.api.downloadApiSessionAccounts
+import com.moneymanager.ui.api.downloadApiSessionTransactions
+import com.moneymanager.ui.api.importApiSessionTransactions
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+/**
+ * End-to-end import against the built-in Wise strategy, exercising the parts of the generic engine
+ * that Monzo does not: a three-level hierarchy (profiles → balances → statement) with ids in the
+ * URL path, bare top-level JSON arrays, decimal amounts in nested objects, sign taken from a
+ * separate `type` field, and date-window pagination (which fetches the same statement across
+ * several windows — the importer must de-duplicate by referenceNumber).
+ */
+private const val PROFILE_ID = "111"
+private const val BALANCE_ID = "222"
+
+private val PROFILES_JSON =
+    """
+[
+  { "id": $PROFILE_ID, "type": "personal" }
+]
+    """.trimIndent()
+
+private val BALANCES_JSON =
+    """
+[
+  { "id": $BALANCE_ID, "currency": "GBP", "name": "GBP", "type": "STANDARD" }
+]
+    """.trimIndent()
+
+/**
+ *   tx1 – CREDIT (incoming) 500.00 GBP from "Alice Example"
+ *   tx2 – DEBIT  (outgoing) 12.34 GBP to merchant "Coffee Shop Ltd" (amount value already signed)
+ */
+private val STATEMENT_JSON =
+    """
+{
+  "transactions": [
+    {
+      "type": "CREDIT",
+      "date": "2024-06-02T14:30:00.000Z",
+      "amount": { "value": 500.00, "currency": "GBP" },
+      "totalFees": { "value": 0, "currency": "GBP" },
+      "details": { "type": "DEPOSIT", "description": "Received from Alice", "senderName": "Alice Example" },
+      "referenceNumber": "TRANSFER-1001"
+    },
+    {
+      "type": "DEBIT",
+      "date": "2024-06-03T09:15:00.000Z",
+      "amount": { "value": -12.34, "currency": "GBP" },
+      "totalFees": { "value": 0, "currency": "GBP" },
+      "details": { "type": "CARD", "description": "Coffee at shop", "merchant": { "name": "Coffee Shop Ltd" } },
+      "referenceNumber": "CARD-2002"
+    }
+  ]
+}
+    """.trimIndent()
+
+class WiseImportE2ETest : DbTest() {
+    @Test
+    fun `wise profiles balances and statements import into accounts and transactions`() =
+        runTest {
+            val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+            val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+            val sessionId =
+                repositories.apiSessionRepository.createSession(
+                    token = "test-wise-token",
+                    deviceId = deviceId,
+                    createdAt = now,
+                    expiresAt = null,
+                )
+
+            // Order matters: statement and balances paths both start with /v1/profiles.
+            val mockEngine =
+                MockEngine { request ->
+                    val url = request.url.toString()
+                    val json =
+                        when {
+                            url.contains("statement.json") -> STATEMENT_JSON
+                            url.contains("/balances") -> BALANCES_JSON
+                            url.contains("/v1/profiles") -> PROFILES_JSON
+                            else -> error("Unexpected request: $url")
+                        }
+                    respond(
+                        content = json,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+
+            val apiClient =
+                createApiClient(
+                    trafficRecorder =
+                        ApiSessionTrafficRecorder(
+                            sessionId = sessionId,
+                            apiSessionRepository = repositories.apiSessionRepository,
+                        ),
+                    engine = mockEngine,
+                )
+            val strategy =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .single { it.name == "Wise" }
+
+            downloadApiSessionAccounts(
+                token = "test-wise-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+            downloadApiSessionTransactions(
+                token = "test-wise-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+
+            val importResult =
+                importApiSessionTransactions(
+                    apiSessionRepository = repositories.apiSessionRepository,
+                    accountRepository = repositories.accountRepository,
+                    currencyRepository = repositories.currencyRepository,
+                    transactionRepository = repositories.transactionRepository,
+                    entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                    personRepository = repositories.personRepository,
+                    personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                    personAttributeRepository = repositories.personAttributeRepository,
+                    attributeTypeRepository = repositories.attributeTypeRepository,
+                    accountAttributeRepository = repositories.accountAttributeRepository,
+                    deviceId = deviceId,
+                    sessionId = sessionId,
+                    strategy = strategy,
+                )
+
+            // One balance => one own account; the two unique statement rows import once each even
+            // though date-window pagination replays them across several windows.
+            assertEquals(1, importResult.accountCount, "One Wise balance maps to one own account")
+            assertEquals(2, importResult.transactionCount, "Two unique statement rows should import once each")
+            assertEquals(0, importResult.errorCount, "Should have no import errors")
+
+            val accounts = repositories.accountRepository.getAllAccounts().first()
+            val ownAccount = accounts.single { it.name == "Wise: GBP" }
+            assertNotNull(accounts.singleOrNull { it.name == "Wise Counterparty: Alice Example" }, "credit counterparty account")
+            assertNotNull(accounts.singleOrNull { it.name == "Wise Counterparty: Coffee Shop Ltd" }, "debit merchant account")
+
+            val transfers = repositories.transactionRepository.getTransactionsByAccount(ownAccount.id).first()
+            assertEquals(2, transfers.size, "Own account should have exactly two transfers")
+
+            // CREDIT: 500.00 GBP incoming (target is our account); decimal -> 50000 minor units.
+            val credit = transfers.single { it.amount.amount == 50_000L }
+            assertEquals(ownAccount.id, credit.targetAccountId, "Credit should be incoming to the Wise account")
+
+            // DEBIT: 12.34 GBP outgoing (source is our account); decimal -> 1234 minor units.
+            val debit = transfers.single { it.amount.amount == 1_234L }
+            assertEquals(ownAccount.id, debit.sourceAccountId, "Debit should be outgoing from the Wise account")
+
+            assertTrue(credit.amount.amount > 0 && debit.amount.amount > 0, "Stored magnitudes are positive")
+        }
+}

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
@@ -11,8 +11,8 @@ import com.moneymanager.rest.createApiClient
 import com.moneymanager.test.database.DbTest
 import com.moneymanager.ui.api.downloadApiSessionAccounts
 import com.moneymanager.ui.api.downloadApiSessionPeople
-import com.moneymanager.ui.api.importApiSessionPeople
 import com.moneymanager.ui.api.downloadApiSessionTransactions
+import com.moneymanager.ui.api.importApiSessionPeople
 import com.moneymanager.ui.api.importApiSessionTransactions
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -210,7 +210,11 @@ class WiseImportE2ETest : DbTest() {
                 }
             val apiClient =
                 createApiClient(
-                    trafficRecorder = ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                    trafficRecorder =
+                        ApiSessionTrafficRecorder(
+                            sessionId = sessionId,
+                            apiSessionRepository = repositories.apiSessionRepository,
+                        ),
                     engine = mockEngine,
                 )
             val strategy =
@@ -277,14 +281,24 @@ class WiseImportE2ETest : DbTest() {
 
             fun clientFor(sessionId: com.moneymanager.domain.model.ApiSessionId) =
                 createApiClient(
-                    trafficRecorder = ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                    trafficRecorder =
+                        ApiSessionTrafficRecorder(
+                            sessionId = sessionId,
+                            apiSessionRepository = repositories.apiSessionRepository,
+                        ),
                     engine = engine(),
                 )
 
             // 1. Download + import accounts so the GBP balance exists as an account.
             val accountsSessionId =
                 repositories.apiSessionRepository.createSession("test-wise-token", deviceId, now, null)
-            downloadApiSessionAccounts("test-wise-token", clientFor(accountsSessionId), repositories.apiSessionRepository, accountsSessionId, strategy)
+            downloadApiSessionAccounts(
+                token = "test-wise-token",
+                apiClient = clientFor(accountsSessionId),
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = accountsSessionId,
+                strategy = strategy,
+            )
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 accountRepository = repositories.accountRepository,
@@ -305,7 +319,13 @@ class WiseImportE2ETest : DbTest() {
             val peopleSessionId =
                 repositories.apiSessionRepository.createSession("test-wise-token", deviceId, now, null)
             val downloadResult =
-                downloadApiSessionPeople("test-wise-token", clientFor(peopleSessionId), repositories.apiSessionRepository, peopleSessionId, strategy)
+                downloadApiSessionPeople(
+                    token = "test-wise-token",
+                    apiClient = clientFor(peopleSessionId),
+                    apiSessionRepository = repositories.apiSessionRepository,
+                    sessionId = peopleSessionId,
+                    strategy = strategy,
+                )
             assertEquals(1, downloadResult.personCount, "One profile holder downloaded")
 
             val importResult =
@@ -328,7 +348,11 @@ class WiseImportE2ETest : DbTest() {
             val people = repositories.personRepository.getAllPeople().first()
             val ada = people.single { it.firstName == "Ada" && it.lastName == "Lovelace" }
 
-            val gbpAccount = repositories.accountRepository.getAllAccounts().first().single { it.name == "Wise: GBP" }
+            val gbpAccount =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .single { it.name == "Wise: GBP" }
             val owners =
                 repositories.personAccountOwnershipRepository
                     .getOwnershipsByAccount(gbpAccount.id)
@@ -358,7 +382,11 @@ class WiseImportE2ETest : DbTest() {
             val peopleSessionId = repositories.apiSessionRepository.createSession("test-wise-token", deviceId, now, null)
             val client =
                 createApiClient(
-                    trafficRecorder = ApiSessionTrafficRecorder(sessionId = peopleSessionId, apiSessionRepository = repositories.apiSessionRepository),
+                    trafficRecorder =
+                        ApiSessionTrafficRecorder(
+                            sessionId = peopleSessionId,
+                            apiSessionRepository = repositories.apiSessionRepository,
+                        ),
                     engine =
                         MockEngine { _ ->
                             respond(PROFILES_JSON, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
@@ -379,7 +407,11 @@ class WiseImportE2ETest : DbTest() {
             )
 
             // No duplicate: matched the existing Ada by name and added the Wise id alongside the Monzo id.
-            val matches = repositories.personRepository.getAllPeople().first().filter { it.firstName == "Ada" && it.lastName == "Lovelace" }
+            val matches =
+                repositories.personRepository
+                    .getAllPeople()
+                    .first()
+                    .filter { it.firstName == "Ada" && it.lastName == "Lovelace" }
             assertEquals(1, matches.size, "Ada must be matched by name, not duplicated")
             val attributes =
                 repositories.personAttributeRepository

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
@@ -4,6 +4,8 @@ package com.moneymanager.ui.wise
 
 import com.moneymanager.database.port.DbEntitySource
 import com.moneymanager.domain.model.DeviceInfo
+import com.moneymanager.domain.model.Person
+import com.moneymanager.domain.model.PersonId
 import com.moneymanager.rest.ApiSessionTrafficRecorder
 import com.moneymanager.rest.createApiClient
 import com.moneymanager.test.database.DbTest
@@ -314,6 +316,7 @@ class WiseImportE2ETest : DbTest() {
                     personRepository = repositories.personRepository,
                     personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
                     personAttributeRepository = repositories.personAttributeRepository,
+                    attributeTypeRepository = repositories.attributeTypeRepository,
                     entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
                     sessionId = peopleSessionId,
                     strategy = strategy,
@@ -331,5 +334,60 @@ class WiseImportE2ETest : DbTest() {
                     .getOwnershipsByAccount(gbpAccount.id)
                     .first()
             assertTrue(owners.any { it.personId == ada.id }, "Ada should own the Wise GBP balance")
+        }
+
+    @Test
+    fun `wise people import matches an existing person by name and adds the wise external id`() =
+        runTest {
+            val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+            val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+            val strategy =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .single { it.name == "Wise" }
+
+            // Pre-create the person as if she had already been imported from Monzo.
+            val adaId =
+                repositories.personRepository.createPerson(
+                    Person(id = PersonId(0L), firstName = "Ada", middleName = null, lastName = "Lovelace"),
+                )
+            val monzoAttribute = repositories.attributeTypeRepository.getOrCreate("monzo-external-id")
+            repositories.personAttributeRepository.insert(adaId, monzoAttribute, "monzo-123")
+
+            val peopleSessionId = repositories.apiSessionRepository.createSession("test-wise-token", deviceId, now, null)
+            val client =
+                createApiClient(
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId = peopleSessionId, apiSessionRepository = repositories.apiSessionRepository),
+                    engine =
+                        MockEngine { _ ->
+                            respond(PROFILES_JSON, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+                        },
+                )
+            downloadApiSessionPeople("test-wise-token", client, repositories.apiSessionRepository, peopleSessionId, strategy)
+            importApiSessionPeople(
+                apiSessionRepository = repositories.apiSessionRepository,
+                accountRepository = repositories.accountRepository,
+                accountAttributeRepository = repositories.accountAttributeRepository,
+                personRepository = repositories.personRepository,
+                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                personAttributeRepository = repositories.personAttributeRepository,
+                attributeTypeRepository = repositories.attributeTypeRepository,
+                entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                sessionId = peopleSessionId,
+                strategy = strategy,
+                accountsSessionId = null,
+            )
+
+            // No duplicate: matched the existing Ada by name and added the Wise id alongside the Monzo id.
+            val matches = repositories.personRepository.getAllPeople().first().filter { it.firstName == "Ada" && it.lastName == "Lovelace" }
+            assertEquals(1, matches.size, "Ada must be matched by name, not duplicated")
+            val attributes =
+                repositories.personAttributeRepository
+                    .getByPerson(matches.single().id)
+                    .first()
+                    .associate { it.attributeType.name to it.value }
+            assertEquals("monzo-123", attributes["monzo-external-id"], "the Monzo id is preserved")
+            assertEquals(PROFILE_ID, attributes["wise-external-id"], "the Wise id is backfilled")
         }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
@@ -376,7 +376,6 @@ class WiseImportE2ETest : DbTest() {
                 entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
                 sessionId = peopleSessionId,
                 strategy = strategy,
-                accountsSessionId = null,
             )
 
             // No duplicate: matched the existing Ada by name and added the Wise id alongside the Monzo id.

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
@@ -8,6 +8,8 @@ import com.moneymanager.rest.ApiSessionTrafficRecorder
 import com.moneymanager.rest.createApiClient
 import com.moneymanager.test.database.DbTest
 import com.moneymanager.ui.api.downloadApiSessionAccounts
+import com.moneymanager.ui.api.downloadApiSessionPeople
+import com.moneymanager.ui.api.importApiSessionPeople
 import com.moneymanager.ui.api.downloadApiSessionTransactions
 import com.moneymanager.ui.api.importApiSessionTransactions
 import io.ktor.client.engine.mock.MockEngine
@@ -36,7 +38,7 @@ private const val BALANCE_ID = "222"
 private val PROFILES_JSON =
     """
 [
-  { "id": $PROFILE_ID, "type": "personal" }
+  { "id": $PROFILE_ID, "type": "personal", "details": { "firstName": "Ada", "lastName": "Lovelace" } }
 ]
     """.trimIndent()
 
@@ -246,5 +248,88 @@ class WiseImportE2ETest : DbTest() {
                 accounts.singleOrNull { it.name == "Wise: GBP" },
                 "The Wise balance must be created as an account even with no owners and no transactions",
             )
+        }
+
+    @Test
+    fun `download and import people creates the profile holder and links them to their accounts`() =
+        runTest {
+            val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+            val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+            val strategy =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .single { it.name == "Wise" }
+
+            fun engine() =
+                MockEngine { request ->
+                    val url = request.url.toString()
+                    val json =
+                        when {
+                            url.contains("/balances") -> BALANCES_JSON
+                            url.contains("/v1/profiles") -> PROFILES_JSON
+                            else -> error("Unexpected request: $url")
+                        }
+                    respond(content = json, status = HttpStatusCode.OK, headers = headersOf(HttpHeaders.ContentType, "application/json"))
+                }
+
+            fun clientFor(sessionId: com.moneymanager.domain.model.ApiSessionId) =
+                createApiClient(
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                    engine = engine(),
+                )
+
+            // 1. Download + import accounts so the GBP balance exists as an account.
+            val accountsSessionId =
+                repositories.apiSessionRepository.createSession("test-wise-token", deviceId, now, null)
+            downloadApiSessionAccounts("test-wise-token", clientFor(accountsSessionId), repositories.apiSessionRepository, accountsSessionId, strategy)
+            importApiSessionTransactions(
+                apiSessionRepository = repositories.apiSessionRepository,
+                accountRepository = repositories.accountRepository,
+                currencyRepository = repositories.currencyRepository,
+                transactionRepository = repositories.transactionRepository,
+                entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                personRepository = repositories.personRepository,
+                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                personAttributeRepository = repositories.personAttributeRepository,
+                attributeTypeRepository = repositories.attributeTypeRepository,
+                accountAttributeRepository = repositories.accountAttributeRepository,
+                deviceId = deviceId,
+                sessionId = accountsSessionId,
+                strategy = strategy,
+            )
+
+            // 2. Download + import people from the profiles endpoint.
+            val peopleSessionId =
+                repositories.apiSessionRepository.createSession("test-wise-token", deviceId, now, null)
+            val downloadResult =
+                downloadApiSessionPeople("test-wise-token", clientFor(peopleSessionId), repositories.apiSessionRepository, peopleSessionId, strategy)
+            assertEquals(1, downloadResult.personCount, "One profile holder downloaded")
+
+            val importResult =
+                importApiSessionPeople(
+                    apiSessionRepository = repositories.apiSessionRepository,
+                    accountRepository = repositories.accountRepository,
+                    accountAttributeRepository = repositories.accountAttributeRepository,
+                    personRepository = repositories.personRepository,
+                    personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                    personAttributeRepository = repositories.personAttributeRepository,
+                    entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                    sessionId = peopleSessionId,
+                    strategy = strategy,
+                    accountsSessionId = accountsSessionId,
+                )
+
+            assertEquals(1, importResult.personCount, "The profile holder is created as a person")
+
+            val people = repositories.personRepository.getAllPeople().first()
+            val ada = people.single { it.firstName == "Ada" && it.lastName == "Lovelace" }
+
+            val gbpAccount = repositories.accountRepository.getAllAccounts().first().single { it.name == "Wise: GBP" }
+            val owners =
+                repositories.personAccountOwnershipRepository
+                    .getOwnershipsByAccount(gbpAccount.id)
+                    .first()
+            assertTrue(owners.any { it.personId == ada.id }, "Ada should own the Wise GBP balance")
         }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
@@ -3,6 +3,7 @@
 package com.moneymanager.ui.wise
 
 import com.moneymanager.database.port.DbEntitySource
+import com.moneymanager.domain.model.ApiSessionId
 import com.moneymanager.domain.model.DeviceInfo
 import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.PersonId
@@ -279,7 +280,7 @@ class WiseImportE2ETest : DbTest() {
                     respond(content = json, status = HttpStatusCode.OK, headers = headersOf(HttpHeaders.ContentType, "application/json"))
                 }
 
-            fun clientFor(sessionId: com.moneymanager.domain.model.ApiSessionId) =
+            fun clientFor(sessionId: ApiSessionId) =
                 createApiClient(
                     trafficRecorder =
                         ApiSessionTrafficRecorder(

--- a/app/ui/core/src/jvmAndroidMain/kotlin/com/moneymanager/ui/api/sca/ScaCrypto.jvmAndroid.kt
+++ b/app/ui/core/src/jvmAndroidMain/kotlin/com/moneymanager/ui/api/sca/ScaCrypto.jvmAndroid.kt
@@ -1,0 +1,53 @@
+@file:OptIn(kotlin.io.encoding.ExperimentalEncodingApi::class)
+
+package com.moneymanager.ui.api.sca
+
+import java.security.KeyFactory
+import java.security.KeyPairGenerator
+import java.security.Signature
+import java.security.spec.PKCS8EncodedKeySpec
+import kotlin.io.encoding.Base64
+
+private const val RSA_KEY_SIZE = 2048
+
+actual fun generateScaKeyPair(): ScaKeyPair {
+    val generator = KeyPairGenerator.getInstance("RSA")
+    generator.initialize(RSA_KEY_SIZE)
+    val pair = generator.generateKeyPair()
+    return ScaKeyPair(
+        privateKeyPem = pemEncode("PRIVATE KEY", pair.private.encoded),
+        publicKeyPem = pemEncode("PUBLIC KEY", pair.public.encoded),
+    )
+}
+
+actual fun signScaChallenge(
+    privateKeyPem: String,
+    oneTimeToken: String,
+): String {
+    val der = pemDecode(privateKeyPem)
+    val privateKey = KeyFactory.getInstance("RSA").generatePrivate(PKCS8EncodedKeySpec(der))
+    val signature =
+        Signature.getInstance("SHA256withRSA").apply {
+            initSign(privateKey)
+            update(oneTimeToken.encodeToByteArray())
+        }
+    return Base64.encode(signature.sign())
+}
+
+private fun pemEncode(
+    type: String,
+    der: ByteArray,
+): String {
+    val body = Base64.encode(der).chunked(64).joinToString("\n")
+    return "-----BEGIN $type-----\n$body\n-----END $type-----\n"
+}
+
+private fun pemDecode(pem: String): ByteArray {
+    val body =
+        pem
+            .lineSequence()
+            .filterNot { it.startsWith("-----") }
+            .joinToString("")
+            .trim()
+    return Base64.decode(body)
+}

--- a/app/ui/core/src/jvmAndroidMain/kotlin/com/moneymanager/ui/util/CurrentCountry.jvmAndroid.kt
+++ b/app/ui/core/src/jvmAndroidMain/kotlin/com/moneymanager/ui/util/CurrentCountry.jvmAndroid.kt
@@ -1,0 +1,5 @@
+package com.moneymanager.ui.util
+
+import java.util.Locale
+
+actual fun currentCountryCode(): String? = Locale.getDefault().country.uppercase().takeIf { it.isNotBlank() }

--- a/app/ui/core/src/jvmAndroidMain/kotlin/com/moneymanager/ui/util/CurrentCountry.jvmAndroid.kt
+++ b/app/ui/core/src/jvmAndroidMain/kotlin/com/moneymanager/ui/util/CurrentCountry.jvmAndroid.kt
@@ -2,4 +2,7 @@ package com.moneymanager.ui.util
 
 import java.util.Locale
 
-actual fun currentCountryCode(): String? = Locale.getDefault().country.uppercase().takeIf { it.isNotBlank() }
+actual fun currentCountryCode(): String? {
+    val country = Locale.getDefault().country.uppercase()
+    return country.takeIf { it.isNotBlank() }
+}

--- a/app/ui/core/src/jvmTest/kotlin/com/moneymanager/ui/api/sca/ScaCryptoTest.kt
+++ b/app/ui/core/src/jvmTest/kotlin/com/moneymanager/ui/api/sca/ScaCryptoTest.kt
@@ -1,0 +1,59 @@
+@file:OptIn(kotlin.io.encoding.ExperimentalEncodingApi::class)
+
+package com.moneymanager.ui.api.sca
+
+import java.security.KeyFactory
+import java.security.Signature
+import java.security.spec.X509EncodedKeySpec
+import kotlin.io.encoding.Base64
+import kotlin.test.Test
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class ScaCryptoTest {
+    @Test
+    fun `a generated key signs a token verifiably with its public key`() {
+        val keyPair = generateScaKeyPair()
+        val token = "one-time-token-abc123"
+
+        val signatureBase64 = signScaChallenge(keyPair.privateKeyPem, token)
+
+        val publicKeyDer = Base64.decode(pemBody(keyPair.publicKeyPem))
+        val publicKey = KeyFactory.getInstance("RSA").generatePublic(X509EncodedKeySpec(publicKeyDer))
+        val verifier =
+            Signature.getInstance("SHA256withRSA").apply {
+                initVerify(publicKey)
+                update(token.encodeToByteArray())
+            }
+        assertTrue(verifier.verify(Base64.decode(signatureBase64)), "signature must verify with the public key")
+    }
+
+    @Test
+    fun `the wrong token does not verify`() {
+        val keyPair = generateScaKeyPair()
+        val signatureBase64 = signScaChallenge(keyPair.privateKeyPem, "token-one")
+
+        val publicKey =
+            KeyFactory
+                .getInstance("RSA")
+                .generatePublic(X509EncodedKeySpec(Base64.decode(pemBody(keyPair.publicKeyPem))))
+        val verifier =
+            Signature.getInstance("SHA256withRSA").apply {
+                initVerify(publicKey)
+                update("token-two".encodeToByteArray())
+            }
+        assertTrue(!verifier.verify(Base64.decode(signatureBase64)), "a different token must not verify")
+    }
+
+    @Test
+    fun `each generated key pair is distinct`() {
+        assertNotEquals(generateScaKeyPair().publicKeyPem, generateScaKeyPair().publicKeyPem)
+    }
+
+    private fun pemBody(pem: String): String =
+        pem
+            .lineSequence()
+            .filterNot { it.startsWith("-----") }
+            .joinToString("")
+            .trim()
+}

--- a/utils/rest/src/commonMain/kotlin/com/moneymanager/rest/ApiClient.kt
+++ b/utils/rest/src/commonMain/kotlin/com/moneymanager/rest/ApiClient.kt
@@ -6,9 +6,24 @@ import io.ktor.client.plugins.HttpSend
 import io.ktor.client.plugins.plugin
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.util.AttributeKey
+
+/**
+ * Strong Customer Authentication challenge-signing parameters. When a request is rejected with
+ * [triggerStatus] and carries a [challengeHeader] one-time token, the token is signed via [sign] and
+ * the request is retried once with the challenge echoed back plus the signature in [signatureHeader].
+ * This is generic; the header names and status come from the provider's strategy config.
+ */
+class ScaParams(
+    val challengeHeader: String,
+    val signatureHeader: String,
+    val triggerStatus: Int,
+    val sign: (oneTimeToken: String) -> String,
+)
 
 class ApiClient(
     private val httpClient: HttpClient,
@@ -16,24 +31,35 @@ class ApiClient(
     suspend fun get(
         url: String,
         bearerToken: String,
+        sca: ScaParams? = null,
     ): ApiHttpResponse {
         val response =
             httpClient.get(url) {
                 bearerAuth(bearerToken)
             }
-        val body =
-            response.call.attributes.getOrNull(apiResponseBodyKey)
-                ?: response.bodyAsText()
-        val responseId = response.call.attributes[apiResponseIdKey]
-        val requestId = response.call.attributes[apiRequestIdKey]
-
-        return ApiHttpResponse(
-            statusCode = response.status.value,
-            body = body,
-            responseId = responseId,
-            requestId = requestId,
-        )
+        if (sca != null && response.status.value == sca.triggerStatus) {
+            val oneTimeToken = response.headers[sca.challengeHeader]
+            if (!oneTimeToken.isNullOrBlank()) {
+                val signature = sca.sign(oneTimeToken)
+                val signed =
+                    httpClient.get(url) {
+                        bearerAuth(bearerToken)
+                        header(sca.challengeHeader, oneTimeToken)
+                        header(sca.signatureHeader, signature)
+                    }
+                return signed.toApiHttpResponse()
+            }
+        }
+        return response.toApiHttpResponse()
     }
+
+    private suspend fun HttpResponse.toApiHttpResponse(): ApiHttpResponse =
+        ApiHttpResponse(
+            statusCode = status.value,
+            body = call.attributes.getOrNull(apiResponseBodyKey) ?: bodyAsText(),
+            responseId = call.attributes[apiResponseIdKey],
+            requestId = call.attributes[apiRequestIdKey],
+        )
 }
 
 data class ApiHttpResponse(

--- a/utils/rest/src/commonMain/kotlin/com/moneymanager/rest/ApiClient.kt
+++ b/utils/rest/src/commonMain/kotlin/com/moneymanager/rest/ApiClient.kt
@@ -76,7 +76,10 @@ fun createApiClient(
 
         val call = execute(request)
         val responseBody = call.response.bodyAsText()
-        val responseId = trafficRecorder.recordResponse(requestId, responseBody)
+        // Only persist non-blank bodies: the api_response.json column rejects empty values, and an
+        // empty body (e.g. an error or no-content response) carries nothing importable. The caller
+        // still sees the status code and can surface a meaningful error.
+        val responseId = if (responseBody.isNotBlank()) trafficRecorder.recordResponse(requestId, responseBody) else NO_RESPONSE_ID
         call.attributes.put(apiResponseBodyKey, responseBody)
         call.attributes.put(apiResponseIdKey, responseId)
         call.attributes.put(apiRequestIdKey, requestId)
@@ -86,6 +89,9 @@ fun createApiClient(
 
     return ApiClient(httpClient)
 }
+
+/** Sentinel response id used when an empty body is not persisted (see the traffic interceptor). */
+const val NO_RESPONSE_ID: Long = -1L
 
 private val apiResponseBodyKey = AttributeKey<String>("ApiResponseBody")
 private val apiResponseIdKey = AttributeKey<Long>("ApiResponseId")

--- a/utils/rest/src/commonMain/kotlin/com/moneymanager/rest/ApiClient.kt
+++ b/utils/rest/src/commonMain/kotlin/com/moneymanager/rest/ApiClient.kt
@@ -97,7 +97,7 @@ fun createApiClient(
                     request.headers
                         .entries()
                         .associate { (key, values) -> key to values.joinToString(",") }
-                        .filterKeys { it != HttpHeaders.Authorization },
+                        .filterKeys { !isSensitiveHeader(it) },
             )
 
         val call = execute(request)
@@ -118,6 +118,18 @@ fun createApiClient(
 
 /** Sentinel response id used when an empty body is not persisted (see the traffic interceptor). */
 const val NO_RESPONSE_ID: Long = -1L
+
+/**
+ * Headers that may carry secrets and must never be persisted to the recorded request log:
+ * the bearer token plus any one-time SCA challenge/signature headers (e.g. Wise's
+ * `x-2fa-approval` / `X-Signature`). Matched by substring so provider-specific header names
+ * configured in strategies are still covered without coupling this layer to that config.
+ */
+private fun isSensitiveHeader(key: String): Boolean {
+    if (key.equals(HttpHeaders.Authorization, ignoreCase = true)) return true
+    val lower = key.lowercase()
+    return lower.contains("signature") || lower.contains("2fa") || lower.contains("approval")
+}
 
 private val apiResponseBodyKey = AttributeKey<String>("ApiResponseBody")
 private val apiResponseIdKey = AttributeKey<Long>("ApiResponseId")

--- a/utils/rest/src/commonTest/kotlin/com/moneymanager/rest/ApiClientTest.kt
+++ b/utils/rest/src/commonTest/kotlin/com/moneymanager/rest/ApiClientTest.kt
@@ -80,6 +80,68 @@ class ApiClientTest {
         }
 
     @Test
+    fun `get signs the one-time token and retries on an sca challenge`() =
+        runTest {
+            val recorder = FakeTrafficRecorder(testRequestId, testResponseId)
+            var requestCount = 0
+            val engine =
+                MockEngine { request ->
+                    requestCount++
+                    if (request.headers["X-Signature"] == null) {
+                        // First call: challenge with a one-time token, empty body.
+                        respond(
+                            content = "",
+                            status = HttpStatusCode.Forbidden,
+                            headers = headersOf("x-2fa-approval", "ott-123"),
+                        )
+                    } else {
+                        respond(
+                            content = testBody,
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                        )
+                    }
+                }
+            val client = createApiClient(recorder, engine)
+            var signedToken: String? = null
+            val sca =
+                ScaParams(
+                    challengeHeader = "x-2fa-approval",
+                    signatureHeader = "X-Signature",
+                    triggerStatus = 403,
+                    sign = { oneTimeToken ->
+                        signedToken = oneTimeToken
+                        "signature-of-$oneTimeToken"
+                    },
+                )
+
+            val result = client.get(testUrl, testToken, sca)
+
+            assertEquals(200, result.statusCode)
+            assertEquals(testBody, result.body)
+            assertEquals("ott-123", signedToken, "the one-time token from the challenge header is signed")
+            assertEquals(2, requestCount, "the request is retried once with the signature")
+        }
+
+    @Test
+    fun `get does not retry when no sca params are provided`() =
+        runTest {
+            val recorder = FakeTrafficRecorder(testRequestId, testResponseId)
+            var requestCount = 0
+            val engine =
+                MockEngine { _ ->
+                    requestCount++
+                    respond(content = "", status = HttpStatusCode.Forbidden, headers = headersOf("x-2fa-approval", "ott-123"))
+                }
+            val client = createApiClient(recorder, engine)
+
+            val result = client.get(testUrl, testToken)
+
+            assertEquals(403, result.statusCode)
+            assertEquals(1, requestCount)
+        }
+
+    @Test
     fun `get does not record Authorization header`() =
         runTest {
             val recorder = FakeTrafficRecorder(testRequestId, testResponseId)


### PR DESCRIPTION
## Summary

Generalizes the DB-config-driven API import layer so it supports **Wise** as well as Monzo, with **no provider-specific code left in the import library** — everything is customizable and stored in the `api_import_strategy` config JSON. Wise's shape differs fundamentally from Monzo's: a 3-level hierarchy (profiles → balances → statement) with ids in the URL **path**, **bare top-level JSON arrays**, **decimal** amounts in nested objects, **sign from a separate `type` field**, and **date-window** pagination.

Also makes the **Connect UI** generic so Wise (and any custom strategy) can actually be connected, and ensures existing databases pick up new built-in strategies.

All config changes are additive with Monzo-preserving defaults — existing stored strategies keep working with **no DB migration**.

## Config model (`ApiStrategyConfig.kt` + codec + repo/audit mappers)
- `ancestorEndpoints` — ordered resources fetched before accounts (Wise `profiles`); empty for flat APIs like Monzo.
- Dynamic-source / path-template vocabulary: `account.id`, `account.<field>`, `ancestor[N].<field>`, `parent.id`, `window.start/end`, with `{placeholder}` path substitution.
- `ApiPaginationConfig.mode` = `CURSOR` | `DATE_WINDOW`. Flat shape (not sealed) so the model module needs no serialization-json; **legacy configs without `mode` decode as `CURSOR`**.
- Amount/sign config: `amountFormat` (minor-units-integer vs decimal-major-units), `signSource` (embedded vs separate field), `signField`, `creditValues`.
- De-hardcoded field-name mappings + blank `responseArrayKey` (bare-array responses).
- `builtInCounterpartyRules` — declarative predicate rules (with sign gate) replacing the hardcoded ATM block.

## Engine (`ApiSessionImportService.kt`)
- Three-level download: ancestors → templated accounts → per-account transactions.
- Date-window pagination anchored to fixed epoch boundaries (earlier windows stay cacheable).
- Path/query templating; path-aware request↔account correlation via a template regex, keeping Monzo's query-param path **byte-identical**.
- Decimal/sign amount parsing through `Money.fromDisplayValue` (BigDecimal, per the money policy).
- Generic built-in-counterparty rule evaluator (carried type enum → String).

## Seeds + lifecycle (`DatabaseConfig.kt`, DB managers)
- Add `seedWiseStrategy`; move Monzo's ATM detection into its seed as four declarative rules — Monzo behavior unchanged.
- `ensureBuiltInApiStrategies`: **idempotent** insert of built-in strategies, run on **every** DB open (JVM + Android), so databases created before Wise existed gain it on next launch.

## Connect UI
- Replace the Monzo-only `MonzoAuthScreen` with a generic **`ApiConnectScreen`**: a provider picker listing all strategies, a token field, and a credential linked to the chosen strategy. Optional convenience link to a known provider's token page derived from the strategy base URL. `Screen.MonzoConnect` → `Screen.ConnectApi`.

## Tests
- `WiseImportE2ETest` — full profiles→balances→statement import: bare arrays, templated paths, decimal amounts, CREDIT/DEBIT direction, cross-window de-dup.
- `ApiStrategyJsonCodecTest` — cursor/date-window round-trip + legacy-no-`mode` decode.
- `BuiltInApiStrategySeedTest` — fresh-DB seeding, existing-DB migration (delete Wise → ensure restores it), idempotency.
- Existing **Monzo E2E suite passes unchanged** (regression gate); only adjusted to select the strategy by name now that two are seeded.

`ui:core` promotes `serialization-json` from `implementation` to `api` per buildHealth.

## Verification
`./gradlew build` is green: JVM + Android compile, all unit tests, coverage, detekt, ktlint, buildHealth. Live Wise verification needs a personal API token (paste it against the seeded "Wise" provider in Connect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wise API import: accounts, transactions, and people/profile imports
  * Generic API connection flow and new "Connect API Account" screen (replaces Monzo-specific)
  * People import UI, people linking/backfill, and people-session import flow
  * SCA support: keypair generation, challenge signing, and optional stored signing keys
  * Advanced API options: cursor/date-window pagination, ancestor endpoints, and built-in counterparty rules

* **Tests**
  * Added Wise E2E tests, SCA crypto tests, and seed verification for built-in strategies

* **Documentation**
  * BETA note: no DB migrations/versioning yet; local DB schema changes may require recreation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->