### PR TITLE
Add companion transaction rules for manual entry of implied transactions

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -28,6 +28,7 @@ import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
 import com.moneymanager.domain.model.csvstrategy.ColumnPairSwap
+import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
@@ -1074,6 +1075,10 @@ object DatabaseConfig {
      * the currency code into the account name used by the Wise API import ("Wise: EUR").
      * Balance-to-balance conversions (same name on both sides, different currencies) route the
      * target to the other Wise balance instead of a counterparty account.
+     *
+     * Wise's export omits interest-earned rows, but each monthly "Assets fee" (wise-id like
+     * `ACCRUAL_CHARGE-…`) implies one, so a companion transaction rule flags those transfers
+     * for manual entry of the mirroring interest transfer.
      */
     fun buildWiseCsvStrategy(now: Instant): CsvImportStrategy {
         val sourceAccount =
@@ -1175,6 +1180,16 @@ object DatabaseConfig {
                 AttributeColumnMapping("Note", "note"),
                 AttributeColumnMapping("Created by", "wise-created-by"),
             )
+        val companionRules =
+            listOf(
+                CompanionTransactionRule(
+                    name = "Interest earned",
+                    matchAttributeName = "wise-id",
+                    matchValuePattern = "ACCRUAL_CHARGE-%",
+                    linkAttributeName = "wise-interest-for",
+                    companionDescription = "Interest earned",
+                ),
+            )
         val identificationColumns =
             setOf(
                 "ID",
@@ -1206,6 +1221,7 @@ object DatabaseConfig {
             fieldMappings = fieldMappings,
             attributeMappings = attributeMappings,
             rowPreprocessingRules = rowRules,
+            companionTransactionRules = companionRules,
             createdAt = now,
             updatedAt = now,
         )
@@ -1319,6 +1335,7 @@ object DatabaseConfig {
                 field_mappings_json = FieldMappingJsonCodec.encode(strategy.fieldMappings),
                 attribute_mappings_json = FieldMappingJsonCodec.encodeAttributeMappings(strategy.attributeMappings),
                 row_rules_json = FieldMappingJsonCodec.encodeRowRules(strategy.rowPreprocessingRules),
+                companion_rules_json = FieldMappingJsonCodec.encodeCompanionRules(strategy.companionTransactionRules),
                 created_at = now.toEpochMilliseconds(),
                 updated_at = now.toEpochMilliseconds(),
             )

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/FieldMappingJsonCodec.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/FieldMappingJsonCodec.kt
@@ -1,6 +1,7 @@
 package com.moneymanager.database.json
 
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
+import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.FieldMapping
 import com.moneymanager.domain.model.csvstrategy.RowPreprocessingRule
 import com.moneymanager.domain.model.csvstrategy.TransferField
@@ -57,4 +58,14 @@ object FieldMappingJsonCodec {
      * Decodes row preprocessing rules from JSON array string.
      */
     fun decodeRowRules(jsonString: String): List<RowPreprocessingRule> = json.decodeFromString(jsonString)
+
+    /**
+     * Encodes companion transaction rules to JSON array string.
+     */
+    fun encodeCompanionRules(rules: List<CompanionTransactionRule>): String = json.encodeToString(rules)
+
+    /**
+     * Decodes companion transaction rules from JSON array string.
+     */
+    fun decodeCompanionRules(jsonString: String): List<CompanionTransactionRule> = json.decodeFromString(jsonString)
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/TransferMissingCompanionMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/TransferMissingCompanionMapper.kt
@@ -1,0 +1,49 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.database.mapper
+
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.TransferMissingCompanion
+import kotlin.time.Instant.Companion.fromEpochMilliseconds
+
+object TransferMissingCompanionMapper {
+    @Suppress("LongParameterList")
+    fun mapRaw(
+        id: Long,
+        timestamp: Long,
+        description: String,
+        amount: Long,
+        matchValue: String,
+        sourceAccountId: Long,
+        sourceAccountName: String,
+        targetAccountId: Long,
+        targetAccountName: String,
+        currencyId: Long,
+        currencyCode: String,
+        currencyName: String,
+        currencyScaleFactor: Long,
+    ): TransferMissingCompanion {
+        val currency =
+            Currency(
+                id = CurrencyId(currencyId),
+                code = currencyCode,
+                name = currencyName,
+                scaleFactor = currencyScaleFactor,
+            )
+        return TransferMissingCompanion(
+            transferId = TransferId(id),
+            matchValue = matchValue,
+            timestamp = fromEpochMilliseconds(timestamp),
+            description = description,
+            sourceAccountId = AccountId(sourceAccountId),
+            sourceAccountName = sourceAccountName,
+            targetAccountId = AccountId(targetAccountId),
+            targetAccountName = targetAccountName,
+            amount = Money(amount, currency),
+        )
+    }
+}

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyRepositoryImpl.kt
@@ -63,6 +63,7 @@ class CsvImportStrategyRepositoryImpl(
                 field_mappings_json = FieldMappingJsonCodec.encode(strategy.fieldMappings),
                 attribute_mappings_json = FieldMappingJsonCodec.encodeAttributeMappings(strategy.attributeMappings),
                 row_rules_json = FieldMappingJsonCodec.encodeRowRules(strategy.rowPreprocessingRules),
+                companion_rules_json = FieldMappingJsonCodec.encodeCompanionRules(strategy.companionTransactionRules),
                 created_at = now.toEpochMilliseconds(),
                 updated_at = now.toEpochMilliseconds(),
             )
@@ -78,6 +79,7 @@ class CsvImportStrategyRepositoryImpl(
                 field_mappings_json = FieldMappingJsonCodec.encode(strategy.fieldMappings),
                 attribute_mappings_json = FieldMappingJsonCodec.encodeAttributeMappings(strategy.attributeMappings),
                 row_rules_json = FieldMappingJsonCodec.encodeRowRules(strategy.rowPreprocessingRules),
+                companion_rules_json = FieldMappingJsonCodec.encodeCompanionRules(strategy.companionTransactionRules),
                 updated_at = now.toEpochMilliseconds(),
                 id = strategy.id.id.toString(),
             )
@@ -96,6 +98,7 @@ class CsvImportStrategyRepositoryImpl(
             fieldMappings = FieldMappingJsonCodec.decode(entity.field_mappings_json),
             attributeMappings = FieldMappingJsonCodec.decodeAttributeMappings(entity.attribute_mappings_json),
             rowPreprocessingRules = FieldMappingJsonCodec.decodeRowRules(entity.row_rules_json),
+            companionTransactionRules = FieldMappingJsonCodec.decodeCompanionRules(entity.companion_rules_json),
             createdAt = Instant.fromEpochMilliseconds(entity.created_at),
             updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
         )

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.moneymanager.database.MoneyManagerDatabaseWrapper
 import com.moneymanager.database.mapper.AccountBalanceMapper
 import com.moneymanager.database.mapper.AccountRowMapper
 import com.moneymanager.database.mapper.TransferMapper
+import com.moneymanager.database.mapper.TransferMissingCompanionMapper
 import com.moneymanager.domain.model.AccountBalance
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AccountRow
@@ -23,6 +24,7 @@ import com.moneymanager.domain.model.TransactionId
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferAttribute
 import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.TransferMissingCompanion
 import com.moneymanager.domain.repository.TransactionRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -109,6 +111,20 @@ class TransactionRepositoryImpl(
             ).asFlow()
             .mapToList(Dispatchers.Default)
             .map { loadAttributesForTransfers(it) }
+
+    override fun getTransfersMissingCompanion(
+        matchAttributeName: String,
+        matchValuePattern: String,
+        linkAttributeName: String,
+    ): Flow<List<TransferMissingCompanion>> =
+        transferQueries
+            .selectTransfersMissingCompanion(
+                matchAttributeName,
+                matchValuePattern,
+                linkAttributeName,
+                TransferMissingCompanionMapper::mapRaw,
+            ).asFlow()
+            .mapToList(Dispatchers.Default)
 
     override fun getAccountBalances(): Flow<List<AccountBalance>> =
         transferQueries

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
@@ -163,6 +163,7 @@ class CsvStrategyExportService(
                         )
                     }.orEmpty(),
             rowPreprocessingRules = strategy.rowPreprocessingRules,
+            companionTransactionRules = strategy.companionTransactionRules,
         )
     }
 
