### PR TITLE
Fix back/forward mouse buttons on Linux

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/MouseButtonNavigation.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/MouseButtonNavigation.kt
@@ -4,7 +4,12 @@ import androidx.compose.ui.Modifier
 
 /**
  * Adds mouse back/forward button support for navigation.
- * On desktop, handles mouse button 4 (back) and button 5 (forward).
+ *
+ * On desktop the contract is "navigate on the physical back/forward side buttons", but the
+ * underlying AWT button numbers differ by platform: Windows/macOS report them as buttons 4/5,
+ * while Linux (X11/XWayland) reserves 4-7 for scroll axes and reports the side buttons as 6/7.
+ * The JVM implementation handles this difference (see MouseButtonNavigation.jvm.kt).
+ *
  * On Android, this is a no-op since mouse buttons aren't available.
  */
 expect fun Modifier.mouseButtonNavigation(

--- a/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/navigation/MouseButtonNavigation.jvm.kt
+++ b/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/navigation/MouseButtonNavigation.jvm.kt
@@ -2,22 +2,65 @@
 
 package com.moneymanager.ui.navigation
 
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
+import java.awt.AWTEvent
+import java.awt.Toolkit
+import java.awt.event.AWTEventListener
+import java.awt.event.MouseEvent
+
+private val isLinux: Boolean =
+    System.getProperty("os.name").orEmpty().contains("linux", ignoreCase = true)
+
+// On Linux (X11/XWayland) the physical back/forward side buttons arrive as AWT buttons 6/7
+// (buttons 4/5 are the horizontal scroll wheel). Compose only tracks buttons 1-3 as "pressed",
+// so it never dispatches 6/7 through its pointer pipeline and a Modifier.onPointerEvent never
+// sees them. We therefore listen at the AWT level on Linux instead.
+// See https://github.com/JetBrains/compose-multiplatform/issues/2058
+private const val AWT_BUTTON_BACK = 6
+private const val AWT_BUTTON_FORWARD = 7
 
 actual fun Modifier.mouseButtonNavigation(
     onBack: () -> Unit,
     onForward: () -> Unit,
 ): Modifier =
-    // Listen on the Initial pass so the back/forward mouse buttons are handled at the root before a
-    // child (e.g. a clickable list card) can consume the press. Other buttons are left untouched.
-    this.onPointerEvent(PointerEventType.Press, pass = PointerEventPass.Initial) { event ->
-        when (event.button) {
-            PointerButton.Back -> onBack()
-            PointerButton.Forward -> onForward()
-            else -> {}
+    if (isLinux) {
+        // A global AWT listener catches the side-button presses Compose drops, app-wide.
+        composed {
+            val latestOnBack by rememberUpdatedState(onBack)
+            val latestOnForward by rememberUpdatedState(onForward)
+            DisposableEffect(Unit) {
+                val toolkit = Toolkit.getDefaultToolkit()
+                val listener =
+                    AWTEventListener { event ->
+                        if (event is MouseEvent && event.id == MouseEvent.MOUSE_PRESSED) {
+                            when (event.button) {
+                                AWT_BUTTON_BACK -> latestOnBack()
+                                AWT_BUTTON_FORWARD -> latestOnForward()
+                                else -> {}
+                            }
+                        }
+                    }
+                toolkit.addAWTEventListener(listener, AWTEvent.MOUSE_EVENT_MASK)
+                onDispose { toolkit.removeAWTEventListener(listener) }
+            }
+            this
+        }
+    } else {
+        // Windows/macOS deliver back/forward correctly through Compose. Listen on the Initial pass
+        // so the press is handled at the root before a child (e.g. a clickable card) consumes it.
+        onPointerEvent(PointerEventType.Press, pass = PointerEventPass.Initial) { event ->
+            when (event.button) {
+                PointerButton.Back -> onBack()
+                PointerButton.Forward -> onForward()
+                else -> {}
+            }
         }
     }

--- a/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/navigation/MouseButtonNavigation.jvm.kt
+++ b/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/navigation/MouseButtonNavigation.jvm.kt
@@ -19,10 +19,12 @@ import java.awt.event.MouseEvent
 private val isLinux: Boolean =
     System.getProperty("os.name").orEmpty().contains("linux", ignoreCase = true)
 
-// On Linux (X11/XWayland) the physical back/forward side buttons arrive as AWT buttons 6/7
-// (buttons 4/5 are the horizontal scroll wheel). Compose only tracks buttons 1-3 as "pressed",
-// so it never dispatches 6/7 through its pointer pipeline and a Modifier.onPointerEvent never
-// sees them. We therefore listen at the AWT level on Linux instead.
+// Windows/macOS report the physical back/forward side buttons as AWT buttons 4/5, which Compose
+// recognises and delivers as PointerButton.Back/Forward. Linux (X11/XWayland) reserves buttons 4-7
+// for scroll axes, so the same side buttons arrive as AWT buttons 6/7 (4/5 are the horizontal
+// scroll wheel). Compose only tracks buttons 1-3 as "pressed", so it never dispatches 6/7 through
+// its pointer pipeline and a Modifier.onPointerEvent never sees them. We therefore listen for 6/7
+// at the AWT level on Linux instead.
 // See https://github.com/JetBrains/compose-multiplatform/issues/2058
 private const val AWT_BUTTON_BACK = 6
 private const val AWT_BUTTON_FORWARD = 7


### PR DESCRIPTION
## Problem

The physical back/forward side mouse buttons did not navigate on Linux (X11/XWayland), even though they worked fine on Windows.

## Root cause

Compose Desktop **hardcodes** the back/forward buttons to AWT button numbers **4/5** (`isBackPressed`/`isForwardPressed` in `ComposeSceneMediator`):

```kotlin
isBackPressed    = ... || (id == MOUSE_PRESSED && button == 4),
isForwardPressed = ... || (id == MOUSE_PRESSED && button == 5),
```

- **Windows**: AWT reports the side buttons as 4/5 → matches → `PointerButton.Back`/`Forward` fire → worked.
- **Linux (X11/XWayland)**: X11 reserves buttons 4–7 for scroll axes, so the side buttons are reported by AWT as **6/7**. Compose doesn't recognise these as back/forward, treats them as unknown buttons with an empty pressed-button state, and they never reach any Compose pointer modifier.

This is the still-open [JetBrains/compose-multiplatform#2058](https://github.com/JetBrains/compose-multiplatform/issues/2058).

A standalone AWT test confirmed the JVM does receive these buttons as `button=6` (back) / `button=7` (forward) on the affected setup.

## Fix

Since Compose drops these events on Linux before any modifier can see them, listen at the AWT level via a global `AWTEventListener` (which was verified to receive buttons 6/7). The existing Compose pointer path is kept unchanged for Windows/macOS, where it works correctly.

## Testing

- Verified on Linux + Wayland + KDE Plasma: back/forward side buttons now navigate.
- `./gradlew :app:ui:core:compileKotlinJvm` and `lintFormat` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse back and forward button navigation reliability across all supported platforms
  * Enhanced side mouse button recognition and responsiveness, with platform-specific optimizations applied for better Linux compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->