### PR TITLE
Generate and publish SchemaSpy database docs to the docs site

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,6 +33,14 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup Pages
         uses: actions/configure-pages@v6
+      - name: Install Graphviz
+        # SchemaSpy needs the `dot` binary to render schema relationship diagrams
+        run: sudo apt-get update && sudo apt-get install -y graphviz
+      - name: Generate database schema docs
+        uses: ./.github/actions/gradle-run
+        with:
+          command: ':app:db:schemaspy:publishSchemaSpyDocs --stacktrace'
+          cache-read-only: true
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ app/main/android/src/main/assets/VERSION
 .qodana
 # Monzo API session transcript fixtures
 app/db/core/src/commonTest/resources/monzo/sample-apis/
+
+# Generated SchemaSpy database docs (regenerated and published by CI)
+docs/database/

--- a/app/db/schemaspy/build.gradle.kts
+++ b/app/db/schemaspy/build.gradle.kts
@@ -101,3 +101,16 @@ tasks.register<JavaExec>("generateSchemaSpyDocs") {
         println("Open: ${outputDir.absolutePath}${File.separator}index.html")
     }
 }
+
+val publishedDocsDir = layout.projectDirectory.dir("../../../docs/database")
+
+tasks.register<Sync>("publishSchemaSpyDocs") {
+    group = "documentation"
+    description = "Copy generated SchemaSpy HTML into the published docs site (docs/database)"
+
+    dependsOn("generateSchemaSpyDocs")
+
+    // Sync mirrors the source, removing stale files (e.g. dropped tables/views)
+    from(layout.buildDirectory.dir("schemaspy"))
+    into(publishedDocsDir)
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,6 +117,7 @@
     <div class="links">
       <a class="primary" href="https://github.com/NikolayMetchev/money-manager">View on GitHub</a>
       <a href="https://github.com/NikolayMetchev/money-manager/releases">Releases</a>
+      <a href="database/index.html">Database schema</a>
     </div>
   </header>
 
@@ -180,6 +181,10 @@
         Monetary amounts are handled with exact arithmetic only — never floating point.
         Values are stored as integers scaled per currency, and all parsing and calculation
         goes through <code>BigDecimal</code>, so amounts are always precise.
+      </p>
+      <p>
+        Browse the full <a href="database/index.html">database schema documentation</a>
+        — every table, view, column and relationship, generated with SchemaSpy.
       </p>
     </section>
 


### PR DESCRIPTION
## Summary

Generates the SchemaSpy database schema documentation and publishes it as part of the GitHub Pages docs site, instead of committing generated HTML into the repo.

- **New Gradle task** `:app:db:schemaspy:publishSchemaSpyDocs` (`Sync`) mirrors the generated SchemaSpy HTML into `docs/database/`, depending on the existing `generateSchemaSpyDocs`. Uses `Sync` so dropped tables/views don't leave stale files. Path is resolved relative to the module (project isolation), and the task is configuration-cache safe.
- **CI**: the Pages deploy workflow (`static.yml`) now installs Graphviz (`dot`) and runs `publishSchemaSpyDocs` before uploading `docs/`, so the schema is regenerated and published on every push to `main`.
- **`.gitignore`**: `docs/database/` is ignored — generated output is never committed.
- **Landing page**: `docs/index.html` links to the schema docs from the header and the *Core concepts* section.

## Notes

- Schema docs only refresh on `main` pushes (not PR previews), matching the existing Pages behaviour — so they always reflect the released schema.
- Requires Graphviz locally to run the task by hand (`sudo pacman -S graphviz` / `apt-get install graphviz`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database schema documentation is now automatically generated and published with each deployment.

* **Documentation**
  * Added a link to the database schema documentation in the main documentation header for easy access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->