### PR TITLE
Update README to reflect current features and architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,109 @@
 # Money Manager
-A personal finance money manager
 
-# Goals
-* Explore what can be achieved with KMP and Compose multiplatform
-* Support all types of accounts that a person can have e.g. Banking, Pensions, Investments, Crypto
-* Automate the data entry as much as possible - this is the feature I want to be the distinguishing factor
-* Once I have a version of this tool that can do anything useful contributions will be very welcome
+A personal finance money manager built with **Kotlin Multiplatform** and **Compose Multiplatform**, targeting Desktop (JVM) and Android.
 
-# Planned Features
-* Google drive integration
-* Slicing and dicing - Charting and data exploration
-* Forecasting
-* Budgeting
-* Multi user support
-* JS/WASM versions
-* IOS version
-* Reconciliation support
-* Maybe AI classification of transactions
-* Store all the raw input data in a separate DB to allow querying directly
-* Safe upgrades of DB across versions
-* Categorization hierarchy for Accounts, People, Assets and Transactions
-* Tags on all the objects
+> ⚠️ **BETA**: This app is under active development. There is no database versioning/migration yet
+> ([#426](https://github.com/NikolayMetchev/money-manager/issues/426)), so the database is recreated
+> from scratch on schema changes. Don't store data you can't afford to lose.
+
+## Goals
+
+* Explore what can be achieved with Kotlin Multiplatform and Compose Multiplatform
+* Support all types of accounts a person can have — banking, pensions, investments, crypto
+* Automate data entry as much as possible — this is the feature I want to be the distinguishing factor
+* Once there is a version that can do anything useful, contributions will be very welcome
+
+## Already Working
+
+* **Accounts & Transfers** — create, edit, view and delete transactions across multiple accounts and currencies
+* **Multi-currency** — locale-aware formatting; amounts stored as integers with per-currency scale factors
+* **Categories** — hierarchical (parent/child) categorisation
+* **People & ownership** — track counterparties and who owns which accounts
+* **Importing** — CSV, QIF, and live JSON-API imports through a unified import engine
+  * Built-in strategies for **Monzo**, **Starling** and **Wise**
+  * Reusable, user-definable CSV column-mapping and API strategies
+* **Reconciliation** — cross-source deduplication detects the same transaction seen from different
+  providers (e.g. a manual CSV plus an API feed) and links them via typed transfer relationships
+* **Excluded transactions** — mark transactions to omit them from balance calculations while keeping them visible
+* **Running & account balances** — maintained via incrementally-refreshed materialized views
+* **Audit history** — full audit trail with timestamps and source attribution (device, file, API session)
+* **Desktop app** — JVM/Compose Desktop with native distributions (Windows, macOS, Linux)
+* **Android app**
+* **Database documentation** — auto-generated [SchemaSpy ER diagrams & docs](https://nikolaymetchev.github.io/money-manager/database/)
+* **CI/CD** — automated build, test, coverage, static analysis, tagging and releases
+
+## Planned Features
+
+* Charting, slicing & dicing — data exploration
+* Budgeting and forecasting
+* Google Drive integration
+* AI classification of transactions
 * Export to GnuCash
+* Tags on all objects; categorisation hierarchy for accounts, people and assets
+* Safe DB upgrades / migrations across versions
+* Multi-user support
+* iOS and Web (JS/WASM) versions
 
-# Already working
-* Basic transfers
-* Audit History
-* Basic CSV importing (a lot more to do here)
-* Android app
-* Desktop App
-* Automated Deploys
+## Platform Support
 
-# Features that I am concentrating on and reviewing closely from AI
-* Database design
-* CI/CD
-* Data model
+| Platform | Status |
+|----------|--------|
+| JVM (Desktop) | ✅ Supported — Windows / macOS / Linux distributions |
+| Android | ✅ Supported |
+| iOS | ⚠️ Planned |
+| Web (JS/WASM) | ⚠️ Planned |
+| Native | ❌ Not planned |
 
-# Features that I have vibe coded and will review refactor later
-* The UI
-* Unit tests
+## Technology Stack
+
+* **Language**: Kotlin (Multiplatform) · **Build**: Gradle · **JVM toolchain**: 25
+* **Database**: SQLite via [SQLDelight](https://github.com/sqldelight/sqldelight)
+* **DI**: [Metro](https://github.com/ZacSweers/metro) (compile-time)
+* **UI**: Compose Multiplatform with Material 3
+* **Object mapping**: [Mappie](https://github.com/Mr-Mappie/mappie)
+* **HTTP**: Ktor Client · **Serialization**: kotlinx.serialization
+* **Code quality**: Detekt, ktlint, dependency-analysis (buildHealth)
+* **Money**: `BigDecimal`-only policy — never `Double`/`Float` for monetary values
+
+## Project Structure
+
+| Module | Purpose |
+|--------|---------|
+| `gradle/build-logic/` | Convention plugins (Kotlin, Android, Compose, Metro, Mappie) |
+| `utils/bigdecimal/` | Arbitrary-precision decimal arithmetic |
+| `utils/currency/` | Locale-aware currency formatting |
+| `utils/parsers/csv/`, `utils/parsers/qif/` | CSV and QIF file parsers |
+| `utils/rest/` | REST/HTTP utilities |
+| `utils/compose/*` | Reusable Compose components (file picker, scrollbar) |
+| `app/model/core/` | Domain models and repository interfaces |
+| `app/db/core/` | SQLDelight database, repository implementations, mappers |
+| `app/importmodel/` | Shared import data structures and dedup policies |
+| `app/importer/` | Central import engine (CSV / QIF / API) and deduplication |
+| `app/di/core/` | Metro DI configuration |
+| `app/ui/core/` | Compose UI (JVM/Android) |
+| `app/main/jvm/` | JVM Desktop entry point |
+| `app/main/android/` | Android entry point |
+| `app/db/schemaspy/` | Generates the published SchemaSpy database docs |
+
+## Building & Running
+
+> Always build with `--console=plain`. Requires a JDK 25 toolchain.
+
+| Command | Description |
+|---------|-------------|
+| `./gradlew build` | Build everything, run tests, coverage and dependency health |
+| `./gradlew :app:main:jvm:run` | Run the JVM desktop application |
+| `./gradlew :app:main:android:installDebug` | Install the Android debug APK |
+| `./gradlew lintFormat` | Format code (ktlint + sort dependencies) |
+| `./gradlew detekt` | Static analysis |
+| `./gradlew buildHealth` | Check dependency health |
+
+## Development Notes
+
+* **Database design**, **CI/CD** and the **data model** are designed and reviewed closely.
+* The **UI** and **unit tests** are partly AI-generated and will be reviewed/refactored over time.
+* See [`CLAUDE.md`](CLAUDE.md) for detailed contributor/AI-assistant guidance.
+
+## License
+
+Licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
## Summary

The root `README.md` was last meaningfully updated in November 2025 (#197) and had fallen well behind the project. This rewrites it to accurately describe what now works.

## Changes
- **BETA warning** about no DB migrations yet (#426)
- **"Already Working"** updated: multi-currency, hierarchical categories, people/ownership, **QIF + API imports** (not just CSV), built-in **Monzo / Starling / Wise** strategies, **cross-source reconciliation** via transfer relationships, excluded transactions, materialized-view balances, audit history, native desktop distributions, and the published SchemaSpy database docs site
- **Planned vs. working** split corrected — charting/budgeting/forecasting → planned, reconciliation → working
- Added **platform support table**, full **tech stack**, the current **17-module project structure**, a **build/run command table**, and an **Apache 2.0 license** reference

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)