### PR TITLE
Fix Apply Strategy dialog showing 0 transfers on a database with no accounts

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -178,7 +178,9 @@ fun ApplyStrategyDialog(
     // Prepare baseline import preview from persisted mappings only.
     LaunchedEffect(selectedStrategy, selectedSourceAccountId, rowsToProcess, accounts, currencies, accountMappings) {
         selectedStrategy?.let { strategy ->
-            if (accounts.isNotEmpty() && currencies.isNotEmpty() && rowsToProcess.isNotEmpty()) {
+            // An empty accounts list is fine: the mapper resolves unknown accounts to
+            // placeholders and reports them as new accounts to create during import.
+            if (currencies.isNotEmpty() && rowsToProcess.isNotEmpty()) {
                 try {
                     val accountsByName = accounts.associateBy { it.name }
                     val currenciesById = currencies.associateBy { it.id }
@@ -232,7 +234,7 @@ fun ApplyStrategyDialog(
     ) {
         selectedStrategy?.let { strategy ->
             val basePreparation = baseImportPreparation
-            if (accounts.isNotEmpty() && currencies.isNotEmpty() && rowsToProcess.isNotEmpty() && basePreparation != null) {
+            if (currencies.isNotEmpty() && rowsToProcess.isNotEmpty() && basePreparation != null) {
                 try {
                     val accountsByName = accounts.associateBy { it.name }
                     val currenciesById = currencies.associateBy { it.id }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ImportWiseCsvE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ImportWiseCsvE2ETest.kt
@@ -23,9 +23,11 @@ import com.moneymanager.test.database.createTestDatabaseManager
 import com.moneymanager.test.database.deleteTestDatabase
 import com.moneymanager.ui.test.MoneyManagerTestApp
 import com.moneymanager.ui.test.runMoneyManagerComposeUiTest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -135,6 +137,90 @@ class ImportWiseCsvE2ETest {
                 hasText("All rows have already been imported successfully."),
                 timeoutMillis = 15000,
             )
+        }
+
+    /**
+     * Regression test for importing on a fresh database with no accounts at all: the dialog
+     * must still prepare the import, offer the per-currency Wise accounts ("Wise: EUR",
+     * "Wise: GBP") as new accounts to create, and enable the import button. Previously the
+     * preview was gated on at least one account existing, so a fresh database showed
+     * "Import 0 Transfers" with no way to proceed.
+     */
+    @Test
+    fun importWiseCsv_onFreshDatabaseCreatesWiseAccounts() =
+        runMoneyManagerComposeUiTest {
+            testDbLocation = createTestDatabaseLocation()
+            val databaseManager = createTestDatabaseManager()
+            lateinit var databaseComponent: DatabaseComponent
+
+            runBlocking {
+                val db = databaseManager.openDatabase(testDbLocation!!)
+                databaseComponent = DatabaseComponent.create(db)
+
+                // No accounts are created up front - the import must discover all of them
+                val csvContent = wiseCsvContent()
+                val lines = csvContent.lines().filter { it.isNotBlank() }
+                val headers = parseCsvLine(lines.first())
+                val rows = lines.drop(1).map { parseCsvLine(it) }
+
+                databaseComponent.csvImportRepository.createImport(
+                    fileName = "transaction-history.csv",
+                    headers = headers,
+                    rows = rows,
+                    fileChecksum = "wise_test_export_checksum",
+                    fileLastModified = Instant.fromEpochMilliseconds(1700000000000L),
+                )
+            }
+
+            val testDatabaseManager =
+                SimpleWiseDatabaseManager(
+                    databaseManager = databaseManager,
+                    testLocation = testDbLocation!!,
+                )
+
+            setContent {
+                MoneyManagerTestApp(
+                    databaseManager = testDatabaseManager,
+                    appVersion = AppVersion("1.0.0-test"),
+                )
+            }
+
+            waitForIdle()
+            waitUntilAtLeastOneExists(hasText("Your Accounts"), timeoutMillis = 20000)
+
+            // Navigate to the imported Wise CSV
+            waitUntilAtLeastOneExists(hasText("Imports"), timeoutMillis = 10000)
+            onNodeWithText("Imports", useUnmergedTree = true).performClick()
+            waitForIdle()
+
+            waitUntilExactlyOneExists(hasText("transaction-history.csv"), timeoutMillis = 15000)
+            onNodeWithText("transaction-history.csv").performClick()
+            waitUntilExactlyOneExists(hasText("5 rows"), timeoutMillis = 10000)
+
+            waitUntilAtLeastOneExists(hasText("Apply Strategy") and isEnabled(), timeoutMillis = 15000)
+            onAllNodesWithText("Apply Strategy").onFirst().performClick()
+            waitUntilAtLeastOneExists(hasText("Apply Import Strategy"), timeoutMillis = 15000)
+            waitUntilExactlyOneExists(hasText("Wise CSV"), timeoutMillis = 10000)
+            waitForIdle()
+
+            // The per-currency source accounts are offered as new accounts alongside counterparties
+            waitUntilAtLeastOneExists(hasText("New Account Handling"), timeoutMillis = 15000)
+            waitUntilAtLeastOneExists(hasText("Wise: EUR"), timeoutMillis = 10000)
+            waitUntilAtLeastOneExists(hasText("Wise: GBP"), timeoutMillis = 10000)
+            waitUntilAtLeastOneExists(hasText("Avolta - Tenerife"), timeoutMillis = 10000)
+
+            // All five rows import even though no account existed beforehand
+            waitUntilAtLeastOneExists(hasText("Import 5 Transfers") and isEnabled(), timeoutMillis = 15000)
+            onNodeWithText("Import 5 Transfers").performClick()
+            waitUntilDoesNotExist(hasText("Apply Import Strategy"), timeoutMillis = 30000)
+            waitForIdle()
+
+            // The per-currency Wise accounts were created during the import
+            runBlocking {
+                val accounts = databaseComponent.accountRepository.getAllAccounts().first()
+                assertNotNull(accounts.singleOrNull { it.name == "Wise: EUR" }, "Wise: EUR account is created")
+                assertNotNull(accounts.singleOrNull { it.name == "Wise: GBP" }, "Wise: GBP account is created")
+            }
         }
 
     /**


### PR DESCRIPTION
## Problem

Selecting the built-in Wise CSV strategy in the Apply Strategy dialog on a fresh/default database showed a disabled **"Import 0 Transfers"** button with no error message and no way to proceed.

## Root cause

The default database seeds no accounts (only categories, currencies, and strategies). The dialog gated import preparation on at least one account existing:

```kotlin
if (accounts.isNotEmpty() && currencies.isNotEmpty() && rowsToProcess.isNotEmpty()) {
```

With zero accounts, `prepareImport()` never ran, so `importPreparation` stayed null. The mapper itself already handles missing accounts fully — it resolves unknown accounts to placeholders and reports them as new accounts to create during import, including the per-currency `Wise: EUR` / `Wise: GBP` source accounts from the template mapping.

## Fix

Drop the `accounts.isNotEmpty()` guard from both preparation `LaunchedEffect`s in `ApplyStrategyDialog`. The currencies guard remains since currencies are always seeded and genuinely required for parsing.

## Tests

The existing E2E test pre-created the Wise accounts before opening the dialog, which is why this was never caught. Added `importWiseCsv_onFreshDatabaseCreatesWiseAccounts` which imports the Wise CSV on a completely empty database and verifies:
- the dialog offers `Wise: EUR`, `Wise: GBP`, and counterparties as new accounts,
- "Import 5 Transfers" is enabled,
- the Wise accounts exist in the database after the import.

Full `./gradlew build` passes locally. Manually verified working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV import preview now works correctly even when no existing accounts are present.

* **Tests**
  * Added regression test verifying CSV import correctly creates new accounts during import from fresh database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->