### PR TITLE
Unify API import into a single Download and Import

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiSessionRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiSessionRepositoryImpl.kt
@@ -14,7 +14,6 @@ import com.moneymanager.domain.model.ApiResponseTransactionId
 import com.moneymanager.domain.model.ApiResponseTransactionState
 import com.moneymanager.domain.model.ApiSession
 import com.moneymanager.domain.model.ApiSessionId
-import com.moneymanager.domain.model.ApiSessionKind
 import com.moneymanager.domain.model.ApiSessionType
 import com.moneymanager.domain.model.DeviceId
 import com.moneymanager.domain.model.JsonPath
@@ -106,7 +105,6 @@ class ApiSessionRepositoryImpl(
         expiresAt: Instant?,
         type: ApiSessionType,
         credentialId: MonzoCredentialId?,
-        kind: ApiSessionKind?,
     ): ApiSessionId =
         withContext(Dispatchers.Default) {
             val id =
@@ -118,7 +116,6 @@ class ApiSessionRepositoryImpl(
                         created_at = createdAt.toEpochMilliseconds(),
                         expires_at = expiresAt?.toEpochMilliseconds(),
                         credential_id = credentialId?.id,
-                        kind = kind?.value,
                     )
                     queries.lastInsertRowId().executeAsOne()
                 }