@@ -373,6 +374,7 @@ class CsvStrategyExportService(
                 },
             attributeMappings = export.attributeMappings,
             rowPreprocessingRules = export.rowPreprocessingRules,
+            companionTransactionRules = export.companionTransactionRules,
             createdAt = now,
             updatedAt = now,
         )

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/CsvImportStrategy.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/CsvImportStrategy.sq
@@ -6,6 +6,7 @@ CREATE TABLE csv_import_strategy (
     field_mappings_json TEXT NOT NULL,
     attribute_mappings_json TEXT NOT NULL,
     row_rules_json TEXT NOT NULL DEFAULT '[]',
+    companion_rules_json TEXT NOT NULL DEFAULT '[]',
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
 );
@@ -26,13 +27,13 @@ SELECT * FROM csv_import_strategy WHERE name = ?;
 
 -- Insert a new strategy
 insert:
-INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- Update an existing strategy
 update:
 UPDATE csv_import_strategy
-SET name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, updated_at = ?
+SET name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, updated_at = ?
 WHERE id = ?;
 
 -- Delete a strategy by ID

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Transfer.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Transfer.sq
@@ -450,3 +450,37 @@ moveTransfersTargetAccount:
 UPDATE transfer
 SET revision_id = revision_id + 1, target_account_id = :targetAccount
 WHERE target_account_id = :accountToDelete;
+
+-- Transfers whose match attribute fits the LIKE pattern but for which no transfer
+-- carries the link attribute with the same value (companion transaction missing).
+selectTransfersMissingCompanion:
+SELECT
+    transfer.id,
+    transfer.timestamp,
+    transfer.description,
+    transfer.amount,
+    match_attr.attribute_value AS match_value,
+    source_account.id AS source_account_id,
+    source_account.name AS source_account_name,
+    target_account.id AS target_account_id,
+    target_account.name AS target_account_name,
+    currency.id AS currency_id,
+    currency.code AS currency_code,
+    currency.name AS currency_name,
+    currency.scale_factor AS currency_scale_factor
+FROM transfer
+JOIN transfer_attribute match_attr ON match_attr.transaction_id = transfer.id
+JOIN attribute_type match_type ON match_attr.attribute_type_id = match_type.id
+JOIN account source_account ON transfer.source_account_id = source_account.id
+JOIN account target_account ON transfer.target_account_id = target_account.id
+JOIN currency ON transfer.currency_id = currency.id
+WHERE match_type.name = :matchAttributeName
+  AND match_attr.attribute_value LIKE :matchValuePattern
+  AND NOT EXISTS (
+    SELECT 1
+    FROM transfer_attribute link_attr
+    JOIN attribute_type link_type ON link_attr.attribute_type_id = link_type.id
+    WHERE link_type.name = :linkAttributeName
+      AND link_attr.attribute_value = match_attr.attribute_value
+  )
+ORDER BY transfer.timestamp DESC, transfer.id DESC;

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BuiltInCsvStrategySeedTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BuiltInCsvStrategySeedTest.kt
@@ -79,6 +79,15 @@ class BuiltInCsvStrategySeedTest : DbTest() {
             // The Wise transaction ID drives duplicate detection on re-import
             val idMapping = strategy.attributeMappings.single { it.columnName == "ID" }
             assertTrue(idMapping.isUniqueIdentifier)
+
+            // Assets fees require a manually entered interest transfer (companion rule
+            // survives the JSON round trip through the database)
+            val companionRule = strategy.companionTransactionRules.single()
+            assertEquals("Interest earned", companionRule.name)
+            assertEquals("wise-id", companionRule.matchAttributeName)
+            assertEquals("ACCRUAL_CHARGE-%", companionRule.matchValuePattern)
+            assertEquals("wise-interest-for", companionRule.linkAttributeName)
+            assertEquals("Interest earned", companionRule.companionDescription)
         }
 
     @Test

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/json/CsvStrategyExportCodecTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/json/CsvStrategyExportCodecTest.kt
@@ -1,6 +1,7 @@
 package com.moneymanager.database.json
 
 import com.moneymanager.domain.model.csvstrategy.AmountMode
