### PR TITLE
Add Starling Bank as a built-in API import strategy

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -13,6 +13,7 @@ import com.moneymanager.domain.model.apistrategy.ApiAmountFormat
 import com.moneymanager.domain.model.apistrategy.ApiAuthType
 import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiPaginationConfig
+import com.moneymanager.domain.model.apistrategy.ApiPeopleMappings
 import com.moneymanager.domain.model.apistrategy.ApiPersonImportConfig
 import com.moneymanager.domain.model.apistrategy.ApiQueryParam
 import com.moneymanager.domain.model.apistrategy.ApiSignSource
@@ -1085,10 +1086,28 @@ object DatabaseConfig {
                         creditValues = setOf("IN"),
                         idField = "feedItemUid",
                         counterpartyNameField = "counterPartyName",
+                        // The counterparty's stable id keys the counterparty account (stored as its
+                        // external-id attribute) so it survives name changes and dedupes across imports.
+                        counterpartyIdField = "counterPartyUid",
                         // Declined feed items never moved money; import them but exclude from balances
                         // (same treatment as Monzo's `decline_reason`), keyed off Starling's status.
                         declineStatusField = "status",
                         declinedStatusValues = setOf("DECLINED"),
+                        // Persist the feed item's stable id as a transaction attribute so each imported
+                        // transfer is uniquely identifiable and re-imports dedupe on it.
+                        customFields = mapOf("starling-transaction-id" to "feedItemUid"),
+                        uniqueIdentifierFields = setOf("starling-transaction-id"),
+                    ),
+                // Starling's counterparty fields are flat on the feed item (no nested object), so the
+                // counterparty object path is blank (the item itself). PAYEE/SENDER counterparties are
+                // people; MERCHANT/STARLING are not. counterPartyUid identifies the person.
+                peopleMappings =
+                    ApiPeopleMappings(
+                        counterpartyObjectField = "",
+                        beneficiaryAccountTypeField = "counterPartyType",
+                        personalBeneficiaryAccountTypeValues = setOf("PAYEE", "SENDER"),
+                        counterpartyNameField = "counterPartyName",
+                        counterpartyUserIdField = "counterPartyUid",
                     ),
                 accountNamePrefix = "Starling: ",
                 counterpartyPrefix = "Starling Counterparty: ",

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -819,10 +819,11 @@ object DatabaseConfig {
             attributeTypeQueries.insertWithId(id = ACCOUNT_SORT_CODE_ATTR_TYPE_ID, name = "account-sort-code")
             attributeTypeQueries.insertWithId(id = ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID, name = "account-account-number")
 
-            // Seed the built-in Monzo and Wise API import strategies (after triggers and system
-            // device are created so the INSERT trigger records the initial audit entry and source)
+            // Seed the built-in Monzo, Wise and Starling API import strategies (after triggers and
+            // system device are created so the INSERT trigger records the initial audit entry/source)
             seedMonzoStrategy(systemDeviceId)
             seedWiseStrategy(systemDeviceId)
+            seedStarlingStrategy(systemDeviceId)
 
             // Seed the built-in CSV import strategies
             seedBuiltInCsvStrategies()
@@ -1025,6 +1026,83 @@ object DatabaseConfig {
         )
         apiImportStrategyQueries.insertSource(
             strategy_id = wiseStrategyId.toString(),
+            revision_id = 1,
+            source_type_id = SourceType.SYSTEM.id.toLong(),
+            device_id = systemDeviceId,
+        )
+    }
+
+    /** Fixed UUID for the built-in Starling strategy so it can be referenced reliably. */
+    private val starlingStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-000000000005")
+
+    /**
+     * Seeds the built-in Starling Bank API import strategy. Starling is a flat two-level API like
+     * Monzo: a single Bearer token lists accounts, and each account's transaction feed is fetched
+     * from a path templated with the account id and its `defaultCategory`. Amounts are integer minor
+     * units and the direction lives in a separate `direction` field (IN/OUT). The whole feed is
+     * returned in one response, so no pagination is configured. The account holder is a single global
+     * object (`/api/v2/account-holder/individual`) linked to every imported account.
+     */
+    private fun MoneyManagerDatabaseWrapper.seedStarlingStrategy(systemDeviceId: Long) {
+        val config =
+            ApiStrategyConfigJson(
+                baseUrl = "https://api.starlingbank.com",
+                authType = ApiAuthType.BEARER_TOKEN,
+                accountsEndpoint =
+                    ApiEndpointConfig(
+                        path = "/api/v2/accounts",
+                        responseArrayKey = "accounts",
+                    ),
+                transactionsEndpoint =
+                    ApiEndpointConfig(
+                        // {account.defaultCategory} resolves the account's defaultCategory from its raw
+                        // JSON; the feed endpoint returns the full history in a single response.
+                        path = "/api/v2/feed/account/{account.id}/category/{account.defaultCategory}",
+                        responseArrayKey = "feedItems",
+                    ),
+                accountMappings =
+                    ApiAccountMappings(
+                        idField = "accountUid",
+                        descriptionField = "name",
+                        currencyField = "currency",
+                        ownersArrayField = null,
+                    ),
+                transactionMappings =
+                    ApiTransactionMappings(
+                        amountField = "amount.minorUnits",
+                        currencyField = "amount.currency",
+                        timestampField = "transactionTime",
+                        descriptionField = "reference",
+                        amountFormat = ApiAmountFormat.MINOR_UNITS_INTEGER,
+                        signSource = ApiSignSource.FIELD,
+                        signField = "direction",
+                        creditValues = setOf("IN"),
+                        idField = "feedItemUid",
+                        counterpartyNameField = "counterPartyName",
+                    ),
+                accountNamePrefix = "Starling: ",
+                counterpartyPrefix = "Starling Counterparty: ",
+                // The account holder is global (one per connection) and returned as a single object,
+                // so it is linked to every account imported in the session.
+                peopleDownload =
+                    ApiPersonImportConfig(
+                        endpoint = ApiEndpointConfig(path = "/api/v2/account-holder/individual", responseArrayKey = ""),
+                        firstNameField = "firstName",
+                        lastNameField = "lastName",
+                        ownsAllAccounts = true,
+                    ),
+                personExternalIdAttribute = "starling-external-id",
+            )
+        val now = Clock.System.now().toEpochMilliseconds()
+        apiImportStrategyQueries.insert(
+            id = starlingStrategyId.toString(),
+            name = "Starling",
+            config_json = ApiStrategyJsonCodec.encode(config),
+            created_at = now,
+            updated_at = now,
+        )
+        apiImportStrategyQueries.insertSource(
+            strategy_id = starlingStrategyId.toString(),
             revision_id = 1,
             source_type_id = SourceType.SYSTEM.id.toLong(),
             device_id = systemDeviceId,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -1059,6 +1059,12 @@ object DatabaseConfig {
                         // JSON; the feed endpoint returns the full history in a single response.
                         path = "/api/v2/feed/account/{account.id}/category/{account.defaultCategory}",
                         responseArrayKey = "feedItems",
+                        // Starling requires a mandatory `changesSince` ISO-8601 bound; anchoring it to
+                        // the epoch returns the account's entire feed history in one response.
+                        queryParams =
+                            listOf(
+                                ApiQueryParam(name = "changesSince", value = "1970-01-01T00:00:00.000Z"),
+                            ),
                     ),
                 accountMappings =
                     ApiAccountMappings(
@@ -1079,6 +1085,10 @@ object DatabaseConfig {
                         creditValues = setOf("IN"),
                         idField = "feedItemUid",
                         counterpartyNameField = "counterPartyName",
+                        // Declined feed items never moved money; import them but exclude from balances
+                        // (same treatment as Monzo's `decline_reason`), keyed off Starling's status.
+                        declineStatusField = "status",
+                        declinedStatusValues = setOf("DECLINED"),
                     ),
                 accountNamePrefix = "Starling: ",
                 counterpartyPrefix = "Starling Counterparty: ",

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BuiltInApiStrategySeedTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BuiltInApiStrategySeedTest.kt
@@ -55,6 +55,18 @@ class BuiltInApiStrategySeedTest : DbTest() {
                 assertEquals("feedItemUid", idField)
                 assertEquals("status", declineStatusField)
                 assertEquals(setOf("DECLINED"), declinedStatusValues)
+                assertEquals("counterPartyUid", counterpartyIdField)
+                assertEquals(mapOf("starling-transaction-id" to "feedItemUid"), customFields)
+                assertEquals(setOf("starling-transaction-id"), uniqueIdentifierFields)
+            }
+
+            // PAYEE/SENDER counterparties are treated as people, read from flat feed-item fields.
+            with(starling.peopleMappings) {
+                assertEquals("", counterpartyObjectField)
+                assertEquals("counterPartyType", beneficiaryAccountTypeField)
+                assertEquals(setOf("PAYEE", "SENDER"), personalBeneficiaryAccountTypeValues)
+                assertEquals("counterPartyName", counterpartyNameField)
+                assertEquals("counterPartyUid", counterpartyUserIdField)
             }
 
             val people = assertNotNull(starling.peopleDownload, "Starling should configure a people download")

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BuiltInApiStrategySeedTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BuiltInApiStrategySeedTest.kt
@@ -1,14 +1,18 @@
 package com.moneymanager.database
 
+import com.moneymanager.domain.model.apistrategy.ApiAmountFormat
+import com.moneymanager.domain.model.apistrategy.ApiSignSource
 import com.moneymanager.test.database.DbTest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class BuiltInApiStrategySeedTest : DbTest() {
     @Test
-    fun `a fresh database seeds both built-in strategies`() =
+    fun `a fresh database seeds the built-in API strategies`() =
         runTest {
             val names =
                 repositories.apiImportStrategyRepository
@@ -16,6 +20,43 @@ class BuiltInApiStrategySeedTest : DbTest() {
                     .first()
                     .map { it.name }
                     .toSet()
-            assertEquals(setOf("Monzo", "Wise"), names)
+            assertEquals(setOf("Monzo", "Wise", "Starling"), names)
+        }
+
+    @Test
+    fun `the Starling strategy seeds with its expected configuration`() =
+        runTest {
+            val starling =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .first { it.name == "Starling" }
+
+            assertEquals("https://api.starlingbank.com", starling.baseUrl)
+            assertEquals("/api/v2/accounts", starling.accountsEndpoint.path)
+            assertEquals("accounts", starling.accountsEndpoint.responseArrayKey)
+            assertEquals(
+                "/api/v2/feed/account/{account.id}/category/{account.defaultCategory}",
+                starling.transactionsEndpoint.path,
+            )
+            assertEquals("feedItems", starling.transactionsEndpoint.responseArrayKey)
+            // Full history is returned in one response, so no pagination is configured.
+            assertEquals(null, starling.transactionsEndpoint.pagination)
+
+            assertEquals("accountUid", starling.accountMappings.idField)
+            assertEquals("currency", starling.accountMappings.currencyField)
+
+            with(starling.transactionMappings) {
+                assertEquals("amount.minorUnits", amountField)
+                assertEquals(ApiAmountFormat.MINOR_UNITS_INTEGER, amountFormat)
+                assertEquals(ApiSignSource.FIELD, signSource)
+                assertEquals("direction", signField)
+                assertEquals(setOf("IN"), creditValues)
+                assertEquals("feedItemUid", idField)
+            }
+
+            val people = assertNotNull(starling.peopleDownload, "Starling should configure a people download")
+            assertEquals("/api/v2/account-holder/individual", people.endpoint.path)
+            assertTrue(people.ownsAllAccounts, "Starling's global holder should own all accounts")
         }
 }

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BuiltInApiStrategySeedTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BuiltInApiStrategySeedTest.kt
@@ -53,6 +53,8 @@ class BuiltInApiStrategySeedTest : DbTest() {
                 assertEquals("direction", signField)
                 assertEquals(setOf("IN"), creditValues)
                 assertEquals("feedItemUid", idField)
+                assertEquals("status", declineStatusField)
+                assertEquals(setOf("DECLINED"), declinedStatusValues)
             }
 
             val people = assertNotNull(starling.peopleDownload, "Starling should configure a people download")

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
@@ -193,9 +193,16 @@ data class ApiTransactionMappings(
 
 @Serializable
 data class ApiPeopleMappings(
+    // Blank resolves to the transaction item itself, for providers whose counterparty fields are flat
+    // (e.g. Starling) rather than nested under an object (e.g. Monzo's "counterparty").
     val counterpartyObjectField: String = "counterparty",
     val beneficiaryAccountTypeField: String = "beneficiary_account_type",
     val personalBeneficiaryAccountTypeValue: String = "Personal",
+    // Additional values of [beneficiaryAccountTypeField] that mark a counterparty as a person, for
+    // providers that classify person-like counterparties under several types (e.g. Starling's
+    // PAYEE/SENDER). A counterparty is personal when its type matches [personalBeneficiaryAccountTypeValue]
+    // or any of these.
+    val personalBeneficiaryAccountTypeValues: Set<String> = emptySet(),
     val counterpartyNameField: String = "name",
     val counterpartyUserIdField: String = "user_id",
     val counterpartySortCodeField: String = "sort_code",

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
@@ -292,6 +292,10 @@ data class ApiSigningConfig(
  * @property accountOwnerAncestorExpr When set, links each imported person to the accounts fetched
  *                                    under the matching ancestor value (e.g. "ancestor[0].id" links a
  *                                    profile to the balances fetched under that profile id).
+ * @property ownsAllAccounts When true, the holder(s) returned by [endpoint] are linked to every
+ *                           account imported in the session, regardless of ancestor/id. Use for flat
+ *                           providers with a single global account holder and no ancestor hierarchy
+ *                           (e.g. Starling). Mutually exclusive with [accountOwnerAncestorExpr].
  */
 @Serializable
 data class ApiPersonImportConfig(
@@ -302,6 +306,7 @@ data class ApiPersonImportConfig(
     val preferredNameField: String? = null,
     val fallbackNameField: String? = null,
     val accountOwnerAncestorExpr: String? = null,
+    val ownsAllAccounts: Boolean = false,
 )
 
 /**

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
@@ -157,7 +157,14 @@ enum class ApiSignSource {
  * @property idField Dot-path to the transaction's stable id, used for de-duplication
  * @property merchantNameField Optional dot-path to a merchant name; preferred counterparty name
  * @property counterpartyNameField Optional dot-path to a counterparty name; fallback for merchant
- * @property declineReasonField Optional dot-path to a decline reason for declined transactions
+ * @property declineReasonField Optional dot-path to a decline reason for declined transactions.
+ *                              Present-and-non-blank means declined (Monzo's `decline_reason` shape).
+ * @property declineStatusField Optional dot-path to a status field whose value flags declines
+ *                              (Starling's `status` shape, where the field is always present). When
+ *                              the resolved value is in [declinedStatusValues] the transaction is
+ *                              treated as declined — imported but excluded from balances — exactly
+ *                              like a non-blank [declineReasonField].
+ * @property declinedStatusValues Values of [declineStatusField] that mean "declined" (e.g. {"DECLINED"}).
  * @property localAmountField Optional dot-path to a local/original amount (foreign transactions)
  * @property localCurrencyField Optional dot-path to a local/original currency code
  */
@@ -176,6 +183,8 @@ data class ApiTransactionMappings(
     val counterpartyNameField: String? = null,
     val counterpartyIdField: String? = null,
     val declineReasonField: String? = null,
+    val declineStatusField: String? = null,
+    val declinedStatusValues: Set<String> = emptySet(),
     val localAmountField: String? = null,
     val localCurrencyField: String? = null,
     val customFields: Map<String, String> = emptyMap(),

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -2200,6 +2200,22 @@ private fun ApiTransactionPageItem.errorRecord(
         errorMessage = message,
     )
 
+/**
+ * Resolves a transaction's decline reason, used downstream to exclude it from balances. Two shapes
+ * are supported: a dedicated reason field that is only present when declined (Monzo's
+ * `decline_reason`), and an always-present status field whose value flags the decline (Starling's
+ * `status` == "DECLINED"). The status, when matched, doubles as the human-readable reason.
+ */
+private fun resolveDeclineReason(
+    obj: JsonObject,
+    mappings: ApiTransactionMappings,
+): String? {
+    val reason = mappings.declineReasonField?.let { obj.resolveJsonPath(it) }
+    if (!reason.isNullOrBlank()) return reason
+    val status = mappings.declineStatusField?.let { obj.resolveJsonPath(it) }
+    return status?.takeIf { it in mappings.declinedStatusValues }
+}
+
 private fun parseTransactionsWithPath(
     json: String,
     strategy: ApiImportStrategy,
@@ -2212,7 +2228,7 @@ private fun parseTransactionsWithPath(
                 val created = obj.resolveJsonPath(mappings.timestampField)?.let { Instant.parse(it) }
                 val amount = parseAmount(obj, mappings)
                 val currency = obj.resolveJsonPath(mappings.currencyField)
-                val declineReason = mappings.declineReasonField?.let { obj.resolveJsonPath(it) }
+                val declineReason = resolveDeclineReason(obj, mappings)
                 val localAmount = mappings.localAmountField?.let { obj.resolveJsonPath(it) }?.toLongOrNull()
                 val localCurrency = mappings.localCurrencyField?.let { obj.resolveJsonPath(it) }
                 if (created != null && amount != null && currency != null) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -281,7 +281,11 @@ suspend fun downloadApiSessionTransactions(
                 before = transactions.minOfOrNull { it.created }
                 hasTransactions = transactions.isNotEmpty()
                 page += 1
-            } while (hasTransactions)
+                // A null pagination config means the endpoint returns the whole feed in one response
+                // (e.g. Starling); fetch exactly one page. Cursor mode keeps paging until a page is
+                // empty. Without this guard a non-paginating endpoint that ignores the cursor would
+                // return the same items forever and loop indefinitely.
+            } while (hasTransactions && pagination != null)
         }
     }
 
@@ -343,12 +347,24 @@ suspend fun importApiSessionPeople(
         }
     val ownedAccountsByProfile =
         buildProfileAccountMap(apiSessionRepository, accountRepository, accountAttributeRepository, accountsSessionId, strategy, config)
+    // Flat providers with a single global account holder (no ancestor hierarchy) link that holder to
+    // every account imported in the session.
+    val allSessionAccountIds =
+        if (config.ownsAllAccounts) {
+            loadSessionAccountIds(apiSessionRepository, accountRepository, accountAttributeRepository, accountsSessionId, strategy)
+        } else {
+            emptyList()
+        }
     // Ownership links can only be created against accounts that already exist. When people are
     // imported before their accounts (no accounts session, or accounts not yet imported), the
     // profile→account map is empty and people are created without ownerships; flag that so the
     // empty-ownership outcome isn't mistaken for a successful link.
-    if (config.accountOwnerAncestorExpr != null && ownedAccountsByProfile.isEmpty()) {
-        logger.warn { "Importing people with no imported accounts to link; ownerships will not be created. Import accounts first." }
+    val noLinkableAccounts =
+        if (config.ownsAllAccounts) allSessionAccountIds.isEmpty() else ownedAccountsByProfile.isEmpty()
+    if (config.accountOwnerAncestorExpr != null || config.ownsAllAccounts) {
+        if (noLinkableAccounts) {
+            logger.warn { "Importing people with no imported accounts to link; ownerships will not be created. Import accounts first." }
+        }
     }
     val peopleIndex = loadPeopleIndex(personRepository, personAttributeRepository, externalIdAttributeTypeId)
 
@@ -360,7 +376,8 @@ suspend fun importApiSessionPeople(
             ?.forEachIndexed { index, element ->
                 val obj = element as? JsonObject ?: return@forEachIndexed
                 val owner = obj.toPersonOwner(config, index) ?: return@forEachIndexed
-                val ownedAccounts = ownedAccountsByProfile[owner.userId].orEmpty()
+                val ownedAccounts =
+                    if (config.ownsAllAccounts) allSessionAccountIds else ownedAccountsByProfile[owner.userId].orEmpty()
                 if (ownedAccounts.isEmpty()) {
                     val created =
                         resolveOrCreatePerson(
@@ -425,6 +442,29 @@ private suspend fun buildProfileAccountMap(
         }
     }
     return result
+}
+
+/** Returns every [AccountId] imported under [accountsSessionId] (used for [ApiPersonImportConfig.ownsAllAccounts]). */
+private suspend fun loadSessionAccountIds(
+    apiSessionRepository: ApiSessionRepository,
+    accountRepository: AccountRepository,
+    accountAttributeRepository: AccountAttributeRepository,
+    accountsSessionId: ApiSessionId?,
+    strategy: ApiImportStrategy,
+): List<AccountId> {
+    if (accountsSessionId == null) return emptyList()
+    val accountIdByExternalId = loadAccountExternalIdIndex(accountRepository, accountAttributeRepository)
+    val requestsById = apiSessionRepository.getRequestsBySession(accountsSessionId).associateBy { it.id }
+    val result = mutableListOf<AccountId>()
+    for (response in apiSessionRepository.getResponsesBySession(accountsSessionId)) {
+        val isAccountsResponse = requestsById[response.requestId]?.isAccountsRequest(strategy) == true
+        if (isAccountsResponse) {
+            for (account in parseAccounts(response.json, strategy)) {
+                accountIdByExternalId[account.id]?.let { result.add(it) }
+            }
+        }
+    }
+    return result.distinct()
 }
 
 /** Maps a profile object to an owner; returns null when no usable name can be derived. */
@@ -2269,7 +2309,11 @@ private fun arrayItemJsonPath(
     index: Int,
 ): JsonPath = if (responseArrayKey.isBlank()) JsonPath("$[$index]") else JsonPath("$.$responseArrayKey[$index]")
 
-/** Extracts the items array from a response body; a blank [responseArrayKey] means the body is the array. */
+/**
+ * Extracts the items array from a response body; a blank [responseArrayKey] means the body is the
+ * array. A bare JSON object body (e.g. a single-resource endpoint like Starling's account holder) is
+ * wrapped as a one-element array so single-object responses parse like any other.
+ */
 private fun responseItemsArray(
     json: String,
     responseArrayKey: String,
@@ -2277,7 +2321,11 @@ private fun responseItemsArray(
     try {
         val root = Json.parseToJsonElement(json)
         if (responseArrayKey.isBlank()) {
-            root as? JsonArray
+            when (root) {
+                is JsonArray -> root
+                is JsonObject -> JsonArray(listOf(root))
+                else -> null
+            }
         } else {
             (root as? JsonObject)?.get(responseArrayKey)?.jsonArray
         }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -338,6 +338,12 @@ suspend fun importApiSessionPeople(
     accountsSessionId: ApiSessionId? = null,
 ): ApiPeopleImportResult {
     val config = strategy.peopleDownload ?: return ApiPeopleImportResult(personCount = 0, ownershipCount = 0)
+    // The two ownership-linking strategies are mutually exclusive: ownsAllAccounts links a single
+    // global holder to every account, while accountOwnerAncestorExpr derives ownership from the
+    // resource hierarchy. Allowing both would silently prefer ownsAllAccounts and persist wrong links.
+    require(!(config.ownsAllAccounts && config.accountOwnerAncestorExpr != null)) {
+        "Invalid peopleDownload config: ownsAllAccounts and accountOwnerAncestorExpr are mutually exclusive."
+    }
     val externalIdAttributeTypeId = strategy.personExternalIdAttribute?.let { attributeTypeRepository.getOrCreate(it) }
     val requestsById = apiSessionRepository.getRequestsBySession(sessionId).associateBy { it.id }
     val peopleResponses =

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -860,7 +860,61 @@ private suspend fun importPeopleFromSession(setup: ImportSetup): Int {
             personAccountOwnershipRepository = setup.personAccountOwnershipRepository,
             personAttributeRepository = setup.personAttributeRepository,
             externalIdAttributeTypeId = externalIdAttributeTypeId,
-        )
+        ) +
+        linkGlobalHolderToOwnAccounts(setup, externalIdAttributeTypeId)
+}
+
+/**
+ * Links the global account holder to every own account in this import, sourcing the holder from the
+ * credential's already-downloaded PEOPLE session(s). This makes `ownsAllAccounts` ownership
+ * order-independent: [importApiSessionPeople] links the holder when the PEOPLE session is imported
+ * after the accounts, and this covers the reverse — accounts imported after the holder — by re-linking
+ * each time accounts are imported. Idempotent: [importOwnersForAccount] skips already-linked owners.
+ */
+private suspend fun linkGlobalHolderToOwnAccounts(
+    setup: ImportSetup,
+    externalIdAttributeTypeId: AttributeTypeId?,
+): Int {
+    val config = setup.strategy.peopleDownload ?: return 0
+    if (!config.ownsAllAccounts || setup.accountsById.isEmpty()) return 0
+    val credentialId = setup.apiSessionRepository.getSessionById(setup.sessionId)?.credentialId ?: return 0
+
+    // Resolve the AccountIds of the own accounts known to this import (idempotent — they already exist).
+    val ownAccountIds =
+        setup.accountsById.values.map { account ->
+            setup.accountCache.getOrCreateAccountId(account.id, account.displayName(setup.strategy))
+        }
+
+    val peopleIndex = loadPeopleIndex(setup.personRepository, setup.personAttributeRepository, externalIdAttributeTypeId)
+    var newPeopleCount = 0
+    val peopleSessions =
+        setup.apiSessionRepository
+            .getSessionsByCredential(credentialId)
+            .filter { it.kind == ApiSessionKind.PEOPLE }
+    for (session in peopleSessions) {
+        for (response in setup.apiSessionRepository.getResponsesBySession(session.id)) {
+            responseItemsArray(response.json, config.endpoint.responseArrayKey)
+                ?.forEachIndexed { index, element ->
+                    val owner = (element as? JsonObject)?.toPersonOwner(config, index) ?: return@forEachIndexed
+                    for (accountId in ownAccountIds) {
+                        newPeopleCount +=
+                            importOwnersForAccount(
+                                owners = listOf(owner),
+                                accountId = accountId,
+                                peopleIndex = peopleIndex,
+                                personRepository = setup.personRepository,
+                                personAccountOwnershipRepository = setup.personAccountOwnershipRepository,
+                                personAttributeRepository = setup.personAttributeRepository,
+                                externalIdAttributeTypeId = externalIdAttributeTypeId,
+                                entitySource = setup.entitySource,
+                                sessionId = session.id,
+                                requestId = response.requestId,
+                            ).newPeople
+                    }
+                }
+        }
+    }
+    return newPeopleCount
 }
 
 private suspend fun flushPostTransactionAttributes(setup: ImportSetup) {
@@ -1230,32 +1284,39 @@ private suspend fun importPeopleFromCounterparties(
 
     for (response in transactionResponses) {
         val request = requestsById[response.requestId] ?: continue
-        val personalCounterpartyItems = mutableListOf<Triple<ApiTransactionPageItem, ApiImportAccountOwner, PersonalCounterpartyIdentity>>()
+        val personalCounterpartyItems = mutableListOf<Pair<ApiTransactionPageItem, ApiImportAccountOwner>>()
         for (item in parseTransactionsWithPath(response.json, strategy)) {
             val isBuiltIn = item.rawJson?.resolveBuiltInCounterpartyType(strategy.builtInCounterpartyRules, item.amountSign) != null
             if (!item.isZeroAmount && !isBuiltIn) {
-                val owner = item.personalCounterpartyOwner(strategy.peopleMappings)
-                val personalCounterpartyIdentity = owner?.personalCounterpartyIdentity()
-                if (owner != null && personalCounterpartyIdentity != null) {
-                    personalCounterpartyItems.add(Triple(item, owner, personalCounterpartyIdentity))
-                }
+                // Providers with full bank details (Monzo) yield a personalCounterpartyIdentity;
+                // providers with only a name + id (Starling) do not, but are still personal owners.
+                item.personalCounterpartyOwner(strategy.peopleMappings)?.let { personalCounterpartyItems.add(item to it) }
             }
         }
-        for ((item, owner, personalCounterpartyIdentity) in personalCounterpartyItems) {
+        for ((item, owner) in personalCounterpartyItems) {
+            val identity = owner.personalCounterpartyIdentity()
+            val counterpartyId = item.rawJson?.resolveCounterpartyIdentity(counterpartyIdField, strategy.peopleMappings)
+            val counterpartyName =
+                identity?.name ?: owner.preferredName?.takeIf { it.isNotBlank() } ?: item.counterpartyName(nameMappings)
+            // Need a stable key to hang the ownership on: a counterparty id, a bank identity, or at
+            // least a usable name. Skip otherwise to avoid creating orphan people.
+            if (counterpartyId == null && identity == null && counterpartyName.isBlank()) continue
             val counterpartyAccountId =
                 accountCache.getOrCreateCounterpartyAccountId(
-                    counterpartyId = item.rawJson?.resolveCounterpartyIdentity(counterpartyIdField, strategy.peopleMappings),
+                    counterpartyId = counterpartyId,
                     builtInType = null,
-                    name = nameMappings.counterpartyPrefix + personalCounterpartyIdentity.name,
-                    dedupeKey = personalCounterpartyIdentity.dedupeKey,
+                    name = nameMappings.counterpartyPrefix + counterpartyName,
+                    dedupeKey = identity?.dedupeKey,
                     apiSource = AccountApiSource(sessionId, request.id, JsonPath("${item.jsonPath.value}.counterparty")),
-                    personalIdentity = personalCounterpartyIdentity,
+                    personalIdentity = identity,
                 )
-            accountAttributeRepository.ensureCounterpartyPersonalAttributes(
-                accountId = counterpartyAccountId,
-                sortCode = personalCounterpartyIdentity.sortCode,
-                accountNumber = personalCounterpartyIdentity.accountNumber,
-            )
+            if (identity != null) {
+                accountAttributeRepository.ensureCounterpartyPersonalAttributes(
+                    accountId = counterpartyAccountId,
+                    sortCode = identity.sortCode,
+                    accountNumber = identity.accountNumber,
+                )
+            }
             newPeopleCount +=
                 importOwnersForAccount(
                     owners = listOf(owner),
@@ -1367,7 +1428,10 @@ private suspend fun resolveOrCreatePerson(
         if (externalIdAttributeTypeId != null && externalId != null && existing.externalId == null) {
             logger.info { "Backfilling external id for imported person '${existing.fullName}'" }
             runCatching {
-                personAttributeRepository.insert(existing.person.id, externalIdAttributeTypeId, externalId)
+                // Creation mode records the attribute at the person's existing revision rather than
+                // bumping a new one, matching how all other import-time attributes are written and
+                // avoiding an orphan person revision with no entity source.
+                personAttributeRepository.insertInCreationMode(existing.person.id, externalIdAttributeTypeId, externalId)
             }
             peopleIndex.replace(existing.person, externalId)
             return existing.person to false
@@ -1631,10 +1695,17 @@ private suspend fun AccountAttributeRepository.upsertAccountAttributeInCreationM
     }
 }
 
+/** Whether [type] marks a counterparty as a person, per the single or multi-value personal config. */
+private fun ApiPeopleMappings.isPersonalBeneficiaryType(type: String?): Boolean {
+    if (type == null) return false
+    if (type.equals(personalBeneficiaryAccountTypeValue, ignoreCase = true)) return true
+    return personalBeneficiaryAccountTypeValues.any { it.equals(type, ignoreCase = true) }
+}
+
 private fun ApiTransactionPageItem.personalCounterpartyOwner(peopleMappings: ApiPeopleMappings): ApiImportAccountOwner? {
     val counterparty = rawJson?.resolveJsonObjectPath(peopleMappings.counterpartyObjectField) ?: return null
     val beneficiaryAccountType = counterparty.stringOrNull(peopleMappings.beneficiaryAccountTypeField)
-    if (beneficiaryAccountType?.equals(peopleMappings.personalBeneficiaryAccountTypeValue, ignoreCase = true) != true) return null
+    if (!peopleMappings.isPersonalBeneficiaryType(beneficiaryAccountType)) return null
 
     val name = counterparty.stringOrNull(peopleMappings.counterpartyNameField)?.takeIf { it.isNotBlank() }
     val userId = counterparty.stringOrNull(peopleMappings.counterpartyUserIdField)?.takeIf { it.isNotBlank() }.orEmpty()
@@ -1653,7 +1724,7 @@ private fun ApiTransactionPageItem.personalCounterpartyOwner(peopleMappings: Api
 private fun JsonObject.personalCounterpartyIdentity(peopleMappings: ApiPeopleMappings): PersonalCounterpartyIdentity? {
     val counterparty = resolveJsonObjectPath(peopleMappings.counterpartyObjectField) ?: return null
     val beneficiaryAccountType = counterparty.stringOrNull(peopleMappings.beneficiaryAccountTypeField)
-    if (beneficiaryAccountType?.equals(peopleMappings.personalBeneficiaryAccountTypeValue, ignoreCase = true) != true) return null
+    if (!peopleMappings.isPersonalBeneficiaryType(beneficiaryAccountType)) return null
     val sortCode = counterparty.stringOrNull(peopleMappings.counterpartySortCodeField)?.takeIf { it.isNotBlank() } ?: return null
     val accountNumber = counterparty.stringOrNull(peopleMappings.counterpartyAccountNumberField)?.takeIf { it.isNotBlank() } ?: return null
     val name = counterparty.stringOrNull(peopleMappings.counterpartyNameField)?.takeIf { it.isNotBlank() } ?: return null
@@ -2940,6 +3011,9 @@ private fun JsonObject.resolveCounterpartyIdentity(
 }
 
 private fun JsonObject.resolveJsonObjectPath(dotPath: String): JsonObject? {
+    // A blank path means "this object" — used by providers whose counterparty fields are flat on the
+    // transaction item rather than nested under a sub-object.
+    if (dotPath.isBlank()) return this
     var current: JsonElement = this
     for (part in dotPath.split(".")) {
         current = (current as? JsonObject)?.get(part) ?: return null

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -320,6 +320,18 @@ suspend fun downloadApiSessionPeople(
 }
 
 /**
+ * The two ownership-linking strategies are mutually exclusive: [ApiPersonImportConfig.ownsAllAccounts]
+ * links a single global holder to every account, while [ApiPersonImportConfig.accountOwnerAncestorExpr]
+ * derives ownership from the resource hierarchy. Allowing both would silently prefer ownsAllAccounts and
+ * persist wrong links, so every code path that acts on the config validates it first.
+ */
+private fun validatePeopleOwnershipConfig(config: ApiPersonImportConfig) {
+    require(!(config.ownsAllAccounts && config.accountOwnerAncestorExpr != null)) {
+        "Invalid peopleDownload config: ownsAllAccounts and accountOwnerAncestorExpr are mutually exclusive."
+    }
+}
+
+/**
  * Imports people from a people-download session: creates a [Person] for each profile holder and, when
  * [accountsSessionId] is provided, links each person as an owner of the accounts fetched under their
  * profile (via [ApiPersonImportConfig.accountOwnerAncestorExpr]).
@@ -338,12 +350,7 @@ suspend fun importApiSessionPeople(
     accountsSessionId: ApiSessionId? = null,
 ): ApiPeopleImportResult {
     val config = strategy.peopleDownload ?: return ApiPeopleImportResult(personCount = 0, ownershipCount = 0)
-    // The two ownership-linking strategies are mutually exclusive: ownsAllAccounts links a single
-    // global holder to every account, while accountOwnerAncestorExpr derives ownership from the
-    // resource hierarchy. Allowing both would silently prefer ownsAllAccounts and persist wrong links.
-    require(!(config.ownsAllAccounts && config.accountOwnerAncestorExpr != null)) {
-        "Invalid peopleDownload config: ownsAllAccounts and accountOwnerAncestorExpr are mutually exclusive."
-    }
+    validatePeopleOwnershipConfig(config)
     val externalIdAttributeTypeId = strategy.personExternalIdAttribute?.let { attributeTypeRepository.getOrCreate(it) }
     val requestsById = apiSessionRepository.getRequestsBySession(sessionId).associateBy { it.id }
     val peopleResponses =
@@ -876,6 +883,7 @@ private suspend fun linkGlobalHolderToOwnAccounts(
     externalIdAttributeTypeId: AttributeTypeId?,
 ): Int {
     val config = setup.strategy.peopleDownload ?: return 0
+    validatePeopleOwnershipConfig(config)
     if (!config.ownsAllAccounts || setup.accountsById.isEmpty()) return 0
     val credentialId = setup.apiSessionRepository.getSessionById(setup.sessionId)?.credentialId ?: return 0
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiConnectScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiConnectScreen.kt
@@ -243,6 +243,7 @@ private fun providerTokenPageUrl(strategy: ApiImportStrategy?): String? =
     when (providerKind(strategy)) {
         ProviderKind.MONZO -> "https://developers.monzo.com/"
         ProviderKind.WISE -> "https://wise.com/your-account/integrations-and-tools/api-tokens"
+        ProviderKind.STARLING -> "https://developer.starlingbank.com/"
         null -> null
     }
 
@@ -268,16 +269,24 @@ private fun connectInstructions(strategy: ApiImportStrategy?): List<String> =
                 "Note: retrieving statements via the API is only supported for accounts based in the US, Canada, " +
                     "Australia, New Zealand, Singapore, and Malaysia.",
             )
+        ProviderKind.STARLING ->
+            listOf(
+                "Open the Starling Developer portal in your browser and sign in with your Starling account.",
+                "Create a personal access token with the account:read, transaction:read and " +
+                    "account-holder-name:read scopes.",
+                "Copy the token, paste it below and tap \"Save Token\".",
+            )
         null -> emptyList()
     }
 
-private enum class ProviderKind { MONZO, WISE }
+private enum class ProviderKind { MONZO, WISE, STARLING }
 
 private fun providerKind(strategy: ApiImportStrategy?): ProviderKind? {
     val baseUrl = strategy?.baseUrl?.lowercase() ?: return null
     return when {
         "monzo" in baseUrl -> ProviderKind.MONZO
         "wise" in baseUrl || "transferwise" in baseUrl -> ProviderKind.WISE
+        "starling" in baseUrl -> ProviderKind.STARLING
         else -> null
     }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
@@ -75,6 +75,48 @@ private val FEED_JSON =
 }
     """.trimIndent()
 
+/**
+ * Two settled items plus one DECLINED item. Declined feed items never moved money, so they are
+ * imported (for the record) but excluded from balances — mirroring Monzo's `decline_reason` handling.
+ */
+private val FEED_WITH_DECLINED_JSON =
+    """
+{
+  "feedItems": [
+    {
+      "feedItemUid": "f1",
+      "categoryUid": "$CATEGORY_UID",
+      "amount": { "currency": "GBP", "minorUnits": 1250 },
+      "direction": "OUT",
+      "status": "SETTLED",
+      "transactionTime": "2024-06-03T09:15:00.000Z",
+      "reference": "COFFEE SHOP",
+      "counterPartyName": "Coffee Shop"
+    },
+    {
+      "feedItemUid": "f2",
+      "categoryUid": "$CATEGORY_UID",
+      "amount": { "currency": "GBP", "minorUnits": 50000 },
+      "direction": "IN",
+      "status": "SETTLED",
+      "transactionTime": "2024-06-02T14:30:00.000Z",
+      "reference": "SALARY",
+      "counterPartyName": "ACME Ltd"
+    },
+    {
+      "feedItemUid": "f3",
+      "categoryUid": "$CATEGORY_UID",
+      "amount": { "currency": "GBP", "minorUnits": 200000 },
+      "direction": "OUT",
+      "status": "DECLINED",
+      "transactionTime": "2024-06-04T11:00:00.000Z",
+      "reference": "CRYPTO.COM",
+      "counterPartyName": "Crypto.com"
+    }
+  ]
+}
+    """.trimIndent()
+
 private val ACCOUNT_HOLDER_JSON =
     """
 {
@@ -87,13 +129,18 @@ private val ACCOUNT_HOLDER_JSON =
     """.trimIndent()
 
 class StarlingImportE2ETest : DbTest() {
-    private fun mockEngine() =
+    private val feedRequestUrls = mutableListOf<String>()
+
+    private fun mockEngine(feedJson: String = FEED_JSON) =
         MockEngine { request ->
             val url = request.url.toString()
             val json =
                 when {
                     url.contains("/account-holder/individual") -> ACCOUNT_HOLDER_JSON
-                    url.contains("/feed/account/") -> FEED_JSON
+                    url.contains("/feed/account/") -> {
+                        feedRequestUrls += url
+                        feedJson
+                    }
                     url.contains("/api/v2/accounts") -> ACCOUNTS_JSON
                     else -> error("Unexpected request: $url")
                 }
@@ -153,6 +200,14 @@ class StarlingImportE2ETest : DbTest() {
 
             assertEquals(2, importResult.transactionCount, "Both feed items should import")
             assertEquals(0, importResult.errorCount, "No import errors expected")
+
+            // Starling's feed endpoint rejects requests without the mandatory `changesSince` bound
+            // with HTTP 400, so every feed request must carry it.
+            assertTrue(feedRequestUrls.isNotEmpty(), "A feed request should have been made")
+            assertTrue(
+                feedRequestUrls.all { it.contains("changesSince=") },
+                "Every Starling feed request must include the mandatory changesSince parameter: $feedRequestUrls",
+            )
 
             val allAccounts = repositories.accountRepository.getAllAccounts().first()
             val ownAccount = allAccounts.single { it.name == "Starling: Personal" }
@@ -252,5 +307,71 @@ class StarlingImportE2ETest : DbTest() {
                     .first()
             assertTrue(owners.any { it.personId == ada.id }, "The account holder should own the Starling account")
             assertNotNull(ada)
+        }
+
+    @Test
+    fun `declined starling feed items are imported but excluded from the account balance`() =
+        runTest {
+            val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+            val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+            val sessionId = repositories.apiSessionRepository.createSession("test-starling-token", deviceId, now, null)
+            val strategy =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .single { it.name == "Starling" }
+
+            val apiClient =
+                createApiClient(
+                    trafficRecorder =
+                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                    engine = mockEngine(feedJson = FEED_WITH_DECLINED_JSON),
+                )
+
+            downloadApiSessionAccounts(
+                token = "test-starling-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+            downloadApiSessionTransactions(
+                token = "test-starling-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+            val importResult =
+                importApiSessionTransactions(
+                    apiSessionRepository = repositories.apiSessionRepository,
+                    accountRepository = repositories.accountRepository,
+                    currencyRepository = repositories.currencyRepository,
+                    transactionRepository = repositories.transactionRepository,
+                    entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                    personRepository = repositories.personRepository,
+                    personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                    personAttributeRepository = repositories.personAttributeRepository,
+                    attributeTypeRepository = repositories.attributeTypeRepository,
+                    accountAttributeRepository = repositories.accountAttributeRepository,
+                    deviceId = deviceId,
+                    sessionId = sessionId,
+                    strategy = strategy,
+                )
+
+            // All three items are imported, including the declined one (kept for the record).
+            assertEquals(3, importResult.transactionCount, "All feed items import, declined included")
+
+            // Balances are served from a materialized view that import does not refresh inline.
+            repositories.maintenanceService.refreshMaterializedViews()
+
+            val accounts = repositories.accountRepository.getAllAccounts().first()
+            val ownAccount = accounts.single { it.name == "Starling: Personal" }
+            val balances = repositories.transactionRepository.getAccountBalances().first()
+            val ownBalance = balances.single { it.accountId == ownAccount.id }
+
+            // Balance reflects only the two settled items (+50000 in, -1250 out); the 200000 declined
+            // outgoing is excluded. Were it counted, the balance would be -151250 instead of 48750.
+            assertEquals(48750L, ownBalance.balance.amount, "Declined item must not affect the balance")
         }
 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
@@ -464,7 +464,6 @@ class StarlingImportE2ETest : DbTest() {
                 entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
                 sessionId = peopleSessionId,
                 strategy = strategy,
-                accountsSessionId = null,
             )
 
             // 2) Accounts AFTER the holder — the accounts import must back-link the holder to the own account.
@@ -546,7 +545,6 @@ class StarlingImportE2ETest : DbTest() {
                 entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
                 sessionId = peopleSessionId,
                 strategy = strategy,
-                accountsSessionId = null,
             )
 
             // Importing the SENDER counterparty "Ada Lovelace" matches the holder by name and backfills

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
@@ -129,23 +129,24 @@ private val ACCOUNT_HOLDER_JSON =
     """.trimIndent()
 
 class StarlingImportE2ETest : DbTest() {
-    private val feedRequestUrls = mutableListOf<String>()
-
-    private fun mockEngine(feedJson: String = FEED_JSON) =
-        MockEngine { request ->
-            val url = request.url.toString()
-            val json =
-                when {
-                    url.contains("/account-holder/individual") -> ACCOUNT_HOLDER_JSON
-                    url.contains("/feed/account/") -> {
-                        feedRequestUrls += url
-                        feedJson
-                    }
-                    url.contains("/api/v2/accounts") -> ACCOUNTS_JSON
-                    else -> error("Unexpected request: $url")
+    // Pass a per-test list to capture feed request URLs; kept local so tests stay isolated.
+    private fun mockEngine(
+        feedJson: String = FEED_JSON,
+        feedRequestUrls: MutableList<String>? = null,
+    ) = MockEngine { request ->
+        val url = request.url.toString()
+        val json =
+            when {
+                url.contains("/account-holder/individual") -> ACCOUNT_HOLDER_JSON
+                url.contains("/feed/account/") -> {
+                    feedRequestUrls?.add(url)
+                    feedJson
                 }
-            respond(content = json, status = HttpStatusCode.OK, headers = headersOf(HttpHeaders.ContentType, "application/json"))
-        }
+                url.contains("/api/v2/accounts") -> ACCOUNTS_JSON
+                else -> error("Unexpected request: $url")
+            }
+        respond(content = json, status = HttpStatusCode.OK, headers = headersOf(HttpHeaders.ContentType, "application/json"))
+    }
 
     @Test
     fun `starling feed items import with direction-based sign and minor-unit amounts`() =
@@ -159,11 +160,12 @@ class StarlingImportE2ETest : DbTest() {
                     .first()
                     .single { it.name == "Starling" }
 
+            val feedRequestUrls = mutableListOf<String>()
             val apiClient =
                 createApiClient(
                     trafficRecorder =
                         ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
-                    engine = mockEngine(),
+                    engine = mockEngine(feedRequestUrls = feedRequestUrls),
                 )
 
             downloadApiSessionAccounts(

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
@@ -1,0 +1,256 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.ui.starling
+
+import com.moneymanager.database.port.DbEntitySource
+import com.moneymanager.domain.model.ApiSessionId
+import com.moneymanager.domain.model.DeviceInfo
+import com.moneymanager.rest.ApiSessionTrafficRecorder
+import com.moneymanager.rest.createApiClient
+import com.moneymanager.test.database.DbTest
+import com.moneymanager.ui.api.downloadApiSessionAccounts
+import com.moneymanager.ui.api.downloadApiSessionPeople
+import com.moneymanager.ui.api.downloadApiSessionTransactions
+import com.moneymanager.ui.api.importApiSessionPeople
+import com.moneymanager.ui.api.importApiSessionTransactions
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+private const val ACCOUNT_UID = "11111111-1111-1111-1111-111111111111"
+private const val CATEGORY_UID = "22222222-2222-2222-2222-222222222222"
+
+private val ACCOUNTS_JSON =
+    """
+{
+  "accounts": [
+    {
+      "accountUid": "$ACCOUNT_UID",
+      "accountType": "PRIMARY",
+      "defaultCategory": "$CATEGORY_UID",
+      "currency": "GBP",
+      "createdAt": "2021-01-01T00:00:00.000Z",
+      "name": "Personal"
+    }
+  ]
+}
+    """.trimIndent()
+
+/**
+ * One outgoing and one incoming feed item. The direction (IN/OUT) — not the amount sign — determines
+ * which side is the user's account; amounts are integer minor units.
+ */
+private val FEED_JSON =
+    """
+{
+  "feedItems": [
+    {
+      "feedItemUid": "f1",
+      "categoryUid": "$CATEGORY_UID",
+      "amount": { "currency": "GBP", "minorUnits": 1250 },
+      "direction": "OUT",
+      "transactionTime": "2024-06-03T09:15:00.000Z",
+      "reference": "COFFEE SHOP",
+      "counterPartyName": "Coffee Shop"
+    },
+    {
+      "feedItemUid": "f2",
+      "categoryUid": "$CATEGORY_UID",
+      "amount": { "currency": "GBP", "minorUnits": 50000 },
+      "direction": "IN",
+      "transactionTime": "2024-06-02T14:30:00.000Z",
+      "reference": "SALARY",
+      "counterPartyName": "ACME Ltd"
+    }
+  ]
+}
+    """.trimIndent()
+
+private val ACCOUNT_HOLDER_JSON =
+    """
+{
+  "title": "Ms",
+  "firstName": "Ada",
+  "lastName": "Lovelace",
+  "dateOfBirth": "1990-01-01",
+  "email": "ada@example.com"
+}
+    """.trimIndent()
+
+class StarlingImportE2ETest : DbTest() {
+    private fun mockEngine() =
+        MockEngine { request ->
+            val url = request.url.toString()
+            val json =
+                when {
+                    url.contains("/account-holder/individual") -> ACCOUNT_HOLDER_JSON
+                    url.contains("/feed/account/") -> FEED_JSON
+                    url.contains("/api/v2/accounts") -> ACCOUNTS_JSON
+                    else -> error("Unexpected request: $url")
+                }
+            respond(content = json, status = HttpStatusCode.OK, headers = headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+
+    @Test
+    fun `starling feed items import with direction-based sign and minor-unit amounts`() =
+        runTest {
+            val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+            val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+            val sessionId = repositories.apiSessionRepository.createSession("test-starling-token", deviceId, now, null)
+            val strategy =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .single { it.name == "Starling" }
+
+            val apiClient =
+                createApiClient(
+                    trafficRecorder =
+                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                    engine = mockEngine(),
+                )
+
+            downloadApiSessionAccounts(
+                token = "test-starling-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+            downloadApiSessionTransactions(
+                token = "test-starling-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+
+            val importResult =
+                importApiSessionTransactions(
+                    apiSessionRepository = repositories.apiSessionRepository,
+                    accountRepository = repositories.accountRepository,
+                    currencyRepository = repositories.currencyRepository,
+                    transactionRepository = repositories.transactionRepository,
+                    entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                    personRepository = repositories.personRepository,
+                    personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                    personAttributeRepository = repositories.personAttributeRepository,
+                    attributeTypeRepository = repositories.attributeTypeRepository,
+                    accountAttributeRepository = repositories.accountAttributeRepository,
+                    deviceId = deviceId,
+                    sessionId = sessionId,
+                    strategy = strategy,
+                )
+
+            assertEquals(2, importResult.transactionCount, "Both feed items should import")
+            assertEquals(0, importResult.errorCount, "No import errors expected")
+
+            val allAccounts = repositories.accountRepository.getAllAccounts().first()
+            val ownAccount = allAccounts.single { it.name == "Starling: Personal" }
+            val transfers = repositories.transactionRepository.getTransactionsByAccount(ownAccount.id).first()
+            assertEquals(2, transfers.size)
+
+            val coffee = allAccounts.single { it.name == "Starling Counterparty: Coffee Shop" }
+            val acme = allAccounts.single { it.name == "Starling Counterparty: ACME Ltd" }
+
+            val outgoing = transfers.single { it.amount.amount == 1250L }
+            assertEquals(ownAccount.id, outgoing.sourceAccountId, "OUT direction: money leaves the user's account")
+            assertEquals(coffee.id, outgoing.targetAccountId)
+
+            val incoming = transfers.single { it.amount.amount == 50000L }
+            assertEquals(acme.id, incoming.sourceAccountId)
+            assertEquals(ownAccount.id, incoming.targetAccountId, "IN direction: money arrives at the user's account")
+        }
+
+    @Test
+    fun `starling account holder is imported and linked to every account`() =
+        runTest {
+            val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+            val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+            val strategy =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .single { it.name == "Starling" }
+
+            fun clientFor(session: ApiSessionId) =
+                createApiClient(
+                    trafficRecorder =
+                        ApiSessionTrafficRecorder(sessionId = session, apiSessionRepository = repositories.apiSessionRepository),
+                    engine = mockEngine(),
+                )
+
+            // Import accounts (and transactions) so the Starling account exists.
+            val accountsSessionId = repositories.apiSessionRepository.createSession("test-starling-token", deviceId, now, null)
+            downloadApiSessionAccounts(
+                token = "test-starling-token",
+                apiClient = clientFor(accountsSessionId),
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = accountsSessionId,
+                strategy = strategy,
+            )
+            importApiSessionTransactions(
+                apiSessionRepository = repositories.apiSessionRepository,
+                accountRepository = repositories.accountRepository,
+                currencyRepository = repositories.currencyRepository,
+                transactionRepository = repositories.transactionRepository,
+                entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                personRepository = repositories.personRepository,
+                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                personAttributeRepository = repositories.personAttributeRepository,
+                attributeTypeRepository = repositories.attributeTypeRepository,
+                accountAttributeRepository = repositories.accountAttributeRepository,
+                deviceId = deviceId,
+                sessionId = accountsSessionId,
+                strategy = strategy,
+            )
+
+            // Download + import the single global account holder.
+            val peopleSessionId = repositories.apiSessionRepository.createSession("test-starling-token", deviceId, now, null)
+            val downloadResult =
+                downloadApiSessionPeople(
+                    token = "test-starling-token",
+                    apiClient = clientFor(peopleSessionId),
+                    apiSessionRepository = repositories.apiSessionRepository,
+                    sessionId = peopleSessionId,
+                    strategy = strategy,
+                )
+            assertEquals(1, downloadResult.personCount, "The single account holder object should be counted")
+
+            val importResult =
+                importApiSessionPeople(
+                    apiSessionRepository = repositories.apiSessionRepository,
+                    accountRepository = repositories.accountRepository,
+                    accountAttributeRepository = repositories.accountAttributeRepository,
+                    personRepository = repositories.personRepository,
+                    personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                    personAttributeRepository = repositories.personAttributeRepository,
+                    attributeTypeRepository = repositories.attributeTypeRepository,
+                    entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                    sessionId = peopleSessionId,
+                    strategy = strategy,
+                    accountsSessionId = accountsSessionId,
+                )
+            assertEquals(1, importResult.personCount, "The account holder is created as a person")
+
+            val people = repositories.personRepository.getAllPeople().first()
+            val ada = people.single { it.firstName == "Ada" && it.lastName == "Lovelace" }
+            val accounts = repositories.accountRepository.getAllAccounts().first()
+            val ownAccount = accounts.single { it.name == "Starling: Personal" }
+            val owners =
+                repositories.personAccountOwnershipRepository
+                    .getOwnershipsByAccount(ownAccount.id)
+                    .first()
+            assertTrue(owners.any { it.personId == ada.id }, "The account holder should own the Starling account")
+            assertNotNull(ada)
+        }
+}

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
@@ -331,7 +331,11 @@ class StarlingImportE2ETest : DbTest() {
             val coffeeOwners = repositories.personAccountOwnershipRepository.getOwnershipsByAccount(coffee.id).first()
             assertTrue(coffeeOwners.isEmpty(), "The MERCHANT counterparty should not gain an owner")
 
-            val acmePerson = repositories.personRepository.getAllPeople().first().single { it.firstName == "ACME" }
+            val acmePerson =
+                repositories.personRepository
+                    .getAllPeople()
+                    .first()
+                    .single { it.firstName == "ACME" }
             assertEquals(acmeOwners.single().personId, acmePerson.id)
         }
 
@@ -490,14 +494,22 @@ class StarlingImportE2ETest : DbTest() {
                 strategy = strategy,
             )
 
-            val ada = repositories.personRepository.getAllPeople().first().single { it.firstName == "Ada" && it.lastName == "Lovelace" }
-            val ownAccount = repositories.accountRepository.getAllAccounts().first().single { it.name == "Starling: Personal" }
+            val ada =
+                repositories.personRepository
+                    .getAllPeople()
+                    .first()
+                    .single { it.firstName == "Ada" && it.lastName == "Lovelace" }
+            val ownAccount =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .single { it.name == "Starling: Personal" }
             val owners = repositories.personAccountOwnershipRepository.getOwnershipsByAccount(ownAccount.id).first()
             assertTrue(owners.any { it.personId == ada.id }, "The holder should own the own account regardless of import order")
         }
 
     @Test
-    fun `backfilling a matched person's external id does not create an orphan revision`() =
+    fun `backfilling a matched person external id does not create an orphan revision`() =
         runTest {
             val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
             val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
@@ -570,7 +582,11 @@ class StarlingImportE2ETest : DbTest() {
                 strategy = strategy,
             )
 
-            val ada = repositories.personRepository.getAllPeople().first().single { it.firstName == "Ada" && it.lastName == "Lovelace" }
+            val ada =
+                repositories.personRepository
+                    .getAllPeople()
+                    .first()
+                    .single { it.firstName == "Ada" && it.lastName == "Lovelace" }
             assertEquals(1L, ada.revisionId, "Backfilling an external id must not bump the person revision")
             // The backfill still happened: the external id is now stored.
             val externalId =

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
@@ -3,7 +3,9 @@
 package com.moneymanager.ui.starling
 
 import com.moneymanager.database.port.DbEntitySource
+import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.ApiSessionId
+import com.moneymanager.domain.model.ApiSessionKind
 import com.moneymanager.domain.model.DeviceInfo
 import com.moneymanager.rest.ApiSessionTrafficRecorder
 import com.moneymanager.rest.createApiClient
@@ -47,7 +49,8 @@ private val ACCOUNTS_JSON =
 
 /**
  * One outgoing and one incoming feed item. The direction (IN/OUT) — not the amount sign — determines
- * which side is the user's account; amounts are integer minor units.
+ * which side is the user's account; amounts are integer minor units. The MERCHANT counterparty is not
+ * a person; the SENDER one is, so it should gain a linked person/owner.
  */
 private val FEED_JSON =
     """
@@ -60,6 +63,8 @@ private val FEED_JSON =
       "direction": "OUT",
       "transactionTime": "2024-06-03T09:15:00.000Z",
       "reference": "COFFEE SHOP",
+      "counterPartyType": "MERCHANT",
+      "counterPartyUid": "cp-coffee",
       "counterPartyName": "Coffee Shop"
     },
     {
@@ -69,6 +74,8 @@ private val FEED_JSON =
       "direction": "IN",
       "transactionTime": "2024-06-02T14:30:00.000Z",
       "reference": "SALARY",
+      "counterPartyType": "SENDER",
+      "counterPartyUid": "cp-acme",
       "counterPartyName": "ACME Ltd"
     }
   ]
@@ -112,6 +119,26 @@ private val FEED_WITH_DECLINED_JSON =
       "transactionTime": "2024-06-04T11:00:00.000Z",
       "reference": "CRYPTO.COM",
       "counterPartyName": "Crypto.com"
+    }
+  ]
+}
+    """.trimIndent()
+
+/** A single incoming item from a SENDER counterparty whose name matches the account holder (Ada Lovelace). */
+private val FEED_HOLDER_COUNTERPARTY_JSON =
+    """
+{
+  "feedItems": [
+    {
+      "feedItemUid": "f1",
+      "categoryUid": "$CATEGORY_UID",
+      "amount": { "currency": "GBP", "minorUnits": 50000 },
+      "direction": "IN",
+      "transactionTime": "2024-06-02T14:30:00.000Z",
+      "reference": "REPAYMENT",
+      "counterPartyType": "SENDER",
+      "counterPartyUid": "cp-ada",
+      "counterPartyName": "Ada Lovelace"
     }
   ]
 }
@@ -229,6 +256,86 @@ class StarlingImportE2ETest : DbTest() {
         }
 
     @Test
+    fun `starling import sets identifying attributes and makes personal counterparties owners`() =
+        runTest {
+            val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+            val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+            val sessionId = repositories.apiSessionRepository.createSession("test-starling-token", deviceId, now, null)
+            val strategy =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .single { it.name == "Starling" }
+
+            val apiClient =
+                createApiClient(
+                    trafficRecorder =
+                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                    engine = mockEngine(),
+                )
+
+            downloadApiSessionAccounts(
+                token = "test-starling-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+            downloadApiSessionTransactions(
+                token = "test-starling-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+            importApiSessionTransactions(
+                apiSessionRepository = repositories.apiSessionRepository,
+                accountRepository = repositories.accountRepository,
+                currencyRepository = repositories.currencyRepository,
+                transactionRepository = repositories.transactionRepository,
+                entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                personRepository = repositories.personRepository,
+                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                personAttributeRepository = repositories.personAttributeRepository,
+                attributeTypeRepository = repositories.attributeTypeRepository,
+                accountAttributeRepository = repositories.accountAttributeRepository,
+                deviceId = deviceId,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+
+            val allAccounts = repositories.accountRepository.getAllAccounts().first()
+            val ownAccount = allAccounts.single { it.name == "Starling: Personal" }
+            val coffee = allAccounts.single { it.name == "Starling Counterparty: Coffee Shop" }
+            val acme = allAccounts.single { it.name == "Starling Counterparty: ACME Ltd" }
+
+            // Each transfer carries the feed item's stable id as an identifying attribute.
+            val transfers = repositories.transactionRepository.getTransactionsByAccount(ownAccount.id).first()
+            val txIds =
+                transfers.map { t -> t.attributes.single { it.attributeType.name == "starling-transaction-id" }.value }
+            assertEquals(setOf("f1", "f2"), txIds.toSet(), "Each transfer should record its feedItemUid")
+
+            // Counterparty accounts are keyed by counterPartyUid (stored as the external-id attribute).
+            suspend fun externalId(account: Account) =
+                repositories.accountAttributeRepository
+                    .getByAccount(account.id)
+                    .first()
+                    .single { it.attributeType.name == "account-external-id" }
+                    .value
+            assertEquals("cp-coffee", externalId(coffee))
+            assertEquals("cp-acme", externalId(acme))
+
+            // The SENDER counterparty is a person and becomes an owner; the MERCHANT is not.
+            val acmeOwners = repositories.personAccountOwnershipRepository.getOwnershipsByAccount(acme.id).first()
+            assertEquals(1, acmeOwners.size, "The SENDER counterparty should gain a linked owner")
+            val coffeeOwners = repositories.personAccountOwnershipRepository.getOwnershipsByAccount(coffee.id).first()
+            assertTrue(coffeeOwners.isEmpty(), "The MERCHANT counterparty should not gain an owner")
+
+            val acmePerson = repositories.personRepository.getAllPeople().first().single { it.firstName == "ACME" }
+            assertEquals(acmeOwners.single().personId, acmePerson.id)
+        }
+
+    @Test
     fun `starling account holder is imported and linked to every account`() =
         runTest {
             val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
@@ -309,6 +416,170 @@ class StarlingImportE2ETest : DbTest() {
                     .first()
             assertTrue(owners.any { it.personId == ada.id }, "The account holder should own the Starling account")
             assertNotNull(ada)
+        }
+
+    @Test
+    fun `account holder owns the own account even when people are imported before accounts`() =
+        runTest {
+            val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+            val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+            val strategy =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .single { it.name == "Starling" }
+            // Sessions must share a credential so the accounts import can find the holder's people session.
+            val credentialId = repositories.apiSessionRepository.createCredential("test-starling-token", now)
+
+            fun clientFor(session: ApiSessionId) =
+                createApiClient(
+                    trafficRecorder =
+                        ApiSessionTrafficRecorder(sessionId = session, apiSessionRepository = repositories.apiSessionRepository),
+                    engine = mockEngine(),
+                )
+
+            // 1) People FIRST, before any accounts exist — the holder is created but can link to nothing.
+            val peopleSessionId =
+                repositories.apiSessionRepository
+                    .createSession("test-starling-token", deviceId, now, null, credentialId = credentialId, kind = ApiSessionKind.PEOPLE)
+            downloadApiSessionPeople(
+                token = "test-starling-token",
+                apiClient = clientFor(peopleSessionId),
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = peopleSessionId,
+                strategy = strategy,
+            )
+            importApiSessionPeople(
+                apiSessionRepository = repositories.apiSessionRepository,
+                accountRepository = repositories.accountRepository,
+                accountAttributeRepository = repositories.accountAttributeRepository,
+                personRepository = repositories.personRepository,
+                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                personAttributeRepository = repositories.personAttributeRepository,
+                attributeTypeRepository = repositories.attributeTypeRepository,
+                entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                sessionId = peopleSessionId,
+                strategy = strategy,
+                accountsSessionId = null,
+            )
+
+            // 2) Accounts AFTER the holder — the accounts import must back-link the holder to the own account.
+            val accountsSessionId =
+                repositories.apiSessionRepository
+                    .createSession("test-starling-token", deviceId, now, null, credentialId = credentialId, kind = ApiSessionKind.ACCOUNTS)
+            downloadApiSessionAccounts(
+                token = "test-starling-token",
+                apiClient = clientFor(accountsSessionId),
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = accountsSessionId,
+                strategy = strategy,
+            )
+            importApiSessionTransactions(
+                apiSessionRepository = repositories.apiSessionRepository,
+                accountRepository = repositories.accountRepository,
+                currencyRepository = repositories.currencyRepository,
+                transactionRepository = repositories.transactionRepository,
+                entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                personRepository = repositories.personRepository,
+                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                personAttributeRepository = repositories.personAttributeRepository,
+                attributeTypeRepository = repositories.attributeTypeRepository,
+                accountAttributeRepository = repositories.accountAttributeRepository,
+                deviceId = deviceId,
+                sessionId = accountsSessionId,
+                strategy = strategy,
+            )
+
+            val ada = repositories.personRepository.getAllPeople().first().single { it.firstName == "Ada" && it.lastName == "Lovelace" }
+            val ownAccount = repositories.accountRepository.getAllAccounts().first().single { it.name == "Starling: Personal" }
+            val owners = repositories.personAccountOwnershipRepository.getOwnershipsByAccount(ownAccount.id).first()
+            assertTrue(owners.any { it.personId == ada.id }, "The holder should own the own account regardless of import order")
+        }
+
+    @Test
+    fun `backfilling a matched person's external id does not create an orphan revision`() =
+        runTest {
+            val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+            val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+            val strategy =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .single { it.name == "Starling" }
+
+            fun clientFor(session: ApiSessionId) =
+                createApiClient(
+                    trafficRecorder =
+                        ApiSessionTrafficRecorder(sessionId = session, apiSessionRepository = repositories.apiSessionRepository),
+                    engine = mockEngine(feedJson = FEED_HOLDER_COUNTERPARTY_JSON),
+                )
+
+            // Import the holder first — "Ada Lovelace" is created at revision 1 with no Starling external id.
+            val peopleSessionId = repositories.apiSessionRepository.createSession("test-starling-token", deviceId, now, null)
+            downloadApiSessionPeople(
+                token = "test-starling-token",
+                apiClient = clientFor(peopleSessionId),
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = peopleSessionId,
+                strategy = strategy,
+            )
+            importApiSessionPeople(
+                apiSessionRepository = repositories.apiSessionRepository,
+                accountRepository = repositories.accountRepository,
+                accountAttributeRepository = repositories.accountAttributeRepository,
+                personRepository = repositories.personRepository,
+                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                personAttributeRepository = repositories.personAttributeRepository,
+                attributeTypeRepository = repositories.attributeTypeRepository,
+                entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                sessionId = peopleSessionId,
+                strategy = strategy,
+                accountsSessionId = null,
+            )
+
+            // Importing the SENDER counterparty "Ada Lovelace" matches the holder by name and backfills
+            // its external id — this must NOT bump the person to a new (source-less) revision.
+            val txSessionId = repositories.apiSessionRepository.createSession("test-starling-token", deviceId, now, null)
+            downloadApiSessionAccounts(
+                token = "test-starling-token",
+                apiClient = clientFor(txSessionId),
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = txSessionId,
+                strategy = strategy,
+            )
+            downloadApiSessionTransactions(
+                token = "test-starling-token",
+                apiClient = clientFor(txSessionId),
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = txSessionId,
+                strategy = strategy,
+            )
+            importApiSessionTransactions(
+                apiSessionRepository = repositories.apiSessionRepository,
+                accountRepository = repositories.accountRepository,
+                currencyRepository = repositories.currencyRepository,
+                transactionRepository = repositories.transactionRepository,
+                entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                personRepository = repositories.personRepository,
+                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                personAttributeRepository = repositories.personAttributeRepository,
+                attributeTypeRepository = repositories.attributeTypeRepository,
+                accountAttributeRepository = repositories.accountAttributeRepository,
+                deviceId = deviceId,
+                sessionId = txSessionId,
+                strategy = strategy,
+            )
+
+            val ada = repositories.personRepository.getAllPeople().first().single { it.firstName == "Ada" && it.lastName == "Lovelace" }
+            assertEquals(1L, ada.revisionId, "Backfilling an external id must not bump the person revision")
+            // The backfill still happened: the external id is now stored.
+            val externalId =
+                repositories.personAttributeRepository
+                    .getByPerson(ada.id)
+                    .first()
+                    .single { it.attributeType.name == "starling-external-id" }
+                    .value
+            assertEquals("cp-ada", externalId)
         }
 
     @Test


### PR DESCRIPTION
## Summary

Adds support for importing accounts and transactions from the [Starling Bank API](https://developer.starlingbank.com/docs). Starling is added as a built-in API import strategy — almost entirely **config**, mirroring how Monzo and Wise already work (a single seeded strategy with no provider-specific code path).

- **Accounts:** `GET /api/v2/accounts` → `accounts[]`
- **Transactions:** `GET /api/v2/feed/account/{account.id}/category/{account.defaultCategory}` → `feedItems[]` — the existing `account.<field>` path templating resolves `defaultCategory` from each account's raw JSON, so no engine change was needed for the path
- **Sign:** from the `direction` field (`IN`/`OUT`); **amounts:** `amount.minorUnits` integers; **dedup id:** `feedItemUid`
- **Account holder / People:** `GET /api/v2/account-holder/individual` (a single global holder, linked to all accounts)

## Generic engine improvements

All three benefit any future provider; defaults keep Monzo/Wise byte-identical.

1. **Single-object responses** (`responseItemsArray`) — a bare JSON object body is wrapped as a one-element array, so single-resource endpoints (Starling's account holder) parse like any list.
2. **Global-holder linking** — new `ApiPersonImportConfig.ownsAllAccounts` flag links a single account holder to every account imported in the session, for flat providers with no ancestor hierarchy.
3. **Bug fix:** `downloadApiSessionTransactions` looped `while (hasTransactions)` even when `pagination == null`, contradicting `ApiEndpointConfig`'s own KDoc ("null means only one page is fetched"). Starling's feed ignores the cursor and returns the full feed every call → **infinite loop in production**. Now a null config fetches exactly one page.

## Connect screen

Added a `STARLING` provider kind with base-URL detection, the developer-portal token link, and Personal Access Token setup steps.

## Notes / non-goals

- No `ApiSessionType` enum change (credentials link by `strategyId`; Wise already reuses `MONZO`).
- No DB migration (pre-versioning BETA — DB reseeds from scratch).
- Dropped the originally-planned `localAmount`/`localCurrency` FX mappings: that storage path is gated on Monzo's literal `local_amount` field name, so it would be dead config for Starling.

## Testing

- `./gradlew build` green (detekt, buildHealth, kover, all JVM/Android tests incl. Monzo/Wise regression).
- Extended `BuiltInApiStrategySeedTest` (Starling config round-trips through the JSON codec).
- New `StarlingImportE2ETest`: direction-based sign, minor-unit amounts, and `ownsAllAccounts` people linking.
- ⚠️ Not yet exercised against a live Starling Personal Access Token — recommended before merge (`./gradlew :app:main:jvm:run` → Connect → Starling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Starling as a new bank API import provider; UI includes Starling connect instructions.
  * Support for providers that assign a single owner across all accounts.
  * Decline-detection expanded to support status-based rules.

* **Bug Fixes**
  * Safer pagination to avoid infinite loops for non-paginated endpoints.
  * Declined items imported for records but excluded from computed balances.

* **Tests**
  * New end-to-end and seed tests validating Starling import behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->