@@ -362,7 +359,6 @@ class ApiSessionRepositoryImpl(
             createdAt = Instant.fromEpochMilliseconds(created_at),
             expiresAt = expires_at?.let { Instant.fromEpochMilliseconds(it) },
             credentialId = credential_id?.let { MonzoCredentialId(it) },
-            kind = ApiSessionKind.fromValueOrNull(kind),
             importDurationMillis = import_duration_millis,
         )
 

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/ApiSession.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/ApiSession.sq
@@ -24,7 +24,7 @@ CREATE TABLE api_credential (
 CREATE INDEX idx_api_credential_token ON api_credential(token);
 CREATE INDEX idx_api_credential_strategy_id ON api_credential(strategy_id);
 
--- kind: 'ACCOUNTS' for account-download sessions, 'TRANSACTIONS' for transaction-download sessions
+-- One session holds a full download: accounts, transactions and people are all fetched into it.
 CREATE TABLE api_session (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     type_id INTEGER NOT NULL,
@@ -33,7 +33,6 @@ CREATE TABLE api_session (
     created_at INTEGER NOT NULL,
     expires_at INTEGER,
     credential_id INTEGER,
-    kind TEXT,
     FOREIGN KEY (type_id) REFERENCES api_session_type(id),
     FOREIGN KEY (device_id) REFERENCES device(id),
     FOREIGN KEY (credential_id) REFERENCES api_credential(id) ON DELETE CASCADE
@@ -139,8 +138,8 @@ WHERE (expires_at IS NULL OR expires_at > ?)
 ORDER BY created_at DESC;
 
 insert:
-INSERT INTO api_session(type_id, token, device_id, created_at, expires_at, credential_id, kind)
-VALUES (?, ?, ?, ?, ?, ?, ?);
+INSERT INTO api_session(type_id, token, device_id, created_at, expires_at, credential_id)
+VALUES (?, ?, ?, ?, ?, ?);
 
 insertSessionType:
 INSERT INTO api_session_type(id, name) VALUES (?, ?);

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/tools/MonzoApiSessionFixtureTool.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/tools/MonzoApiSessionFixtureTool.kt
@@ -123,7 +123,7 @@ private fun exportFixtures(
                 jsonPath = row.getString("json_path"),
                 state = row.getLong("state"),
                 transactionId = row.getLongOrNull("transaction_id"),
-                errorMessage = row.getStringOrNull("error_message"),
+                errorMessage = row.getString("error_message"),
                 createdAt = row.getLong("created_at"),
             )
         }
@@ -296,8 +296,6 @@ private fun printUsageAndExit(): Nothing {
     )
     exitProcess(1)
 }
-
-private fun java.sql.ResultSet.getStringOrNull(column: String): String? = getString(column)
 
 private fun java.sql.ResultSet.getLongOrNull(column: String): Long? =
     getObject(column)?.let {

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/tools/MonzoApiSessionFixtureTool.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/tools/MonzoApiSessionFixtureTool.kt
@@ -73,7 +73,6 @@ private fun exportFixtures(
                 createdAt = row.getLong("created_at"),
                 expiresAt = row.getLongOrNull("expires_at"),
                 credentialId = row.getLongOrNull("credential_id"),
-                kind = row.getStringOrNull("kind"),
             )
         }
         exportTable(connection, outputDir, "api_import", "api_import.json", ApiImportRow.serializer()) { row ->
@@ -162,7 +161,7 @@ private fun importFixtures(
             insertTable(inputDir, "api_session.json", ApiSessionRow.serializer()) { row ->
                 connection
                     .prepareStatement(
-                        "INSERT OR IGNORE INTO api_session(id, type_id, token, device_id, created_at, expires_at, credential_id, kind) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                        "INSERT OR IGNORE INTO api_session(id, type_id, token, device_id, created_at, expires_at, credential_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
                     ).use { ps ->
                         ps.setLong(1, row.id)
                         ps.setLong(2, row.typeId)
@@ -171,7 +170,6 @@ private fun importFixtures(
                         ps.setLong(5, row.createdAt)
                         if (row.expiresAt == null) ps.setNull(6, java.sql.Types.INTEGER) else ps.setLong(6, row.expiresAt)
                         if (row.credentialId == null) ps.setNull(7, java.sql.Types.INTEGER) else ps.setLong(7, row.credentialId)
-                        if (row.kind == null) ps.setNull(8, java.sql.Types.VARCHAR) else ps.setString(8, row.kind)
                         ps.executeUpdate()
                     }
             }
@@ -334,7 +332,6 @@ private data class ApiSessionRow(
     val createdAt: Long,
     val expiresAt: Long? = null,
     val credentialId: Long? = null,
-    val kind: String? = null,
 )
 
 @Serializable

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ApiSession.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ApiSession.kt
@@ -30,19 +30,6 @@ value class MonzoCredentialId(
     override fun toString() = id.toString()
 }
 
-enum class ApiSessionKind(
-    val value: String,
-) {
-    ACCOUNTS("ACCOUNTS"),
-    TRANSACTIONS("TRANSACTIONS"),
-    PEOPLE("PEOPLE"),
-    ;
-
-    companion object {
-        fun fromValueOrNull(value: String?): ApiSessionKind? = value?.let { v -> entries.firstOrNull { it.value == v } }
-    }
-}
-
 data class ApiSession(
     val id: ApiSessionId,
     val type: ApiSessionType,
@@ -51,7 +38,6 @@ data class ApiSession(
     val createdAt: Instant,
     val expiresAt: Instant?,
     val credentialId: MonzoCredentialId?,
-    val kind: ApiSessionKind?,
     val importDurationMillis: Long? = null,
 )
 

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ApiSessionRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ApiSessionRepository.kt
@@ -11,7 +11,6 @@ import com.moneymanager.domain.model.ApiResponseTransactionId
 import com.moneymanager.domain.model.ApiResponseTransactionState
 import com.moneymanager.domain.model.ApiSession
 import com.moneymanager.domain.model.ApiSessionId
-import com.moneymanager.domain.model.ApiSessionKind
 import com.moneymanager.domain.model.ApiSessionType
 import com.moneymanager.domain.model.DeviceId
 import com.moneymanager.domain.model.JsonPath
@@ -87,7 +86,6 @@ interface ApiSessionRepository {
      * @param createdAt The creation timestamp
      * @param expiresAt Optional expiry timestamp; null means the session never expires
      * @param credentialId Optional credential this session was created from
-     * @param kind Whether this session downloaded accounts or transactions
      * @return The ID of the newly created session
      */
     suspend fun createSession(
@@ -97,7 +95,6 @@ interface ApiSessionRepository {
         expiresAt: Instant?,
         type: ApiSessionType = ApiSessionType.MONZO,
         credentialId: MonzoCredentialId? = null,
-        kind: ApiSessionKind? = null,
     ): ApiSessionId
 
     /**

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -101,6 +101,40 @@ data class ApiPeopleDownloadResult(
     val skipped: Boolean = false,
 )
 
+/**
+ * The combined outcome of one download: accounts, plus transactions (null when region-blocked) and
+ * people (null when the strategy has no people-download endpoint), all into a single session.
+ */
+data class ApiSessionDownloadResult(
+    val accounts: ApiAccountsDownloadResult,
+    val transactions: ApiTransactionsDownloadResult?,
+    val people: ApiPeopleDownloadResult?,
+)
+
+fun ApiAccountsDownloadResult.displaySummary(): String =
+    if (skipped) {
+        "Accounts already downloaded: $accountCount account(s) (skipped)."
+    } else {
+        "Accounts downloaded: $accountCount account(s)."
+    }
+
+fun ApiTransactionsDownloadResult.displaySummary(): String =
+    "Transactions downloaded: $accountCount account(s), $transactionResponseCount new response page(s)."
+
+fun ApiPeopleDownloadResult.displaySummary(): String =
+    if (skipped) {
+        "People already downloaded: $personCount person(s) (skipped)."
+    } else {
+        "People downloaded: $personCount person(s)."
+    }
+
+fun ApiSessionDownloadResult.displaySummary(): String =
+    buildList {
+        add(accounts.displaySummary())
+        transactions?.let { add(it.displaySummary()) }
+        people?.let { add(it.displaySummary()) }
+    }.joinToString("\n")
+
 data class ApiPeopleImportResult(
     val personCount: Int,
     val ownershipCount: Int,
@@ -896,10 +930,10 @@ private suspend fun importPeopleFromSession(setup: ImportSetup): Int {
 
 /**
  * Links the global account holder to every own account in this import, sourcing the holder from the
- * credential's already-downloaded PEOPLE session(s). This makes `ownsAllAccounts` ownership
- * order-independent: [importApiSessionPeople] links the holder when the PEOPLE session is imported
- * after the accounts, and this covers the reverse — accounts imported after the holder — by re-linking
- * each time accounts are imported. Idempotent: [importOwnersForAccount] skips already-linked owners.
+ * people responses downloaded into this same session. This makes `ownsAllAccounts` ownership
+ * order-independent: [importApiSessionPeople] links the holder when run after accounts are imported,
+ * and this covers the reverse — the holder linked while transactions import — by re-linking each time
+ * accounts are imported. Idempotent: [importOwnersForAccount] skips already-linked owners.
  */
 private suspend fun linkGlobalHolderToOwnAccounts(
     setup: ImportSetup,
@@ -908,7 +942,6 @@ private suspend fun linkGlobalHolderToOwnAccounts(
     val config = setup.strategy.peopleDownload ?: return 0
     validatePeopleOwnershipConfig(config)
     if (!config.ownsAllAccounts || setup.accountsById.isEmpty()) return 0
-    val credentialId = setup.apiSessionRepository.getSessionById(setup.sessionId)?.credentialId ?: return 0
 
     // Resolve the AccountIds of the own accounts known to this import (idempotent — they already exist).
     val ownAccountIds =
@@ -918,32 +951,33 @@ private suspend fun linkGlobalHolderToOwnAccounts(
 
     val peopleIndex = loadPeopleIndex(setup.personRepository, setup.personAttributeRepository, externalIdAttributeTypeId)
     var newPeopleCount = 0
-    val peopleSessions =
-        setup.apiSessionRepository
-            .getSessionsByCredential(credentialId)
-            .filter { it.kind == ApiSessionKind.PEOPLE }
-    for (session in peopleSessions) {
-        for (response in setup.apiSessionRepository.getResponsesBySession(session.id)) {
-            responseItemsArray(response.json, config.endpoint.responseArrayKey)
-                ?.forEachIndexed { index, element ->
-                    val owner = (element as? JsonObject)?.toPersonOwner(config, index) ?: return@forEachIndexed
-                    for (accountId in ownAccountIds) {
-                        newPeopleCount +=
-                            importOwnersForAccount(
-                                owners = listOf(owner),
-                                accountId = accountId,
-                                peopleIndex = peopleIndex,
-                                personRepository = setup.personRepository,
-                                personAccountOwnershipRepository = setup.personAccountOwnershipRepository,
-                                personAttributeRepository = setup.personAttributeRepository,
-                                externalIdAttributeTypeId = externalIdAttributeTypeId,
-                                entitySource = setup.entitySource,
-                                sessionId = session.id,
-                                requestId = response.requestId,
-                            ).newPeople
-                    }
-                }
+    // People are downloaded into the same session as accounts/transactions; select the holder
+    // responses by matching the people endpoint path (the same predicate importApiSessionPeople uses).
+    val peopleResponses =
+        setup.apiSessionRepository.getResponsesBySession(setup.sessionId).filter { response ->
+            val path = setup.requestsById[response.requestId]?.encodedPath() ?: return@filter false
+            extractPathVariables(config.endpoint.path, path) != null
         }
+    for (response in peopleResponses) {
+        responseItemsArray(response.json, config.endpoint.responseArrayKey)
+            ?.forEachIndexed { index, element ->
+                val owner = (element as? JsonObject)?.toPersonOwner(config, index) ?: return@forEachIndexed
+                for (accountId in ownAccountIds) {
+                    newPeopleCount +=
+                        importOwnersForAccount(
+                            owners = listOf(owner),
+                            accountId = accountId,
+                            peopleIndex = peopleIndex,
+                            personRepository = setup.personRepository,
+                            personAccountOwnershipRepository = setup.personAccountOwnershipRepository,
+                            personAttributeRepository = setup.personAttributeRepository,
+                            externalIdAttributeTypeId = externalIdAttributeTypeId,
+                            entitySource = setup.entitySource,
+                            sessionId = setup.sessionId,
+                            requestId = response.requestId,
+                        ).newPeople
+                }
+            }
     }
     return newPeopleCount
 }
@@ -3018,7 +3052,9 @@ private fun RuleSign.matches(sign: Int): Boolean =
 private fun JsonObject.evaluatePredicate(predicate: RulePredicate): Boolean {
     val operand = predicate.value.orEmpty()
     return when (predicate.op) {
-        PredicateOp.EXISTS -> resolveJsonElementPath(predicate.path) != null
+        // A present-but-JSON-null field (e.g. Monzo sends `atm_fees_detailed: null` on every
+        // non-ATM transaction) does not count as existing, otherwise every transaction matches.
+        PredicateOp.EXISTS -> resolveJsonElementPath(predicate.path).let { it != null && it != JsonNull }
         PredicateOp.EQUALS -> resolveJsonPath(predicate.path) == predicate.value
         PredicateOp.EQUALS_IGNORE_CASE -> resolveJsonPath(predicate.path)?.equals(predicate.value, ignoreCase = true) == true
         PredicateOp.STARTS_WITH -> resolveJsonPath(predicate.path)?.startsWith(operand) == true

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -62,7 +62,6 @@ import com.moneymanager.domain.model.ApiResponseTransaction
 import com.moneymanager.domain.model.ApiResponseTransactionState
 import com.moneymanager.domain.model.ApiSession
 import com.moneymanager.domain.model.ApiSessionId
-import com.moneymanager.domain.model.ApiSessionKind
 import com.moneymanager.domain.model.DeviceId
 import com.moneymanager.domain.model.MonzoCredential
 import com.moneymanager.domain.model.MonzoCredentialId
@@ -81,13 +80,13 @@ import com.moneymanager.domain.repository.TransactionRepository
 import com.moneymanager.rest.ApiSessionTrafficRecorder
 import com.moneymanager.rest.ScaParams
 import com.moneymanager.rest.createApiClient
-import com.moneymanager.ui.api.ApiAccountsDownloadResult
 import com.moneymanager.ui.api.ApiCounterpartySuggestion
+import com.moneymanager.ui.api.ApiSessionDownloadResult
 import com.moneymanager.ui.api.ApiSessionImportProgress
 import com.moneymanager.ui.api.ApiSessionImportResult
 import com.moneymanager.ui.api.ApiTransactionsDownloadProgress
-import com.moneymanager.ui.api.ApiTransactionsDownloadResult
 import com.moneymanager.ui.api.discoverApiCounterpartiesToCreate
+import com.moneymanager.ui.api.displaySummary
 import com.moneymanager.ui.api.downloadApiSessionAccounts
 import com.moneymanager.ui.api.downloadApiSessionPeople
 import com.moneymanager.ui.api.downloadApiSessionTransactions
@@ -148,7 +147,6 @@ fun ApiSessionsScreen(
     var strategyNameByCredential by remember { mutableStateOf<Map<MonzoCredentialId, String>>(emptyMap()) }
     var requiresSigningByCredential by remember { mutableStateOf<Map<MonzoCredentialId, Boolean>>(emptyMap()) }
     var transactionsBlockReasonByCredential by remember { mutableStateOf<Map<MonzoCredentialId, String>>(emptyMap()) }
-    var peopleDownloadSupportedByCredential by remember { mutableStateOf<Map<MonzoCredentialId, Boolean>>(emptyMap()) }
     var isLoading by remember { mutableStateOf(true) }
     // Per-session import state
     var importResultBySession by remember { mutableStateOf<Map<ApiSessionId, ApiSessionImportResult>>(emptyMap()) }
@@ -156,8 +154,7 @@ fun ApiSessionsScreen(
     var importProgressBySession by remember { mutableStateOf<Map<ApiSessionId, ApiSessionImportProgress>>(emptyMap()) }
 
     // Per-credential download result state (cleared when a new download starts)
-    var accountsDownloadResultByCredential by remember { mutableStateOf<Map<MonzoCredentialId, ApiAccountsDownloadResult>>(emptyMap()) }
-    var downloadResultByCredential by remember { mutableStateOf<Map<MonzoCredentialId, ApiTransactionsDownloadResult>>(emptyMap()) }
+    var downloadResultByCredential by remember { mutableStateOf<Map<MonzoCredentialId, ApiSessionDownloadResult>>(emptyMap()) }
     var downloadProgressByCredential by remember { mutableStateOf<Map<MonzoCredentialId, ApiTransactionsDownloadProgress?>>(emptyMap()) }
     var pendingImport by remember { mutableStateOf<PendingApiImport?>(null) }
 
@@ -222,11 +219,6 @@ fun ApiSessionsScreen(
                         val strategy = credential.strategyId?.let { strategyById[it] } ?: fallbackStrategy
                         credential.id to (strategy?.signing != null)
                     }
-                peopleDownloadSupportedByCredential =
-                    allCredentials.associate { credential ->
-                        val strategy = credential.strategyId?.let { strategyById[it] } ?: fallbackStrategy
-                        credential.id to (strategy?.peopleDownload != null)
-                    }
                 val country = currentCountryCode()
                 transactionsBlockReasonByCredential =
                     allCredentials
@@ -252,64 +244,63 @@ fun ApiSessionsScreen(
 
     fun startImport(
         session: ApiSession,
-        accountsSession: ApiSession?,
         strategy: ApiImportStrategy,
         counterpartyAccountNames: Map<String, String>,
     ) {
-        val importLabel =
-            when (session.kind) {
-                ApiSessionKind.ACCOUNTS -> "Import Accounts"
-                ApiSessionKind.PEOPLE -> "Import People"
-                else -> "Import Transactions"
-            }
         backgroundTasks.startTask(
             key = monzoImportTaskKey(session.id),
-            title = importLabel,
-            initialDetail = "Starting $importLabel for session #${session.id}.",
+            title = "Import",
+            initialDetail = "Starting import for session #${session.id}.",
         ) {
             val importStartedAt = System.currentTimeMillis()
-            val result =
-                if (session.kind == ApiSessionKind.PEOPLE) {
-                    val peopleResult =
-                        importApiSessionPeople(
-                            apiSessionRepository = apiSessionRepository,
-                            accountRepository = accountRepository,
-                            accountAttributeRepository = accountAttributeRepository,
-                            personRepository = personRepository,
-                            personAccountOwnershipRepository = personAccountOwnershipRepository,
-                            personAttributeRepository = personAttributeRepository,
-                            attributeTypeRepository = attributeTypeRepository,
-                            entitySource = entitySource,
-                            sessionId = session.id,
-                            strategy = strategy,
-                            accountsSessionId = accountsSession?.id,
-                        )
-                    ApiSessionImportResult(accountCount = 0, transactionCount = 0, personCount = peopleResult.personCount)
-                } else {
-                    importApiSessionTransactions(
+            // Transactions import creates the accounts and the people derived from transactions/accounts.
+            val transactionsResult =
+                importApiSessionTransactions(
+                    apiSessionRepository = apiSessionRepository,
+                    accountRepository = accountRepository,
+                    currencyRepository = currencyRepository,
+                    transactionRepository = transactionRepository,
+                    entitySource = entitySource,
+                    personRepository = personRepository,
+                    personAccountOwnershipRepository = personAccountOwnershipRepository,
+                    personAttributeRepository = personAttributeRepository,
+                    attributeTypeRepository = attributeTypeRepository,
+                    accountAttributeRepository = accountAttributeRepository,
+                    deviceId = deviceId,
+                    sessionId = session.id,
+                    strategy = strategy,
+                    counterpartyAccountNames = counterpartyAccountNames,
+                    onProgress = { progress ->
+                        scope.launch {
+                            importProgressBySession = importProgressBySession + (session.id to progress)
+                        }
+                        update(progress.detail, progress.progress)
+                    },
+                )
+            // The dedicated people endpoint (account holders) is imported afterwards so the accounts
+            // it links owners to already exist. No-op when the strategy has no people-download config.
+            val peopleResult =
+                if (strategy.peopleDownload != null) {
+                    importApiSessionPeople(
                         apiSessionRepository = apiSessionRepository,
                         accountRepository = accountRepository,
-                        currencyRepository = currencyRepository,
-                        transactionRepository = transactionRepository,
-                        entitySource = entitySource,
+                        accountAttributeRepository = accountAttributeRepository,
                         personRepository = personRepository,
                         personAccountOwnershipRepository = personAccountOwnershipRepository,
                         personAttributeRepository = personAttributeRepository,
                         attributeTypeRepository = attributeTypeRepository,
-                        accountAttributeRepository = accountAttributeRepository,
-                        deviceId = deviceId,
+                        entitySource = entitySource,
                         sessionId = session.id,
-                        accountsSessionId = accountsSession?.id,
                         strategy = strategy,
-                        counterpartyAccountNames = counterpartyAccountNames,
-                        onProgress = { progress ->
-                            scope.launch {
-                                importProgressBySession = importProgressBySession + (session.id to progress)
-                            }
-                            update(progress.detail, progress.progress)
-                        },
+                        accountsSessionId = session.id,
                     )
+                } else {
+                    null
                 }
+            val result =
+                transactionsResult.copy(
+                    personCount = transactionsResult.personCount + (peopleResult?.personCount ?: 0),
+                )
             val importDurationMillis = System.currentTimeMillis() - importStartedAt
             apiSessionRepository.markSessionImported(
                 id = session.id,
@@ -366,16 +357,12 @@ fun ApiSessionsScreen(
                     LazyColumn(state = lazyListState, verticalArrangement = Arrangement.spacedBy(12.dp)) {
                         items(credentials) { credential ->
                             val credentialSessions = sessionsByCredential[credential.id].orEmpty()
-                            val isDownloadingAccounts = backgroundTasks.isRunning(monzoAccountsDownloadTaskKey(credential.id))
-                            val isDownloadingTransactions = backgroundTasks.isRunning(monzoTransactionsDownloadTaskKey(credential.id))
-                            val isDownloadingPeople = backgroundTasks.isRunning(monzoPeopleDownloadTaskKey(credential.id))
+                            val isDownloading = backgroundTasks.isRunning(monzoDownloadTaskKey(credential.id))
                             CredentialCard(
                                 credential = credential,
                                 providerLabel = strategyNameByCredential[credential.id],
                                 requiresSigning = requiresSigningByCredential[credential.id] == true,
                                 transactionsBlockReason = transactionsBlockReasonByCredential[credential.id],
-                                peopleDownloadSupported = peopleDownloadSupportedByCredential[credential.id] == true,
-                                isDownloadingPeople = isDownloadingPeople,
                                 onGenerateSigningKey = {
                                     scope.launch {
                                         val keyPair = withContext(Dispatchers.Default) { generateScaKeyPair() }
@@ -389,9 +376,7 @@ fun ApiSessionsScreen(
                                 },
                                 onCopyText = { text -> scope.launch { clipboard.setPlainText(text) } },
                                 sessions = credentialSessions,
-                                isDownloadingAccounts = isDownloadingAccounts,
-                                isDownloadingTransactions = isDownloadingTransactions,
-                                accountsDownloadResult = accountsDownloadResultByCredential[credential.id],
+                                isDownloading = isDownloading,
                                 downloadResult = downloadResultByCredential[credential.id],
                                 downloadProgress = downloadProgressByCredential[credential.id],
                                 importResultBySession = importResultBySession,
@@ -400,92 +385,10 @@ fun ApiSessionsScreen(
                                 importedSessionRevisions = importedSessionRevisions,
                                 selectedStrategyRevision = currentStrategyRevisionByCredential[credential.id],
                                 isImportingSession = { sessionId -> backgroundTasks.isRunning(monzoImportTaskKey(sessionId)) },
-                                onDownloadAccounts = {
-                                    accountsDownloadResultByCredential = accountsDownloadResultByCredential - credential.id
-                                    scope.launch {
-                                        val strategy = resolveStrategy(credential) ?: return@launch
-                                        val newSessionId =
-                                            apiSessionRepository.createSession(
-                                                token = credential.token,
-                                                deviceId = deviceId,
-                                                createdAt = Clock.System.now(),
-                                                expiresAt = null,
-                                                credentialId = credential.id,
-                                                kind = ApiSessionKind.ACCOUNTS,
-                                            )
-                                        refresh()
-                                        backgroundTasks.startTask(
-                                            key = monzoAccountsDownloadTaskKey(credential.id),
-                                            title = "Download Accounts",
-                                            initialDetail = "Starting accounts download for session #$newSessionId.",
-                                        ) {
-                                            val result =
-                                                downloadApiSessionAccounts(
-                                                    token = credential.token,
-                                                    apiClient =
-                                                        createApiClient(
-                                                            trafficRecorder =
-                                                                ApiSessionTrafficRecorder(
-                                                                    sessionId = newSessionId,
-                                                                    apiSessionRepository = apiSessionRepository,
-                                                                ),
-                                                            engine = null,
-                                                        ),
-                                                    apiSessionRepository = apiSessionRepository,
-                                                    sessionId = newSessionId,
-                                                    strategy = strategy,
-                                                    sca = scaParamsFor(strategy, credential),
-                                                )
-                                            accountsDownloadResultByCredential =
-                                                accountsDownloadResultByCredential + (credential.id to result)
-                                            result.displaySummary()
-                                        }
-                                    }
-                                },
-                                onDownloadPeople = {
-                                    scope.launch {
-                                        val strategy = resolveStrategy(credential) ?: return@launch
-                                        val newSessionId =
-                                            apiSessionRepository.createSession(
-                                                token = credential.token,
-                                                deviceId = deviceId,
-                                                createdAt = Clock.System.now(),
-                                                expiresAt = null,
-                                                credentialId = credential.id,
-                                                kind = ApiSessionKind.PEOPLE,
-                                            )
-                                        refresh()
-                                        backgroundTasks.startTask(
-                                            key = monzoPeopleDownloadTaskKey(credential.id),
-                                            title = "Download People",
-                                            initialDetail = "Starting people download for session #$newSessionId.",
-                                        ) {
-                                            val result =
-                                                downloadApiSessionPeople(
-                                                    token = credential.token,
-                                                    apiClient =
-                                                        createApiClient(
-                                                            trafficRecorder =
-                                                                ApiSessionTrafficRecorder(
-                                                                    sessionId = newSessionId,
-                                                                    apiSessionRepository = apiSessionRepository,
-                                                                ),
-                                                            engine = null,
-                                                        ),
-                                                    apiSessionRepository = apiSessionRepository,
-                                                    sessionId = newSessionId,
-                                                    strategy = strategy,
-                                                    sca = scaParamsFor(strategy, credential),
-                                                )
-                                            refresh()
-                                            "Downloaded ${result.personCount} ${if (result.personCount == 1) "person" else "people"}."
-                                        }
-                                    }
-                                },
-                                onDownloadTransactions = {
+                                onDownload = {
                                     downloadResultByCredential = downloadResultByCredential - credential.id
                                     downloadProgressByCredential = downloadProgressByCredential - credential.id
-                                    val accountsSession = credentialSessions.firstOrNull { it.kind == ApiSessionKind.ACCOUNTS }
+                                    val transactionsBlocked = transactionsBlockReasonByCredential[credential.id] != null
                                     scope.launch {
                                         val strategy = resolveStrategy(credential) ?: return@launch
                                         val newSessionId =
@@ -495,39 +398,77 @@ fun ApiSessionsScreen(
                                                 createdAt = Clock.System.now(),
                                                 expiresAt = null,
                                                 credentialId = credential.id,
-                                                kind = ApiSessionKind.TRANSACTIONS,
                                             )
                                         refresh()
                                         backgroundTasks.startTask(
-                                            key = monzoTransactionsDownloadTaskKey(credential.id),
-                                            title = "Download Transactions",
-                                            initialDetail = "Starting transactions download for session #$newSessionId.",
+                                            key = monzoDownloadTaskKey(credential.id),
+                                            title = "Download",
+                                            initialDetail = "Starting download for session #$newSessionId.",
                                         ) {
-                                            val result =
-                                                downloadApiSessionTransactions(
-                                                    token = credential.token,
-                                                    apiClient =
-                                                        createApiClient(
-                                                            trafficRecorder =
-                                                                ApiSessionTrafficRecorder(
-                                                                    sessionId = newSessionId,
-                                                                    apiSessionRepository = apiSessionRepository,
-                                                                ),
-                                                            engine = null,
+                                            // One client/session for accounts, transactions and people.
+                                            val apiClient =
+                                                createApiClient(
+                                                    trafficRecorder =
+                                                        ApiSessionTrafficRecorder(
+                                                            sessionId = newSessionId,
+                                                            apiSessionRepository = apiSessionRepository,
                                                         ),
+                                                    engine = null,
+                                                )
+                                            val sca = scaParamsFor(strategy, credential)
+                                            update("Downloading accounts...")
+                                            val accounts =
+                                                downloadApiSessionAccounts(
+                                                    token = credential.token,
+                                                    apiClient = apiClient,
                                                     apiSessionRepository = apiSessionRepository,
                                                     sessionId = newSessionId,
                                                     strategy = strategy,
-                                                    accountsSessionId = accountsSession?.id,
-                                                    sca = scaParamsFor(strategy, credential),
-                                                    onProgress = { progress ->
-                                                        downloadProgressByCredential =
-                                                            downloadProgressByCredential + (credential.id to progress)
-                                                        update(progress.downloadDetail())
-                                                    },
+                                                    sca = sca,
                                                 )
-                                            downloadResultByCredential = downloadResultByCredential + (credential.id to result)
+                                            val transactions =
+                                                if (transactionsBlocked) {
+                                                    null
+                                                } else {
+                                                    update("Downloading transactions...")
+                                                    downloadApiSessionTransactions(
+                                                        token = credential.token,
+                                                        apiClient = apiClient,
+                                                        apiSessionRepository = apiSessionRepository,
+                                                        sessionId = newSessionId,
+                                                        strategy = strategy,
+                                                        sca = sca,
+                                                        onProgress = { progress ->
+                                                            downloadProgressByCredential =
+                                                                downloadProgressByCredential + (credential.id to progress)
+                                                            update(progress.downloadDetail())
+                                                        },
+                                                    )
+                                                }
+                                            val people =
+                                                if (strategy.peopleDownload != null) {
+                                                    update("Downloading people...")
+                                                    downloadApiSessionPeople(
+                                                        token = credential.token,
+                                                        apiClient = apiClient,
+                                                        apiSessionRepository = apiSessionRepository,
+                                                        sessionId = newSessionId,
+                                                        strategy = strategy,
+                                                        sca = sca,
+                                                    )
+                                                } else {
+                                                    null
+                                                }
+                                            val result =
+                                                ApiSessionDownloadResult(
+                                                    accounts = accounts,
+                                                    transactions = transactions,
+                                                    people = people,
+                                                )
+                                            downloadResultByCredential =
+                                                downloadResultByCredential + (credential.id to result)
                                             downloadProgressByCredential = downloadProgressByCredential - credential.id
+                                            refresh()
                                             result.displaySummary()
                                         }
                                     }
@@ -535,14 +476,6 @@ fun ApiSessionsScreen(
                                 onImport = { session ->
                                     importResultBySession = importResultBySession - session.id
                                     importErrorBySession = importErrorBySession - session.id
-                                    // Transactions and People imports both correlate against the
-                                    // accounts session (to attach transactions / link owners to accounts).
-                                    val accountsSession =
-                                        if (session.kind == ApiSessionKind.TRANSACTIONS || session.kind == ApiSessionKind.PEOPLE) {
-                                            credentialSessions.firstOrNull { it.kind == ApiSessionKind.ACCOUNTS }
-                                        } else {
-                                            null
-                                        }
                                     scope.launch {
                                         val strategy =
                                             resolveStrategy(credential) ?: run {
@@ -550,25 +483,22 @@ fun ApiSessionsScreen(
                                                     importErrorBySession + (session.id to "No import strategy configured")
                                                 return@launch
                                             }
+                                        // Safe for all providers: returns empty when the strategy has no
+                                        // counterparty field, skipping the confirmation dialog.
                                         val suggestions =
-                                            if (session.kind == ApiSessionKind.TRANSACTIONS) {
-                                                discoverApiCounterpartiesToCreate(
-                                                    apiSessionRepository = apiSessionRepository,
-                                                    accountRepository = accountRepository,
-                                                    accountAttributeRepository = accountAttributeRepository,
-                                                    sessionId = session.id,
-                                                    strategy = strategy,
-                                                )
-                                            } else {
-                                                emptyList()
-                                            }
+                                            discoverApiCounterpartiesToCreate(
+                                                apiSessionRepository = apiSessionRepository,
+                                                accountRepository = accountRepository,
+                                                accountAttributeRepository = accountAttributeRepository,
+                                                sessionId = session.id,
+                                                strategy = strategy,
+                                            )
                                         if (suggestions.isEmpty()) {
-                                            startImport(session, accountsSession, strategy, emptyMap())
+                                            startImport(session, strategy, emptyMap())
                                         } else {
                                             pendingImport =
                                                 PendingApiImport(
                                                     session = session,
-                                                    accountsSession = accountsSession,
                                                     strategy = strategy,
                                                     counterparties = suggestions,
                                                 )
@@ -597,7 +527,6 @@ fun ApiSessionsScreen(
                 pendingImport = null
                 startImport(
                     session = import.session,
-                    accountsSession = import.accountsSession,
                     strategy = import.strategy,
                     counterpartyAccountNames = namesByCounterpartyId,
                 )
@@ -608,7 +537,6 @@ fun ApiSessionsScreen(
 
 private data class PendingApiImport(
     val session: ApiSession,
-    val accountsSession: ApiSession?,
     val strategy: ApiImportStrategy,
     val counterparties: List<ApiCounterpartySuggestion>,
 )
@@ -727,16 +655,11 @@ private fun CredentialCard(
     providerLabel: String?,
     requiresSigning: Boolean,
     transactionsBlockReason: String?,
-    peopleDownloadSupported: Boolean,
-    isDownloadingPeople: Boolean,
     onGenerateSigningKey: () -> Unit,
     onCopyText: (String) -> Unit,
-    onDownloadPeople: () -> Unit,
     sessions: List<ApiSession>,
-    isDownloadingAccounts: Boolean,
-    isDownloadingTransactions: Boolean,
-    accountsDownloadResult: ApiAccountsDownloadResult?,
-    downloadResult: ApiTransactionsDownloadResult?,
+    isDownloading: Boolean,
+    downloadResult: ApiSessionDownloadResult?,
     downloadProgress: ApiTransactionsDownloadProgress?,
     importResultBySession: Map<ApiSessionId, ApiSessionImportResult>,
     importErrorBySession: Map<ApiSessionId, String>,
@@ -744,8 +667,7 @@ private fun CredentialCard(
     importedSessionRevisions: Set<ApiSessionImportRevision>,
     selectedStrategyRevision: Long?,
     isImportingSession: (ApiSessionId) -> Boolean,
-    onDownloadAccounts: () -> Unit,
-    onDownloadTransactions: () -> Unit,
+    onDownload: () -> Unit,
     onImport: (ApiSession) -> Unit,
     onSessionClick: (ApiSession) -> Unit,
     onCopyError: (String) -> Unit,
@@ -756,8 +678,6 @@ private fun CredentialCard(
         } else {
             credential.token
         }
-    val isCredentialBusy = isDownloadingAccounts || isDownloadingTransactions || isDownloadingPeople
-
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text(
@@ -790,25 +710,15 @@ private fun CredentialCard(
                 )
             }
 
-            accountsDownloadResult?.let {
-                Text(text = it.displaySummary(), color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.bodySmall)
-            }
             downloadResult?.let {
                 Text(text = it.displaySummary(), color = MaterialTheme.colorScheme.primary, style = MaterialTheme.typography.bodySmall)
             }
 
-            if (isDownloadingAccounts) {
-                Text(
-                    text = "Downloading accounts...",
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-            if (isDownloadingTransactions) {
+            if (isDownloading) {
                 Text(
                     text =
                         if (downloadProgress == null) {
-                            "Preparing download..."
+                            "Downloading..."
                         } else {
                             "Downloading account ${downloadProgress.accountIndex}/${downloadProgress.accountCount}, " +
                                 "page ${downloadProgress.page}. ${downloadProgress.downloadedResponsePageCount} response(s) so far."
@@ -818,24 +728,11 @@ private fun CredentialCard(
                 )
             }
 
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Button(onClick = onDownloadAccounts, enabled = !isCredentialBusy, modifier = Modifier.weight(1f)) {
-                    if (isDownloadingAccounts) {
-                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
-                    } else {
-                        Text("Download Accounts")
-                    }
-                }
-                Button(
-                    onClick = onDownloadTransactions,
-                    enabled = !isCredentialBusy && transactionsBlockReason == null,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    if (isDownloadingTransactions) {
-                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
-                    } else {
-                        Text("Download Transactions")
-                    }
+            Button(onClick = onDownload, enabled = !isDownloading, modifier = Modifier.fillMaxWidth()) {
+                if (isDownloading) {
+                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                } else {
+                    Text("Download")
                 }
             }
             transactionsBlockReason?.let { reason ->
@@ -844,19 +741,6 @@ private fun CredentialCard(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
                 )
-            }
-            if (peopleDownloadSupported) {
-                OutlinedButton(
-                    onClick = onDownloadPeople,
-                    enabled = !isCredentialBusy,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    if (isDownloadingPeople) {
-                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
-                    } else {
-                        Text("Download People")
-                    }
-                }
             }
 
             if (sessions.isNotEmpty()) {
@@ -917,14 +801,7 @@ private fun SessionRow(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            val kindLabel =
-                when (session.kind) {
-                    ApiSessionKind.ACCOUNTS -> "Accounts session"
-                    ApiSessionKind.TRANSACTIONS -> "Transactions session"
-                    ApiSessionKind.PEOPLE -> "People session"
-                    null -> "Session"
-                }
-            Text(text = kindLabel, style = MaterialTheme.typography.labelLarge)
+            Text(text = "Session", style = MaterialTheme.typography.labelLarge)
             Row(horizontalArrangement = Arrangement.spacedBy(4.dp), verticalAlignment = Alignment.CenterVertically) {
                 if (isAlreadyImported) {
                     ImportedBadge()
@@ -952,14 +829,7 @@ private fun SessionRow(
         }
 
         if (isImporting) {
-            val importLabel =
-                when (session.kind) {
-                    ApiSessionKind.ACCOUNTS -> "Importing accounts..."
-                    ApiSessionKind.TRANSACTIONS -> "Importing transactions..."
-                    ApiSessionKind.PEOPLE -> "Importing people..."
-                    null -> "Importing..."
-                }
-            Text(text = importLabel, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
+            Text(text = "Importing...", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
             importProgress?.let {
                 val percent = it.progress?.let { p -> " (${(p * 100).toInt().coerceIn(0, 100)}%)" }.orEmpty()
                 Text(
@@ -983,13 +853,6 @@ private fun SessionRow(
         }
 
         if (isActive) {
-            val importButtonLabel =
-                when (session.kind) {
-                    ApiSessionKind.ACCOUNTS -> "Import Accounts"
-                    ApiSessionKind.TRANSACTIONS -> "Import Transactions"
-                    ApiSessionKind.PEOPLE -> "Import People"
-                    null -> "Import Transactions"
-                }
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
                     onClick = onImport,
@@ -999,7 +862,7 @@ private fun SessionRow(
                     if (isImporting) {
                         CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
                     } else {
-                        Text(importButtonLabel)
+                        Text("Import")
                     }
                 }
                 OutlinedButton(onClick = onOpenTraffic) { Text("Traffic") }
@@ -1767,16 +1630,6 @@ private fun ApiRequest.displayBody(): String =
         }
     }.trimEnd()
 
-private fun ApiAccountsDownloadResult.displaySummary(): String =
-    if (skipped) {
-        "Accounts already downloaded: $accountCount account(s) (skipped)."
-    } else {
-        "Accounts downloaded: $accountCount account(s)."
-    }
-
-private fun ApiTransactionsDownloadResult.displaySummary(): String =
-    "Transactions downloaded: $accountCount account(s), $transactionResponseCount new response page(s)."
-
 private fun ApiTransactionsDownloadProgress.downloadDetail(): String =
     "Downloading account $accountIndex/$accountCount, page $page. $downloadedResponsePageCount response page(s) downloaded so far."
 
@@ -1816,12 +1669,7 @@ private const val LEGACY_DEFAULT_STRATEGY_NAME = "Monzo"
 private fun legacyDefaultStrategy(strategies: List<ApiImportStrategy>): ApiImportStrategy? =
     strategies.firstOrNull { it.name == LEGACY_DEFAULT_STRATEGY_NAME }
 
-private fun monzoAccountsDownloadTaskKey(credentialId: MonzoCredentialId): String = "monzo-accounts-download-cred-${credentialId.id}"
-
-private fun monzoTransactionsDownloadTaskKey(credentialId: MonzoCredentialId): String =
-    "monzo-transactions-download-cred-${credentialId.id}"
-
-private fun monzoPeopleDownloadTaskKey(credentialId: MonzoCredentialId): String = "monzo-people-download-cred-${credentialId.id}"
+private fun monzoDownloadTaskKey(credentialId: MonzoCredentialId): String = "monzo-download-cred-${credentialId.id}"
 
 private fun monzoImportTaskKey(sessionId: ApiSessionId): String = "monzo-import-${sessionId.id}"
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
@@ -42,7 +42,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.moneymanager.domain.model.ApiSessionKind
 import com.moneymanager.domain.model.apistrategy.ApiAccountMappings
 import com.moneymanager.domain.model.apistrategy.ApiAuthType
 import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
@@ -181,35 +180,21 @@ fun ApiStrategyEditDialog(
             } else {
                 allCredentials
             }
+        // Accounts, transactions and people all land in one session now, so scan each session's
+        // responses and pick the first item matching each response array key.
         for (credential in credentials) {
-            val sessions = apiSessionRepository.getSessionsByCredential(credential.id)
-            if (accountSampleItem == null) {
-                sessions
-                    .filter { it.kind == ApiSessionKind.ACCOUNTS }
-                    .maxByOrNull { it.createdAt }
-                    ?.let { session ->
-                        for (response in apiSessionRepository.getResponsesBySession(session.id)) {
-                            val item = extractFirstArrayItem(response.json, accountsResponseArrayKey)
-                            if (item != null) {
-                                accountSampleItem = item
-                                break
-                            }
-                        }
+            val sessions = apiSessionRepository.getSessionsByCredential(credential.id).sortedByDescending { it.createdAt }
+            for (session in sessions) {
+                for (response in apiSessionRepository.getResponsesBySession(session.id)) {
+                    if (accountSampleItem == null) {
+                        extractFirstArrayItem(response.json, accountsResponseArrayKey)?.let { accountSampleItem = it }
                     }
-            }
-            if (txSampleItem == null) {
-                sessions
-                    .filter { it.kind == ApiSessionKind.TRANSACTIONS }
-                    .maxByOrNull { it.createdAt }
-                    ?.let { session ->
-                        for (response in apiSessionRepository.getResponsesBySession(session.id)) {
-                            val item = extractFirstArrayItem(response.json, transactionsResponseArrayKey)
-                            if (item != null) {
-                                txSampleItem = item
-                                break
-                            }
-                        }
+                    if (txSampleItem == null) {
+                        extractFirstArrayItem(response.json, transactionsResponseArrayKey)?.let { txSampleItem = it }
                     }
+                    if (accountSampleItem != null && txSampleItem != null) break
+                }
+                if (accountSampleItem != null && txSampleItem != null) break
             }
             if (accountSampleItem != null && txSampleItem != null) break
         }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategyEditDialog.kt
@@ -173,6 +173,11 @@ fun ApiStrategyEditDialog(
     // Prefer credentials linked to this strategy; fall back to all credentials so
     // existing Monzo credentials (created before the strategy was linked) still work.
     LaunchedEffect(strategy?.id, accountsResponseArrayKey, transactionsResponseArrayKey) {
+        // Reset before rescanning so a key/strategy change discards the previous results
+        // instead of short-circuiting on stale samples.
+        accountSampleItem = null
+        txSampleItem = null
+
         val allCredentials = apiSessionRepository.getAllCredentials()
         val credentials =
             if (strategy != null) {
@@ -180,27 +185,29 @@ fun ApiStrategyEditDialog(
             } else {
                 allCredentials
             }
+        var foundAccountSample: String? = null
+        var foundTxSample: String? = null
         // Accounts, transactions and people all land in one session now, so scan each session's
         // responses and pick the first item matching each response array key.
         for (credential in credentials) {
             val sessions = apiSessionRepository.getSessionsByCredential(credential.id).sortedByDescending { it.createdAt }
             for (session in sessions) {
                 for (response in apiSessionRepository.getResponsesBySession(session.id)) {
-                    if (accountSampleItem == null) {
-                        extractFirstArrayItem(response.json, accountsResponseArrayKey)?.let { accountSampleItem = it }
+                    if (foundAccountSample == null) {
+                        extractFirstArrayItem(response.json, accountsResponseArrayKey)?.let { foundAccountSample = it }
                     }
-                    if (txSampleItem == null) {
-                        extractFirstArrayItem(response.json, transactionsResponseArrayKey)?.let { txSampleItem = it }
+                    if (foundTxSample == null) {
+                        extractFirstArrayItem(response.json, transactionsResponseArrayKey)?.let { foundTxSample = it }
                     }
-                    if (accountSampleItem != null && txSampleItem != null) break
+                    if (foundAccountSample != null && foundTxSample != null) break
                 }
-                if (accountSampleItem != null && txSampleItem != null) break
+                if (foundAccountSample != null && foundTxSample != null) break
             }
-            if (accountSampleItem != null && txSampleItem != null) break
+            if (foundAccountSample != null && foundTxSample != null) break
         }
-        // Mark as "searched but nothing found" so we don't show a loading state forever
-        if (accountSampleItem == null) accountSampleItem = ""
-        if (txSampleItem == null) txSampleItem = ""
+        // Empty string marks "searched but nothing found" so we don't show a loading state forever.
+        accountSampleItem = foundAccountSample ?: ""
+        txSampleItem = foundTxSample ?: ""
     }
 
     // Which field's setter is currently awaiting a path pick

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoBalanceFixtureE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoBalanceFixtureE2ETest.kt
@@ -4,8 +4,6 @@ package com.moneymanager.ui.monzo
 
 import com.moneymanager.database.port.DbEntitySource
 import com.moneymanager.domain.model.ApiRequestId
-import com.moneymanager.domain.model.ApiSessionId
-import com.moneymanager.domain.model.ApiSessionKind
 import com.moneymanager.domain.model.DeviceId
 import com.moneymanager.domain.model.DeviceInfo
 import com.moneymanager.test.database.DbTest
@@ -35,7 +33,6 @@ private data class SessionFixture(
     val createdAt: Long,
     val expiresAt: Long? = null,
     val credentialId: Long? = null,
-    val kind: String? = null,
     val importedAt: Long? = null,
 )
 
@@ -76,25 +73,23 @@ class MonzoBalanceFixtureE2ETest : DbTest() {
             val responses = loadResponses()
 
             val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("fixture-machine", "fixture-os"))
-            val sessionIdMap = mutableMapOf<Long, ApiSessionId>()
             val requestIdMap = mutableMapOf<Long, ApiRequestId>()
 
-            sessions.sortedBy { it.id }.forEach { fixture ->
-                val created =
-                    repositories.apiSessionRepository.createSession(
-                        token = fixture.token,
-                        deviceId = deviceId,
-                        createdAt = Instant.fromEpochMilliseconds(fixture.createdAt),
-                        expiresAt = fixture.expiresAt?.let(Instant.Companion::fromEpochMilliseconds),
-                        kind = fixture.kind?.let(ApiSessionKind::valueOf),
-                    )
-                sessionIdMap[fixture.id] = created
-            }
+            // Accounts, transactions and people are now downloaded into one session, so collapse the
+            // fixture's separate accounts/transactions sessions (same token) into a single session.
+            val firstSession = sessions.minByOrNull { it.id } ?: return@runTest
+            val sessionId =
+                repositories.apiSessionRepository.createSession(
+                    token = firstSession.token,
+                    deviceId = deviceId,
+                    createdAt = Instant.fromEpochMilliseconds(firstSession.createdAt),
+                    expiresAt = firstSession.expiresAt?.let(Instant.Companion::fromEpochMilliseconds),
+                )
 
             requests.sortedBy { it.id }.forEach { fixture ->
                 val created =
                     repositories.apiSessionRepository.insertRequest(
-                        sessionId = sessionIdMap.getValue(fixture.sessionId),
+                        sessionId = sessionId,
                         method = fixture.method,
                         url = fixture.url,
                         headers = emptyMap(),
@@ -105,15 +100,11 @@ class MonzoBalanceFixtureE2ETest : DbTest() {
             responses.sortedBy { it.id }.forEach { fixture ->
                 repositories.apiSessionRepository.insertResponse(
                     requestId = requestIdMap.getValue(fixture.requestId),
-                    sessionId = sessionIdMap.getValue(fixture.sessionId),
+                    sessionId = sessionId,
                     json = fixture.json,
                 )
             }
 
-            val firstAccountsSession =
-                sessions.firstOrNull { it.kind == ApiSessionKind.ACCOUNTS.name }
-                    ?: return@runTest
-            val transactionSessions = sessions.filter { it.kind == ApiSessionKind.TRANSACTIONS.name }
             val strategy =
                 repositories.apiImportStrategyRepository
                     .getAllStrategies()
@@ -132,27 +123,9 @@ class MonzoBalanceFixtureE2ETest : DbTest() {
                 attributeTypeRepository = repositories.attributeTypeRepository,
                 accountAttributeRepository = repositories.accountAttributeRepository,
                 deviceId = DeviceId(deviceId.id),
-                sessionId = sessionIdMap.getValue(firstAccountsSession.id),
+                sessionId = sessionId,
                 strategy = strategy,
             )
-
-            transactionSessions.sortedBy { it.id }.forEach { fixture ->
-                importApiSessionTransactions(
-                    apiSessionRepository = repositories.apiSessionRepository,
-                    accountRepository = repositories.accountRepository,
-                    currencyRepository = repositories.currencyRepository,
-                    transactionRepository = repositories.transactionRepository,
-                    entitySource = DbEntitySource(database.entitySourceQueries, database.transferSourceQueries, DeviceId(deviceId.id)),
-                    personRepository = repositories.personRepository,
-                    personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
-                    personAttributeRepository = repositories.personAttributeRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
-                    accountAttributeRepository = repositories.accountAttributeRepository,
-                    deviceId = DeviceId(deviceId.id),
-                    sessionId = sessionIdMap.getValue(fixture.id),
-                    strategy = strategy,
-                )
-            }
 
             repositories.transactionRepository.getAccountBalances().first().let { actualBalances ->
                 val expectedBalances = json.decodeFromString<List<ExpectedBalance>>(balancesFile.readText())

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
@@ -358,6 +358,32 @@ private val TRANSACTIONS_WITH_ATM_AND_COUNTERPARTY_IDS_JSON =
     """.trimIndent()
 
 /**
+ * A single ordinary (non-ATM) outgoing payment in the exact shape Monzo's real API returns: the
+ * `atm_fees_detailed` key is present on every transaction but set to JSON `null` unless it is an
+ * actual ATM withdrawal. The built-in ATM rule must NOT match this, or every payment becomes an ATM.
+ */
+private val TRANSACTION_WITH_NULL_ATM_FEES_JSON =
+    """
+{
+  "transactions": [
+    {
+      "id": "tx_00009TEST000000000050",
+      "account_id": "$ACCOUNT_ID",
+      "created": "2024-06-03T09:15:00.000Z",
+      "amount": -1250,
+      "currency": "GBP",
+      "description": "COFFEE SHOP LTD LONDON GBR",
+      "merchant": { "name": "Coffee Shop Ltd" },
+      "counterparty": {},
+      "metadata": {},
+      "labels": null,
+      "atm_fees_detailed": null
+    }
+  ]
+}
+    """.trimIndent()
+
+/**
  * A page that contains only declined transactions — no settled tx at all.
  * Used to verify that an all-declined page does not prematurely stop pagination.
  */
@@ -1360,6 +1386,89 @@ class MonzoImportE2ETest : DbTest() {
                         .any { it.attributeType.name == "built-in type" && it.value == "ATM" }
                 }
             assertEquals(1, atmAccounts.size, "All ATM withdrawals must consolidate into one built-in ATM account")
+        }
+
+    @Test
+    fun `ordinary payments with a null atm_fees_detailed field are not routed to the ATM account`() =
+        runTest {
+            val deviceId =
+                repositories.deviceRepository.getOrCreateDevice(
+                    DeviceInfo.Jvm("test-machine", "Test OS"),
+                )
+            val strategy =
+                repositories.apiImportStrategyRepository
+                    .getAllStrategies()
+                    .first()
+                    .single { it.name == "Monzo" }
+            val sessionId =
+                repositories.apiSessionRepository.createSession(
+                    token = "test-monzo-token",
+                    deviceId = deviceId,
+                    createdAt = Instant.fromEpochMilliseconds(1_700_000_000_000L),
+                    expiresAt = null,
+                )
+            val mockEngine =
+                MockEngine { request ->
+                    val url = request.url.toString()
+                    val json =
+                        when {
+                            url.contains("/accounts") -> ACCOUNTS_JSON
+                            url.contains("/transactions") && !url.contains("before=") ->
+                                TRANSACTION_WITH_NULL_ATM_FEES_JSON
+                            url.contains("/transactions") && url.contains("before=") -> EMPTY_TRANSACTIONS_JSON
+                            else -> error("Unexpected request: $url")
+                        }
+                    respond(
+                        content = json,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+            val apiClient =
+                createApiClient(
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.apiSessionRepository),
+                    engine = mockEngine,
+                )
+
+            downloadApiSessionAccounts(
+                token = "test-monzo-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+            downloadApiSessionTransactions(
+                token = "test-monzo-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+            importApiSessionTransactions(
+                apiSessionRepository = repositories.apiSessionRepository,
+                accountRepository = repositories.accountRepository,
+                currencyRepository = repositories.currencyRepository,
+                transactionRepository = repositories.transactionRepository,
+                entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                personRepository = repositories.personRepository,
+                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                personAttributeRepository = repositories.personAttributeRepository,
+                attributeTypeRepository = repositories.attributeTypeRepository,
+                accountAttributeRepository = repositories.accountAttributeRepository,
+                deviceId = deviceId,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+
+            val allAccounts = repositories.accountRepository.getAllAccounts().first()
+            val atmAccounts =
+                allAccounts.filter { account ->
+                    repositories.accountAttributeRepository
+                        .getByAccount(account.id)
+                        .first()
+                        .any { it.attributeType.name == "built-in type" && it.value == "ATM" }
+                }
+            assertEquals(0, atmAccounts.size, "A present-but-null atm_fees_detailed field must not create an ATM account")
         }
 
     @Test

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
@@ -1444,21 +1444,25 @@ class MonzoImportE2ETest : DbTest() {
                 sessionId = sessionId,
                 strategy = strategy,
             )
-            importApiSessionTransactions(
-                apiSessionRepository = repositories.apiSessionRepository,
-                accountRepository = repositories.accountRepository,
-                currencyRepository = repositories.currencyRepository,
-                transactionRepository = repositories.transactionRepository,
-                entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
-                personRepository = repositories.personRepository,
-                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
-                personAttributeRepository = repositories.personAttributeRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
-                accountAttributeRepository = repositories.accountAttributeRepository,
-                deviceId = deviceId,
-                sessionId = sessionId,
-                strategy = strategy,
-            )
+            val importResult =
+                importApiSessionTransactions(
+                    apiSessionRepository = repositories.apiSessionRepository,
+                    accountRepository = repositories.accountRepository,
+                    currencyRepository = repositories.currencyRepository,
+                    transactionRepository = repositories.transactionRepository,
+                    entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                    personRepository = repositories.personRepository,
+                    personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                    personAttributeRepository = repositories.personAttributeRepository,
+                    attributeTypeRepository = repositories.attributeTypeRepository,
+                    accountAttributeRepository = repositories.accountAttributeRepository,
+                    deviceId = deviceId,
+                    sessionId = sessionId,
+                    strategy = strategy,
+                )
+
+            assertEquals(1, importResult.transactionCount, "Transaction should be imported")
+            assertEquals(0, importResult.errorCount, "Should have no import errors")
 
             val allAccounts = repositories.accountRepository.getAllAccounts().first()
             val atmAccounts =

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
@@ -5,7 +5,6 @@ package com.moneymanager.ui.starling
 import com.moneymanager.database.port.DbEntitySource
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.ApiSessionId
-import com.moneymanager.domain.model.ApiSessionKind
 import com.moneymanager.domain.model.DeviceInfo
 import com.moneymanager.rest.ApiSessionTrafficRecorder
 import com.moneymanager.rest.createApiClient
@@ -350,22 +349,40 @@ class StarlingImportE2ETest : DbTest() {
                     .first()
                     .single { it.name == "Starling" }
 
-            fun clientFor(session: ApiSessionId) =
+            // One session holds accounts, transactions and the account holder.
+            val sessionId = repositories.apiSessionRepository.createSession("test-starling-token", deviceId, now, null)
+            val apiClient =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = session, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
                     engine = mockEngine(),
                 )
 
-            // Import accounts (and transactions) so the Starling account exists.
-            val accountsSessionId = repositories.apiSessionRepository.createSession("test-starling-token", deviceId, now, null)
             downloadApiSessionAccounts(
                 token = "test-starling-token",
-                apiClient = clientFor(accountsSessionId),
+                apiClient = apiClient,
                 apiSessionRepository = repositories.apiSessionRepository,
-                sessionId = accountsSessionId,
+                sessionId = sessionId,
                 strategy = strategy,
             )
+            downloadApiSessionTransactions(
+                token = "test-starling-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+            val downloadResult =
+                downloadApiSessionPeople(
+                    token = "test-starling-token",
+                    apiClient = apiClient,
+                    apiSessionRepository = repositories.apiSessionRepository,
+                    sessionId = sessionId,
+                    strategy = strategy,
+                )
+            assertEquals(1, downloadResult.personCount, "The single account holder object should be counted")
+
+            // Mirrors the UI's combined import: transactions first (creates accounts), then people.
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 accountRepository = repositories.accountRepository,
@@ -378,37 +395,22 @@ class StarlingImportE2ETest : DbTest() {
                 attributeTypeRepository = repositories.attributeTypeRepository,
                 accountAttributeRepository = repositories.accountAttributeRepository,
                 deviceId = deviceId,
-                sessionId = accountsSessionId,
+                sessionId = sessionId,
                 strategy = strategy,
             )
-
-            // Download + import the single global account holder.
-            val peopleSessionId = repositories.apiSessionRepository.createSession("test-starling-token", deviceId, now, null)
-            val downloadResult =
-                downloadApiSessionPeople(
-                    token = "test-starling-token",
-                    apiClient = clientFor(peopleSessionId),
-                    apiSessionRepository = repositories.apiSessionRepository,
-                    sessionId = peopleSessionId,
-                    strategy = strategy,
-                )
-            assertEquals(1, downloadResult.personCount, "The single account holder object should be counted")
-
-            val importResult =
-                importApiSessionPeople(
-                    apiSessionRepository = repositories.apiSessionRepository,
-                    accountRepository = repositories.accountRepository,
-                    accountAttributeRepository = repositories.accountAttributeRepository,
-                    personRepository = repositories.personRepository,
-                    personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
-                    personAttributeRepository = repositories.personAttributeRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
-                    entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
-                    sessionId = peopleSessionId,
-                    strategy = strategy,
-                    accountsSessionId = accountsSessionId,
-                )
-            assertEquals(1, importResult.personCount, "The account holder is created as a person")
+            importApiSessionPeople(
+                apiSessionRepository = repositories.apiSessionRepository,
+                accountRepository = repositories.accountRepository,
+                accountAttributeRepository = repositories.accountAttributeRepository,
+                personRepository = repositories.personRepository,
+                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                personAttributeRepository = repositories.personAttributeRepository,
+                attributeTypeRepository = repositories.attributeTypeRepository,
+                entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
+                sessionId = sessionId,
+                strategy = strategy,
+                accountsSessionId = sessionId,
+            )
 
             val people = repositories.personRepository.getAllPeople().first()
             val ada = people.single { it.firstName == "Ada" && it.lastName == "Lovelace" }
@@ -432,27 +434,32 @@ class StarlingImportE2ETest : DbTest() {
                     .getAllStrategies()
                     .first()
                     .single { it.name == "Starling" }
-            // Sessions must share a credential so the accounts import can find the holder's people session.
-            val credentialId = repositories.apiSessionRepository.createCredential("test-starling-token", now)
 
-            fun clientFor(session: ApiSessionId) =
+            // Accounts and the holder are downloaded into one session; importing people before the
+            // transactions still ends with the holder owning the own account.
+            val sessionId = repositories.apiSessionRepository.createSession("test-starling-token", deviceId, now, null)
+            val apiClient =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = session, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
                     engine = mockEngine(),
                 )
-
-            // 1) People FIRST, before any accounts exist — the holder is created but can link to nothing.
-            val peopleSessionId =
-                repositories.apiSessionRepository
-                    .createSession("test-starling-token", deviceId, now, null, credentialId = credentialId, kind = ApiSessionKind.PEOPLE)
-            downloadApiSessionPeople(
+            downloadApiSessionAccounts(
                 token = "test-starling-token",
-                apiClient = clientFor(peopleSessionId),
+                apiClient = apiClient,
                 apiSessionRepository = repositories.apiSessionRepository,
-                sessionId = peopleSessionId,
+                sessionId = sessionId,
                 strategy = strategy,
             )
+            downloadApiSessionPeople(
+                token = "test-starling-token",
+                apiClient = apiClient,
+                apiSessionRepository = repositories.apiSessionRepository,
+                sessionId = sessionId,
+                strategy = strategy,
+            )
+
+            // 1) People FIRST, before any accounts exist — the holder is created but can link to nothing.
             importApiSessionPeople(
                 apiSessionRepository = repositories.apiSessionRepository,
                 accountRepository = repositories.accountRepository,
@@ -462,21 +469,13 @@ class StarlingImportE2ETest : DbTest() {
                 personAttributeRepository = repositories.personAttributeRepository,
                 attributeTypeRepository = repositories.attributeTypeRepository,
                 entitySource = DbEntitySource(repositories.entitySourceQueries, repositories.transferSourceQueries, deviceId),
-                sessionId = peopleSessionId,
+                sessionId = sessionId,
                 strategy = strategy,
+                accountsSessionId = sessionId,
             )
 
-            // 2) Accounts AFTER the holder — the accounts import must back-link the holder to the own account.
-            val accountsSessionId =
-                repositories.apiSessionRepository
-                    .createSession("test-starling-token", deviceId, now, null, credentialId = credentialId, kind = ApiSessionKind.ACCOUNTS)
-            downloadApiSessionAccounts(
-                token = "test-starling-token",
-                apiClient = clientFor(accountsSessionId),
-                apiSessionRepository = repositories.apiSessionRepository,
-                sessionId = accountsSessionId,
-                strategy = strategy,
-            )
+            // 2) Accounts AFTER the holder — the transactions import back-links the holder to the own
+            // account by reading the people responses from the same session.
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 accountRepository = repositories.accountRepository,
@@ -489,7 +488,7 @@ class StarlingImportE2ETest : DbTest() {
                 attributeTypeRepository = repositories.attributeTypeRepository,
                 accountAttributeRepository = repositories.accountAttributeRepository,
                 deviceId = deviceId,
-                sessionId = accountsSessionId,
+                sessionId = sessionId,
                 strategy = strategy,
             )
 


### PR DESCRIPTION
## Context

Now that CSV, QIF and API imports share a central import engine (#513), the three-step API flow — separate **Download Accounts / Download Transactions / Download People** plus a per-kind **Import** — is redundant friction. The download/import service functions already accept one `sessionId` and treat `accountsSessionId` as defaulting to it, so this is mostly a UI/orchestration refactor plus retiring the obsolete `ApiSessionKind`.

## What changed

- **One Download button** — creates one session and fetches accounts → transactions → people (when the strategy supports people, skipping transactions when region-blocked) into it, on a single API client/background task, with a combined `ApiSessionDownloadResult` summary.
- **One Import button** — runs counterparty discovery + confirmation, then imports transactions (creating accounts + people-from-data) and, when configured, the dedicated account-holder people endpoint afterward so the accounts it links to already exist. The session is marked imported once, only after both succeed.
- **`ApiSessionKind` removed end to end** — enum, `ApiSession.kind`, the `createSession(kind=…)` parameter, repo mapping, and the `api_session.kind` column (BETA, no migrations). `linkGlobalHolderToOwnAccounts` now finds holder responses *within the same session* via the people-endpoint path predicate instead of a cross-session `kind` lookup. `ApiStrategyEditDialog`'s sample-JSON lookup now scans all session responses.

## Bug fix: every Monzo transaction routed to ATM

The built-in counterparty `EXISTS` predicate treated a present-but-JSON-`null` field as existing. Monzo sends `atm_fees_detailed: null` on **every** transaction, so the ATM rule matched all negative transactions (confirmed against a local DB: 1226 transfers wrongly routed to `Monzo Counterparty: ATM`). `EXISTS` now excludes `JsonNull`. Added a regression test using Monzo's real shape.

> Note: this fixes future imports only — existing DBs need to be recreated (BETA) to clear the mis-routed data.

## Tests

- Starling and Monzo E2E tests rewritten to the single-session model (including the order-independence holder-linking test).
- Monzo balance fixture test collapses its two kind-tagged sessions into one at load time (no fixture JSON edits).
- New regression test: `ordinary payments with a null atm_fees_detailed field are not routed to the ATM account`.

Verified with `./gradlew build` (JVM + Android tests, ktlint, detekt, coverage verify, buildHealth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified API session download experience with a single download action per credential, consolidating accounts, transactions, and people data handling.

* **Bug Fixes**
  * Fixed transaction rule evaluation to properly handle JSON fields with null values.
  * Corrected ATM routing logic to ignore payments where the ATM fees field is null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->