+import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.RegexRule
 import com.moneymanager.domain.model.csvstrategy.TransferField
 import com.moneymanager.domain.model.csvstrategy.export.AccountLookupExport
@@ -236,6 +237,54 @@ class CsvStrategyExportCodecTest {
         assertEquals("Name", decoded.accountMappings.first().columnName)
         assertEquals(".*Acme.*", decoded.accountMappings.first().valuePattern)
         assertEquals("Acme Bank", decoded.accountMappings.first().accountName)
+    }
+
+    @Test
+    fun `encode and decode export with companion transaction rules`() {
+        val export =
+            CsvStrategyExport(
+                version = "1.0.0",
+                name = "With companion rules",
+                identificationColumns = setOf("ID"),
+                fieldMappings = emptyMap(),
+                companionTransactionRules =
+                    listOf(
+                        CompanionTransactionRule(
+                            name = "Interest earned",
+                            matchAttributeName = "wise-id",
+                            matchValuePattern = "ACCRUAL_CHARGE-%",
+                            linkAttributeName = "wise-interest-for",
+                            companionDescription = "Interest earned",
+                        ),
+                    ),
+            )
+
+        val json = CsvStrategyExportCodec.encode(export)
+        val decoded = CsvStrategyExportCodec.decode(json)
+
+        val rule = decoded.companionTransactionRules.single()
+        assertEquals("Interest earned", rule.name)
+        assertEquals("wise-id", rule.matchAttributeName)
+        assertEquals("ACCRUAL_CHARGE-%", rule.matchValuePattern)
+        assertEquals("wise-interest-for", rule.linkAttributeName)
+        assertEquals("Interest earned", rule.companionDescription)
+    }
+
+    @Test
+    fun `decode legacy export without companion rules defaults to empty list`() {
+        val legacyJson =
+            """
+            {
+                "version": "1.0.0",
+                "name": "Legacy",
+                "identificationColumns": ["Date"],
+                "fieldMappings": {}
+            }
+            """.trimIndent()
+
+        val decoded = CsvStrategyExportCodec.decode(legacyJson)
+
+        assertTrue(decoded.companionTransactionRules.isEmpty())
     }
 
     @Test

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/TransfersMissingCompanionTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/TransfersMissingCompanionTest.kt
@@ -1,0 +1,159 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.database.repository
+
+import com.moneymanager.database.SampleGeneratorSourceRecorder
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.DeviceInfo
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.test.database.DbTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+class TransfersMissingCompanionTest : DbTest() {
+    private suspend fun createAttributedTransfer(
+        transfer: Transfer,
+        attributes: Map<String, String>,
+    ): TransferId {
+        val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+        val newAttributes =
+            attributes.map { (name, value) ->
+                NewAttribute(repositories.attributeTypeRepository.getOrCreate(name), value)
+            }
+        return repositories.transactionRepository
+            .createTransfers(
+                transfers = listOf(transfer),
+                newAttributes = mapOf(transfer.id to newAttributes),
+                sourceRecorder = SampleGeneratorSourceRecorder(transferSourceQueries, deviceId),
+            ).single()
+    }
+
+    private fun transfer(
+        timestamp: Instant,
+        description: String,
+        sourceAccountId: AccountId,
+        targetAccountId: AccountId,
+        currency: Currency,
+        amount: String,
+    ) = Transfer(
+        id = TransferId(0L),
+        timestamp = timestamp,
+        description = description,
+        sourceAccountId = sourceAccountId,
+        targetAccountId = targetAccountId,
+        amount = Money.fromDisplayValue(amount, currency),
+    )
+
+    @Test
+    fun `reports matched transfers until their companion is created`() =
+        runTest {
+            val now = Clock.System.now()
+            val wiseEur =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Wise: EUR", openingDate = now),
+                )
+            val transferwise =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "TransferWise", openingDate = now),
+                )
+            val currencyId = repositories.currencyRepository.upsertCurrencyByCode("EUR", "Euro")
+            val currency = repositories.currencyRepository.getCurrencyById(currencyId).first()!!
+
+            // An assets fee that needs an interest companion
+            createAttributedTransfer(
+                transfer(now, "Assets fee 1", wiseEur, transferwise, currency, "0.06"),
+                attributes = mapOf("wise-id" to "ACCRUAL_CHARGE-1"),
+            )
+            // A transfer whose wise-id doesn't match the pattern is never reported
+            createAttributedTransfer(
+                transfer(now, "Card payment", wiseEur, transferwise, currency, "10.00"),
+                attributes = mapOf("wise-id" to "BALANCE-2"),
+            )
+
+            val missing =
+                repositories.transactionRepository
+                    .getTransfersMissingCompanion("wise-id", "ACCRUAL_CHARGE-%", "wise-interest-for")
+                    .first()
+
+            val pending = missing.single()
+            assertEquals("ACCRUAL_CHARGE-1", pending.matchValue)
+            assertEquals("Assets fee 1", pending.description)
+            assertEquals(now.toEpochMilliseconds(), pending.timestamp.toEpochMilliseconds())
+            assertEquals(wiseEur, pending.sourceAccountId)
+            assertEquals("Wise: EUR", pending.sourceAccountName)
+            assertEquals(transferwise, pending.targetAccountId)
+            assertEquals("TransferWise", pending.targetAccountName)
+            assertEquals(Money.fromDisplayValue("0.06", currency), pending.amount)
+
+            // A link attribute for a DIFFERENT fee does not satisfy this one
+            createAttributedTransfer(
+                transfer(now, "Interest earned (other)", transferwise, wiseEur, currency, "0.10"),
+                attributes = mapOf("wise-interest-for" to "ACCRUAL_CHARGE-99"),
+            )
+            assertEquals(
+                1,
+                repositories.transactionRepository
+                    .getTransfersMissingCompanion("wise-id", "ACCRUAL_CHARGE-%", "wise-interest-for")
+                    .first()
+                    .size,
+            )
+
+            // The mirror companion linked to this fee clears it from the list
+            createAttributedTransfer(
+                transfer(now, "Interest earned", transferwise, wiseEur, currency, "0.42"),
+                attributes = mapOf("wise-interest-for" to "ACCRUAL_CHARGE-1"),
+            )
+            assertTrue(
+                repositories.transactionRepository
+                    .getTransfersMissingCompanion("wise-id", "ACCRUAL_CHARGE-%", "wise-interest-for")
+                    .first()
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun `attribute names are matched exactly`() =
+        runTest {
+            val now = Clock.System.now()
+            val wiseEur =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Wise: EUR", openingDate = now),
+                )
+            val transferwise =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "TransferWise", openingDate = now),
+                )
+            val currencyId = repositories.currencyRepository.upsertCurrencyByCode("EUR", "Euro")
+            val currency = repositories.currencyRepository.getCurrencyById(currencyId).first()!!
+
+            createAttributedTransfer(
+                transfer(now, "Assets fee 1", wiseEur, transferwise, currency, "0.06"),
+                attributes = mapOf("wise-id" to "ACCRUAL_CHARGE-1"),
+            )
+
+            // A different match attribute name finds nothing
+            assertTrue(
+                repositories.transactionRepository
+                    .getTransfersMissingCompanion("monzo-id", "ACCRUAL_CHARGE-%", "wise-interest-for")
+                    .first()
+                    .isEmpty(),
+            )
+            // A non-matching pattern finds nothing
+            assertTrue(
+                repositories.transactionRepository
+                    .getTransfersMissingCompanion("wise-id", "CARD_TRANSACTION-%", "wise-interest-for")
+                    .first()
+                    .isEmpty(),
+            )
+        }
+}

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TransferMissingCompanion.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TransferMissingCompanion.kt
@@ -1,0 +1,29 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.domain.model
+
+import kotlin.time.Instant
+
+/**
+ * A transfer matched by a companion transaction rule that has no companion transfer yet.
+ *
+ * Carries everything needed to display the match and create its mirror companion:
+ * the companion flips [sourceAccountId]/[targetAccountId] and reuses [timestamp] and
+ * the currency of [amount].
+ *
+ * @property matchValue The matched attribute value (e.g. "ACCRUAL_CHARGE-18326272")
+ *                      that the companion's link attribute must reference
+ * @property amount The matched transfer's amount, shown for context when entering
+ *                  the companion amount
+ */
+data class TransferMissingCompanion(
+    val transferId: TransferId,
+    val matchValue: String,
+    val timestamp: Instant,
+    val description: String,
+    val sourceAccountId: AccountId,
+    val sourceAccountName: String,
+    val targetAccountId: AccountId,
+    val targetAccountName: String,
+    val amount: Money,
+)

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CompanionTransactionRule.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CompanionTransactionRule.kt
@@ -1,0 +1,35 @@
+package com.moneymanager.domain.model.csvstrategy
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Declares that imported transfers matching an attribute pattern require a manually
+ * entered companion transaction.
+ *
+ * Some exports omit one side of a recurring pair of transactions. Wise's CSV, for
+ * example, includes the monthly "Assets fee" but not the interest payment it implies,
+ * so the interest must be entered by hand. A rule identifies the imported transfers
+ * needing a companion via [matchAttributeName]/[matchValuePattern], and the companion
+ * transfer records the matched transfer's attribute value under [linkAttributeName] so
+ * the pair can be detected. A matched transfer with no such link is "missing" its
+ * companion and is surfaced for manual entry.
+ *
+ * The companion mirrors the matched transfer: source/target accounts flipped, same
+ * currency and timestamp; only the amount is entered by the user.
+ *
+ * @property name Human-readable name for the rule (e.g. "Interest earned")
+ * @property matchAttributeName Attribute identifying matched transfers (e.g. "wise-id")
+ * @property matchValuePattern SQL LIKE pattern the attribute value must match
+ *                             (e.g. "ACCRUAL_CHARGE-%")
+ * @property linkAttributeName Attribute stored on the companion transfer holding the
+ *                             matched transfer's [matchAttributeName] value
+ * @property companionDescription Description given to created companion transfers
+ */
+@Serializable
+data class CompanionTransactionRule(
+    val name: String,
+    val matchAttributeName: String,
+    val matchValuePattern: String,
+    val linkAttributeName: String,
+    val companionDescription: String,
+)

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategy.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategy.kt
@@ -15,6 +15,8 @@ import kotlin.time.Instant
  * @property fieldMappings Map of TransferField to FieldMapping defining how each field is populated
  * @property rowPreprocessingRules Rules that may swap column values / flip accounts per row
  *                                 before field mappings run (see [RowPreprocessingRule])
