### PR TITLE
Bring CSV import UI to parity with QIF

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/BulkImportResult.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/BulkImportResult.kt
@@ -1,0 +1,22 @@
+package com.moneymanager.ui.screens
+
+/**
+ * Outcome of a bulk import run across many files (CSV or QIF). Both flows produce identical summary
+ * text, so [toSummary] lives here and the format stays in one place.
+ */
+internal interface BulkImportResult {
+    val filesImported: Int
+    val transfersCreated: Int
+    val duplicatesSkipped: Int
+    val filesSkippedNoStrategy: Int
+    val filesFailed: Int
+
+    fun toSummary(): String =
+        buildString {
+            append("Imported $filesImported file${if (filesImported == 1) "" else "s"}")
+            append(" · $transfersCreated new")
+            if (duplicatesSkipped > 0) append(" · $duplicatesSkipped duplicates skipped")
+            if (filesSkippedNoStrategy > 0) append(" · $filesSkippedNoStrategy skipped (no strategy)")
+            if (filesFailed > 0) append(" · $filesFailed failed")
+        }
+}

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
@@ -15,11 +15,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -30,24 +32,47 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.moneymanager.compose.filepicker.rememberFilePicker
+import com.moneymanager.compose.filepicker.rememberMultipleFilePicker
 import com.moneymanager.csv.CsvParseOptions
 import com.moneymanager.csv.CsvParser
