### PR TITLE
Add transfer_relationship table; reconcile via it + reconciled column

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/Application.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/Application.kt
@@ -21,8 +21,10 @@ import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.QifImportRepository
+import com.moneymanager.domain.repository.RelationshipTypeRepository
 import com.moneymanager.domain.repository.SettingsRepository
 import com.moneymanager.domain.repository.TransactionRepository
+import com.moneymanager.domain.repository.TransferRelationshipRepository
 import com.moneymanager.domain.repository.TransferSourceRepository
 
 data class Application(
@@ -58,6 +60,8 @@ data class Transactions(
     val transactionRepository: TransactionRepository,
     val transferSourceRepository: TransferSourceRepository,
     val attributeTypeRepository: AttributeTypeRepository,
+    val relationshipTypeRepository: RelationshipTypeRepository,
+    val transferRelationshipRepository: TransferRelationshipRepository,
     val entitySource: EntitySource,
     val sampleEntitySource: EntitySource,
 )

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -71,6 +71,12 @@ object DatabaseConfig {
     /** Stable ID for the "account number" account attribute type used for personal counterparties. */
     const val ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID: Long = -6
 
+    /** Stable ID for the "reconciled" relationship type: id1 mirrors id2 seen from another source. */
+    const val RECONCILED_RELATIONSHIP_TYPE_ID: Long = 1
+
+    /** Stable ID for the "fee" relationship type: id1 is the main transaction, id2 its fee transfer. */
+    const val FEE_RELATIONSHIP_TYPE_ID: Long = 2
+
     /**
      * SQL statements to execute when opening a database connection.
      * Applied to all database connections (JVM, Android, etc.)
@@ -823,6 +829,11 @@ object DatabaseConfig {
             attributeTypeQueries.insertWithId(id = BUILT_IN_COUNTERPARTY_TYPE_ATTR_TYPE_ID, name = "built-in type")
             attributeTypeQueries.insertWithId(id = ACCOUNT_SORT_CODE_ATTR_TYPE_ID, name = "account-sort-code")
             attributeTypeQueries.insertWithId(id = ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID, name = "account-account-number")
+
+            // Seed well-known relationship types with stable IDs so importers can reference them
+            // without a DB lookup.
+            relationshipTypeQueries.insertWithId(id = RECONCILED_RELATIONSHIP_TYPE_ID, name = "reconciled")
+            relationshipTypeQueries.insertWithId(id = FEE_RELATIONSHIP_TYPE_ID, name = "fee")
 
             // Seed the built-in Monzo, Wise and Starling API import strategies (after triggers and
             // system device are created so the INSERT trigger records the initial audit entry/source)

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/MoneyManagerDatabaseWrapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/MoneyManagerDatabaseWrapper.kt
@@ -113,6 +113,8 @@ class MoneyManagerDatabaseWrapper(
             "device",
             "attribute_type",
             "transfer_attribute",
+            "relationship_type",
+            "transfer_relationship",
             "account_attribute",
             "person_attribute",
             "_import_batch",

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountRowMapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountRowMapper.kt
@@ -26,6 +26,7 @@ object AccountRowMapper {
         sourceAccountId: Long,
         targetAccountId: Long,
         isExcluded: Long,
+        isReconciled: Long,
     ): AccountRow =
         AccountRow(
             transactionId = TransferId(id),
@@ -55,5 +56,6 @@ object AccountRowMapper {
             sourceAccountId = AccountId(sourceAccountId),
             targetAccountId = AccountId(targetAccountId),
             isExcluded = isExcluded != 0L,
+            isReconciled = isReconciled != 0L,
         )
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/RelationshipTypeRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/RelationshipTypeRepositoryImpl.kt
@@ -1,0 +1,74 @@
+package com.moneymanager.database.repository
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import com.moneymanager.database.MoneyManagerDatabaseWrapper
+import com.moneymanager.domain.model.RelationshipType
+import com.moneymanager.domain.model.RelationshipTypeId
+import com.moneymanager.domain.repository.RelationshipTypeRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+class RelationshipTypeRepositoryImpl(
+    database: MoneyManagerDatabaseWrapper,
+) : RelationshipTypeRepository {
+    private val queries = database.relationshipTypeQueries
+
+    override fun getAll(): Flow<List<RelationshipType>> =
+        queries
+            .selectAll()
+            .asFlow()
+            .mapToList(Dispatchers.Default)
+            .map { list ->
+                list.map { row ->
+                    RelationshipType(
+                        id = RelationshipTypeId(row.id),
+                        name = row.name,
+                    )
+                }
+            }
+
+    override fun getById(id: RelationshipTypeId): Flow<RelationshipType?> =
+        queries
+            .selectById(id.id)
+            .asFlow()
+            .mapToOneOrNull(Dispatchers.Default)
+            .map { row ->
+                row?.let {
+                    RelationshipType(
+                        id = RelationshipTypeId(it.id),
+                        name = it.name,
+                    )
+                }
+            }
+
+    override fun getByName(name: String): Flow<RelationshipType?> =
+        queries
+            .selectByName(name)
+            .asFlow()
+            .mapToOneOrNull(Dispatchers.Default)
+            .map { row ->
+                row?.let {
+                    RelationshipType(
+                        id = RelationshipTypeId(it.id),
+                        name = it.name,
+                    )
+                }
+            }
+
+    override suspend fun getOrCreate(name: String): RelationshipTypeId =
+        withContext(Dispatchers.Default) {
+            queries.transactionWithResult {
+                val existing = queries.selectByName(name).executeAsOneOrNull()
+                existing?.let { RelationshipTypeId(it.id) }
+                    ?: run {
+                        queries.insert(name)
+                        val newId = queries.selectByName(name).executeAsOne().id
+                        RelationshipTypeId(newId)
+                    }
+            }
+        }
+}

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionRepositoryImpl.kt
@@ -16,6 +16,7 @@ import com.moneymanager.domain.model.AccountRow
 import com.moneymanager.domain.model.AttributeType
 import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.NewRelationship
 import com.moneymanager.domain.model.PageWithTargetIndex
 import com.moneymanager.domain.model.PagingInfo
 import com.moneymanager.domain.model.PagingResult
@@ -39,6 +40,7 @@ class TransactionRepositoryImpl(
     private val transferQueries = database.transferQueries
     private val transactionIdQueries = database.transactionIdQueries
     private val transferAttributeQueries = database.transferAttributeQueries
+    private val transferRelationshipQueries = database.transferRelationshipQueries
 
     private fun loadAttributesForTransfers(transfers: List<Transfer>): List<Transfer> {
         if (transfers.isEmpty()) return transfers
@@ -321,7 +323,7 @@ class TransactionRepositoryImpl(
                     // This allows initial attributes to be recorded at revision 1.
                     database.beginCreationMode()
                     try {
-                        createdIds += insertNewTransfers(batch, newAttributes, sourceRecorder)
+                        createdIds += insertNewTransfers(batch, newAttributes, newRelationships = emptyMap(), sourceRecorder)
                     } finally {
                         // Always restore normal trigger behavior
                         database.endCreationMode()
@@ -413,6 +415,7 @@ class TransactionRepositoryImpl(
     override suspend fun importTransfers(
         transfers: List<Transfer>,
         newAttributes: Map<TransferId, List<NewAttribute>>,
+        newRelationships: Map<TransferId, List<NewRelationship>>,
         sourceRecorder: SourceRecorder,
         updates: List<TransferUpdate>,
         updateSourceRecorder: SourceRecorder,
@@ -425,7 +428,7 @@ class TransactionRepositoryImpl(
                 if (transfers.isNotEmpty()) {
                     database.beginCreationMode()
                     try {
-                        createdIds += insertNewTransfers(transfers, newAttributes, sourceRecorder)
+                        createdIds += insertNewTransfers(transfers, newAttributes, newRelationships, sourceRecorder)
                     } finally {
                         database.endCreationMode()
                     }
@@ -474,6 +477,7 @@ class TransactionRepositoryImpl(
     private fun insertNewTransfers(
         transfers: List<Transfer>,
         newAttributes: Map<TransferId, List<NewAttribute>>,
+        newRelationships: Map<TransferId, List<NewRelationship>>,
         sourceRecorder: SourceRecorder,
     ): List<TransferId> {
         val createdIds = mutableListOf<TransferId>()
@@ -496,6 +500,14 @@ class TransactionRepositoryImpl(
                     transaction_id = generatedId,
                     attribute_type_id = attr.typeId.id,
                     attribute_value = attr.value,
+                )
+            }
+            // The just-created transfer is id1; the related (existing) transfer is id2.
+            newRelationships[transfer.id].orEmpty().forEach { rel ->
+                transferRelationshipQueries.insert(
+                    id1 = generatedId,
+                    id2 = rel.relatedTransferId.id,
+                    relationship_type_id = rel.typeId.id,
                 )
             }
             sourceRecorder.insert(transfer.copy(id = TransferId(generatedId)))

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferRelationshipRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/TransferRelationshipRepositoryImpl.kt
@@ -1,0 +1,57 @@
+package com.moneymanager.database.repository
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import com.moneymanager.database.MoneyManagerDatabaseWrapper
+import com.moneymanager.domain.model.RelationshipType
+import com.moneymanager.domain.model.RelationshipTypeId
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.TransferRelationship
+import com.moneymanager.domain.repository.TransferRelationshipRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+class TransferRelationshipRepositoryImpl(
+    database: MoneyManagerDatabaseWrapper,
+) : TransferRelationshipRepository {
+    private val queries = database.transferRelationshipQueries
+
+    override fun getByTransfer(transferId: TransferId): Flow<List<TransferRelationship>> =
+        queries
+            .selectByTransfer(transferId.id, transferId.id)
+            .asFlow()
+            .mapToList(Dispatchers.Default)
+            .map { list ->
+                list.map { row ->
+                    TransferRelationship(
+                        id1 = TransferId(row.id1),
+                        id2 = TransferId(row.id2),
+                        relationshipType =
+                            RelationshipType(
+                                id = RelationshipTypeId(row.relationship_type_id),
+                                name = row.relationship_type_name,
+                            ),
+                    )
+                }
+            }
+
+    override suspend fun insert(
+        id1: TransferId,
+        id2: TransferId,
+        typeId: RelationshipTypeId,
+    ): Unit =
+        withContext(Dispatchers.Default) {
+            queries.insert(id1.id, id2.id, typeId.id)
+        }
+
+    override suspend fun delete(
+        id1: TransferId,
+        id2: TransferId,
+        typeId: RelationshipTypeId,
+    ): Unit =
+        withContext(Dispatchers.Default) {
+            queries.delete(id1.id, id2.id, typeId.id)
+        }
+}

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/RelationshipType.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/RelationshipType.sq
@@ -1,0 +1,19 @@
+CREATE TABLE relationship_type (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE
+);
+
+selectAll:
+SELECT * FROM relationship_type ORDER BY name;
+
+selectById:
+SELECT * FROM relationship_type WHERE id = ?;
+
+selectByName:
+SELECT * FROM relationship_type WHERE name = ?;
+
+insert:
+INSERT INTO relationship_type (name) VALUES (?);
+
+insertWithId:
+INSERT INTO relationship_type (id, name) VALUES (?, ?);

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Transfer.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/Transfer.sq
@@ -335,7 +335,12 @@ SELECT
     currency.scale_factor AS currency_scale_factor,
     transfer.source_account_id,
     transfer.target_account_id,
-    running_balance_materialized_view.is_excluded
+    running_balance_materialized_view.is_excluded,
+    CASE WHEN EXISTS (
+        SELECT 1 FROM transfer_relationship tr
+        WHERE (tr.id1 = running_balance_materialized_view.id OR tr.id2 = running_balance_materialized_view.id)
+          AND tr.relationship_type_id = 1   -- RECONCILED_RELATIONSHIP_TYPE_ID; mirrors the hardcoded -1 used for is_excluded
+    ) THEN 1 ELSE 0 END AS is_reconciled
 FROM running_balance_materialized_view
 JOIN currency ON running_balance_materialized_view.currency_id = currency.id
 JOIN transfer ON running_balance_materialized_view.id = transfer.id
@@ -363,7 +368,12 @@ SELECT
     currency.scale_factor AS currency_scale_factor,
     transfer.source_account_id,
     transfer.target_account_id,
-    running_balance_materialized_view.is_excluded
+    running_balance_materialized_view.is_excluded,
+    CASE WHEN EXISTS (
+        SELECT 1 FROM transfer_relationship tr
+        WHERE (tr.id1 = running_balance_materialized_view.id OR tr.id2 = running_balance_materialized_view.id)
+          AND tr.relationship_type_id = 1   -- RECONCILED_RELATIONSHIP_TYPE_ID; mirrors the hardcoded -1 used for is_excluded
+    ) THEN 1 ELSE 0 END AS is_reconciled
 FROM running_balance_materialized_view
 JOIN currency ON running_balance_materialized_view.currency_id = currency.id
 JOIN transfer ON running_balance_materialized_view.id = transfer.id
@@ -398,7 +408,12 @@ SELECT
     currency.scale_factor AS currency_scale_factor,
     transfer.source_account_id,
     transfer.target_account_id,
-    running_balance_materialized_view.is_excluded
+    running_balance_materialized_view.is_excluded,
+    CASE WHEN EXISTS (
+        SELECT 1 FROM transfer_relationship tr
+        WHERE (tr.id1 = running_balance_materialized_view.id OR tr.id2 = running_balance_materialized_view.id)
+          AND tr.relationship_type_id = 1   -- RECONCILED_RELATIONSHIP_TYPE_ID; mirrors the hardcoded -1 used for is_excluded
+    ) THEN 1 ELSE 0 END AS is_reconciled
 FROM running_balance_materialized_view
 JOIN currency ON running_balance_materialized_view.currency_id = currency.id
 JOIN transfer ON running_balance_materialized_view.id = transfer.id

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/TransferRelationship.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/TransferRelationship.sq
@@ -1,0 +1,39 @@
+-- A typed relationship between two transfers. The composite primary key allows a pair of transfers
+-- to carry more than one relationship (a different relationship_type_id per row).
+--   id1 = the primary/owning transfer (the reconciled duplicate; later: the main transaction)
+--   id2 = the related transfer       (the original it mirrors; later: the fee transfer)
+-- FKs reference transaction_id(id) (the permanent id table), matching transfer.id's own FK.
+CREATE TABLE transfer_relationship (
+    id1 INTEGER NOT NULL,
+    id2 INTEGER NOT NULL,
+    relationship_type_id INTEGER NOT NULL,
+    PRIMARY KEY (id1, id2, relationship_type_id),
+    FOREIGN KEY (id1) REFERENCES transaction_id(id) ON DELETE CASCADE,
+    FOREIGN KEY (id2) REFERENCES transaction_id(id) ON DELETE CASCADE,
+    FOREIGN KEY (relationship_type_id) REFERENCES relationship_type(id) ON DELETE RESTRICT
+);
+
+CREATE INDEX idx_transfer_relationship_id1 ON transfer_relationship(id1);
+CREATE INDEX idx_transfer_relationship_id2 ON transfer_relationship(id2);
+CREATE INDEX idx_transfer_relationship_type ON transfer_relationship(relationship_type_id);
+
+-- All relationships touching a transfer, from either side of the pair.
+selectByTransfer:
+SELECT
+    transfer_relationship.id1,
+    transfer_relationship.id2,
+    transfer_relationship.relationship_type_id,
+    relationship_type.id AS relationship_type_id,
+    relationship_type.name AS relationship_type_name
+FROM transfer_relationship
+JOIN relationship_type ON transfer_relationship.relationship_type_id = relationship_type.id
+WHERE transfer_relationship.id1 = ? OR transfer_relationship.id2 = ?
+ORDER BY relationship_type.name;
+
+insert:
+INSERT INTO transfer_relationship (id1, id2, relationship_type_id)
+VALUES (?, ?, ?);
+
+delete:
+DELETE FROM transfer_relationship
+WHERE id1 = ? AND id2 = ? AND relationship_type_id = ?;

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/TransferRelationship.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/TransferRelationship.sq
@@ -2,14 +2,15 @@
 -- to carry more than one relationship (a different relationship_type_id per row).
 --   id1 = the primary/owning transfer (the reconciled duplicate; later: the main transaction)
 --   id2 = the related transfer       (the original it mirrors; later: the fee transfer)
--- FKs reference transaction_id(id) (the permanent id table), matching transfer.id's own FK.
+-- FKs reference transfer(id) ON DELETE CASCADE so deleting either transfer removes the link
+-- (transaction_id rows are never deleted, so referencing them would leave stale links behind).
 CREATE TABLE transfer_relationship (
     id1 INTEGER NOT NULL,
     id2 INTEGER NOT NULL,
     relationship_type_id INTEGER NOT NULL,
     PRIMARY KEY (id1, id2, relationship_type_id),
-    FOREIGN KEY (id1) REFERENCES transaction_id(id) ON DELETE CASCADE,
-    FOREIGN KEY (id2) REFERENCES transaction_id(id) ON DELETE CASCADE,
+    FOREIGN KEY (id1) REFERENCES transfer(id) ON DELETE CASCADE,
+    FOREIGN KEY (id2) REFERENCES transfer(id) ON DELETE CASCADE,
     FOREIGN KEY (relationship_type_id) REFERENCES relationship_type(id) ON DELETE RESTRICT
 );
 

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/TransferRelationshipReconciliationTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/TransferRelationshipReconciliationTest.kt
@@ -1,0 +1,161 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.database.repository
+
+import com.moneymanager.database.DatabaseConfig
+import com.moneymanager.database.SampleGeneratorSourceRecorder
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AttributeTypeId
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.DeviceInfo
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.NewRelationship
+import com.moneymanager.domain.model.RelationshipTypeId
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.test.database.DbTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+
+/**
+ * Verifies that an import which reconciles a cross-source duplicate persists the link as a
+ * `reconciled` transfer_relationship row (not as an id embedded in the excluded attribute), while
+ * the duplicate still carries the plain `excluded` attribute so it stays out of balances.
+ */
+class TransferRelationshipReconciliationTest : DbTest() {
+    private val baseTime = Instant.fromEpochMilliseconds(1_700_000_000_000)
+
+    private suspend fun gbp(): Currency =
+        repositories.currencyRepository
+            .getAllCurrencies()
+            .first()
+            .first { it.code == "GBP" }
+
+    private suspend fun createAccount(name: String): AccountId {
+        repositories.accountRepository.createAccount(Account(id = AccountId(0), name = name, openingDate = baseTime))
+        return repositories.accountRepository
+            .getAllAccounts()
+            .first()
+            .first { it.name == name }
+            .id
+    }
+
+    /**
+     * Imports an original transfer and a reconciled duplicate of it (between the same accounts),
+     * returning their ids as (original, duplicate). The duplicate carries the plain excluded attribute
+     * and a `reconciled` relationship pointing back to the original.
+     */
+    private suspend fun importReconciledPair(
+        currency: Currency,
+        sourceId: AccountId,
+        targetId: AccountId,
+    ): Pair<TransferId, TransferId> {
+        val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-machine", "Test OS"))
+
+        fun recorder() = SampleGeneratorSourceRecorder(transferSourceQueries, deviceId)
+
+        fun transfer() =
+            Transfer(
+                id = TransferId(-1),
+                timestamp = baseTime,
+                description = "Coffee",
+                sourceAccountId = sourceId,
+                targetAccountId = targetId,
+                amount = Money(500, currency),
+            )
+
+        val originalId =
+            repositories.transactionRepository
+                .importTransfers(
+                    transfers = listOf(transfer()),
+                    newAttributes = emptyMap(),
+                    sourceRecorder = recorder(),
+                    updates = emptyList(),
+                    updateSourceRecorder = recorder(),
+                ).single()
+
+        val excludedTypeId = AttributeTypeId(DatabaseConfig.EXCLUDED_ATTR_TYPE_ID)
+        val reconciledTypeId = RelationshipTypeId(DatabaseConfig.RECONCILED_RELATIONSHIP_TYPE_ID)
+        val duplicateId =
+            repositories.transactionRepository
+                .importTransfers(
+                    transfers = listOf(transfer()),
+                    newAttributes = mapOf(TransferId(-1) to listOf(NewAttribute(excludedTypeId, "reconciled"))),
+                    newRelationships =
+                        mapOf(TransferId(-1) to listOf(NewRelationship(relatedTransferId = originalId, typeId = reconciledTypeId))),
+                    sourceRecorder = recorder(),
+                    updates = emptyList(),
+                    updateSourceRecorder = recorder(),
+                ).single()
+
+        return originalId to duplicateId
+    }
+
+    @Test
+    fun reconciledDuplicate_persistsRelationshipAndExclusion() =
+        runTest {
+            val currency = gbp()
+            val sourceId = createAccount("Checking")
+            val targetId = createAccount("Coffee Shop")
+
+            val (originalId, duplicateId) = importReconciledPair(currency, sourceId, targetId)
+
+            // The link lives in the relationship table: duplicate (id1) -> original (id2), type reconciled.
+            val relationships = repositories.transferRelationshipRepository.getByTransfer(duplicateId).first()
+            assertEquals(1, relationships.size)
+            val relationship = relationships.single()
+            assertEquals(duplicateId, relationship.id1)
+            assertEquals(originalId, relationship.id2)
+            assertEquals("reconciled", relationship.relationshipType.name)
+
+            // Looking it up from the original side finds the same row.
+            assertEquals(relationships, repositories.transferRelationshipRepository.getByTransfer(originalId).first())
+
+            // The duplicate keeps the plain excluded attribute so balances still leave it out.
+            val attributes = repositories.transferAttributeRepository.getByTransaction(duplicateId).first()
+            assertEquals("reconciled", attributes.single { it.attributeType.name == "excluded" }.value)
+        }
+
+    @Test
+    fun runningBalanceRows_flagBothSidesOfReconciledPairAsReconciled() =
+        runTest {
+            val currency = gbp()
+            val checkingId = createAccount("Checking")
+            val coffeeShopId = createAccount("Coffee Shop")
+            val groceriesId = createAccount("Groceries")
+
+            val (originalId, duplicateId) = importReconciledPair(currency, checkingId, coffeeShopId)
+
+            // An ordinary, unrelated transfer that must NOT be flagged reconciled.
+            val plain =
+                createTransfer(
+                    Transfer(
+                        id = TransferId(-1),
+                        timestamp = baseTime,
+                        description = "Groceries",
+                        sourceAccountId = checkingId,
+                        targetAccountId = groceriesId,
+                        amount = Money(700, currency),
+                    ),
+                )
+
+            repositories.maintenanceService.fullRefreshMaterializedViews()
+
+            val rows =
+                repositories.transactionRepository
+                    .getRunningBalanceByAccountPaginated(checkingId, pageSize = 50, pagingInfo = null)
+                    .items
+                    .associateBy { it.transactionId }
+
+            // Both sides of the reconciled pair (original id2 and duplicate id1) are flagged reconciled.
+            assertEquals(true, rows.getValue(originalId).isReconciled)
+            assertEquals(true, rows.getValue(duplicateId).isReconciled)
+            // The unrelated transfer is not.
+            assertEquals(false, rows.getValue(plain.id).isReconciled)
+        }
+}

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/TransferRelationshipReconciliationTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/TransferRelationshipReconciliationTest.kt
@@ -122,6 +122,30 @@ class TransferRelationshipReconciliationTest : DbTest() {
         }
 
     @Test
+    fun deletingTransfer_cascadeDeletesItsRelationships() =
+        runTest {
+            val currency = gbp()
+            val sourceId = createAccount("Checking")
+            val targetId = createAccount("Coffee Shop")
+
+            val (originalId, duplicateId) = importReconciledPair(currency, sourceId, targetId)
+            assertEquals(
+                1,
+                repositories.transferRelationshipRepository
+                    .getByTransfer(originalId)
+                    .first()
+                    .size,
+            )
+
+            // Deleting one side of the pair must remove the relationship (FK transfer(id) ON DELETE CASCADE),
+            // leaving no stale reconciliation link on the surviving transfer.
+            repositories.transactionRepository.deleteTransaction(duplicateId.id)
+
+            assertEquals(emptyList(), repositories.transferRelationshipRepository.getByTransfer(originalId).first())
+            assertEquals(emptyList(), repositories.transferRelationshipRepository.getByTransfer(duplicateId).first())
+        }
+
+    @Test
     fun runningBalanceRows_flagBothSidesOfReconciledPairAsReconciled() =
         runTest {
             val currency = gbp()

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/ApplicationMapper.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/ApplicationMapper.kt
@@ -38,6 +38,8 @@ fun DatabaseComponent.toApplication() =
                 transactionRepository = transactionRepository,
                 transferSourceRepository = transferSourceRepository,
                 attributeTypeRepository = attributeTypeRepository,
+                relationshipTypeRepository = relationshipTypeRepository,
+                transferRelationshipRepository = transferRelationshipRepository,
                 entitySource = DbEntitySource(entitySourceQueries, transferSourceQueries, deviceId),
                 sampleEntitySource = DbSampleEntitySource(entitySourceQueries, transferSourceQueries, deviceId),
             ),

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/DatabaseComponent.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/DatabaseComponent.kt
@@ -23,9 +23,11 @@ import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.QifImportRepository
+import com.moneymanager.domain.repository.RelationshipTypeRepository
 import com.moneymanager.domain.repository.SettingsRepository
 import com.moneymanager.domain.repository.TransactionRepository
 import com.moneymanager.domain.repository.TransferAttributeRepository
+import com.moneymanager.domain.repository.TransferRelationshipRepository
 import com.moneymanager.domain.repository.TransferSourceRepository
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
@@ -54,9 +56,11 @@ interface DatabaseComponent {
     val personAttributeRepository: PersonAttributeRepository
     val personRepository: PersonRepository
     val qifImportRepository: QifImportRepository
+    val relationshipTypeRepository: RelationshipTypeRepository
     val settingsRepository: SettingsRepository
     val transactionRepository: TransactionRepository
     val transferAttributeRepository: TransferAttributeRepository
+    val transferRelationshipRepository: TransferRelationshipRepository
     val transferSourceRepository: TransferSourceRepository
     val transferSourceQueries: TransferSourceQueries
     val entitySourceQueries: EntitySourceQueries

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/RepositoryModule.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/RepositoryModule.kt
@@ -19,9 +19,11 @@ import com.moneymanager.database.repository.PersonAccountOwnershipRepositoryImpl
 import com.moneymanager.database.repository.PersonAttributeRepositoryImpl
 import com.moneymanager.database.repository.PersonRepositoryImpl
 import com.moneymanager.database.repository.QifImportRepositoryImpl
+import com.moneymanager.database.repository.RelationshipTypeRepositoryImpl
 import com.moneymanager.database.repository.SettingsRepositoryImpl
 import com.moneymanager.database.repository.TransactionRepositoryImpl
 import com.moneymanager.database.repository.TransferAttributeRepositoryImpl
+import com.moneymanager.database.repository.TransferRelationshipRepositoryImpl
 import com.moneymanager.database.repository.TransferSourceRepositoryImpl
 import com.moneymanager.database.service.CsvStrategyExportService
 import com.moneymanager.database.sql.EntitySourceQueries
@@ -44,9 +46,11 @@ import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.QifImportRepository
+import com.moneymanager.domain.repository.RelationshipTypeRepository
 import com.moneymanager.domain.repository.SettingsRepository
 import com.moneymanager.domain.repository.TransactionRepository
 import com.moneymanager.domain.repository.TransferAttributeRepository
+import com.moneymanager.domain.repository.TransferRelationshipRepository
 import com.moneymanager.domain.repository.TransferSourceRepository
 import com.moneymanager.importer.ImportEngine
 import dev.zacsweers.metro.ContributesTo
@@ -166,6 +170,16 @@ interface RepositoryModule {
     @SingleIn(DatabaseScope::class)
     fun provideTransferAttributeRepository(database: MoneyManagerDatabaseWrapper): TransferAttributeRepository =
         TransferAttributeRepositoryImpl(database)
+
+    @Provides
+    @SingleIn(DatabaseScope::class)
+    fun provideRelationshipTypeRepository(database: MoneyManagerDatabaseWrapper): RelationshipTypeRepository =
+        RelationshipTypeRepositoryImpl(database)
+
+    @Provides
+    @SingleIn(DatabaseScope::class)
+    fun provideTransferRelationshipRepository(database: MoneyManagerDatabaseWrapper): TransferRelationshipRepository =
+        TransferRelationshipRepositoryImpl(database)
 
     @Provides
     @SingleIn(DatabaseScope::class)

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
@@ -5,6 +5,7 @@ package com.moneymanager.importer
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.NewRelationship
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.ImportStatus
@@ -132,14 +133,15 @@ class ImportDeduper(
     /**
      * Classifies [transfer] as a cross-source reconciliation of an existing transfer when the policy
      * enables it and a same source+target+amount transfer from a different source exists within the
-     * reconcile window. The returned transfer carries an extra exclusion attribute
-     * (value "reconciled:<existingId>") so it is kept and linked but excluded from balance totals;
-     * null when reconciliation is disabled or no match is found.
+     * reconcile window. The returned transfer carries a plain exclusion attribute (value "reconciled")
+     * so it is kept but excluded from balance totals, plus a `reconciled` relationship linking it
+     * (id1) to the existing transfer (id2). Null when reconciliation is disabled or no match is found.
      */
     private fun classifyAsReconciled(transfer: ImportTransfer): Classified? {
         val apiPolicy = policy as? DedupePolicy.ApiMultiKey ?: return null
         val window = apiPolicy.reconcileWindow ?: return null
         val exclusionTypeId = apiPolicy.reconciledExclusionAttributeTypeId ?: return null
+        val relationshipTypeId = apiPolicy.reconciledRelationshipTypeId ?: return null
         val matchId =
             reconcileCandidates.firstOrNull { (_, existing) -> reconcileMatches(transfer, existing, window) }?.first
                 ?: return null
@@ -147,9 +149,14 @@ class ImportDeduper(
             if (transfer.attributes.any { it.typeId == exclusionTypeId }) {
                 transfer.attributes
             } else {
-                transfer.attributes + NewAttribute(exclusionTypeId, "reconciled:${matchId.id}")
+                transfer.attributes + NewAttribute(exclusionTypeId, "reconciled")
             }
-        return Classified(transfer.copy(attributes = attributes), ImportStatus.IMPORTED, existing = null)
+        val relationships = transfer.relationships + NewRelationship(relatedTransferId = matchId, typeId = relationshipTypeId)
+        return Classified(
+            transfer.copy(attributes = attributes, relationships = relationships),
+            ImportStatus.IMPORTED,
+            existing = null,
+        )
     }
 
     private fun reconcileMatches(

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngine.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngine.kt
@@ -7,6 +7,7 @@ import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.EntityType
 import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.NewRelationship
 import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.Transfer
@@ -415,9 +416,10 @@ class ImportEngine(
     ): List<TransferId> {
         if (toImport.isEmpty() && toUpdate.isEmpty()) return emptyList()
 
-        // Assign negative temp ids so newAttributes can be keyed before real ids exist.
+        // Assign negative temp ids so newAttributes/newRelationships can be keyed before real ids exist.
         val transfersToCreate = mutableListOf<Transfer>()
         val newAttributes = mutableMapOf<TransferId, List<NewAttribute>>()
+        val newRelationships = mutableMapOf<TransferId, List<NewRelationship>>()
         val orderedRowKeys = mutableListOf<ImportRowKey>()
         toImport.forEachIndexed { index, classified ->
             val tempId = TransferId(-(index + 1).toLong())
@@ -432,6 +434,7 @@ class ImportEngine(
                     amount = t.amount,
                 )
             if (t.attributes.isNotEmpty()) newAttributes[tempId] = t.attributes
+            if (t.relationships.isNotEmpty()) newRelationships[tempId] = t.relationships
             orderedRowKeys += t.rowKey
         }
 
@@ -460,6 +463,7 @@ class ImportEngine(
             transactionRepository.importTransfers(
                 transfers = transfersToCreate,
                 newAttributes = newAttributes,
+                newRelationships = newRelationships,
                 sourceRecorder = batch.provenance.transferRecorder(orderedRowKeys),
                 updates = updates,
                 updateSourceRecorder = batch.provenance.updatedTransferRecorder(orderedUpdateRowKeys),

--- a/app/importer/src/commonTest/kotlin/com/moneymanager/importer/ImportDeduperTest.kt
+++ b/app/importer/src/commonTest/kotlin/com/moneymanager/importer/ImportDeduperTest.kt
@@ -8,6 +8,8 @@ import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.NewRelationship
+import com.moneymanager.domain.model.RelationshipTypeId
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.ImportStatus
@@ -208,6 +210,7 @@ class ImportDeduperTest {
         DedupePolicy.ApiMultiKey(
             reconcileWindow = 5.minutes,
             reconciledExclusionAttributeTypeId = AttributeTypeId(-1),
+            reconciledRelationshipTypeId = RelationshipTypeId(1),
         )
 
     @Test
@@ -221,9 +224,15 @@ class ImportDeduperTest {
                 .classify(listOf(importTransfer(0, description = "from other bank", apiId = "monzo-1", timestamp = baseTime + 1.minutes)))
                 .single()
         assertEquals(ImportStatus.IMPORTED, result.status)
+        // The duplicate keeps a plain exclusion attribute (no embedded id) so balances still exclude it...
         assertEquals(
-            NewAttribute(AttributeTypeId(-1), "reconciled:9"),
+            NewAttribute(AttributeTypeId(-1), "reconciled"),
             result.transfer.attributes.single { it.typeId == AttributeTypeId(-1) },
+        )
+        // ...and the link to the existing transfer lives in a reconciled relationship instead.
+        assertEquals(
+            NewRelationship(relatedTransferId = TransferId(9), typeId = RelationshipTypeId(1)),
+            result.transfer.relationships.single(),
         )
     }
 

--- a/app/importmodel/src/commonMain/kotlin/com/moneymanager/importmodel/DedupePolicy.kt
+++ b/app/importmodel/src/commonMain/kotlin/com/moneymanager/importmodel/DedupePolicy.kt
@@ -1,6 +1,7 @@
 package com.moneymanager.importmodel
 
 import com.moneymanager.domain.model.AttributeTypeId
+import com.moneymanager.domain.model.RelationshipTypeId
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 
@@ -42,17 +43,19 @@ sealed interface DedupePolicy {
      * matches rather than updating them. Requires [ImportBatch.apiIdExtractor]/[ImportBatch.uniqueKeyExtractor]
      * to derive the same keys from existing transfers.
      *
-     * Cross-source reconciliation: when [reconcileWindow] and [reconciledExclusionAttributeTypeId] are
-     * set, an incoming transfer that does NOT match by id/key/exact-fields but does match an existing
-     * transfer from a *different* source (same source+target+amount, timestamp within [reconcileWindow])
-     * is still IMPORTED — but tagged with the exclusion attribute (value "reconciled:<otherId>") so it is
-     * kept and linked yet excluded from balance totals, leaving the movement counted once. Restricted to
-     * existing transfers this provider cannot itself identify (apiId == null) so genuine repeat transfers
-     * from the same provider are never collapsed.
+     * Cross-source reconciliation: when [reconcileWindow], [reconciledExclusionAttributeTypeId] and
+     * [reconciledRelationshipTypeId] are set, an incoming transfer that does NOT match by
+     * id/key/exact-fields but does match an existing transfer from a *different* source
+     * (same source+target+amount, timestamp within [reconcileWindow]) is still IMPORTED — but tagged
+     * with the plain exclusion attribute (so it is kept yet excluded from balance totals) and linked to
+     * the existing transfer via a `reconciled` [com.moneymanager.domain.model.TransferRelationship],
+     * leaving the movement counted once. Restricted to existing transfers this provider cannot itself
+     * identify (apiId == null) so genuine repeat transfers from the same provider are never collapsed.
      */
     data class ApiMultiKey(
         val reconcileWindow: Duration? = null,
         val reconciledExclusionAttributeTypeId: AttributeTypeId? = null,
+        val reconciledRelationshipTypeId: RelationshipTypeId? = null,
     ) : DedupePolicy
 
     /** No deduplication — every transfer is imported. */

--- a/app/importmodel/src/commonMain/kotlin/com/moneymanager/importmodel/ImportBatch.kt
+++ b/app/importmodel/src/commonMain/kotlin/com/moneymanager/importmodel/ImportBatch.kt
@@ -8,6 +8,7 @@ import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.Category
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.NewRelationship
 import com.moneymanager.domain.model.Transfer
 import kotlin.jvm.JvmInline
 import kotlin.time.Instant
@@ -127,6 +128,7 @@ data class ImportOwnershipIntent(
  *
  * @property rowKey Opaque per-row provenance + status-writeback key.
  * @property attributes Transfer attributes with type ids already resolved by the builder.
+ * @property relationships Relationships to existing transfers, created once this transfer's id exists.
  * @property uniqueKey Unique-identifier dedupe key (attribute name -> value), or null for fuzzy dedupe.
  */
 data class ImportTransfer(
@@ -137,6 +139,7 @@ data class ImportTransfer(
     val description: String,
     val amount: Money,
     val attributes: List<NewAttribute> = emptyList(),
+    val relationships: List<NewRelationship> = emptyList(),
     val uniqueKey: Map<String, String>? = null,
     // API transaction id, for DedupePolicy.ApiMultiKey.
     val apiId: String? = null,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AccountRow.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AccountRow.kt
@@ -14,4 +14,5 @@ data class AccountRow(
     val sourceAccountId: AccountId,
     val targetAccountId: AccountId,
     val isExcluded: Boolean = false,
+    val isReconciled: Boolean = false,
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/RelationshipType.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/RelationshipType.kt
@@ -1,0 +1,16 @@
+package com.moneymanager.domain.model
+
+import kotlinx.serialization.Serializable
+
+data class RelationshipType(
+    val id: RelationshipTypeId,
+    val name: String,
+)
+
+@Serializable
+@JvmInline
+value class RelationshipTypeId(
+    val id: Long,
+) {
+    override fun toString() = id.toString()
+}

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TransferRelationship.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TransferRelationship.kt
@@ -1,0 +1,21 @@
+package com.moneymanager.domain.model
+
+/**
+ * A typed relationship between two transfers.
+ *   [id1] = the primary/owning transfer (e.g. the reconciled duplicate, or the main transaction)
+ *   [id2] = the related transfer        (e.g. the original it mirrors, or the fee transfer)
+ */
+data class TransferRelationship(
+    val id1: TransferId,
+    val id2: TransferId,
+    val relationshipType: RelationshipType,
+)
+
+/**
+ * A relationship to be created during import, before the owning transfer's id exists.
+ * The owning transfer becomes id1; [relatedTransferId] becomes id2.
+ */
+data class NewRelationship(
+    val relatedTransferId: TransferId,
+    val typeId: RelationshipTypeId,
+)

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/RelationshipTypeRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/RelationshipTypeRepository.kt
@@ -1,0 +1,20 @@
+package com.moneymanager.domain.repository
+
+import com.moneymanager.domain.model.RelationshipType
+import com.moneymanager.domain.model.RelationshipTypeId
+import kotlinx.coroutines.flow.Flow
+
+interface RelationshipTypeRepository {
+    fun getAll(): Flow<List<RelationshipType>>
+
+    fun getById(id: RelationshipTypeId): Flow<RelationshipType?>
+
+    fun getByName(name: String): Flow<RelationshipType?>
+
+    /**
+     * Gets or creates a relationship type by name.
+     * If one with the given name already exists, returns its ID.
+     * Otherwise, creates a new one and returns its ID.
+     */
+    suspend fun getOrCreate(name: String): RelationshipTypeId
+}

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionRepository.kt
@@ -155,6 +155,11 @@ interface TransactionRepository {
         updates: List<TransferUpdate>,
         updateSourceRecorder: SourceRecorder,
     ): List<TransferId> {
+        // The default path delegates to createTransfers, which has no way to persist relationships.
+        // Fail loudly rather than silently dropping them; the real DB impl overrides this method.
+        require(newRelationships.isEmpty()) {
+            "Default importTransfers does not persist newRelationships; override importTransfers in this implementation."
+        }
         // Default (non-atomic) implementation for fakes/alternative impls; the real impl overrides this
         // to run everything in one transaction.
         val created =

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionRepository.kt
@@ -6,6 +6,7 @@ import com.moneymanager.domain.model.AccountBalance
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AccountRow
 import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.NewRelationship
 import com.moneymanager.domain.model.PageWithTargetIndex
 import com.moneymanager.domain.model.PagingInfo
 import com.moneymanager.domain.model.PagingResult
@@ -139,6 +140,8 @@ interface TransactionRepository {
      * import engine.
      *
      * @param transfers New transfers to create (with placeholder ids); attributes keyed by placeholder id.
+     * @param newRelationships Relationships to create per new transfer, keyed by placeholder id; the new
+     *   transfer becomes id1 and [NewRelationship.relatedTransferId] (an existing transfer) becomes id2.
      * @param sourceRecorder Records the source of each created transfer (called once per transfer in order).
      * @param updates Existing transfers to update, each with attributes to add.
      * @param updateSourceRecorder Records the source of each updated transfer (once per update in order).
@@ -147,6 +150,7 @@ interface TransactionRepository {
     suspend fun importTransfers(
         transfers: List<Transfer>,
         newAttributes: Map<TransferId, List<NewAttribute>>,
+        newRelationships: Map<TransferId, List<NewRelationship>> = emptyMap(),
         sourceRecorder: SourceRecorder,
         updates: List<TransferUpdate>,
         updateSourceRecorder: SourceRecorder,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransferRelationshipRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransferRelationshipRepository.kt
@@ -1,0 +1,28 @@
+package com.moneymanager.domain.repository
+
+import com.moneymanager.domain.model.RelationshipTypeId
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.TransferRelationship
+import kotlinx.coroutines.flow.Flow
+
+interface TransferRelationshipRepository {
+    /**
+     * Gets all relationships touching a transfer, from either side of the pair (id1 or id2).
+     * Results are ordered by relationship type name.
+     */
+    fun getByTransfer(transferId: TransferId): Flow<List<TransferRelationship>>
+
+    /** Inserts a relationship linking [id1] to [id2] of the given type. */
+    suspend fun insert(
+        id1: TransferId,
+        id2: TransferId,
+        typeId: RelationshipTypeId,
+    )
+
+    /** Deletes the relationship identified by the full key. */
+    suspend fun delete(
+        id1: TransferId,
+        id2: TransferId,
+        typeId: RelationshipTypeId,
+    )
+}

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/api/ApiSessionImportService.kt
@@ -2202,6 +2202,7 @@ private suspend fun importTransactionPages(
                 DedupePolicy.ApiMultiKey(
                     reconcileWindow = RECONCILE_WINDOW,
                     reconciledExclusionAttributeTypeId = AttributeTypeId(DatabaseConfig.EXCLUDED_ATTR_TYPE_ID),
+                    reconciledRelationshipTypeId = RelationshipTypeId(DatabaseConfig.RECONCILED_RELATIONSHIP_TYPE_ID),
                 ),
             provenance = ApiImportProvenance(setup.entitySource, setup.sessionId),
             apiIdExtractor =

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionCard.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionCard.kt
@@ -2,14 +2,17 @@ package com.moneymanager.ui.screens.transactions
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -80,6 +83,11 @@ fun AccountTransactionCard(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            // Reconciled column: read-only tick when this transfer is part of a reconciliation
+            Box(modifier = Modifier.width(40.dp), contentAlignment = Alignment.Center) {
+                Checkbox(checked = runningBalance.isReconciled, onCheckedChange = null)
+            }
+
             // Date column
             val dateTime = runningBalance.timestamp.toLocalDateTime(TimeZone.currentSystemDefault())
             Text(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -686,6 +686,15 @@ fun AccountTransactionsScreen(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
+                        text = "Rec.",
+                        style = headerStyle,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        maxLines = 1,
+                        softWrap = false,
+                        modifier = Modifier.width(40.dp),
+                    )
+                    Text(
                         text = "Date",
                         style = headerStyle,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,


### PR DESCRIPTION
## Summary

Introduces a first-class, typed relationship between transfers and uses it for cross-source reconciliation, replacing the old hack of encoding the link as a `"reconciled:<id>"` string inside the well-known `excluded` attribute.

### Data model
- New `relationship_type` lookup table (seeded `reconciled` = 1, `fee` = 2).
- New `transfer_relationship` table keyed on `(id1, id2, relationship_type_id)` so a pair of transfers can carry more than one typed link. FKs to `transaction_id(id)` and `relationship_type(id)`.
- Domain models (`RelationshipType`/`RelationshipTypeId`, `TransferRelationship`/`NewRelationship`), two repositories, and Metro DI wiring.
- Both tables excluded from the audit trail (composite PK / derived metadata).

### Reconciliation rewire
- The reconciled duplicate now keeps a **plain** `excluded` attribute (so balances are unaffected), and the link moves into a `reconciled` `transfer_relationship` row (`id1` = duplicate, `id2` = original).
- Threaded a `newRelationships` map through `DedupePolicy.ApiMultiKey` → `ImportTransfer` → `ImportDeduper` → `ImportEngine` → `TransactionRepositoryImpl.insertNewTransfers`, reusing the existing negative-temp-id mechanism. The matched (`id2`) transfer always pre-exists, so id allocation is clean.

### UI: reconciled column
- New **leading read-only tickbox** column in the per-account transactions view, ticked when a transaction participates in a reconciled relationship.
- **Both sides** of a pair tick (original *and* duplicate), computed via `EXISTS` against `transfer_relationship` in the three running-balance pagination queries — deliberately SELECT-time rather than a materialized-view column, since the timestamp-scoped incremental refresh would otherwise leave the older side stale.

### Scope
- Reconciliation only. The `fee` relationship type is seeded but its logic is deferred — tracked in #523.

## Test plan
- `./gradlew build` — green (all tests, detekt, ktlint, buildHealth).
- `ImportDeduperTest` updated to assert the plain `reconciled` attribute **and** the new `NewRelationship`.
- New `TransferRelationshipReconciliationTest`:
  - persists the relationship row (and verifies it from both sides) while the duplicate keeps its `excluded` attribute;
  - after a materialized-view refresh, `getRunningBalanceByAccountPaginated` reports `isReconciled = true` for **both** the original and the duplicate, and `false` for an unrelated transfer.
- Manual: delete `~/.moneymanager/money_manager.db`, run the JVM app, import the same movement from two providers within the 5-minute window, and confirm the tick appears on both the kept original and the greyed duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added reconciliation tracking for transfers with visual indicators in transaction lists
* Enabled transfer relationship linking to connect related transfers  
* Extended importer to support creating transfer relationships during import

<!-- end of auto-generated comment: release notes by coderabbit.ai -->