+ * @property companionTransactionRules Rules flagging imported transfers that require a manually
+ *                                     entered companion transaction (see [CompanionTransactionRule])
  * @property createdAt Timestamp when this strategy was created
  * @property updatedAt Timestamp when this strategy was last modified
  */
@@ -25,6 +27,7 @@ data class CsvImportStrategy(
     val fieldMappings: Map<TransferField, FieldMapping>,
     val attributeMappings: List<AttributeColumnMapping> = emptyList(),
     val rowPreprocessingRules: List<RowPreprocessingRule> = emptyList(),
+    val companionTransactionRules: List<CompanionTransactionRule> = emptyList(),
     val createdAt: Instant,
     val updatedAt: Instant,
 ) {

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExport.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExport.kt
@@ -2,6 +2,7 @@ package com.moneymanager.domain.model.csvstrategy.export
 
 import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
+import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.RegexRule
 import com.moneymanager.domain.model.csvstrategy.RowCondition
 import com.moneymanager.domain.model.csvstrategy.RowPreprocessingRule
@@ -19,6 +20,7 @@ import kotlinx.serialization.Serializable
  * @property attributeMappings Attribute column mappings (already portable, no IDs)
  * @property accountMappings Persisted account mappings (optional; empty for legacy exports)
  * @property rowPreprocessingRules Row preprocessing rules (already portable, no IDs)
+ * @property companionTransactionRules Companion transaction rules (already portable, no IDs)
  */
 @Serializable
 data class CsvStrategyExport(
@@ -29,6 +31,7 @@ data class CsvStrategyExport(
     val attributeMappings: List<AttributeColumnMapping> = emptyList(),
     val accountMappings: List<CsvAccountMappingExport> = emptyList(),
     val rowPreprocessingRules: List<RowPreprocessingRule> = emptyList(),
+    val companionTransactionRules: List<CompanionTransactionRule> = emptyList(),
 )
 
 /**

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionRepository.kt
@@ -13,6 +13,7 @@ import com.moneymanager.domain.model.SourceRecorder
 import com.moneymanager.domain.model.TransactionId
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.TransferMissingCompanion
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Instant
 
@@ -33,6 +34,18 @@ interface TransactionRepository {
     ): Flow<List<Transfer>>
 
     fun getAccountBalances(): Flow<List<AccountBalance>>
+
+    /**
+     * Finds transfers matched by a companion transaction rule that have no companion yet:
+     * transfers carrying an attribute named [matchAttributeName] whose value matches the
+     * SQL LIKE [matchValuePattern], where no transfer carries an attribute named
+     * [linkAttributeName] with that same value.
+     */
+    fun getTransfersMissingCompanion(
+        matchAttributeName: String,
+        matchValuePattern: String,
+        linkAttributeName: String,
+    ): Flow<List<TransferMissingCompanion>>
 
     suspend fun getRunningBalanceByAccountPaginated(
         accountId: AccountId,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -367,6 +367,7 @@ fun MoneyManagerApp(
                                             navigationHistory.replaceCurrentScreen(Screen.Imports(tab))
                                         },
                                         csvImportRepository = services.imports.csvImportRepository,
+                                        csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
                                         apiSessionRepository = services.imports.apiSessionRepository,
                                         apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
                                         attributeTypeRepository = services.transactions.attributeTypeRepository,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
@@ -11,7 +11,7 @@ import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
 import com.moneymanager.domain.model.csv.CsvImportId
 
-enum class ImportTab { CSV, API }
+enum class ImportTab { CSV, API, MANUAL }
 
 sealed class Screen(
     val title: String,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
@@ -18,6 +18,7 @@ import com.moneymanager.domain.repository.ApiImportStrategyRepository
 import com.moneymanager.domain.repository.ApiSessionRepository
 import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.CsvImportRepository
+import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
@@ -30,6 +31,7 @@ fun ImportsScreen(
     selectedTab: ImportTab,
     onTabSelected: (ImportTab) -> Unit,
     csvImportRepository: CsvImportRepository,
+    csvImportStrategyRepository: CsvImportStrategyRepository,
     apiSessionRepository: ApiSessionRepository,
     apiImportStrategyRepository: ApiImportStrategyRepository,
     attributeTypeRepository: AttributeTypeRepository,
@@ -62,6 +64,11 @@ fun ImportsScreen(
                 onClick = { onTabSelected(ImportTab.API) },
                 text = { Text("API") },
             )
+            Tab(
+                selected = selectedTab == ImportTab.MANUAL,
+                onClick = { onTabSelected(ImportTab.MANUAL) },
+                text = { Text("Manual Entries") },
+            )
         }
 
         when (selectedTab) {
@@ -89,6 +96,15 @@ fun ImportsScreen(
                     onMonzoConnectClick = onAddCredentialClick,
                     onApiStrategiesClick = onApiStrategiesClick,
                     onSessionClick = onSessionClick,
+                    onTransactionsImported = onTransactionsImported,
+                )
+            ImportTab.MANUAL ->
+                ManualEntriesScreen(
+                    csvImportStrategyRepository = csvImportStrategyRepository,
+                    transactionRepository = transactionRepository,
+                    attributeTypeRepository = attributeTypeRepository,
+                    entitySource = entitySource,
+                    maintenance = maintenance,
                     onTransactionsImported = onTransactionsImported,
                 )
         }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ManualEntriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ManualEntriesScreen.kt
@@ -1,0 +1,310 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.moneymanager.bigdecimal.BigDecimal
+import com.moneymanager.domain.EntitySource
+import com.moneymanager.domain.Maintenance
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.TransferMissingCompanion
+import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
+import com.moneymanager.domain.repository.AttributeTypeRepository
+import com.moneymanager.domain.repository.CsvImportStrategyRepository
+import com.moneymanager.domain.repository.TransactionRepository
+import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import com.moneymanager.ui.util.displayDateTime
+import com.moneymanager.ui.util.formatAmount
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * Transfers matched by one strategy's companion rule that still need their companion entered.
+ */
+private data class PendingCompanionGroup(
+    val strategyName: String,
+    val rule: CompanionTransactionRule,
+    val pending: List<TransferMissingCompanion>,
+)
+
+/**
+ * Lists imported transfers flagged by companion transaction rules as requiring a manually
+ * entered companion (e.g. Wise assets fees needing their interest payment) and bulk-creates
+ * the companions: mirrored accounts, same timestamp and currency, user-entered amount.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@Composable
+fun ManualEntriesScreen(
+    csvImportStrategyRepository: CsvImportStrategyRepository,
+    transactionRepository: TransactionRepository,
+    attributeTypeRepository: AttributeTypeRepository,
+    entitySource: EntitySource,
+    maintenance: Maintenance,
+    onTransactionsImported: () -> Unit,
+) {
+    val scope = rememberSchemaAwareCoroutineScope()
+    val groupsFlow =
+        remember(csvImportStrategyRepository, transactionRepository) {
+            csvImportStrategyRepository.getAllStrategies().flatMapLatest { strategies ->
+                val ruleFlows =
+                    strategies.flatMap { strategy ->
+                        strategy.companionTransactionRules.map { rule ->
+                            transactionRepository
+                                .getTransfersMissingCompanion(
+                                    matchAttributeName = rule.matchAttributeName,
+                                    matchValuePattern = rule.matchValuePattern,
+                                    linkAttributeName = rule.linkAttributeName,
+                                ).map { pending -> PendingCompanionGroup(strategy.name, rule, pending) }
+                        }
+                    }
+                // combine() over an empty list never emits, so short-circuit instead.
+                if (ruleFlows.isEmpty()) flowOf(emptyList()) else combine(ruleFlows) { it.toList() }
+            }
+        }
+    val groups by groupsFlow.collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val amounts = remember { mutableStateMapOf<TransferId, String>() }
+    var isSaving by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    val visibleGroups = groups.filter { it.pending.isNotEmpty() }
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+    ) {
+        Text(
+            text = "Manual Entries",
+            style = MaterialTheme.typography.headlineMedium,
+        )
+
+        errorMessage?.let { error ->
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = error,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        if (visibleGroups.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = "No pending manual entries.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        } else {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                visibleGroups.forEach { group ->
+                    item(key = "${group.strategyName}/${group.rule.name}") {
+                        PendingGroupHeader(
+                            group = group,
+                            amounts = amounts,
+                            isSaving = isSaving,
+                            onCreate = { entries ->
+                                isSaving = true
+                                errorMessage = null
+                                scope.launch {
+                                    try {
+                                        createCompanionTransfers(
+                                            rule = group.rule,
+                                            entries = entries,
+                                            transactionRepository = transactionRepository,
+                                            attributeTypeRepository = attributeTypeRepository,
+                                            entitySource = entitySource,
+                                        )
+                                        maintenance.refreshMaterializedViews()
+                                        entries.forEach { (matched, _) -> amounts.remove(matched.transferId) }
+                                        onTransactionsImported()
+                                    } catch (expected: Exception) {
+                                        errorMessage = "Failed to create transactions: ${expected.message}"
+                                    } finally {
+                                        isSaving = false
+                                    }
+                                }
+                            },
+                        )
+                    }
+                    items(group.pending, key = { it.transferId.id }) { matched ->
+                        PendingCompanionCard(
+                            matched = matched,
+                            amountText = amounts[matched.transferId].orEmpty(),
+                            onAmountChange = { amounts[matched.transferId] = it },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Creates one mirror transfer per entry, each linked to its matched transfer via the
+ * rule's link attribute so the pair is no longer reported as missing.
+ */
+private suspend fun createCompanionTransfers(
+    rule: CompanionTransactionRule,
+    entries: List<Pair<TransferMissingCompanion, BigDecimal>>,
+    transactionRepository: TransactionRepository,
+    attributeTypeRepository: AttributeTypeRepository,
+    entitySource: EntitySource,
+) {
+    val linkTypeId = attributeTypeRepository.getOrCreate(rule.linkAttributeName)
+    val transfers =
+        entries.mapIndexed { index, (matched, amount) ->
+            Transfer(
+                // Distinct placeholder ids: createTransfers keys newAttributes by them.
+                id = TransferId(-(index + 1L)),
+                timestamp = matched.timestamp,
+                description = rule.companionDescription,
+                sourceAccountId = matched.targetAccountId,
+                targetAccountId = matched.sourceAccountId,
+                amount = Money.fromDisplayValue(amount, matched.amount.currency),
+            )
+        }
+    val newAttributes =
+        transfers
+            .mapIndexed { index, transfer ->
+                transfer.id to listOf(NewAttribute(linkTypeId, entries[index].first.matchValue))
+            }.toMap()
+    transactionRepository.createTransfers(
+        transfers = transfers,
+        newAttributes = newAttributes,
+        sourceRecorder = entitySource.manualRecorder(),
+    )
+}
+
+private fun parseAmount(text: String): BigDecimal? {
+    if (text.isBlank()) return null
+    val parsed = runCatching { BigDecimal(text.trim()) }.getOrNull() ?: return null
+    return parsed.takeIf { it > BigDecimal.ZERO }
+}
+
+@Composable
+private fun PendingGroupHeader(
+    group: PendingCompanionGroup,
+    amounts: Map<TransferId, String>,
+    isSaving: Boolean,
+    onCreate: (List<Pair<TransferMissingCompanion, BigDecimal>>) -> Unit,
+) {
+    val entries =
+        group.pending.mapNotNull { matched ->
+            val text = amounts[matched.transferId].orEmpty()
+            if (text.isBlank()) return@mapNotNull null
+            parseAmount(text)?.let { matched to it }
+        }
+    val hasInvalidInput =
+        group.pending.any { matched ->
+            val text = amounts[matched.transferId].orEmpty()
+            text.isNotBlank() && parseAmount(text) == null
+        }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "${group.strategyName} — ${group.rule.name}",
+            style = MaterialTheme.typography.titleLarge,
+        )
+        Button(
+            onClick = { onCreate(entries) },
+            enabled = entries.isNotEmpty() && !hasInvalidInput && !isSaving,
+        ) {
+            Text("Create ${entries.size} transaction${if (entries.size == 1) "" else "s"}")
+        }
+    }
+}
+
+@Composable
+private fun PendingCompanionCard(
+    matched: TransferMissingCompanion,
+    amountText: String,
+    onAmountChange: (String) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = matched.description,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text =
+                        "${matched.timestamp.displayDateTime()} • " +
+                            "${matched.sourceAccountName} → ${matched.targetAccountName} • " +
+                            formatAmount(matched.amount),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = "Companion: ${matched.targetAccountName} → ${matched.sourceAccountName}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            OutlinedTextField(
+                value = amountText,
+                onValueChange = onAmountChange,
+                label = { Text("Amount (${matched.amount.currency.code})") },
+                isError = amountText.isNotBlank() && parseAmount(amountText) == null,
+                singleLine = true,
+                modifier = Modifier.width(180.dp),
+            )
+        }
+    }
+}

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CreateCsvStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CreateCsvStrategyDialog.kt
@@ -1072,9 +1072,10 @@ fun CreateCsvStrategyDialog(
                                         identificationColumns = identificationColumns,
                                         fieldMappings = fieldMappings,
                                         attributeMappings = attributeMappings,
-                                        // The form has no editor for row preprocessing rules, so they
-                                        // are always carried over unchanged.
+                                        // The form has no editor for row preprocessing or companion
+                                        // transaction rules, so they are always carried over unchanged.
                                         rowPreprocessingRules = existingStrategy?.rowPreprocessingRules.orEmpty(),
+                                        companionTransactionRules = existingStrategy?.companionTransactionRules.orEmpty(),
                                         createdAt = existingStrategy?.createdAt ?: now,
                                         updatedAt = now,
                                     )

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ManualEntriesE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ManualEntriesE2ETest.kt
@@ -1,0 +1,179 @@
+@file:OptIn(ExperimentalTime::class, ExperimentalUuidApi::class)
+
+package com.moneymanager.ui.screens
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
+import androidx.compose.ui.test.waitUntilDoesNotExist
+import com.moneymanager.database.DatabaseManager
+import com.moneymanager.database.SampleGeneratorSourceRecorder
+import com.moneymanager.di.database.DatabaseComponent
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AppVersion
+import com.moneymanager.domain.model.DbLocation
+import com.moneymanager.domain.model.DeviceInfo
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.test.database.createTestDatabaseLocation
+import com.moneymanager.test.database.createTestDatabaseManager
+import com.moneymanager.test.database.deleteTestDatabase
+import com.moneymanager.ui.test.MoneyManagerTestApp
+import com.moneymanager.ui.test.runMoneyManagerComposeUiTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+
+/**
+ * End-to-end test for the Manual Entries tab: a Wise assets fee (matched by the seeded
+ * companion transaction rule) is listed as missing its interest transfer, and entering
+ * an amount creates the mirrored companion linked via the wise-interest-for attribute.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ManualEntriesE2ETest {
+    private var testDbLocation: DbLocation? = null
+
+    @AfterTest
+    fun cleanup() {
+        testDbLocation?.let { location ->
+            deleteTestDatabase(location)
+        }
+    }
+
+    @Test
+    fun manualEntries_createsCompanionInterestTransferForAssetsFee() =
+        runMoneyManagerComposeUiTest {
+            testDbLocation = createTestDatabaseLocation()
+            val databaseManager = createTestDatabaseManager()
+            lateinit var databaseComponent: DatabaseComponent
+            var wiseEurOrNull: AccountId? = null
+            var transferwiseOrNull: AccountId? = null
+            val feeTimestamp = Instant.fromEpochMilliseconds(1717340000000L)
+
+            runBlocking {
+                val db = databaseManager.openDatabase(testDbLocation!!)
+                databaseComponent = DatabaseComponent.create(db)
+
+                val wiseEur =
+                    databaseComponent.accountRepository.createAccount(
+                        Account(id = AccountId(0), name = "Wise: EUR", openingDate = feeTimestamp),
+                    )
+                val transferwise =
+                    databaseComponent.accountRepository.createAccount(
+                        Account(id = AccountId(0), name = "TransferWise", openingDate = feeTimestamp),
+                    )
+                wiseEurOrNull = wiseEur
+                transferwiseOrNull = transferwise
+                val currencyId = databaseComponent.currencyRepository.upsertCurrencyByCode("EUR", "Euro")
+                val currency = databaseComponent.currencyRepository.getCurrencyById(currencyId).first()!!
+
+                // An imported Wise assets fee that still lacks its interest companion
+                val fee =
+                    Transfer(
+                        id = TransferId(0L),
+                        timestamp = feeTimestamp,
+                        description = "Assets fee 18326272",
+                        sourceAccountId = wiseEur,
+                        targetAccountId = transferwise,
+                        amount = Money.fromDisplayValue("0.06", currency),
+                    )
+                val deviceId =
+                    databaseComponent.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+                val wiseIdType = databaseComponent.attributeTypeRepository.getOrCreate("wise-id")
+                databaseComponent.transactionRepository.createTransfers(
+                    transfers = listOf(fee),
+                    newAttributes = mapOf(fee.id to listOf(NewAttribute(wiseIdType, "ACCRUAL_CHARGE-18326272"))),
+                    sourceRecorder = SampleGeneratorSourceRecorder(db.transferSourceQueries, deviceId),
+                )
+            }
+
+            val testDatabaseManager =
+                ManualEntriesTestDatabaseManager(
+                    databaseManager = databaseManager,
+                    testLocation = testDbLocation!!,
+                )
+
+            setContent {
+                MoneyManagerTestApp(
+                    databaseManager = testDatabaseManager,
+                    appVersion = AppVersion("1.0.0-test"),
+                )
+            }
+
+            waitForIdle()
+            waitUntilAtLeastOneExists(hasText("Your Accounts"), timeoutMillis = 20000)
+
+            // Navigate to the Manual Entries tab on the Imports screen
+            waitUntilAtLeastOneExists(hasText("Imports"), timeoutMillis = 10000)
+            onNodeWithText("Imports", useUnmergedTree = true).performClick()
+            waitForIdle()
+            waitUntilAtLeastOneExists(hasText("Manual Entries"), timeoutMillis = 15000)
+            onNodeWithText("Manual Entries").performClick()
+            waitForIdle()
+
+            // The assets fee is listed under the seeded Wise companion rule
+            waitUntilAtLeastOneExists(hasText("Wise CSV — Interest earned"), timeoutMillis = 15000)
+            waitUntilAtLeastOneExists(hasText("Assets fee 18326272"), timeoutMillis = 10000)
+
+            // Entering an amount enables the create button
+            onNodeWithText("Amount (EUR)").performTextInput("1.23")
+            waitUntilAtLeastOneExists(hasText("Create 1 transaction") and isEnabled(), timeoutMillis = 10000)
+            onNodeWithText("Create 1 transaction").performClick()
+
+            // The fee disappears once its companion exists
+            waitUntilDoesNotExist(hasText("Assets fee 18326272"), timeoutMillis = 30000)
+            waitForIdle()
+            waitUntilAtLeastOneExists(hasText("No pending manual entries."), timeoutMillis = 15000)
+
+            // The companion mirrors the fee and is linked via wise-interest-for
+            runBlocking {
+                val wiseEur = assertNotNull(wiseEurOrNull)
+                val transferwise = assertNotNull(transferwiseOrNull)
+                val companion =
+                    databaseComponent.transactionRepository
+                        .getTransactionsByAccount(wiseEur)
+                        .first()
+                        .singleOrNull { it.description == "Interest earned" }
+                assertNotNull(companion, "Companion interest transfer is created")
+                assertEquals(transferwise, companion.sourceAccountId)
+                assertEquals(wiseEur, companion.targetAccountId)
+                assertEquals(feeTimestamp.toEpochMilliseconds(), companion.timestamp.toEpochMilliseconds())
+                assertEquals("EUR", companion.amount.currency.code)
+                assertEquals(123L, companion.amount.amount)
+                val link = companion.attributes.single { it.attributeType.name == "wise-interest-for" }
+                assertEquals("ACCRUAL_CHARGE-18326272", link.value)
+
+                assertTrue(
+                    databaseComponent.transactionRepository
+                        .getTransfersMissingCompanion("wise-id", "ACCRUAL_CHARGE-%", "wise-interest-for")
+                        .first()
+                        .isEmpty(),
+                    "No assets fee is missing its companion any more",
+                )
+            }
+        }
+}
+
+/**
+ * Simple DatabaseManager wrapper that only overrides getDefaultLocation.
+ */
+private class ManualEntriesTestDatabaseManager(
+    private val databaseManager: DatabaseManager,
+    private val testLocation: DbLocation,
+) : DatabaseManager by databaseManager {
+    override fun getDefaultLocation(): DbLocation = testLocation
+}