+import com.moneymanager.domain.EntitySource
+import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csv.CsvImportId
+import com.moneymanager.domain.repository.AccountRepository
+import com.moneymanager.domain.repository.AttributeTypeRepository
+import com.moneymanager.domain.repository.CategoryRepository
+import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportRepository
+import com.moneymanager.domain.repository.CsvImportStrategyRepository
+import com.moneymanager.domain.repository.CurrencyRepository
+import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
+import com.moneymanager.domain.repository.PersonRepository
+import com.moneymanager.importer.ImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import com.moneymanager.ui.screens.csv.CsvImportAllDialog
 import com.moneymanager.ui.util.displayDateTime
 import com.moneymanager.ui.util.sha256Hex
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 
-// The QIF imports screen mirrors this one (QIF reuses the CSV import engine); overlap is intentional.
-@Suppress("DuplicatedCode")
+// Mirrors QifImportsScreen (QIF reuses the CSV import engine); overlap is intentional.
+@Suppress("LongParameterList", "DuplicatedCode")
 @Composable
 fun CsvImportsScreen(
     csvImportRepository: CsvImportRepository,
+    csvImportStrategyRepository: CsvImportStrategyRepository,
+    csvAccountMappingRepository: CsvAccountMappingRepository,
+    accountRepository: AccountRepository,
+    categoryRepository: CategoryRepository,
+    currencyRepository: CurrencyRepository,
+    personRepository: PersonRepository,
+    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
+    attributeTypeRepository: AttributeTypeRepository,
+    maintenance: Maintenance,
+    entitySource: EntitySource,
+    importEngine: ImportEngine,
     onImportClick: (CsvImportId) -> Unit,
     onStrategiesClick: () -> Unit = {},
 ) {
@@ -56,58 +81,60 @@ fun CsvImportsScreen(
         .getAllImports()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     var isImporting by remember { mutableStateOf(false) }
-    var importError by remember { mutableStateOf<String?>(null) }
-    var duplicateImport by remember { mutableStateOf<CsvImport?>(null) }
+    var importMessage by remember { mutableStateOf<String?>(null) }
+    var importMessageIsError by remember { mutableStateOf(false) }
 
     val filePicker =
-        rememberFilePicker(
+        rememberMultipleFilePicker(
             mimeTypes = listOf("text/csv", "text/plain", "text/comma-separated-values"),
-        ) { result ->
-            if (result != null) {
+        ) { results ->
+            if (results.isNotEmpty()) {
                 isImporting = true
-                importError = null
+                importMessage = null
                 scope.launch {
-                    try {
-                        val checksum = sha256Hex(result.content)
-                        val existing = csvImportRepository.findImportsByChecksum(checksum)
-                        if (existing.isNotEmpty()) {
-                            duplicateImport = existing.first()
-                            isImporting = false
-                            return@launch
-                        }
-                        val parser = CsvParser()
-                        val delimiter = parser.detectDelimiter(result.content)
-                        val parseResult =
-                            parser.parse(
-                                result.content,
-                                CsvParseOptions(delimiter = delimiter),
+                    var imported = 0
+                    var skipped = 0
+                    val failures = mutableListOf<String>()
+                    for (result in results) {
+                        try {
+                            val checksum = sha256Hex(result.content)
+                            if (csvImportRepository.findImportsByChecksum(checksum).isNotEmpty()) {
+                                skipped++
+                                continue
+                            }
+                            val parser = CsvParser()
+                            val delimiter = parser.detectDelimiter(result.content)
+                            val parseResult =
+                                parser.parse(
+                                    result.content,
+                                    CsvParseOptions(delimiter = delimiter),
+                                )
+                            csvImportRepository.createImport(
+                                fileName = result.fileName,
+                                headers = parseResult.headers,
+                                rows = parseResult.rows,
+                                fileChecksum = checksum,
+                                fileLastModified = result.lastModified ?: Clock.System.now(),
                             )
-                        csvImportRepository.createImport(
-                            fileName = result.fileName,
-                            headers = parseResult.headers,
-                            rows = parseResult.rows,
-                            fileChecksum = checksum,
-                            fileLastModified = result.lastModified ?: Clock.System.now(),
-                        )
-                    } catch (expected: Exception) {
-                        importError = "Failed to import CSV: ${expected.message}"
-                    } finally {
-                        isImporting = false
+                            imported++
+                        } catch (expected: Exception) {
+                            failures.add("${result.fileName}: ${expected.message}")
+                        }
                     }
+                    isImporting = false
+                    importMessageIsError = failures.isNotEmpty()
+                    importMessage =
+                        buildString {
+                            append("Imported $imported file${if (imported == 1) "" else "s"}")
+                            if (skipped > 0) append(", skipped $skipped already imported")
+                            if (failures.isNotEmpty()) {
+                                append(", ${failures.size} failed: ")
+                                append(failures.joinToString("; "))
+                            }
+                        }
                 }
             }
         }
-
-    duplicateImport?.let { existing ->
-        DuplicateImportDialog(
-            existingImport = existing,
-            onDismiss = { duplicateImport = null },
-            onViewExisting = {
-                duplicateImport = null
-                onImportClick(existing.id)
-            },
-        )
-    }
 
     Column(
         modifier =
@@ -147,11 +174,11 @@ fun CsvImportsScreen(
             }
         }
 
-        importError?.let { error ->
+        importMessage?.let { message ->
             Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = error,
-                color = MaterialTheme.colorScheme.error,
+                text = message,
+                color = if (importMessageIsError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
                 style = MaterialTheme.typography.bodySmall,
             )
         }
@@ -164,20 +191,86 @@ fun CsvImportsScreen(
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
-                    text = "No CSV files imported yet. Click '+ Import CSV' to add one.",
+                    text = "No CSV files imported yet. Click '+ Import CSV' to add one or more.",
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         } else {
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                items(imports) { import ->
-                    CsvImportCard(
-                        import = import,
-                        onClick = { onImportClick(import.id) },
+            // Split files into those still needing a strategy applied vs. already imported, so a large
+            // set of files is easy to work through. The Unimported tab is the default/actionable one.
+            val unimported = remember(imports) { imports.filter { it.lastAppliedAt == null } }
+            val importedList = remember(imports) { imports.filter { it.lastAppliedAt != null } }
+            var selectedTab by remember { mutableStateOf(0) }
+
+            SecondaryTabRow(selectedTabIndex = selectedTab) {
+                Tab(
+                    selected = selectedTab == 0,
+                    onClick = { selectedTab = 0 },
+                    text = { Text("Unimported (${unimported.size})") },
+                )
+                Tab(
+                    selected = selectedTab == 1,
+                    onClick = { selectedTab = 1 },
+                    text = { Text("Imported (${importedList.size})") },
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            var showImportAll by remember { mutableStateOf(false) }
+            if (selectedTab == 0 && unimported.isNotEmpty()) {
+                Button(
+                    onClick = { showImportAll = true },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Import all (${unimported.size})")
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            if (showImportAll) {
+                CsvImportAllDialog(
+                    unimported = unimported,
+                    csvImportStrategyRepository = csvImportStrategyRepository,
+                    csvAccountMappingRepository = csvAccountMappingRepository,
+                    accountRepository = accountRepository,
+                    categoryRepository = categoryRepository,
+                    currencyRepository = currencyRepository,
+                    personRepository = personRepository,
+                    personAccountOwnershipRepository = personAccountOwnershipRepository,
+                    csvImportRepository = csvImportRepository,
+                    attributeTypeRepository = attributeTypeRepository,
+                    maintenance = maintenance,
+                    entitySource = entitySource,
+                    importEngine = importEngine,
+                    onDismiss = { showImportAll = false },
+                    onComplete = { showImportAll = false },
+                )
+            }
+
+            val shown = if (selectedTab == 0) unimported else importedList
+            if (shown.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = if (selectedTab == 0) "All files have been imported." else "No files imported yet.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+                }
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(shown, key = { it.id.toString() }) { import ->
+                        CsvImportCard(
+                            import = import,
+                            onClick = { onImportClick(import.id) },
+                        )
+                    }
                 }
             }
         }
@@ -322,32 +415,4 @@ private fun ImportStateBadge(isImported: Boolean) {
             color = contentColor,
         )
     }
-}
-
-@Composable
-private fun DuplicateImportDialog(
-    existingImport: CsvImport,
-    onDismiss: () -> Unit,
-    onViewExisting: () -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("File Already Imported") },
-        text = {
-            Text(
-                "This file has already been imported as \"${existingImport.originalFileName}\" " +
-                    "on ${existingImport.importTimestamp.displayDateTime()}.",
-            )
-        },
-        confirmButton = {
-            TextButton(onClick = onViewExisting) {
-                Text("View Existing")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Dismiss")
-            }
-        },
-    )
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
@@ -92,6 +92,17 @@ fun ImportsScreen(
             ImportTab.CSV ->
                 CsvImportsScreen(
                     csvImportRepository = csvImportRepository,
+                    csvImportStrategyRepository = csvImportStrategyRepository,
+                    csvAccountMappingRepository = csvAccountMappingRepository,
+                    accountRepository = accountRepository,
+                    categoryRepository = categoryRepository,
+                    currencyRepository = currencyRepository,
+                    personRepository = personRepository,
+                    personAccountOwnershipRepository = personAccountOwnershipRepository,
+                    attributeTypeRepository = attributeTypeRepository,
+                    maintenance = maintenance,
+                    entitySource = entitySource,
+                    importEngine = importEngine,
                     onImportClick = onCsvImportClick,
                     onStrategiesClick = onCsvStrategiesClick,
                 )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.moneymanager.database.csv.CsvImportProvenance
 import com.moneymanager.database.csv.CsvTransferMapper
 import com.moneymanager.database.csv.DiscoveredAccountMapping
 import com.moneymanager.database.csv.ImportPreparation
@@ -52,9 +51,7 @@ import com.moneymanager.domain.EntitySource
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
-import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.Transfer
-import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csv.CsvRow
@@ -74,12 +71,6 @@ import com.moneymanager.domain.repository.CurrencyRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.importer.ImportEngine
-import com.moneymanager.importmodel.AccountRef
-import com.moneymanager.importmodel.DedupePolicy
-import com.moneymanager.importmodel.ExistingUniqueKeyExtractor
-import com.moneymanager.importmodel.ImportBatch
-import com.moneymanager.importmodel.ImportRowKey
-import com.moneymanager.importmodel.ImportTransfer
 import com.moneymanager.ui.components.AccountPicker
 import com.moneymanager.ui.components.LoadingTextButton
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
@@ -98,6 +89,7 @@ private val logger = logging()
 data class CsvImportResult(
     val successCount: Int,
     val failedRows: List<FailedRow>,
+    val duplicateCount: Int = 0,
 ) {
     data class FailedRow(
         val rowIndex: Long,
@@ -376,377 +368,26 @@ fun ApplyStrategyDialog(
 
                     scope.launch {
                         try {
-                            logger.info { "Starting CSV import with ${prep.validTransfers.size} valid transfers" }
-
-                            val accountsToCreate =
-                                buildAccountsToCreate(
-                                    preparation = basePrep,
-                                    existingAccountSelections = selectedExistingAccounts,
-                                    newAccountNames = selectedNewAccountNames,
-                                )
-                            val selectedMappingsToPersist =
-                                buildPendingAccountMappings(
-                                    preparation = basePrep,
-                                    strategyId = strategy.id,
-                                    accountSelections = selectedExistingAccounts,
-                                )
-                            if (selectedMappingsToPersist.isNotEmpty()) {
-                                try {
-                                    csvAccountMappingRepository.createMappings(selectedMappingsToPersist)
-                                    logger.info { "Saved ${selectedMappingsToPersist.size} selected account mappings" }
-                                } catch (expected: Exception) {
-                                    // Batch is atomic, nothing was committed — retry per mapping
-                                    // so one bad mapping doesn't block the rest
-                                    logger.warn(expected) {
-                                        "Bulk mapping save failed, falling back to per-mapping save"
-                                    }
-                                    for (mapping in selectedMappingsToPersist) {
-                                        try {
-                                            csvAccountMappingRepository.createMapping(
-                                                strategyId = mapping.strategyId,
-                                                columnName = mapping.columnName,
-                                                valuePattern = mapping.valuePattern,
-                                                accountId = mapping.accountId,
-                                            )
-                                        } catch (expectedMappingError: Exception) {
-                                            logger.warn(expectedMappingError) {
-                                                "Failed to save selected mapping '${mapping.valuePattern.pattern}'"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            // Create new accounts first (skip failures - transfers using them will fail later)
-                            val createdAccountNames = mutableSetOf<String>()
-                            if (accountsToCreate.isNotEmpty()) {
-                                val newAccounts =
-                                    accountsToCreate.map { newAccount ->
-                                        Account(
-                                            id = AccountId(0),
-                                            name = newAccount.name,
-                                            openingDate = Clock.System.now(),
-                                            categoryId = newAccount.categoryId,
-                                        )
-                                    }
-                                try {
-                                    // Bulk-create all accounts in a single database transaction
-                                    accountRepository.createAccountsBatch(newAccounts)
-                                    createdAccountNames.addAll(accountsToCreate.map { it.name })
-                                    logger.info { "Created ${accountsToCreate.size} new accounts" }
-                                } catch (expected: Exception) {
-                                    // Batch is atomic, nothing was committed — fall back to
-                                    // per-account creation to skip only the failing accounts
-                                    logger.warn(expected) {
-                                        "Bulk account creation failed, falling back to per-account creation"
-                                    }
-                                    for (account in newAccounts) {
-                                        try {
-                                            accountRepository.createAccount(account)
-                                            createdAccountNames.add(account.name)
-                                            logger.info { "Created new account: ${account.name}" }
-                                        } catch (expectedAccountError: Exception) {
-                                            logger.warn(expectedAccountError) {
-                                                "Skipping account '${account.name}': ${expectedAccountError.message}"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            // Auto-capture mappings for newly created accounts
-                            if (createdAccountNames.isNotEmpty()) {
-                                val updatedAccountsForMapping = accountRepository.getAllAccounts().first()
-                                val accountsByNameForMapping = updatedAccountsForMapping.associateBy { it.name }
-
-                                // Collect discovered mappings, separating regex matches from exact matches
-                                val allDiscoveredMappings =
-                                    prep.validTransfers.flatMap { it.discoveredMappings }
-
-                                // For regex matches (matchedPattern != null), deduplicate by pattern
-                                // This ensures only ONE mapping is created per regex rule
-                                val regexMappings =
-                                    allDiscoveredMappings
-                                        .filter { it.matchedPattern != null }
-                                        .distinctBy { it.matchedPattern }
-
-                                // For exact matches (matchedPattern == null), deduplicate by csvValue
-                                val exactMappings =
-                                    allDiscoveredMappings
-                                        .filter { it.matchedPattern == null }
-                                        .distinctBy { it.csvValue }
-
-                                val mappingCreatedAt = Clock.System.now()
-                                val mappingsToCapture =
-                                    (regexMappings + exactMappings).mapIndexedNotNull { index, discoveredMapping ->
-                                        val createdAccountName =
-                                            selectedNewAccountNames[discoveredMapping.targetAccountName]
-                                                ?.trim()
-                                                ?.takeIf { it.isNotBlank() }
-                                                ?: discoveredMapping.targetAccountName
-
-                                        // Look up the account by the final name created for this detected value
-                                        val createdAccount =
-                                            accountsByNameForMapping[createdAccountName]
-                                                ?.takeIf { it.name in createdAccountNames }
-                                                ?: return@mapIndexedNotNull null
-
-                                        // Use the matched regex pattern if available,
-                                        // otherwise create an exact-match pattern for the CSV value
-                                        val matchedPattern = discoveredMapping.matchedPattern
-                                        val pattern =
-                                            if (matchedPattern != null) {
-                                                Regex(matchedPattern, RegexOption.IGNORE_CASE)
-                                            } else {
-                                                Regex(
-                                                    "^${Regex.escape(discoveredMapping.csvValue)}$",
-                                                    RegexOption.IGNORE_CASE,
-                                                )
-                                            }
-                                        CsvAccountMapping(
-                                            id = -(index + 1).toLong(),
-                                            strategyId = strategy.id,
-                                            columnName = discoveredMapping.columnName,
-                                            valuePattern = pattern,
-                                            accountId = createdAccount.id,
-                                            createdAt = mappingCreatedAt,
-                                            updatedAt = mappingCreatedAt,
-                                        )
-                                    }
-
-                                if (mappingsToCapture.isNotEmpty()) {
-                                    try {
-                                        // Bulk-save all auto-captured mappings in a single database transaction
-                                        csvAccountMappingRepository.createMappings(mappingsToCapture)
-                                        logger.info { "Auto-captured ${mappingsToCapture.size} account mappings" }
-                                    } catch (expected: Exception) {
-                                        // Batch is atomic, nothing was committed — retry per mapping
-                                        // so one bad mapping doesn't block the rest
-                                        logger.warn(expected) {
-                                            "Bulk auto-capture failed, falling back to per-mapping save"
-                                        }
-                                        for (mapping in mappingsToCapture) {
-                                            try {
-                                                csvAccountMappingRepository.createMapping(
-                                                    strategyId = mapping.strategyId,
-                                                    columnName = mapping.columnName,
-                                                    valuePattern = mapping.valuePattern,
-                                                    accountId = mapping.accountId,
-                                                )
-                                            } catch (expectedMappingError: Exception) {
-                                                logger.warn(expectedMappingError) {
-                                                    "Failed to auto-capture mapping '${mapping.valuePattern.pattern}'"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            // Re-map with new account IDs
-                            logger.info { "Re-mapping transfers with updated account IDs" }
-                            val updatedAccounts = accountRepository.getAllAccounts().first()
-                            val accountsByName = updatedAccounts.associateBy { it.name }
-                            val currenciesById = currencies.associateBy { it.id }
-                            val currenciesByCode = currencies.associateBy { it.code.uppercase() }
-
-                            // Duplicate detection now happens inside the central import engine, which
-                            // loads existing transfers itself — the mapper only maps rows to transfers.
-                            val latestAccountMappings =
-                                csvAccountMappingRepository.getMappingsForStrategy(strategy.id).first()
-
-                            val mapper =
-                                CsvTransferMapper(
-                                    strategy = strategy,
+                            val result =
+                                runCsvImport(
+                                    csvImport = csvImport,
+                                    rows = rowsToProcess,
                                     columns = csvImport.columns,
-                                    existingAccounts = accountsByName,
-                                    existingCurrencies = currenciesById,
-                                    existingCurrenciesByCode = currenciesByCode,
-                                    accountMappings = latestAccountMappings,
-                                    sourceAccountOverride = selectedSourceAccountId,
+                                    strategy = strategy,
+                                    basePrep = basePrep,
+                                    selectedExistingAccounts = selectedExistingAccounts,
+                                    selectedNewAccountNames = selectedNewAccountNames,
+                                    selectedSourceAccountId = selectedSourceAccountId,
+                                    currencies = currencies,
+                                    csvAccountMappingRepository = csvAccountMappingRepository,
+                                    accountRepository = accountRepository,
+                                    csvImportRepository = csvImportRepository,
+                                    attributeTypeRepository = attributeTypeRepository,
+                                    maintenance = maintenance,
+                                    entitySource = entitySource,
+                                    importEngine = importEngine,
                                 )
-
-                            // Handle case when all rows are already processed
-                            // (rowsToProcess is already filtered at the top of the composable)
-                            if (rowsToProcess.isEmpty()) {
-                                logger.info { "No rows to process - all rows already imported" }
-                                onImportComplete(
-                                    CsvImportResult(
-                                        successCount = 0,
-                                        failedRows = emptyList(),
-                                    ),
-                                )
-                                return@launch
-                            }
-
-                            val finalPrep = mapper.prepareImport(rowsToProcess)
-                            val validCount = finalPrep.validTransfers.size
-                            val errorCount = finalPrep.errorRows.size
-                            logger.info { "Prepared $validCount valid transfers, $errorCount error rows" }
-
-                            // Mark mapping errors as ERROR status in database and save error messages
-                            for (errorRow in finalPrep.errorRows) {
-                                csvImportRepository.updateRowStatus(
-                                    csvImport.id,
-                                    errorRow.rowIndex,
-                                    ImportStatus.ERROR.name,
-                                )
-                                csvImportRepository.saveError(
-                                    csvImport.id,
-                                    errorRow.rowIndex,
-                                    errorRow.errorMessage,
-                                )
-                            }
-
-                            // Pre-resolve attribute types
-                            val allAttributeTypeNames =
-                                finalPrep.validTransfers
-                                    .flatMap { it.attributes }
-                                    .map { it.first }
-                                    .toSet()
-                            val attributeTypeIdByName =
-                                allAttributeTypeNames.associateWith { name ->
-                                    attributeTypeRepository.getOrCreate(name)
-                                }
-
-                            logger.info { "Starting to import $validCount transfers" }
-
-                            // Convert attributes from (typeName, value) to NewAttribute
-                            fun attributesFor(attributes: List<Pair<String, String>>): List<NewAttribute> =
-                                attributes.mapNotNull { (typeName, value) ->
-                                    val typeId = attributeTypeIdByName[typeName]
-                                    if (typeId != null) NewAttribute(typeId, value) else null
-                                }
-
-                            // Build the unified import batch. Accounts were already resolved/created
-                            // above, so transfers carry Existing refs and the central engine only
-                            // dedupes, writes transfers, applies updates and records sources.
-                            val uniqueIdTypeNames =
-                                strategy.attributeMappings
-                                    .filter { it.isUniqueIdentifier }
-                                    .map { it.attributeTypeName }
-                                    .toSet()
-
-                            val importTransfers =
-                                finalPrep.validTransfers.map { row ->
-                                    val uniqueKey =
-                                        if (uniqueIdTypeNames.isEmpty()) {
-                                            null
-                                        } else {
-                                            row.attributes
-                                                .filter { (name, _) -> name in uniqueIdTypeNames }
-                                                .associate { (name, value) -> name to value }
-                                        }
-                                    ImportTransfer(
-                                        rowKey = ImportRowKey.CsvRow(row.rowIndex),
-                                        source = AccountRef.Existing(row.transfer.sourceAccountId),
-                                        target = AccountRef.Existing(row.transfer.targetAccountId),
-                                        timestamp = row.transfer.timestamp,
-                                        description = row.transfer.description,
-                                        amount = row.transfer.amount,
-                                        attributes = attributesFor(row.attributes),
-                                        uniqueKey = uniqueKey,
-                                    )
-                                }
-
-                            val batch =
-                                ImportBatch(
-                                    transfers = importTransfers,
-                                    dedupePolicy =
-                                        if (uniqueIdTypeNames.isEmpty()) {
-                                            DedupePolicy.FuzzyAllFields()
-                                        } else {
-                                            DedupePolicy.UniqueIdentifier
-                                        },
-                                    provenance = CsvImportProvenance(entitySource, csvImport.id),
-                                    uniqueKeyExtractor =
-                                        if (uniqueIdTypeNames.isEmpty()) {
-                                            null
-                                        } else {
-                                            ExistingUniqueKeyExtractor { transfer ->
-                                                transfer.attributes
-                                                    .filter { it.attributeType.name in uniqueIdTypeNames }
-                                                    .associate { it.attributeType.name to it.value }
-                                            }
-                                        },
-                                )
-
-                            val importResult = importEngine.import(batch)
-
-                            // Write back per-row CSV statuses from the engine outcome.
-                            val importedStatuses = mutableMapOf<Long, TransferId?>()
-                            val duplicateStatuses = mutableMapOf<Long, TransferId?>()
-                            val updatedStatuses = mutableMapOf<Long, TransferId?>()
-                            for ((rowKey, outcome) in importResult.rowOutcomes) {
-                                val rowIndex = (rowKey as ImportRowKey.CsvRow).rowIndex
-                                when (outcome.status) {
-                                    ImportStatus.IMPORTED -> importedStatuses[rowIndex] = outcome.transferId
-                                    ImportStatus.DUPLICATE -> duplicateStatuses[rowIndex] = outcome.transferId
-                                    ImportStatus.UPDATED -> updatedStatuses[rowIndex] = outcome.transferId
-                                    ImportStatus.ERROR -> Unit
-                                }
-                            }
-                            if (importedStatuses.isNotEmpty()) {
-                                csvImportRepository.updateRowStatusesBatch(
-                                    csvImport.id,
-                                    ImportStatus.IMPORTED.name,
-                                    importedStatuses,
-                                )
-                                csvImportRepository.clearErrors(csvImport.id, importedStatuses.keys.toList())
-                            }
-                            if (duplicateStatuses.isNotEmpty()) {
-                                csvImportRepository.updateRowStatusesBatch(
-                                    csvImport.id,
-                                    ImportStatus.DUPLICATE.name,
-                                    duplicateStatuses,
-                                )
-                            }
-                            if (updatedStatuses.isNotEmpty()) {
-                                csvImportRepository.updateRowStatusesBatch(
-                                    csvImport.id,
-                                    ImportStatus.UPDATED.name,
-                                    updatedStatuses,
-                                )
-                                csvImportRepository.clearErrors(csvImport.id, updatedStatuses.keys.toList())
-                            }
-                            val successCount = importResult.transfersImported + importResult.updated
-                            val duplicateCount = importResult.duplicates
-
-                            logger.info {
-                                "Transfer import complete: $successCount imported/updated, ${importResult.duplicates} duplicate(s)"
-                            }
-
-                            // Note: CSV rows are updated with status and transfer IDs during import loop above
-
-                            // Refresh materialized views so transfers are visible
-                            logger.info { "Refreshing materialized views" }
-                            maintenance.refreshMaterializedViews()
-
-                            if ((successCount + duplicateCount) > 0) {
-                                runCatching {
-                                    csvImportRepository.recordImportApplication(
-                                        id = csvImport.id,
-                                        strategyId = strategy.id,
-                                        strategyName = strategy.name,
-                                        appliedAt = Clock.System.now(),
-                                    )
-                                }.onFailure { error ->
-                                    logger.warn {
-                                        "Import application history could not be recorded for import ${csvImport.id}: ${error.message}"
-                                    }
-                                }
-                            }
-
-                            logger.info { "Import completed successfully" }
-
-                            // The engine import is atomic: on success there are no per-row failures
-                            // (any failure throws to the outer catch below), so the import is complete.
-                            onImportComplete(
-                                CsvImportResult(
-                                    successCount = successCount,
-                                    failedRows = emptyList(),
-                                ),
-                            )
+                            onImportComplete(result)
                         } catch (expected: Exception) {
                             logger.error(expected) { "Import failed: ${expected.message}" }
                             errorMessage = "Import failed: ${expected.message}"

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -361,7 +361,6 @@ fun ApplyStrategyDialog(
                 onClick = {
                     val strategy = selectedStrategy ?: return@LoadingTextButton
                     val basePrep = baseImportPreparation ?: return@LoadingTextButton
-                    val prep = importPreparation ?: return@LoadingTextButton
 
                     isImporting = true
                     errorMessage = null

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
@@ -143,23 +143,26 @@ fun CsvImportAllDialog(
                         if (needsSourceAccount && sourceAccountId == null) return@LoadingTextButton
                         isImporting = true
                         scope.launch {
-                            val result =
-                                bulkApplyCsv(
-                                    imports = unimported,
-                                    sourceAccountOverride = sourceAccountId,
-                                    strategies = strategies,
-                                    currencies = currencies,
-                                    csvAccountMappingRepository = csvAccountMappingRepository,
-                                    accountRepository = accountRepository,
-                                    csvImportRepository = csvImportRepository,
-                                    attributeTypeRepository = attributeTypeRepository,
-                                    maintenance = maintenance,
-                                    entitySource = entitySource,
-                                    importEngine = importEngine,
-                                    onProgress = { done, total -> progress = done to total },
-                                )
-                            summary = result.toSummary()
-                            isImporting = false
+                            try {
+                                val result =
+                                    bulkApplyCsv(
+                                        imports = unimported,
+                                        sourceAccountOverride = sourceAccountId,
+                                        strategies = strategies,
+                                        currencies = currencies,
+                                        csvAccountMappingRepository = csvAccountMappingRepository,
+                                        accountRepository = accountRepository,
+                                        csvImportRepository = csvImportRepository,
+                                        attributeTypeRepository = attributeTypeRepository,
+                                        maintenance = maintenance,
+                                        entitySource = entitySource,
+                                        importEngine = importEngine,
+                                        onProgress = { done, total -> progress = done to total },
+                                    )
+                                summary = result.toSummary()
+                            } finally {
+                                isImporting = false
+                            }
                         }
                     },
                     enabled = !isImporting && (!needsSourceAccount || sourceAccountId != null),

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
@@ -175,14 +175,3 @@ fun CsvImportAllDialog(
         },
     )
 }
-
-// Mirrors QifBulkResult.toSummary() by design.
-@Suppress("DuplicatedCode")
-private fun CsvBulkResult.toSummary(): String =
-    buildString {
-        append("Imported $filesImported file${if (filesImported == 1) "" else "s"}")
-        append(" · $transfersCreated new")
-        if (duplicatesSkipped > 0) append(" · $duplicatesSkipped duplicates skipped")
-        if (filesSkippedNoStrategy > 0) append(" · $filesSkippedNoStrategy skipped (no strategy)")
-        if (filesFailed > 0) append(" · $filesFailed failed")
-    }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
@@ -1,0 +1,186 @@
+package com.moneymanager.ui.screens.csv
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.moneymanager.database.csv.StrategyMatcher
+import com.moneymanager.domain.EntitySource
+import com.moneymanager.domain.Maintenance
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.csv.CsvImport
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.repository.AccountRepository
+import com.moneymanager.domain.repository.AttributeTypeRepository
+import com.moneymanager.domain.repository.CategoryRepository
+import com.moneymanager.domain.repository.CsvAccountMappingRepository
+import com.moneymanager.domain.repository.CsvImportRepository
+import com.moneymanager.domain.repository.CsvImportStrategyRepository
+import com.moneymanager.domain.repository.CurrencyRepository
+import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
+import com.moneymanager.domain.repository.PersonRepository
+import com.moneymanager.importer.ImportEngine
+import com.moneymanager.ui.components.AccountPicker
+import com.moneymanager.ui.components.LoadingTextButton
+import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+
+/**
+ * Applies the matching strategy to every unimported CSV file in one go. Each file's strategy is
+ * auto-matched from its column headers (files with no match are skipped). The shared source account
+ * chosen here is used only for files whose strategy needs a user-chosen source; strategies that
+ * hard-code or per-row-resolve the source ignore it. Payee accounts auto-create with detected names.
+ * Mirrors QifImportAllDialog by design (CSV has no currency choice — currency comes from the strategy).
+ */
+@Composable
+@Suppress("LongParameterList", "LongMethod", "DuplicatedCode")
+fun CsvImportAllDialog(
+    unimported: List<CsvImport>,
+    csvImportStrategyRepository: CsvImportStrategyRepository,
+    csvAccountMappingRepository: CsvAccountMappingRepository,
+    accountRepository: AccountRepository,
+    categoryRepository: CategoryRepository,
+    currencyRepository: CurrencyRepository,
+    personRepository: PersonRepository,
+    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
+    csvImportRepository: CsvImportRepository,
+    attributeTypeRepository: AttributeTypeRepository,
+    maintenance: Maintenance,
+    entitySource: EntitySource,
+    importEngine: ImportEngine,
+    onDismiss: () -> Unit,
+    onComplete: () -> Unit,
+) {
+    val scope = rememberSchemaAwareCoroutineScope()
+    val strategies by csvImportStrategyRepository.getAllStrategies().collectAsStateWithSchemaErrorHandling(emptyList())
+    val currencies by currencyRepository.getAllCurrencies().collectAsStateWithSchemaErrorHandling(emptyList())
+
+    var sourceAccountId by remember { mutableStateOf<AccountId?>(null) }
+    var isImporting by remember { mutableStateOf(false) }
+    var progress by remember { mutableStateOf<Pair<Int, Int>?>(null) }
+    var summary by remember { mutableStateOf<String?>(null) }
+
+    // Match each file's strategy by its columns, so we can tell how many files will be skipped (no
+    // matching strategy) and whether any matched strategy needs a user-chosen source account.
+    // getAllImports() doesn't populate columns, so load each file's columns before matching.
+    var matchedStrategies by remember { mutableStateOf<List<CsvImportStrategy?>?>(null) }
+    LaunchedEffect(unimported, strategies) {
+        if (strategies.isEmpty()) {
+            matchedStrategies = null
+            return@LaunchedEffect
+        }
+        matchedStrategies =
+            unimported.map { listedImport ->
+                val fullImport = csvImportRepository.getImport(listedImport.id).first()
+                val columnNames = fullImport?.columns.orEmpty().map { it.originalName }
+                StrategyMatcher.findMatchingStrategy(columnNames, strategies)
+            }
+    }
+    val matches = matchedStrategies
+    val skippedNoStrategyCount = if (matches == null) 0 else unimported.size - matches.count { it != null }
+    val needsSourceAccount = matches?.any { it != null && it.needsSourceAccountOverride() } ?: false
+
+    AlertDialog(
+        onDismissRequest = { if (!isImporting) onDismiss() },
+        title = { Text(if (summary != null) "Import complete" else "Import all unimported files") },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                val currentSummary = summary
+                if (currentSummary != null) {
+                    Text(currentSummary, style = MaterialTheme.typography.bodyMedium)
+                } else {
+                    if (needsSourceAccount) {
+                        AccountPicker(
+                            selectedAccountId = sourceAccountId,
+                            onAccountSelected = { sourceAccountId = it },
+                            label = "Source account (for files whose strategy needs one)",
+                            accountRepository = accountRepository,
+                            categoryRepository = categoryRepository,
+                            personRepository = personRepository,
+                            personAccountOwnershipRepository = personAccountOwnershipRepository,
+                            entitySource = entitySource,
+                            enabled = !isImporting,
+                            isError = sourceAccountId == null,
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                    }
+                    if (skippedNoStrategyCount > 0) {
+                        Text(
+                            text =
+                                "$skippedNoStrategyCount file${if (skippedNoStrategyCount == 1) "" else "s"} " +
+                                    "have no matching strategy and will be skipped.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    progress?.let { (done, total) ->
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text("Importing ${done.coerceAtMost(total)} of $total…", style = MaterialTheme.typography.bodySmall)
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            if (summary != null) {
+                TextButton(onClick = onComplete) { Text("Done") }
+            } else {
+                LoadingTextButton(
+                    onClick = {
+                        if (needsSourceAccount && sourceAccountId == null) return@LoadingTextButton
+                        isImporting = true
+                        scope.launch {
+                            val result =
+                                bulkApplyCsv(
+                                    imports = unimported,
+                                    sourceAccountOverride = sourceAccountId,
+                                    strategies = strategies,
+                                    currencies = currencies,
+                                    csvAccountMappingRepository = csvAccountMappingRepository,
+                                    accountRepository = accountRepository,
+                                    csvImportRepository = csvImportRepository,
+                                    attributeTypeRepository = attributeTypeRepository,
+                                    maintenance = maintenance,
+                                    entitySource = entitySource,
+                                    importEngine = importEngine,
+                                    onProgress = { done, total -> progress = done to total },
+                                )
+                            summary = result.toSummary()
+                            isImporting = false
+                        }
+                    },
+                    enabled = !isImporting && (!needsSourceAccount || sourceAccountId != null),
+                    loading = isImporting,
+                    label = "Import ${unimported.size} files",
+                )
+            }
+        },
+        dismissButton = {
+            if (summary == null) {
+                TextButton(onClick = onDismiss, enabled = !isImporting) { Text("Cancel") }
+            }
+        },
+    )
+}
+
+private fun CsvBulkResult.toSummary(): String =
+    buildString {
+        append("Imported $filesImported file${if (filesImported == 1) "" else "s"}")
+        append(" · $transfersCreated new")
+        if (duplicatesSkipped > 0) append(" · $duplicatesSkipped duplicates skipped")
+        if (filesSkippedNoStrategy > 0) append(" · $filesSkippedNoStrategy skipped (no strategy)")
+        if (filesFailed > 0) append(" · $filesFailed failed")
+    }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
@@ -176,6 +176,8 @@ fun CsvImportAllDialog(
     )
 }
 
+// Mirrors QifBulkResult.toSummary() by design.
+@Suppress("DuplicatedCode")
 private fun CsvBulkResult.toSummary(): String =
     buildString {
         append("Imported $filesImported file${if (filesImported == 1) "" else "s"}")

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportApplier.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportApplier.kt
@@ -1,0 +1,561 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.ui.screens.csv
+
+import com.moneymanager.database.csv.CsvImportProvenance
+import com.moneymanager.database.csv.CsvTransferMapper
+import com.moneymanager.database.csv.DiscoveredAccountMapping
+import com.moneymanager.database.csv.ImportPreparation
+import com.moneymanager.database.csv.NewAccount
+import com.moneymanager.database.csv.StrategyMatcher
+import com.moneymanager.domain.EntitySource
+import com.moneymanager.domain.Maintenance
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.csv.CsvColumn
+import com.moneymanager.domain.model.csv.CsvImport
+import com.moneymanager.domain.model.csv.CsvRow
+import com.moneymanager.domain.model.csv.ImportStatus
+import com.moneymanager.domain.model.csvstrategy.CsvAccountMapping
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.model.csvstrategy.HardCodedAccountMapping
+import com.moneymanager.domain.model.csvstrategy.TransferField
+import com.moneymanager.domain.repository.AccountRepository
+import com.moneymanager.domain.repository.AttributeTypeRepository
+import com.moneymanager.domain.repository.CsvAccountMappingRepository
+import com.moneymanager.domain.repository.CsvImportRepository
+import com.moneymanager.importer.ImportEngine
+import com.moneymanager.importmodel.AccountRef
+import com.moneymanager.importmodel.DedupePolicy
+import com.moneymanager.importmodel.ExistingUniqueKeyExtractor
+import com.moneymanager.importmodel.ImportBatch
+import com.moneymanager.importmodel.ImportRowKey
+import com.moneymanager.importmodel.ImportTransfer
+import kotlinx.coroutines.flow.first
+import org.lighthousegames.logging.logging
+import kotlin.time.Clock
+
+private val logger = logging()
+
+/** Summary of a bulk CSV import run across many files. Mirrors QifBulkResult by design. */
+internal data class CsvBulkResult(
+    val filesImported: Int,
+    val transfersCreated: Int,
+    val duplicatesSkipped: Int,
+    val filesSkippedNoStrategy: Int,
+    val filesFailed: Int,
+)
+
+/**
+ * Applies the matching strategy to every [imports] file. Each file's strategy is auto-matched from its
+ * column headers, so files from different banks each get the right strategy; files with no match are
+ * skipped and counted. Payee/counterparty accounts auto-create with their detected names (no per-file
+ * confirmation). The shared [sourceAccountOverride] is used only for files whose strategy needs a
+ * user-chosen source (no SOURCE_ACCOUNT mapping); hard-coded and per-row strategies resolve their own.
+ * Refreshes materialized views once at the end. Reports progress via [onProgress].
+ */
+@Suppress("LongParameterList")
+internal suspend fun bulkApplyCsv(
+    imports: List<CsvImport>,
+    sourceAccountOverride: AccountId?,
+    strategies: List<CsvImportStrategy>,
+    currencies: List<Currency>,
+    csvAccountMappingRepository: CsvAccountMappingRepository,
+    accountRepository: AccountRepository,
+    csvImportRepository: CsvImportRepository,
+    attributeTypeRepository: AttributeTypeRepository,
+    maintenance: Maintenance,
+    entitySource: EntitySource,
+    importEngine: ImportEngine,
+    onProgress: (done: Int, total: Int) -> Unit,
+): CsvBulkResult {
+    var filesImported = 0
+    var transfers = 0
+    var duplicates = 0
+    var skippedNoStrategy = 0
+    var failed = 0
+
+    imports.forEachIndexed { index, listedImport ->
+        onProgress(index, imports.size)
+        // getAllImports() doesn't populate columns, so re-fetch the full import (which loads them)
+        // for the column-based strategy match below.
+        val csvImport = csvImportRepository.getImport(listedImport.id).first() ?: listedImport
+        val columnNames = csvImport.columns.map { it.originalName }
+        val matched = StrategyMatcher.findMatchingStrategy(columnNames, strategies)
+        if (matched == null) {
+            skippedNoStrategy++
+            return@forEachIndexed
+        }
+        try {
+            val allRows = csvImportRepository.getImportRows(csvImport.id, limit = csvImport.rowCount.coerceAtLeast(1), offset = 0)
+            val rows = allRows.filter { it.importStatus == null || it.importStatus == ImportStatus.ERROR }
+            if (rows.isEmpty()) return@forEachIndexed
+
+            // The shared override only applies to strategies that need a user-chosen source. A
+            // hard-coded mapping resolves its own account; a per-row mapping decides per row.
+            val effectiveSource = effectiveSourceFor(matched, sourceAccountOverride)
+
+            // Re-fetch accounts so payee accounts created by earlier files are seen.
+            val accounts = accountRepository.getAllAccounts().first()
+            val mappings = csvAccountMappingRepository.getMappingsForStrategy(matched.id).first()
+            val basePrep =
+                buildCsvMapper(matched, csvImport.columns, accounts, currencies, mappings, effectiveSource)
+                    .prepareImport(rows)
+
+            val result =
+                runCsvImport(
+                    csvImport = csvImport,
+                    rows = rows,
+                    columns = csvImport.columns,
+                    strategy = matched,
+                    basePrep = basePrep,
+                    selectedExistingAccounts = emptyMap(),
+                    selectedNewAccountNames = emptyMap(),
+                    selectedSourceAccountId = effectiveSource,
+                    currencies = currencies,
+                    csvAccountMappingRepository = csvAccountMappingRepository,
+                    accountRepository = accountRepository,
+                    csvImportRepository = csvImportRepository,
+                    attributeTypeRepository = attributeTypeRepository,
+                    maintenance = maintenance,
+                    entitySource = entitySource,
+                    importEngine = importEngine,
+                    refreshViews = false,
+                )
+            filesImported++
+            transfers += result.successCount
+            duplicates += result.duplicateCount
+        } catch (expected: Exception) {
+            logger.error(expected) { "Bulk CSV import failed for ${csvImport.originalFileName}: ${expected.message}" }
+            failed++
+        }
+    }
+
+    onProgress(imports.size, imports.size)
+    maintenance.refreshMaterializedViews()
+
+    return CsvBulkResult(
+        filesImported = filesImported,
+        transfersCreated = transfers,
+        duplicatesSkipped = duplicates,
+        filesSkippedNoStrategy = skippedNoStrategy,
+        filesFailed = failed,
+    )
+}
+
+/**
+ * Resolves the source account to use for a file under [strategy]:
+ * - a [HardCodedAccountMapping] resolves its own account (the override is ignored),
+ * - a per-row SOURCE_ACCOUNT mapping decides per row (null override),
+ * - no SOURCE_ACCOUNT mapping falls back to the shared [override].
+ */
+internal fun effectiveSourceFor(
+    strategy: CsvImportStrategy,
+    override: AccountId?,
+): AccountId? =
+    when (val mapping = strategy.fieldMappings[TransferField.SOURCE_ACCOUNT]) {
+        is HardCodedAccountMapping -> mapping.accountId
+        null -> override
+        else -> null
+    }
+
+/** True when [strategy] needs a user-chosen source account (no SOURCE_ACCOUNT mapping of its own). */
+internal fun CsvImportStrategy.needsSourceAccountOverride(): Boolean = fieldMappings[TransferField.SOURCE_ACCOUNT] == null
+
+internal fun buildCsvMapper(
+    strategy: CsvImportStrategy,
+    columns: List<CsvColumn>,
+    accounts: List<Account>,
+    currencies: List<Currency>,
+    accountMappings: List<CsvAccountMapping>,
+    sourceAccountOverride: AccountId?,
+): CsvTransferMapper =
+    CsvTransferMapper(
+        strategy = strategy,
+        columns = columns,
+        existingAccounts = accounts.associateBy { it.name },
+        existingCurrencies = currencies.associateBy { it.id },
+        existingCurrenciesByCode = currencies.associateBy { it.code.uppercase() },
+        accountMappings = accountMappings,
+        sourceAccountOverride = sourceAccountOverride,
+    )
+
+/**
+ * Saves [mappings] in a single batch, falling back to per-mapping saves if the atomic batch fails so
+ * one bad mapping doesn't block the rest. [kind] just labels log messages ("selected"/"auto-captured").
+ */
+private suspend fun persistMappingsWithFallback(
+    csvAccountMappingRepository: CsvAccountMappingRepository,
+    mappings: List<CsvAccountMapping>,
+    kind: String,
+) {
+    if (mappings.isEmpty()) return
+    try {
+        csvAccountMappingRepository.createMappings(mappings)
+        logger.info { "Saved ${mappings.size} $kind account mappings" }
+    } catch (expected: Exception) {
+        // Batch is atomic, nothing was committed — retry per mapping so one bad mapping doesn't block the rest
+        logger.warn(expected) { "Bulk $kind mapping save failed, falling back to per-mapping save" }
+        for (mapping in mappings) {
+            try {
+                csvAccountMappingRepository.createMapping(
+                    strategyId = mapping.strategyId,
+                    columnName = mapping.columnName,
+                    valuePattern = mapping.valuePattern,
+                    accountId = mapping.accountId,
+                )
+            } catch (expectedMappingError: Exception) {
+                logger.warn(expectedMappingError) { "Failed to save $kind mapping '${mapping.valuePattern.pattern}'" }
+            }
+        }
+    }
+}
+
+/**
+ * Creates the [accountsToCreate] (bulk, with per-account fallback) and returns the names actually
+ * created. Failures are skipped — transfers referencing a missing account fail later.
+ */
+private suspend fun createNewAccounts(
+    accountRepository: AccountRepository,
+    accountsToCreate: List<NewAccount>,
+): Set<String> {
+    if (accountsToCreate.isEmpty()) return emptySet()
+    val createdAccountNames = mutableSetOf<String>()
+    val newAccounts =
+        accountsToCreate.map { newAccount ->
+            Account(
+                id = AccountId(0),
+                name = newAccount.name,
+                openingDate = Clock.System.now(),
+                categoryId = newAccount.categoryId,
+            )
+        }
+    try {
+        // Bulk-create all accounts in a single database transaction
+        accountRepository.createAccountsBatch(newAccounts)
+        createdAccountNames.addAll(accountsToCreate.map { it.name })
+        logger.info { "Created ${accountsToCreate.size} new accounts" }
+    } catch (expected: Exception) {
+        // Batch is atomic, nothing was committed — fall back to per-account creation to skip only failing accounts
+        logger.warn(expected) { "Bulk account creation failed, falling back to per-account creation" }
+        for (account in newAccounts) {
+            try {
+                accountRepository.createAccount(account)
+                createdAccountNames.add(account.name)
+                logger.info { "Created new account: ${account.name}" }
+            } catch (expectedAccountError: Exception) {
+                logger.warn(expectedAccountError) { "Skipping account '${account.name}': ${expectedAccountError.message}" }
+            }
+        }
+    }
+    return createdAccountNames
+}
+
+/**
+ * Builds account mappings for the just-created accounts from the rows' discovered mappings: regex
+ * matches deduped by pattern, exact matches deduped by CSV value, so only one mapping is created per
+ * rule. Only mappings whose target was actually created are kept.
+ */
+private fun buildAutoCapturedMappings(
+    accountsByName: Map<String, Account>,
+    discoveredMappings: List<DiscoveredAccountMapping>,
+    createdAccountNames: Set<String>,
+    selectedNewAccountNames: Map<String, String>,
+    strategyId: CsvImportStrategyId,
+): List<CsvAccountMapping> {
+    // Regex matches (matchedPattern != null) deduped by pattern; exact matches deduped by csvValue
+    val regexMappings = discoveredMappings.filter { it.matchedPattern != null }.distinctBy { it.matchedPattern }
+    val exactMappings = discoveredMappings.filter { it.matchedPattern == null }.distinctBy { it.csvValue }
+    val mappingCreatedAt = Clock.System.now()
+    return (regexMappings + exactMappings).mapIndexedNotNull { index, discoveredMapping ->
+        val createdAccountName =
+            selectedNewAccountNames[discoveredMapping.targetAccountName]
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
+                ?: discoveredMapping.targetAccountName
+
+        // Look up the account by the final name created for this detected value
+        val createdAccount =
+            accountsByName[createdAccountName]
+                ?.takeIf { it.name in createdAccountNames }
+                ?: return@mapIndexedNotNull null
+
+        // Use the matched regex pattern if available, otherwise an exact-match pattern for the CSV value
+        val matchedPattern = discoveredMapping.matchedPattern
+        val pattern =
+            if (matchedPattern != null) {
+                Regex(matchedPattern, RegexOption.IGNORE_CASE)
+            } else {
+                Regex("^${Regex.escape(discoveredMapping.csvValue)}$", RegexOption.IGNORE_CASE)
+            }
+        CsvAccountMapping(
+            id = -(index + 1).toLong(),
+            strategyId = strategyId,
+            columnName = discoveredMapping.columnName,
+            valuePattern = pattern,
+            accountId = createdAccount.id,
+            createdAt = mappingCreatedAt,
+            updatedAt = mappingCreatedAt,
+        )
+    }
+}
+
+/**
+ * Applies [strategy] to [rows] of a single [csvImport] and writes back per-row statuses. Creates new
+ * accounts the user accepted, persists/auto-captures account mappings, runs the central import engine,
+ * and records the strategy application. Shared by the single-file dialog and the bulk path; the bulk
+ * path passes [refreshViews] = false and refreshes once at the end. Mirrors QifImportApplier.runImport.
+ */
+@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
+internal suspend fun runCsvImport(
+    csvImport: CsvImport,
+    rows: List<CsvRow>,
+    columns: List<CsvColumn>,
+    strategy: CsvImportStrategy,
+    basePrep: ImportPreparation,
+    selectedExistingAccounts: Map<String, AccountId>,
+    selectedNewAccountNames: Map<String, String>,
+    selectedSourceAccountId: AccountId?,
+    currencies: List<Currency>,
+    csvAccountMappingRepository: CsvAccountMappingRepository,
+    accountRepository: AccountRepository,
+    csvImportRepository: CsvImportRepository,
+    attributeTypeRepository: AttributeTypeRepository,
+    maintenance: Maintenance,
+    entitySource: EntitySource,
+    importEngine: ImportEngine,
+    refreshViews: Boolean = true,
+): CsvImportResult {
+    logger.info { "Starting CSV import with ${basePrep.validTransfers.size} valid transfers" }
+
+    val accountsToCreate =
+        buildAccountsToCreate(
+            preparation = basePrep,
+            existingAccountSelections = selectedExistingAccounts,
+            newAccountNames = selectedNewAccountNames,
+        )
+    val selectedMappingsToPersist =
+        buildPendingAccountMappings(
+            preparation = basePrep,
+            strategyId = strategy.id,
+            accountSelections = selectedExistingAccounts,
+        )
+    persistMappingsWithFallback(csvAccountMappingRepository, selectedMappingsToPersist, "selected")
+
+    // Create new accounts first (skip failures - transfers using them will fail later)
+    val createdAccountNames = createNewAccounts(accountRepository, accountsToCreate)
+
+    // Auto-capture mappings for newly created accounts
+    if (createdAccountNames.isNotEmpty()) {
+        val mappingsToCapture =
+            buildAutoCapturedMappings(
+                accountsByName = accountRepository.getAllAccounts().first().associateBy { it.name },
+                discoveredMappings = basePrep.validTransfers.flatMap { it.discoveredMappings },
+                createdAccountNames = createdAccountNames,
+                selectedNewAccountNames = selectedNewAccountNames,
+                strategyId = strategy.id,
+            )
+        persistMappingsWithFallback(csvAccountMappingRepository, mappingsToCapture, "auto-captured")
+    }
+
+    // Re-map with new account IDs
+    logger.info { "Re-mapping transfers with updated account IDs" }
+    val updatedAccounts = accountRepository.getAllAccounts().first()
+    val accountsByName = updatedAccounts.associateBy { it.name }
+    val currenciesById = currencies.associateBy { it.id }
+    val currenciesByCode = currencies.associateBy { it.code.uppercase() }
+
+    // Duplicate detection now happens inside the central import engine, which
+    // loads existing transfers itself — the mapper only maps rows to transfers.
+    val latestAccountMappings =
+        csvAccountMappingRepository.getMappingsForStrategy(strategy.id).first()
+
+    val mapper =
+        CsvTransferMapper(
+            strategy = strategy,
+            columns = columns,
+            existingAccounts = accountsByName,
+            existingCurrencies = currenciesById,
+            existingCurrenciesByCode = currenciesByCode,
+            accountMappings = latestAccountMappings,
+            sourceAccountOverride = selectedSourceAccountId,
+        )
+
+    // Handle case when all rows are already processed (rows is already filtered by the caller)
+    if (rows.isEmpty()) {
+        logger.info { "No rows to process - all rows already imported" }
+        return CsvImportResult(successCount = 0, failedRows = emptyList())
+    }
+
+    val finalPrep = mapper.prepareImport(rows)
+    val validCount = finalPrep.validTransfers.size
+    val errorCount = finalPrep.errorRows.size
+    logger.info { "Prepared $validCount valid transfers, $errorCount error rows" }
+
+    // Mark mapping errors as ERROR status in database and save error messages
+    for (errorRow in finalPrep.errorRows) {
+        csvImportRepository.updateRowStatus(
+            csvImport.id,
+            errorRow.rowIndex,
+            ImportStatus.ERROR.name,
+        )
+        csvImportRepository.saveError(
+            csvImport.id,
+            errorRow.rowIndex,
+            errorRow.errorMessage,
+        )
+    }
+
+    // Pre-resolve attribute types
+    val allAttributeTypeNames =
+        finalPrep.validTransfers
+            .flatMap { it.attributes }
+            .map { it.first }
+            .toSet()
+    val attributeTypeIdByName =
+        allAttributeTypeNames.associateWith { name ->
+            attributeTypeRepository.getOrCreate(name)
+        }
+
+    logger.info { "Starting to import $validCount transfers" }
+
+    // Convert attributes from (typeName, value) to NewAttribute
+    fun attributesFor(attributes: List<Pair<String, String>>): List<NewAttribute> =
+        attributes.mapNotNull { (typeName, value) ->
+            val typeId = attributeTypeIdByName[typeName]
+            if (typeId != null) NewAttribute(typeId, value) else null
+        }
+
+    // Build the unified import batch. Accounts were already resolved/created
+    // above, so transfers carry Existing refs and the central engine only
+    // dedupes, writes transfers, applies updates and records sources.
+    val uniqueIdTypeNames =
+        strategy.attributeMappings
+            .filter { it.isUniqueIdentifier }
+            .map { it.attributeTypeName }
+            .toSet()
+
+    val importTransfers =
+        finalPrep.validTransfers.map { row ->
+            val uniqueKey =
+                if (uniqueIdTypeNames.isEmpty()) {
+                    null
+                } else {
+                    row.attributes
+                        .filter { (name, _) -> name in uniqueIdTypeNames }
+                        .associate { (name, value) -> name to value }
+                }
+            ImportTransfer(
+                rowKey = ImportRowKey.CsvRow(row.rowIndex),
+                source = AccountRef.Existing(row.transfer.sourceAccountId),
+                target = AccountRef.Existing(row.transfer.targetAccountId),
+                timestamp = row.transfer.timestamp,
+                description = row.transfer.description,
+                amount = row.transfer.amount,
+                attributes = attributesFor(row.attributes),
+                uniqueKey = uniqueKey,
+            )
+        }
+
+    val batch =
+        ImportBatch(
+            transfers = importTransfers,
+            dedupePolicy =
+                if (uniqueIdTypeNames.isEmpty()) {
+                    DedupePolicy.FuzzyAllFields()
+                } else {
+                    DedupePolicy.UniqueIdentifier
+                },
+            provenance = CsvImportProvenance(entitySource, csvImport.id),
+            uniqueKeyExtractor =
+                if (uniqueIdTypeNames.isEmpty()) {
+                    null
+                } else {
+                    ExistingUniqueKeyExtractor { transfer ->
+                        transfer.attributes
+                            .filter { it.attributeType.name in uniqueIdTypeNames }
+                            .associate { it.attributeType.name to it.value }
+                    }
+                },
+        )
+
+    val importResult = importEngine.import(batch)
+
+    // Write back per-row CSV statuses from the engine outcome.
+    val importedStatuses = mutableMapOf<Long, TransferId?>()
+    val duplicateStatuses = mutableMapOf<Long, TransferId?>()
+    val updatedStatuses = mutableMapOf<Long, TransferId?>()
+    for ((rowKey, outcome) in importResult.rowOutcomes) {
+        val rowIndex = (rowKey as ImportRowKey.CsvRow).rowIndex
+        when (outcome.status) {
+            ImportStatus.IMPORTED -> importedStatuses[rowIndex] = outcome.transferId
+            ImportStatus.DUPLICATE -> duplicateStatuses[rowIndex] = outcome.transferId
+            ImportStatus.UPDATED -> updatedStatuses[rowIndex] = outcome.transferId
+            ImportStatus.ERROR -> Unit
+        }
+    }
+    if (importedStatuses.isNotEmpty()) {
+        csvImportRepository.updateRowStatusesBatch(
+            csvImport.id,
+            ImportStatus.IMPORTED.name,
+            importedStatuses,
+        )
+        csvImportRepository.clearErrors(csvImport.id, importedStatuses.keys.toList())
+    }
+    if (duplicateStatuses.isNotEmpty()) {
+        csvImportRepository.updateRowStatusesBatch(
+            csvImport.id,
+            ImportStatus.DUPLICATE.name,
+            duplicateStatuses,
+        )
+    }
+    if (updatedStatuses.isNotEmpty()) {
+        csvImportRepository.updateRowStatusesBatch(
+            csvImport.id,
+            ImportStatus.UPDATED.name,
+            updatedStatuses,
+        )
+        csvImportRepository.clearErrors(csvImport.id, updatedStatuses.keys.toList())
+    }
+    val successCount = importResult.transfersImported + importResult.updated
+    val duplicateCount = importResult.duplicates
+
+    logger.info {
+        "Transfer import complete: $successCount imported/updated, ${importResult.duplicates} duplicate(s)"
+    }
+
+    // Refresh materialized views so transfers are visible (skipped in bulk; refreshed once at the end)
+    if (refreshViews) {
+        logger.info { "Refreshing materialized views" }
+        maintenance.refreshMaterializedViews()
+    }
+
+    if ((successCount + duplicateCount) > 0) {
+        runCatching {
+            csvImportRepository.recordImportApplication(
+                id = csvImport.id,
+                strategyId = strategy.id,
+                strategyName = strategy.name,
+                appliedAt = Clock.System.now(),
+            )
+        }.onFailure { error ->
+            logger.warn {
+                "Import application history could not be recorded for import ${csvImport.id}: ${error.message}"
+            }
+        }
+    }
+
+    logger.info { "Import completed successfully" }
+
+    // The engine import is atomic: on success there are no per-row failures
+    // (any failure throws to the caller), so the import is complete.
+    return CsvImportResult(
+        successCount = successCount,
+        failedRows = emptyList(),
+        duplicateCount = duplicateCount,
+    )
+}

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportApplier.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportApplier.kt
@@ -35,20 +35,21 @@ import com.moneymanager.importmodel.ExistingUniqueKeyExtractor
 import com.moneymanager.importmodel.ImportBatch
 import com.moneymanager.importmodel.ImportRowKey
 import com.moneymanager.importmodel.ImportTransfer
+import com.moneymanager.ui.screens.BulkImportResult
 import kotlinx.coroutines.flow.first
 import org.lighthousegames.logging.logging
 import kotlin.time.Clock
 
 private val logger = logging()
 
-/** Summary of a bulk CSV import run across many files. Mirrors QifBulkResult by design. */
+/** Summary of a bulk CSV import run across many files. */
 internal data class CsvBulkResult(
-    val filesImported: Int,
-    val transfersCreated: Int,
-    val duplicatesSkipped: Int,
-    val filesSkippedNoStrategy: Int,
-    val filesFailed: Int,
-)
+    override val filesImported: Int,
+    override val transfersCreated: Int,
+    override val duplicatesSkipped: Int,
+    override val filesSkippedNoStrategy: Int,
+    override val filesFailed: Int,
+) : BulkImportResult
 
 /**
  * Applies the matching strategy to every [imports] file. Each file's strategy is auto-matched from its

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
@@ -137,25 +137,28 @@ fun QifImportAllDialog(
                         val currency = selectedCurrencyId ?: return@LoadingTextButton
                         isImporting = true
                         scope.launch {
-                            val result =
-                                bulkApplyQif(
-                                    imports = unimported,
-                                    sourceAccountId = source,
-                                    currencyId = currency,
-                                    strategies = strategies,
-                                    currencies = currencies,
-                                    csvAccountMappingRepository = csvAccountMappingRepository,
-                                    accountRepository = accountRepository,
-                                    qifImportRepository = qifImportRepository,
-                                    attributeTypeRepository = attributeTypeRepository,
-                                    maintenance = maintenance,
-                                    entitySource = entitySource,
-                                    importEngine = importEngine,
-                                    onProgress = { done, total -> progress = done to total },
-                                )
-                            settingsRepository.setLastQifAccountId(source)
-                            summary = result.toSummary()
-                            isImporting = false
+                            try {
+                                val result =
+                                    bulkApplyQif(
+                                        imports = unimported,
+                                        sourceAccountId = source,
+                                        currencyId = currency,
+                                        strategies = strategies,
+                                        currencies = currencies,
+                                        csvAccountMappingRepository = csvAccountMappingRepository,
+                                        accountRepository = accountRepository,
+                                        qifImportRepository = qifImportRepository,
+                                        attributeTypeRepository = attributeTypeRepository,
+                                        maintenance = maintenance,
+                                        entitySource = entitySource,
+                                        importEngine = importEngine,
+                                        onProgress = { done, total -> progress = done to total },
+                                    )
+                                settingsRepository.setLastQifAccountId(source)
+                                summary = result.toSummary()
+                            } finally {
+                                isImporting = false
+                            }
                         }
                     },
                     enabled = !isImporting && sourceAccountId != null && selectedCurrencyId != null,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
@@ -171,12 +171,3 @@ fun QifImportAllDialog(
         },
     )
 }
-
-private fun QifBulkResult.toSummary(): String =
-    buildString {
-        append("Imported $filesImported file${if (filesImported == 1) "" else "s"}")
-        append(" · $transfersCreated new")
-        if (duplicatesSkipped > 0) append(" · $duplicatesSkipped duplicates skipped")
-        if (filesSkippedNoStrategy > 0) append(" · $filesSkippedNoStrategy skipped (no strategy)")
-        if (filesFailed > 0) append(" · $filesFailed failed")
-    }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportApplier.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportApplier.kt
@@ -32,6 +32,7 @@ import com.moneymanager.importmodel.DedupePolicy
 import com.moneymanager.importmodel.ImportBatch
 import com.moneymanager.importmodel.ImportRowKey
 import com.moneymanager.importmodel.ImportTransfer
+import com.moneymanager.ui.screens.BulkImportResult
 import com.moneymanager.ui.screens.csv.buildAccountsToCreate
 import com.moneymanager.ui.screens.csv.buildPendingAccountMappings
 import kotlinx.coroutines.flow.first
@@ -43,12 +44,12 @@ private val logger = logging()
 
 /** Summary of a bulk QIF import run across many files. */
 internal data class QifBulkResult(
-    val filesImported: Int,
-    val transfersCreated: Int,
-    val duplicatesSkipped: Int,
-    val filesSkippedNoStrategy: Int,
-    val filesFailed: Int,
-)
+    override val filesImported: Int,
+    override val transfersCreated: Int,
+    override val duplicatesSkipped: Int,
+    override val filesSkippedNoStrategy: Int,
+    override val filesFailed: Int,
+) : BulkImportResult
 
 /**
  * Strategies usable for QIF imports: those whose identification columns are a (non-empty) subset of

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ImportMonzoCsvE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ImportMonzoCsvE2ETest.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.test.waitUntilDoesNotExist
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import com.moneymanager.database.DatabaseManager
 import com.moneymanager.di.database.DatabaseComponent
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AppVersion
 import com.moneymanager.domain.model.DbLocation
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
@@ -380,10 +382,97 @@ class ImportMonzoCsvE2ETest {
             onNodeWithText("Imports", useUnmergedTree = true).performClick()
             waitForIdle()
 
-            waitUntilExactlyOneExists(hasText("already_imported.csv"), timeoutMillis = 15000)
+            // The Unimported tab (default) shows only the file that hasn't been imported yet.
             waitUntilExactlyOneExists(hasText("not_imported_yet.csv"), timeoutMillis = 15000)
-            waitUntilExactlyOneExists(hasText("via Monzo", substring = true), timeoutMillis = 10000)
             waitUntilExactlyOneExists(hasText("Not imported yet"), timeoutMillis = 10000)
+
+            // The already-imported file lives on the Imported tab, with its strategy name shown.
+            onNodeWithText("Imported (1)").performClick()
+            waitForIdle()
+            waitUntilExactlyOneExists(hasText("already_imported.csv"), timeoutMillis = 15000)
+            waitUntilExactlyOneExists(hasText("via Monzo", substring = true), timeoutMillis = 10000)
+        }
+
+    /**
+     * "Import all" auto-matches each file's strategy by its columns (the built-in "Monzo CSV" strategy
+     * here) and applies it to every unimported file in one click. This guards the regression where
+     * getAllImports() returned imports without their columns, so column-based matching skipped every file.
+     */
+    @Test
+    fun importAll_matchesFilesByColumnsAndImportsThemAll() =
+        runMoneyManagerComposeUiTest {
+            testDbLocation = createTestDatabaseLocation()
+            val databaseManager = createTestDatabaseManager()
+
+            runBlocking {
+                val db = databaseManager.openDatabase(testDbLocation!!)
+                val databaseComponent = DatabaseComponent.create(db)
+
+                databaseComponent.currencyRepository.upsertCurrencyByCode("GBP", "British Pound")
+                // A source account for the bulk dialog (the built-in Monzo CSV strategy has no source mapping).
+                databaseComponent.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "My Monzo", openingDate = Instant.fromEpochMilliseconds(1700000000000L)),
+                )
+
+                val csvContent = loadTestCsvContent()
+                val lines = csvContent.lines().filter { it.isNotBlank() }
+                val headers = parseCsvLine(lines.first())
+                val rows = lines.drop(1).take(2).map { parseCsvLine(it) }
+
+                // Rely on the seeded built-in "Monzo CSV" strategy — matching is purely by columns.
+                databaseComponent.csvImportRepository.createImport(
+                    fileName = "first.csv",
+                    headers = headers,
+                    rows = rows,
+                    fileChecksum = "import_all_first",
+                    fileLastModified = Instant.fromEpochMilliseconds(1700000000000L),
+                )
+                databaseComponent.csvImportRepository.createImport(
+                    fileName = "second.csv",
+                    headers = headers,
+                    rows = rows,
+                    fileChecksum = "import_all_second",
+                    fileLastModified = Instant.fromEpochMilliseconds(1700000000001L),
+                )
+            }
+
+            setContent {
+                MoneyManagerTestApp(
+                    databaseManager = SimpleDatabaseManager(databaseManager, testDbLocation!!),
+                    appVersion = AppVersion("1.0.0-test"),
+                )
+            }
+
+            waitForIdle()
+            waitUntilAtLeastOneExists(hasText("Your Accounts"), timeoutMillis = 20000)
+            waitUntilAtLeastOneExists(hasText("Imports"), timeoutMillis = 10000)
+            onNodeWithText("Imports", useUnmergedTree = true).performClick()
+            waitForIdle()
+
+            // The Unimported tab offers a single "Import all (2)" action.
+            waitUntilExactlyOneExists(hasText("Import all (2)"), timeoutMillis = 15000)
+            onNodeWithText("Import all (2)").performClick()
+
+            // The dialog shows a source picker (the strategy has no source mapping); choose "My Monzo".
+            waitUntilExactlyOneExists(hasText("Import all unimported files"), timeoutMillis = 15000)
+            waitUntilAtLeastOneExists(hasText("Select..."), timeoutMillis = 15000)
+            onNodeWithText("Select...").performClick()
+            waitUntilAtLeastOneExists(hasText("My Monzo"), timeoutMillis = 10000)
+            onNodeWithText("My Monzo").performClick()
+            waitForIdle()
+
+            waitUntilAtLeastOneExists(hasText("Import 2 files") and isEnabled(), timeoutMillis = 15000)
+            onNodeWithText("Import 2 files").performClick()
+
+            // Both files matched the Monzo CSV strategy by columns and imported in one click.
+            waitUntilAtLeastOneExists(hasText("Imported 2 files", substring = true), timeoutMillis = 20000)
+            onNodeWithText("Done").performClick()
+            waitForIdle()
+
+            onNodeWithText("Imported (2)").performClick()
+            waitForIdle()
+            waitUntilExactlyOneExists(hasText("second.csv"), timeoutMillis = 15000)
+            onNodeWithText("Unimported (0)").assertExists()
         }
 
     /**


### PR DESCRIPTION
## Summary

Brings the CSV import screen to parity with QIF: a **multi-select file picker**, **Unimported/Imported tabs**, and an **"Import all"** flow that auto-matches each file's strategy by its columns and applies it to every unimported file in one click. Both screens now look and behave identically.

## Changes
- **`CsvImportApplier.kt`** (new) — extracts the per-row import logic that was inlined in `ApplyStrategyDialog`'s confirm button into a reusable `runCsvImport()`, plus `bulkApplyCsv()` + `CsvBulkResult` (mirroring `QifImportApplier`).
- **`CsvImportAllDialog.kt`** (new) — bulk dialog. No currency picker (CSV currency comes from the strategy); a shared source-account picker is shown only when a matched strategy needs one.
- **`ApplyStrategyDialog.kt`** — confirm button delegates to `runCsvImport`; `CsvImportResult` gains `duplicateCount`.
- **`CsvImportsScreen.kt`** — multi-select picker with a summary message, Unimported/Imported tabs, and the "Import all (N)" button. Duplicates are skipped and reported (the per-file `DuplicateImportDialog` is removed), matching QIF.
- **`ImportsScreen.kt`** — forwards the additional repositories to `CsvImportsScreen`.

## Bug fix
`getAllImports()` returns imports **without their columns** (only `getImport(id)` loads them), so column-based matching in the bulk path skipped every file. `bulkApplyCsv`/`CsvImportAllDialog` now re-fetch each file via `getImport()` before matching.

## Behavior decisions
- **Strategy**: auto-matched per file by column headers; files with no match are skipped and counted.
- **Duplicates**: silently skipped with a "skipped N already imported" summary.
- **Bulk source account**: a single shared picker applied only to strategies lacking their own source mapping; hard-coded/per-row strategies resolve their own.

## Testing
- `./gradlew build` passes (compile, tests, detekt, ktlint, buildHealth).
- Updated `ImportMonzoCsvE2ETest` for the new tabs and added `importAll_matchesFilesByColumnsAndImportsThemAll`, a regression test that matches files by columns via the seeded Monzo CSV strategy and imports them in one click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for importing multiple CSV files simultaneously with a single action
  * Tabbed interface separating unimported and already-imported files
  * Real-time progress tracking during bulk import operations
  * Automatic source account selection dialog when required by import strategy
  * Automatic duplicate file detection and skipping
  * Import result summary displaying file counts, transfers created, and any skipped or failed imports

* **Tests**
  * Added end-to-end test coverage for bulk import workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->