### PR DESCRIPTION
## Why

Wise's transaction-history CSV omits interest-earned transactions, but every monthly "Assets fee" it does export implies one — the interest must be entered by hand. Rather than a Wise-specific feature, this adds a generic mechanism any CSV import strategy can use.

## What

**Companion transaction rules** on `CsvImportStrategy`: imported transfers whose match attribute fits a SQL LIKE pattern (e.g. `wise-id LIKE 'ACCRUAL_CHARGE-%'`) require a manually entered companion transfer. The companion is linked back via a link attribute (`wise-interest-for` = the fee's `wise-id`), so a matched transfer with no link is "missing" its companion.

- **Model**: `CompanionTransactionRule` (`name`, `matchAttributeName`, `matchValuePattern`, `linkAttributeName`, `companionDescription`) + `TransferMissingCompanion` result type.
- **Persistence**: new `companion_rules_json` column on `csv_import_strategy` (DB recreated per BETA policy, no migration); codec, repository, and strategy export/import support. The strategy editor carries rules over unchanged, like row preprocessing rules.
- **Query**: `selectTransfersMissingCompanion` — parameterized by attribute names/pattern, exposed as `TransactionRepository.getTransfersMissingCompanion(...): Flow<...>` so the UI auto-refreshes.
- **UI**: new **Manual Entries** tab on the Imports screen, listing pending transfers grouped by `"<strategy> — <rule>"` with inline bulk amount entry (BigDecimal-only parsing). One button creates the companions: mirrored accounts, same timestamp and currency, the matched value stored under the link attribute. Created rows disappear automatically.
- **Seeding**: the built-in Wise CSV strategy declares an "Interest earned" rule.

## Tests

- `TransfersMissingCompanionTest` — query semantics: pattern/attribute-name matching, link clearing, wrong-fee links don't match.
- `ManualEntriesE2ETest` — full UI flow: seeded assets fee appears, entering an amount creates the mirrored linked interest transfer, row disappears.
- Extended `BuiltInCsvStrategySeedTest` (Wise rule survives the DB JSON round trip) and `CsvStrategyExportCodecTest` (export round trip + legacy default).

`./gradlew build` passes (tests, detekt, ktlint, buildHealth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)