### PR TITLE
Config-driven Santander QIF parsing: counterparties, people, attributes

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -20,6 +20,7 @@ import com.moneymanager.domain.model.csv.ImportStatus
 import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
 import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
+import com.moneymanager.domain.model.csvstrategy.ColumnExtraction
 import com.moneymanager.domain.model.csvstrategy.ColumnPairSwap
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
 import com.moneymanager.domain.model.csvstrategy.CsvAccountMapping
@@ -70,6 +71,11 @@ sealed interface MappingResult {
         val discoveredMappings: List<DiscoveredAccountMapping> = emptyList(),
         /** Fee charged on the row, imported as its own linked fee transfer; null when there is none. */
         val feeAmount: Money? = null,
+        /**
+         * Name of the counterparty account when it was resolved via a person-flagged regex rule, so
+         * the import can additionally create a Person + ownership link; null otherwise.
+         */
+        val personalCounterpartyName: String? = null,
     ) : MappingResult {
         /** Convenience for flows where only the target side can discover a new account. */
         val newAccountName: String? get() = newAccounts.firstOrNull()?.name
@@ -112,6 +118,8 @@ data class CsvTransferWithAttributes(
     val discoveredMappings: List<DiscoveredAccountMapping> = emptyList(),
     /** Fee charged on the row, imported as its own linked fee transfer; null when there is none. */
     val feeAmount: Money? = null,
+    /** Counterparty account name when it is a person (drives Person + ownership creation); else null. */
+    val personalCounterpartyName: String? = null,
 )
 
 /**
@@ -217,6 +225,7 @@ class CsvTransferMapper(
                             rowIndex = row.rowIndex,
                             discoveredMappings = result.discoveredMappings,
                             feeAmount = result.feeAmount,
+                            personalCounterpartyName = result.personalCounterpartyName,
                         ),
                     )
                     // Count by status
@@ -326,6 +335,10 @@ class CsvTransferMapper(
             // Parse description
             val description = parseDescription(descriptionMapping, values)
 
+            // Detect a personal counterparty (resolved from the target mapping regardless of any
+            // account flip — the counterparty is the same account on whichever side it ends up).
+            val personalCounterpartyName = resolvePersonalCounterparty(targetMapping, values)
+
             // Create Money with absolute value (direction is indicated by source/target)
             val amount = Money.fromDisplayValue(rawAmount.abs(), currency)
 
@@ -376,6 +389,7 @@ class CsvTransferMapper(
                 existingTransferId = existingTransferId,
                 discoveredMappings = discoveredMappings,
                 feeAmount = feeAmount,
+                personalCounterpartyName = personalCounterpartyName,
             )
         } catch (expected: Exception) {
             MappingResult.Error(row.rowIndex, expected.message ?: "Unknown error")
@@ -390,9 +404,16 @@ class CsvTransferMapper(
         strategy.attributeMappings.mapNotNull { mapping ->
             val value = getColumnValueOrNull(mapping.columnName, values)?.trim()
             if (value.isNullOrBlank()) {
-                null
-            } else {
+                return@mapNotNull null
+            }
+            val extraction = mapping.extraction
+            // Unique-identifier columns always use the whole column value so the dedup key (which reads
+            // the raw column directly) and the stored attribute value never diverge.
+            if (extraction == null || mapping.isUniqueIdentifier) {
                 mapping.attributeTypeName to value
+            } else {
+                val extracted = applyExtraction(value, extraction) ?: return@mapNotNull null
+                mapping.attributeTypeName to (mapping.emitWhenMatched ?: extracted)
             }
         }
 
@@ -702,6 +723,7 @@ class CsvTransferMapper(
         val sourceColumnName: String,
         val sourceColumnValue: String,
         val matchedPattern: String?,
+        val counterpartyIsPerson: Boolean = false,
     )
 
     /**
@@ -718,13 +740,21 @@ class CsvTransferMapper(
         // Try each rule in order; first match wins
         if (primaryValue.isNotBlank()) {
             for (rule in mapping.rules) {
-                val regex = Regex(rule.pattern, RegexOption.IGNORE_CASE)
-                if (regex.containsMatchIn(primaryValue)) {
+                val match = Regex(rule.pattern, RegexOption.IGNORE_CASE).find(primaryValue)
+                if (match != null) {
+                    // When a template is configured, derive the name from the matched text via
+                    // capture-group substitution; otherwise use the fixed account name (legacy behaviour).
+                    val accountName =
+                        rule.accountNameTemplate
+                            ?.let { substituteTemplate(it, match).replace(Regex("\\s+"), " ").trim() }
+                            ?.takeIf { it.isNotBlank() }
+                            ?: rule.accountName
                     return RegexAccountResult(
-                        accountName = rule.accountName,
+                        accountName = accountName,
                         sourceColumnName = mapping.columnName,
                         sourceColumnValue = primaryValue,
                         matchedPattern = rule.pattern,
+                        counterpartyIsPerson = rule.counterpartyIsPerson,
                     )
                 }
             }
@@ -826,15 +856,94 @@ class CsvTransferMapper(
     /**
      * Gets the effective value from a DirectColumnMapping,
      * trying the primary column first, then fallbacks in order.
+     * When an [DirectColumnMapping.extraction] is configured, the resolved value is cleaned through it
+     * (falling back to the raw value if the pattern doesn't match, so nothing is lost).
      */
     private fun getDirectColumnValue(
         mapping: DirectColumnMapping,
         values: List<String>,
-    ): String =
-        mapping.allColumns
-            .map { getColumnValue(it, values) }
-            .firstOrNull { it.isNotBlank() }
-            .orEmpty()
+    ): String {
+        val raw =
+            mapping.allColumns
+                .map { getColumnValue(it, values) }
+                .firstOrNull { it.isNotBlank() }
+                .orEmpty()
+        val extraction = mapping.extraction ?: return raw
+        return applyExtraction(raw, extraction) ?: raw
+    }
+
+    /**
+     * Resolves whether the counterparty (target) account for this row is a person, returning its
+     * resolved account name when so (drives Person + ownership creation), or null otherwise.
+     */
+    private fun resolvePersonalCounterparty(
+        mapping: FieldMapping,
+        values: List<String>,
+    ): String? =
+        when (mapping) {
+            is RegexAccountMapping -> {
+                val result = getAccountNameFromRegexWithPattern(mapping, values)
+                if (result.counterpartyIsPerson && result.accountName.isNotBlank()) result.accountName else null
+            }
+            is ConditionalAccountMapping -> resolvePersonalCounterparty(resolveConditional(mapping, values), values)
+            else -> null
+        }
+
+    /**
+     * Runs [extraction]'s regex (case-insensitively) against [value] and substitutes its
+     * [ColumnExtraction.outputTemplate] from the match. Returns null when the pattern doesn't match.
+     */
+    private fun applyExtraction(
+        value: String,
+        extraction: ColumnExtraction,
+    ): String? {
+        val match = Regex(extraction.pattern, RegexOption.IGNORE_CASE).find(value) ?: return null
+        return substituteTemplate(extraction.outputTemplate, match)
+    }
+
+    /**
+     * Substitutes capture-group references in [template] from [match]. Supports `$0` (whole match),
+     * `$1`..`$9` (numbered groups) and `${name}` (named groups). Unknown/absent groups become "".
+     */
+    private fun substituteTemplate(
+        template: String,
+        match: MatchResult,
+    ): String {
+        val out = StringBuilder()
+        var i = 0
+        while (i < template.length) {
+            val token = parseTemplateToken(template, i, match)
+            if (token == null) {
+                out.append(template[i])
+                i++
+            } else {
+                out.append(token.first)
+                i += token.second
+            }
+        }
+        return out.toString()
+    }
+
+    /**
+     * Parses a `$`-token at [start] in [template], returning (substituted value, characters consumed)
+     * for `${name}` and `$0`..`$9`, or null when there is no token to substitute at this position.
+     */
+    private fun parseTemplateToken(
+        template: String,
+        start: Int,
+        match: MatchResult,
+    ): Pair<String, Int>? {
+        if (template[start] != '$' || start + 1 >= template.length) return null
+        val next = template[start + 1]
+        if (next == '{') {
+            val end = template.indexOf('}', startIndex = start + 2)
+            if (end == -1) return null
+            val value = (match.groups as? MatchNamedGroupCollection)?.get(template.substring(start + 2, end))?.value.orEmpty()
+            return value to (end - start + 1)
+        }
+        if (next.isDigit()) return match.groupValues.getOrNull(next - '0').orEmpty() to 2
+        return null
+    }
 
     private fun parseCurrency(
         mapping: FieldMapping,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/CsvImportStrategyInsert.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/CsvImportStrategyInsert.kt
@@ -1,0 +1,31 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.database
+
+import com.moneymanager.database.json.FieldMappingJsonCodec
+import com.moneymanager.database.sql.CsvImportStrategyQueries
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import kotlin.time.Instant
+
+/**
+ * Inserts a [CsvImportStrategy] row, serialising its config sections to JSON. Shared by the runtime
+ * repository (user-created strategies) and the seeder (built-in strategies) so the column/encoder list
+ * lives in one place.
+ */
+internal fun CsvImportStrategyQueries.insertStrategy(
+    strategy: CsvImportStrategy,
+    now: Instant,
+) {
+    insert(
+        id = strategy.id.id.toString(),
+        name = strategy.name,
+        identification_columns_json = FieldMappingJsonCodec.encodeColumns(strategy.identificationColumns),
+        field_mappings_json = FieldMappingJsonCodec.encode(strategy.fieldMappings),
+        attribute_mappings_json = FieldMappingJsonCodec.encodeAttributeMappings(strategy.attributeMappings),
+        row_rules_json = FieldMappingJsonCodec.encodeRowRules(strategy.rowPreprocessingRules),
+        companion_rules_json = FieldMappingJsonCodec.encodeCompanionRules(strategy.companionTransactionRules),
+        content_match_rules_json = FieldMappingJsonCodec.encodeContentRules(strategy.contentMatchRules),
+        created_at = now.toEpochMilliseconds(),
+        updated_at = now.toEpochMilliseconds(),
+    )
+}

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/CsvImportStrategyInsert.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/CsvImportStrategyInsert.kt
@@ -1,21 +1,17 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
 
 package com.moneymanager.database
 
 import com.moneymanager.database.json.FieldMappingJsonCodec
 import com.moneymanager.database.sql.CsvImportStrategyQueries
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
-import kotlin.time.Instant
 
 /**
  * Inserts a [CsvImportStrategy] row, serialising its config sections to JSON. Shared by the runtime
  * repository (user-created strategies) and the seeder (built-in strategies) so the column/encoder list
- * lives in one place.
+ * lives in one place. created_at/updated_at are filled by the table's DEFAULT (current time).
  */
-internal fun CsvImportStrategyQueries.insertStrategy(
-    strategy: CsvImportStrategy,
-    now: Instant,
-) {
+internal fun CsvImportStrategyQueries.insertStrategy(strategy: CsvImportStrategy) {
     insert(
         id = strategy.id.id.toString(),
         name = strategy.name,
@@ -25,7 +21,5 @@ internal fun CsvImportStrategyQueries.insertStrategy(
         row_rules_json = FieldMappingJsonCodec.encodeRowRules(strategy.rowPreprocessingRules),
         companion_rules_json = FieldMappingJsonCodec.encodeCompanionRules(strategy.companionTransactionRules),
         content_match_rules_json = FieldMappingJsonCodec.encodeContentRules(strategy.contentMatchRules),
-        created_at = now.toEpochMilliseconds(),
-        updated_at = now.toEpochMilliseconds(),
     )
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -5,7 +5,6 @@ package com.moneymanager.database
 import com.moneymanager.currency.Currency
 import com.moneymanager.database.json.ApiStrategyConfigJson
 import com.moneymanager.database.json.ApiStrategyJsonCodec
-import com.moneymanager.database.json.FieldMappingJsonCodec
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.CurrencyScaleFactors
 import com.moneymanager.domain.model.DeviceId
@@ -1652,73 +1651,73 @@ object DatabaseConfig {
                 RegexRule(pattern = "^DIRECT DEBIT INDEMNITY\\b", accountName = "Santander Direct Debit Indemnity"),
                 RegexRule(pattern = "^DIRECT DEBIT REVERSAL\\b", accountName = "Santander Direct Debit Reversal"),
                 RegexRule(
-                    pattern = "^DIRECT DEBIT PAYMENT TO\\s+(?<cp>.+?)(?:\\s+REF\\b|\\s+MANDATE\\b|,)",
+                    pattern = "^DIRECT DEBIT PAYMENT TO\\s+(.+?)(?:\\s+REF\\b|\\s+MANDATE\\b|,)",
                     accountName = "Santander Direct Debit",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                 ),
                 RegexRule(
-                    pattern = "^CARD PAYMENT TO\\s+(?<cp>.+?)(?:,|\\s+ON\\b)",
+                    pattern = "^CARD PAYMENT TO\\s+(.+?)(?:,|\\s+ON\\b)",
                     accountName = "Santander Card Payment",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                 ),
                 RegexRule(
-                    pattern = "^FASTER PAYMENTS RECEIPT\\b.*?\\bFROM\\s+(?<cp>[^,]+?)\\s*,",
+                    pattern = "^FASTER PAYMENTS RECEIPT\\b.*?\\bFROM\\s+([^,]+?)\\s*,",
                     accountName = "Santander Faster Payment",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                     counterpartyIsPerson = true,
                 ),
                 RegexRule(
-                    pattern = "^PAYM\\b.*?\\bFROM\\s+(?<cp>[^,]+?)\\s*(?:,|\\s+REFERENCE\\b)",
+                    pattern = "^PAYM\\b.*?\\bFROM\\s+([^,]+?)\\s*(?:,|\\s+REFERENCE\\b)",
                     accountName = "Santander Paym",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                     counterpartyIsPerson = true,
                 ),
                 RegexRule(
-                    pattern = "^PAYM\\b.*?\\bTO\\s+(?<cp>.+?)(?:\\s+REFERENCE\\b|,)",
+                    pattern = "^PAYM\\b.*?\\bTO\\s+(.+?)(?:\\s+REFERENCE\\b|,)",
                     accountName = "Santander Paym",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                     counterpartyIsPerson = true,
                 ),
                 RegexRule(
-                    pattern = "^BILL PAYMENT\\b.*?\\bTO\\s+(?<cp>.+?)(?:\\s+REFERENCE\\b|\\s+MANDATE\\b|,)",
+                    pattern = "^BILL PAYMENT\\b.*?\\bTO\\s+(.+?)(?:\\s+REFERENCE\\b|\\s+MANDATE\\b|,)",
                     accountName = "Santander Bill Payment",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                     counterpartyIsPerson = true,
                 ),
                 RegexRule(
-                    pattern = "^BILL PAYMENT\\b.*?\\bFROM\\s+(?<cp>[^,]+?)\\s*(?:,|\\s+REFERENCE\\b)",
+                    pattern = "^BILL PAYMENT\\b.*?\\bFROM\\s+([^,]+?)\\s*(?:,|\\s+REFERENCE\\b)",
                     accountName = "Santander Bill Payment",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                     counterpartyIsPerson = true,
                 ),
                 RegexRule(
-                    pattern = "^PENDED\\b.*?\\bTO\\s+(?<cp>.+?)(?:\\s+REFERENCE\\b|,)",
+                    pattern = "^PENDED\\b.*?\\bTO\\s+(.+?)(?:\\s+REFERENCE\\b|,)",
                     accountName = "Santander Pended Payment",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                     counterpartyIsPerson = true,
                 ),
                 RegexRule(
-                    pattern = "^STANDING ORDER\\b.*?\\bTO\\s+(?<cp>.+?)(?:\\s+REFERENCE\\b|\\s+MANDATE\\b|,)",
+                    pattern = "^STANDING ORDER\\b.*?\\bTO\\s+(.+?)(?:\\s+REFERENCE\\b|\\s+MANDATE\\b|,)",
                     accountName = "Santander Standing Order",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                     counterpartyIsPerson = true,
                 ),
                 RegexRule(
-                    pattern = "^Third party payment\\b.*?\\bto\\s+(?<cp>.+?)(?:\\s+Reference\\b|,)",
+                    pattern = "^Third party payment\\b.*?\\bto\\s+(.+?)(?:\\s+Reference\\b|,)",
                     accountName = "Santander Third Party Payment",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                     counterpartyIsPerson = true,
                 ),
                 RegexRule(
-                    pattern = "^TRANSFER\\b.*?\\bTO\\s+(?<cp>.+?)(?:\\s+REFERENCE\\b|,)",
+                    pattern = "^TRANSFER\\b.*?\\bTO\\s+(.+?)(?:\\s+REFERENCE\\b|,)",
                     accountName = "Santander Transfer",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                     counterpartyIsPerson = true,
                 ),
                 RegexRule(
-                    pattern = "^TRANSFER\\b.*?\\bFROM\\s+(?<cp>[^,.]+?)\\s*(?:,|\\.|\\s+REFERENCE\\b)",
+                    pattern = "^TRANSFER\\b.*?\\bFROM\\s+([^,.]+?)\\s*(?:,|\\.|\\s+REFERENCE\\b)",
                     accountName = "Santander Transfer",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                     counterpartyIsPerson = true,
                 ),
                 // Cash / cheque movements consolidate to a single account each.
@@ -1727,14 +1726,14 @@ object DatabaseConfig {
                 RegexRule(pattern = "^CHEQUE\\b", accountName = "Cheque"),
                 // Bank giro credit refs are often "<digits><NAME>"; strip leading digits to consolidate.
                 RegexRule(
-                    pattern = "^BANK GIRO CREDIT REF\\s+\\d*(?<cp>[^,]+?)\\s*,",
+                    pattern = "^BANK GIRO CREDIT REF\\s+\\d*([^,]+?)\\s*,",
                     accountName = "Santander Bank Giro Credit",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                 ),
                 RegexRule(
-                    pattern = "^CREDIT FROM\\s+(?<cp>.+?)(?:\\s+ON\\b|,)",
+                    pattern = "^CREDIT FROM\\s+(.+?)(?:\\s+ON\\b|,)",
                     accountName = "Santander Credit",
-                    accountNameTemplate = "\${cp}",
+                    accountNameTemplate = "$1",
                 ),
                 RegexRule(pattern = "^INTEREST\\b", accountName = "Santander Interest"),
                 RegexRule(pattern = "^LOAN\\b", accountName = "Santander Loan"),
@@ -1769,7 +1768,7 @@ object DatabaseConfig {
                         columnName = QifColumns.COL_PAYEE,
                         fallbackColumns = listOf(QifColumns.COL_MEMO),
                         // Strip the trailing ", <amount>[ GBP]" Santander repeats at the end of the payee.
-                        extraction = ColumnExtraction(pattern = "^(?<d>.*?),\\s*[\\d][\\d.,]*\\s*(?:GBP)?\\s*$", outputTemplate = "\${d}"),
+                        extraction = ColumnExtraction(pattern = "^(.*?),\\s*[\\d][\\d.,]*\\s*(?:GBP)?\\s*$", outputTemplate = "$1"),
                     ),
                 TransferField.AMOUNT to
                     AmountParsingMapping(
@@ -1830,19 +1829,19 @@ object DatabaseConfig {
                         attributeTypeName = "santander-reference",
                         extraction =
                             ColumnExtraction(
-                                pattern = "(?:REFERENCE|REF)\\b\\.?\\s*(?<ref>.+?)\\s*(?:,|\\s+MANDATE\\b)",
-                                outputTemplate = "\${ref}",
+                                pattern = "(?:REFERENCE|REF)\\b\\.?\\s*(.+?)\\s*(?:,|\\s+MANDATE\\b)",
+                                outputTemplate = "$1",
                             ),
                     ),
                     AttributeColumnMapping(
                         columnName = QifColumns.COL_PAYEE,
                         attributeTypeName = "santander-mandate",
-                        extraction = ColumnExtraction(pattern = "MANDATE NO\\s*(?<m>\\d+)", outputTemplate = "\${m}"),
+                        extraction = ColumnExtraction(pattern = "MANDATE NO\\s*(\\d+)", outputTemplate = "$1"),
                     ),
                     AttributeColumnMapping(
                         columnName = QifColumns.COL_PAYEE,
                         attributeTypeName = "santander-posted-date",
-                        extraction = ColumnExtraction(pattern = "\\bON\\s+(?<d>\\d{2}-\\d{2}-\\d{4})", outputTemplate = "\${d}"),
+                        extraction = ColumnExtraction(pattern = "\\bON\\s+(\\d{2}-\\d{2}-\\d{4})", outputTemplate = "$1"),
                     ),
                 )
         return CsvImportStrategy(
@@ -1970,18 +1969,7 @@ object DatabaseConfig {
         // currencies are seeded); the QIF import dialog pre-selects this and the user can change it.
         val qifCurrencyId = CurrencyId(currencyQueries.selectByCode("GBP").executeAsOne().id)
         for (strategy in builtInCsvStrategies(now, qifCurrencyId)) {
-            csvImportStrategyQueries.insert(
-                id = strategy.id.id.toString(),
-                name = strategy.name,
-                identification_columns_json = FieldMappingJsonCodec.encodeColumns(strategy.identificationColumns),
-                field_mappings_json = FieldMappingJsonCodec.encode(strategy.fieldMappings),
-                attribute_mappings_json = FieldMappingJsonCodec.encodeAttributeMappings(strategy.attributeMappings),
-                row_rules_json = FieldMappingJsonCodec.encodeRowRules(strategy.rowPreprocessingRules),
-                companion_rules_json = FieldMappingJsonCodec.encodeCompanionRules(strategy.companionTransactionRules),
-                content_match_rules_json = FieldMappingJsonCodec.encodeContentRules(strategy.contentMatchRules),
-                created_at = now.toEpochMilliseconds(),
-                updated_at = now.toEpochMilliseconds(),
-            )
+            csvImportStrategyQueries.insertStrategy(strategy, now)
             csvImportStrategyQueries.insertSource(
                 strategy_id = strategy.id.id.toString(),
                 revision_id = 1,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -994,10 +994,6 @@ object DatabaseConfig {
             seedMonzoStrategy(systemDeviceId)
             seedWiseStrategy(systemDeviceId)
             seedStarlingStrategy(systemDeviceId)
-            // NOTE: seedBuiltInCsvStrategies (called below) records its own SYSTEM source per strategy.
-
-            // Seed the built-in CSV import strategies
-            seedBuiltInCsvStrategies(systemDeviceId)
 
             // Seed currencies with system source attribution. Recorded directly (not via the repository)
             // so the SYSTEM device is preserved; this runs before the app's current device is known.
@@ -1015,6 +1011,11 @@ object DatabaseConfig {
                     Source.System,
                 )
             }
+
+            // Seed the built-in CSV/QIF import strategies AFTER currencies, so the QIF strategies can
+            // reference the real GBP currency id (their fixed currency is the default the QIF import
+            // dialog pre-selects). Records its own SYSTEM source per strategy.
+            seedBuiltInCsvStrategies(systemDeviceId)
         }
     }
 
@@ -1376,11 +1377,18 @@ object DatabaseConfig {
 
     private fun santanderQifMappingId(index: Int): FieldMappingId = builtInCsvMappingId(strategyGroup = 4, index = index)
 
-    /** All built-in CSV import strategies seeded into a fresh database. */
-    fun builtInCsvStrategies(now: Instant): List<CsvImportStrategy> =
+    /**
+     * All built-in CSV import strategies seeded into a fresh database. [qifCurrencyId] is the fixed
+     * currency the QIF strategies carry (the default the QIF import dialog pre-selects); it is resolved
+     * to GBP at seed time. Defaults to the first currency for callers without a resolved id (e.g. tests).
+     */
+    fun builtInCsvStrategies(
+        now: Instant,
+        qifCurrencyId: CurrencyId = CurrencyId(1),
+    ): List<CsvImportStrategy> =
         listOf(
-            buildQifStrategy(now),
-            buildSantanderQifStrategy(now),
+            buildQifStrategy(now, qifCurrencyId),
+            buildSantanderQifStrategy(now, qifCurrencyId),
             buildWiseCsvStrategy(now),
             buildMonzoCsvStrategy(now),
         )
@@ -1553,7 +1561,10 @@ object DatabaseConfig {
      * it matches any QIF file. The source account and currency are chosen at import time (QIF data
      * carries neither): the seeded CURRENCY mapping is a placeholder the QIF apply flow overrides.
      */
-    fun buildQifStrategy(now: Instant): CsvImportStrategy {
+    fun buildQifStrategy(
+        now: Instant,
+        currencyId: CurrencyId = CurrencyId(1),
+    ): CsvImportStrategy {
         val fieldMappings =
             mapOf(
                 // Prefer an explicit [transfer-account]; otherwise treat the payee (then category) as
@@ -1593,8 +1604,8 @@ object DatabaseConfig {
                     HardCodedCurrencyMapping(
                         id = qifMappingId(5),
                         fieldType = TransferField.CURRENCY,
-                        // Placeholder: the QIF apply flow overrides this with the user's chosen currency.
-                        currencyId = CurrencyId(1),
+                        // The QIF apply flow pre-selects this as the default; the user can override it.
+                        currencyId = currencyId,
                     ),
                 TransferField.TIMEZONE to
                     HardCodedTimezoneMapping(
@@ -1626,7 +1637,10 @@ object DatabaseConfig {
      * generic QIF strategy, the source account and currency are chosen at import time.
      */
     @Suppress("LongMethod")
-    fun buildSantanderQifStrategy(now: Instant): CsvImportStrategy {
+    fun buildSantanderQifStrategy(
+        now: Instant,
+        currencyId: CurrencyId = CurrencyId(1),
+    ): CsvImportStrategy {
         // First-match-wins rules over the Payee field; ${cp} extracts the clean counterparty name.
         // Tuned against a full Santander statement history (~7k records, ~99.9% parsed). The middle
         // rules use ".*?\bTO/\bFROM" to skip "VIA FASTER PAYMENT" / "REF.<x>" preludes that vary per row.
@@ -1769,8 +1783,9 @@ object DatabaseConfig {
                     HardCodedCurrencyMapping(
                         id = santanderQifMappingId(5),
                         fieldType = TransferField.CURRENCY,
-                        // Placeholder: the QIF apply flow overrides this with the user's chosen currency.
-                        currencyId = CurrencyId(1),
+                        // The QIF apply flow pre-selects this as the default (GBP for Santander); the
+                        // user can override it.
+                        currencyId = currencyId,
                     ),
                 TransferField.TIMEZONE to
                     HardCodedTimezoneMapping(
@@ -1951,7 +1966,10 @@ object DatabaseConfig {
     /** Seeds the built-in CSV import strategies during new-database initialisation. */
     private fun MoneyManagerDatabaseWrapper.seedBuiltInCsvStrategies(systemDeviceId: Long) {
         val now = Clock.System.now()
-        for (strategy in builtInCsvStrategies(now)) {
+        // QIF carries no currency, so the built-in QIF strategies default to GBP (resolved now that
+        // currencies are seeded); the QIF import dialog pre-selects this and the user can change it.
+        val qifCurrencyId = CurrencyId(currencyQueries.selectByCode("GBP").executeAsOne().id)
+        for (strategy in builtInCsvStrategies(now, qifCurrencyId)) {
             csvImportStrategyQueries.insert(
                 id = strategy.id.id.toString(),
                 name = strategy.name,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -33,9 +33,11 @@ import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
 import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
+import com.moneymanager.domain.model.csvstrategy.ColumnExtraction
 import com.moneymanager.domain.model.csvstrategy.ColumnPairSwap
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
+import com.moneymanager.domain.model.csvstrategy.ContentMatchRule
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
 import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
@@ -44,6 +46,8 @@ import com.moneymanager.domain.model.csvstrategy.DirectColumnMapping
 import com.moneymanager.domain.model.csvstrategy.FieldMappingId
 import com.moneymanager.domain.model.csvstrategy.HardCodedCurrencyMapping
 import com.moneymanager.domain.model.csvstrategy.HardCodedTimezoneMapping
+import com.moneymanager.domain.model.csvstrategy.RegexAccountMapping
+import com.moneymanager.domain.model.csvstrategy.RegexRule
 import com.moneymanager.domain.model.csvstrategy.RowCondition
 import com.moneymanager.domain.model.csvstrategy.RowConditionOperator
 import com.moneymanager.domain.model.csvstrategy.RowPreprocessingRule
@@ -1344,6 +1348,9 @@ object DatabaseConfig {
     /** Fixed UUID for the built-in QIF strategy so it can be referenced reliably. */
     val qifStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-000000000005")
 
+    /** Fixed UUID for the built-in Santander QIF strategy so it can be referenced reliably. */
+    val santanderQifStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-000000000006")
+
     /** Account name prefix shared with the Wise API import strategy ("Wise: " + currency code). */
     private const val WISE_ACCOUNT_PREFIX = "Wise: "
 
@@ -1367,10 +1374,13 @@ object DatabaseConfig {
 
     private fun qifMappingId(index: Int): FieldMappingId = builtInCsvMappingId(strategyGroup = 3, index = index)
 
+    private fun santanderQifMappingId(index: Int): FieldMappingId = builtInCsvMappingId(strategyGroup = 4, index = index)
+
     /** All built-in CSV import strategies seeded into a fresh database. */
     fun builtInCsvStrategies(now: Instant): List<CsvImportStrategy> =
         listOf(
             buildQifStrategy(now),
+            buildSantanderQifStrategy(now),
             buildWiseCsvStrategy(now),
             buildMonzoCsvStrategy(now),
         )
@@ -1604,6 +1614,244 @@ object DatabaseConfig {
     }
 
     /**
+     * Built-in QIF strategy for Santander UK statement exports. Santander packs the whole
+     * transaction description into the QIF Payee field (e.g. "DIRECT DEBIT PAYMENT TO AMERICAN
+     * EXPRESS REF …, MANDATE NO 0013, 1352.23"). This strategy parses it entirely via config: regex
+     * rules extract the clean counterparty into the target account (flagging person-to-person payees
+     * so the import also creates a Person + ownership), attribute mappings pull out the transaction
+     * type / reference / mandate / posted date, and the description is cleaned of its trailing amount.
+     *
+     * [ContentMatchRule]s let the QIF apply flow auto-detect this strategy from the Payee content;
+     * the generic [buildQifStrategy] (no content rules) remains the fallback for other banks. Like the
+     * generic QIF strategy, the source account and currency are chosen at import time.
+     */
+    @Suppress("LongMethod")
+    fun buildSantanderQifStrategy(now: Instant): CsvImportStrategy {
+        // First-match-wins rules over the Payee field; ${cp} extracts the clean counterparty name.
+        // Tuned against a full Santander statement history (~7k records, ~99.9% parsed). The middle
+        // rules use ".*?\bTO/\bFROM" to skip "VIA FASTER PAYMENT" / "REF.<x>" preludes that vary per row.
+        val counterpartyRules =
+            listOf(
+                // Cashback summary lines ("1 Direct Debit Payment for Water at 1,00% Cashback, 0.36").
+                RegexRule(pattern = "^\\d+ Direct Debit Payments?\\b", accountName = "Santander Cashback"),
+                RegexRule(pattern = "^MY OFFERS\\b", accountName = "Santander Cashback"),
+                RegexRule(pattern = "^DIRECT DEBIT INDEMNITY\\b", accountName = "Santander Direct Debit Indemnity"),
+                RegexRule(pattern = "^DIRECT DEBIT REVERSAL\\b", accountName = "Santander Direct Debit Reversal"),
+                RegexRule(
+                    pattern = "^DIRECT DEBIT PAYMENT TO\\s+(?<cp>.+?)(?:\\s+REF\\b|\\s+MANDATE\\b|,)",
+                    accountName = "Santander Direct Debit",
+                    accountNameTemplate = "\${cp}",
+                ),
+                RegexRule(
+                    pattern = "^CARD PAYMENT TO\\s+(?<cp>.+?)(?:,|\\s+ON\\b)",
+                    accountName = "Santander Card Payment",
+                    accountNameTemplate = "\${cp}",
+                ),
+                RegexRule(
+                    pattern = "^FASTER PAYMENTS RECEIPT\\b.*?\\bFROM\\s+(?<cp>[^,]+?)\\s*,",
+                    accountName = "Santander Faster Payment",
+                    accountNameTemplate = "\${cp}",
+                    counterpartyIsPerson = true,
+                ),
+                RegexRule(
+                    pattern = "^PAYM\\b.*?\\bFROM\\s+(?<cp>[^,]+?)\\s*(?:,|\\s+REFERENCE\\b)",
+                    accountName = "Santander Paym",
+                    accountNameTemplate = "\${cp}",
+                    counterpartyIsPerson = true,
+                ),
+                RegexRule(
+                    pattern = "^PAYM\\b.*?\\bTO\\s+(?<cp>.+?)(?:\\s+REFERENCE\\b|,)",
+                    accountName = "Santander Paym",
+                    accountNameTemplate = "\${cp}",
+                    counterpartyIsPerson = true,
+                ),
+                RegexRule(
+                    pattern = "^BILL PAYMENT\\b.*?\\bTO\\s+(?<cp>.+?)(?:\\s+REFERENCE\\b|\\s+MANDATE\\b|,)",
+                    accountName = "Santander Bill Payment",
+                    accountNameTemplate = "\${cp}",
+                    counterpartyIsPerson = true,
+                ),
+                RegexRule(
+                    pattern = "^BILL PAYMENT\\b.*?\\bFROM\\s+(?<cp>[^,]+?)\\s*(?:,|\\s+REFERENCE\\b)",
+                    accountName = "Santander Bill Payment",
+                    accountNameTemplate = "\${cp}",
+                    counterpartyIsPerson = true,
+                ),
+                RegexRule(
+                    pattern = "^PENDED\\b.*?\\bTO\\s+(?<cp>.+?)(?:\\s+REFERENCE\\b|,)",
+                    accountName = "Santander Pended Payment",
+                    accountNameTemplate = "\${cp}",
+                    counterpartyIsPerson = true,
+                ),
+                RegexRule(
+                    pattern = "^STANDING ORDER\\b.*?\\bTO\\s+(?<cp>.+?)(?:\\s+REFERENCE\\b|\\s+MANDATE\\b|,)",
+                    accountName = "Santander Standing Order",
+                    accountNameTemplate = "\${cp}",
+                    counterpartyIsPerson = true,
+                ),
+                RegexRule(
+                    pattern = "^Third party payment\\b.*?\\bto\\s+(?<cp>.+?)(?:\\s+Reference\\b|,)",
+                    accountName = "Santander Third Party Payment",
+                    accountNameTemplate = "\${cp}",
+                    counterpartyIsPerson = true,
+                ),
+                RegexRule(
+                    pattern = "^TRANSFER\\b.*?\\bTO\\s+(?<cp>.+?)(?:\\s+REFERENCE\\b|,)",
+                    accountName = "Santander Transfer",
+                    accountNameTemplate = "\${cp}",
+                    counterpartyIsPerson = true,
+                ),
+                RegexRule(
+                    pattern = "^TRANSFER\\b.*?\\bFROM\\s+(?<cp>[^,.]+?)\\s*(?:,|\\.|\\s+REFERENCE\\b)",
+                    accountName = "Santander Transfer",
+                    accountNameTemplate = "\${cp}",
+                    counterpartyIsPerson = true,
+                ),
+                // Cash / cheque movements consolidate to a single account each.
+                RegexRule(pattern = "^CASH\\b", accountName = "Cash"),
+                RegexRule(pattern = "^WITHDRAWAL\\b", accountName = "Cash"),
+                RegexRule(pattern = "^CHEQUE\\b", accountName = "Cheque"),
+                // Bank giro credit refs are often "<digits><NAME>"; strip leading digits to consolidate.
+                RegexRule(
+                    pattern = "^BANK GIRO CREDIT REF\\s+\\d*(?<cp>[^,]+?)\\s*,",
+                    accountName = "Santander Bank Giro Credit",
+                    accountNameTemplate = "\${cp}",
+                ),
+                RegexRule(
+                    pattern = "^CREDIT FROM\\s+(?<cp>.+?)(?:\\s+ON\\b|,)",
+                    accountName = "Santander Credit",
+                    accountNameTemplate = "\${cp}",
+                ),
+                RegexRule(pattern = "^INTEREST\\b", accountName = "Santander Interest"),
+                RegexRule(pattern = "^LOAN\\b", accountName = "Santander Loan"),
+                // Fixed-name rules (no template) for the various account-fee narratives.
+                RegexRule(
+                    pattern = "^(MONTHLY ACCOUNT FEE|MAINTAINING THE ACCOUNT|UNARRANGED|NON-STERLING|PENDED|PENDING)\\b",
+                    accountName = "Santander Fees",
+                ),
+            )
+        val fieldMappings =
+            mapOf(
+                TransferField.TARGET_ACCOUNT to
+                    RegexAccountMapping(
+                        id = santanderQifMappingId(1),
+                        fieldType = TransferField.TARGET_ACCOUNT,
+                        columnName = QifColumns.COL_PAYEE,
+                        rules = counterpartyRules,
+                        // Unmatched payees fall back to the explicit transfer-account/category like the generic QIF strategy.
+                        fallbackColumns = listOf(QifColumns.COL_TRANSFER_ACCOUNT, QifColumns.COL_CATEGORY),
+                    ),
+                TransferField.TIMESTAMP to
+                    DateTimeParsingMapping(
+                        id = santanderQifMappingId(2),
+                        fieldType = TransferField.TIMESTAMP,
+                        dateColumnName = QifColumns.COL_DATE,
+                        dateFormat = "dd/MM/yyyy",
+                    ),
+                TransferField.DESCRIPTION to
+                    DirectColumnMapping(
+                        id = santanderQifMappingId(3),
+                        fieldType = TransferField.DESCRIPTION,
+                        columnName = QifColumns.COL_PAYEE,
+                        fallbackColumns = listOf(QifColumns.COL_MEMO),
+                        // Strip the trailing ", <amount>[ GBP]" Santander repeats at the end of the payee.
+                        extraction = ColumnExtraction(pattern = "^(?<d>.*?),\\s*[\\d][\\d.,]*\\s*(?:GBP)?\\s*$", outputTemplate = "\${d}"),
+                    ),
+                TransferField.AMOUNT to
+                    AmountParsingMapping(
+                        id = santanderQifMappingId(4),
+                        fieldType = TransferField.AMOUNT,
+                        mode = AmountMode.SINGLE_COLUMN,
+                        amountColumnName = QifColumns.COL_AMOUNT,
+                        flipAccountsOnPositive = true,
+                    ),
+                TransferField.CURRENCY to
+                    HardCodedCurrencyMapping(
+                        id = santanderQifMappingId(5),
+                        fieldType = TransferField.CURRENCY,
+                        // Placeholder: the QIF apply flow overrides this with the user's chosen currency.
+                        currencyId = CurrencyId(1),
+                    ),
+                TransferField.TIMEZONE to
+                    HardCodedTimezoneMapping(
+                        id = santanderQifMappingId(6),
+                        fieldType = TransferField.TIMEZONE,
+                        timezoneId = "UTC",
+                    ),
+            )
+        // Transaction type: mutually-exclusive anchored patterns tag a fixed label on the matching row.
+        val typeMappings =
+            listOf(
+                "^\\d+ Direct Debit" to "CASHBACK",
+                "^MY OFFERS" to "CASHBACK",
+                "^CARD PAYMENT TO" to "CARD_PAYMENT",
+                "^DIRECT DEBIT" to "DIRECT_DEBIT",
+                "^FASTER PAYMENTS RECEIPT" to "FASTER_PAYMENT_IN",
+                "^PAYM\\b" to "PAYM",
+                "^BILL PAYMENT" to "BILL_PAYMENT",
+                "^STANDING ORDER" to "STANDING_ORDER",
+                "^Third party payment" to "THIRD_PARTY_PAYMENT",
+                "^TRANSFER\\b" to "TRANSFER",
+                "^CASH\\b" to "CASH",
+                "^CHEQUE\\b" to "CHEQUE",
+                "^BANK GIRO CREDIT" to "BANK_GIRO_CREDIT",
+                "^CREDIT FROM" to "CREDIT",
+                "^INTEREST" to "INTEREST",
+                "^LOAN\\b" to "LOAN",
+                "^(MONTHLY ACCOUNT FEE|MAINTAINING THE ACCOUNT)" to "ACCOUNT_FEE",
+            ).map { (pattern, label) ->
+                AttributeColumnMapping(
+                    columnName = QifColumns.COL_PAYEE,
+                    attributeTypeName = "santander-transaction-type",
+                    extraction = ColumnExtraction(pattern = pattern),
+                    emitWhenMatched = label,
+                )
+            }
+        val attributeMappings =
+            typeMappings +
+                listOf(
+                    AttributeColumnMapping(
+                        columnName = QifColumns.COL_PAYEE,
+                        attributeTypeName = "santander-reference",
+                        extraction =
+                            ColumnExtraction(
+                                pattern = "(?:REFERENCE|REF)\\b\\.?\\s*(?<ref>.+?)\\s*(?:,|\\s+MANDATE\\b)",
+                                outputTemplate = "\${ref}",
+                            ),
+                    ),
+                    AttributeColumnMapping(
+                        columnName = QifColumns.COL_PAYEE,
+                        attributeTypeName = "santander-mandate",
+                        extraction = ColumnExtraction(pattern = "MANDATE NO\\s*(?<m>\\d+)", outputTemplate = "\${m}"),
+                    ),
+                    AttributeColumnMapping(
+                        columnName = QifColumns.COL_PAYEE,
+                        attributeTypeName = "santander-posted-date",
+                        extraction = ColumnExtraction(pattern = "\\bON\\s+(?<d>\\d{2}-\\d{2}-\\d{4})", outputTemplate = "\${d}"),
+                    ),
+                )
+        return CsvImportStrategy(
+            id = CsvImportStrategyId(santanderQifStrategyId),
+            name = "Santander (QIF)",
+            identificationColumns = QifColumns.headers.toSet(),
+            fieldMappings = fieldMappings,
+            attributeMappings = attributeMappings,
+            contentMatchRules =
+                listOf(
+                    ContentMatchRule(
+                        columnName = QifColumns.COL_PAYEE,
+                        pattern =
+                            "^(CARD PAYMENT|DIRECT DEBIT|\\d+ DIRECT DEBIT|FASTER PAYMENTS RECEIPT|PAYM|BILL PAYMENT|" +
+                                "STANDING ORDER|Third party payment|CASH |CHEQUE|BANK GIRO CREDIT|MONTHLY ACCOUNT FEE|" +
+                                "INTEREST|MAINTAINING THE ACCOUNT|CREDIT FROM|TRANSFER)",
+                    ),
+                ),
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    /**
      * Builds the built-in Monzo CSV import strategy for Monzo's transaction export.
      *
      * No SOURCE_ACCOUNT mapping is seeded (account ids are database-specific); the user picks
@@ -1712,6 +1960,7 @@ object DatabaseConfig {
                 attribute_mappings_json = FieldMappingJsonCodec.encodeAttributeMappings(strategy.attributeMappings),
                 row_rules_json = FieldMappingJsonCodec.encodeRowRules(strategy.rowPreprocessingRules),
                 companion_rules_json = FieldMappingJsonCodec.encodeCompanionRules(strategy.companionTransactionRules),
+                content_match_rules_json = FieldMappingJsonCodec.encodeContentRules(strategy.contentMatchRules),
                 created_at = now.toEpochMilliseconds(),
                 updated_at = now.toEpochMilliseconds(),
             )

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -1066,13 +1066,10 @@ object DatabaseConfig {
                 builtInCounterpartyRules = monzoAtmRules,
                 personExternalIdAttribute = "monzo-external-id",
             )
-        val now = Clock.System.now().toEpochMilliseconds()
         apiImportStrategyQueries.insert(
             id = monzoStrategyId.toString(),
             name = "Monzo",
             config_json = ApiStrategyJsonCodec.encode(config),
-            created_at = now,
-            updated_at = now,
         )
         apiImportStrategyQueries.insertSource(
             strategy_id = monzoStrategyId.toString(),
@@ -1198,13 +1195,10 @@ object DatabaseConfig {
                     ),
                 personExternalIdAttribute = "wise-external-id",
             )
-        val now = Clock.System.now().toEpochMilliseconds()
         apiImportStrategyQueries.insert(
             id = wiseStrategyId.toString(),
             name = "Wise",
             config_json = ApiStrategyJsonCodec.encode(config),
-            created_at = now,
-            updated_at = now,
         )
         apiImportStrategyQueries.insertSource(
             strategy_id = wiseStrategyId.toString(),
@@ -1323,13 +1317,10 @@ object DatabaseConfig {
                     ),
                 personExternalIdAttribute = "starling-external-id",
             )
-        val now = Clock.System.now().toEpochMilliseconds()
         apiImportStrategyQueries.insert(
             id = starlingStrategyId.toString(),
             name = "Starling",
             config_json = ApiStrategyJsonCodec.encode(config),
-            created_at = now,
-            updated_at = now,
         )
         apiImportStrategyQueries.insertSource(
             strategy_id = starlingStrategyId.toString(),
@@ -1969,7 +1960,7 @@ object DatabaseConfig {
         // currencies are seeded); the QIF import dialog pre-selects this and the user can change it.
         val qifCurrencyId = CurrencyId(currencyQueries.selectByCode("GBP").executeAsOne().id)
         for (strategy in builtInCsvStrategies(now, qifCurrencyId)) {
-            csvImportStrategyQueries.insertStrategy(strategy, now)
+            csvImportStrategyQueries.insertStrategy(strategy)
             csvImportStrategyQueries.insertSource(
                 strategy_id = strategy.id.id.toString(),
                 revision_id = 1,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/FieldMappingJsonCodec.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/json/FieldMappingJsonCodec.kt
@@ -2,6 +2,7 @@ package com.moneymanager.database.json
 
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
+import com.moneymanager.domain.model.csvstrategy.ContentMatchRule
 import com.moneymanager.domain.model.csvstrategy.FieldMapping
 import com.moneymanager.domain.model.csvstrategy.RowPreprocessingRule
 import com.moneymanager.domain.model.csvstrategy.TransferField
@@ -68,4 +69,14 @@ object FieldMappingJsonCodec {
      * Decodes companion transaction rules from JSON array string.
      */
     fun decodeCompanionRules(jsonString: String): List<CompanionTransactionRule> = json.decodeFromString(jsonString)
+
+    /**
+     * Encodes content match rules to JSON array string.
+     */
+    fun encodeContentRules(rules: List<ContentMatchRule>): String = json.encodeToString(rules)
+
+    /**
+     * Decodes content match rules from JSON array string.
+     */
+    fun decodeContentRules(jsonString: String): List<ContentMatchRule> = json.decodeFromString(jsonString)
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiImportStrategyRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/ApiImportStrategyRepositoryImpl.kt
@@ -57,16 +57,12 @@ class ApiImportStrategyRepositoryImpl(
         source: Source,
     ): ApiImportStrategyId =
         withContext(coroutineContext) {
-            // Use the current time as the authoritative creation timestamp rather than the one
-            // supplied in the domain object. This mirrors CsvImportStrategyRepositoryImpl and
-            // ensures the database always records when the row was actually persisted.
-            val now = Clock.System.now()
+            // created_at/updated_at are stamped with the current time by the table's column DEFAULTs,
+            // so the database always records when the row was actually persisted (not a domain value).
             queries.insert(
                 id = strategy.id.id.toString(),
                 name = strategy.name,
                 config_json = ApiStrategyJsonCodec.encode(strategy.toConfigJson()),
-                created_at = now.toEpochMilliseconds(),
-                updated_at = now.toEpochMilliseconds(),
             )
             queries.insertSource(
                 strategy_id = strategy.id.id.toString(),

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyRepositoryImpl.kt
@@ -6,6 +6,7 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.coroutines.mapToOneOrNull
 import com.moneymanager.database.MoneyManagerDatabaseWrapper
+import com.moneymanager.database.insertStrategy
 import com.moneymanager.database.json.FieldMappingJsonCodec
 import com.moneymanager.domain.model.DeviceId
 import com.moneymanager.domain.model.Source
@@ -64,18 +65,7 @@ class CsvImportStrategyRepositoryImpl(
         withContext(coroutineContext) {
             val now = Clock.System.now()
             database.transaction {
-                queries.insert(
-                    id = strategy.id.id.toString(),
-                    name = strategy.name,
-                    identification_columns_json = FieldMappingJsonCodec.encodeColumns(strategy.identificationColumns),
-                    field_mappings_json = FieldMappingJsonCodec.encode(strategy.fieldMappings),
-                    attribute_mappings_json = FieldMappingJsonCodec.encodeAttributeMappings(strategy.attributeMappings),
-                    row_rules_json = FieldMappingJsonCodec.encodeRowRules(strategy.rowPreprocessingRules),
-                    companion_rules_json = FieldMappingJsonCodec.encodeCompanionRules(strategy.companionTransactionRules),
-                    content_match_rules_json = FieldMappingJsonCodec.encodeContentRules(strategy.contentMatchRules),
-                    created_at = now.toEpochMilliseconds(),
-                    updated_at = now.toEpochMilliseconds(),
-                )
+                queries.insertStrategy(strategy, now)
                 queries.insertSource(
                     strategy_id = strategy.id.id.toString(),
                     revision_id = 1,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyRepositoryImpl.kt
@@ -63,9 +63,8 @@ class CsvImportStrategyRepositoryImpl(
         source: Source,
     ): CsvImportStrategyId =
         withContext(coroutineContext) {
-            val now = Clock.System.now()
             database.transaction {
-                queries.insertStrategy(strategy, now)
+                queries.insertStrategy(strategy)
                 queries.insertSource(
                     strategy_id = strategy.id.id.toString(),
                     revision_id = 1,

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyRepositoryImpl.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyRepositoryImpl.kt
@@ -72,6 +72,7 @@ class CsvImportStrategyRepositoryImpl(
                     attribute_mappings_json = FieldMappingJsonCodec.encodeAttributeMappings(strategy.attributeMappings),
                     row_rules_json = FieldMappingJsonCodec.encodeRowRules(strategy.rowPreprocessingRules),
                     companion_rules_json = FieldMappingJsonCodec.encodeCompanionRules(strategy.companionTransactionRules),
+                    content_match_rules_json = FieldMappingJsonCodec.encodeContentRules(strategy.contentMatchRules),
                     created_at = now.toEpochMilliseconds(),
                     updated_at = now.toEpochMilliseconds(),
                 )
@@ -101,6 +102,7 @@ class CsvImportStrategyRepositoryImpl(
                     attribute_mappings_json = FieldMappingJsonCodec.encodeAttributeMappings(strategy.attributeMappings),
                     row_rules_json = FieldMappingJsonCodec.encodeRowRules(strategy.rowPreprocessingRules),
                     companion_rules_json = FieldMappingJsonCodec.encodeCompanionRules(strategy.companionTransactionRules),
+                    content_match_rules_json = FieldMappingJsonCodec.encodeContentRules(strategy.contentMatchRules),
                     updated_at = now.toEpochMilliseconds(),
                     id = strategy.id.id.toString(),
                 )
@@ -129,6 +131,7 @@ class CsvImportStrategyRepositoryImpl(
             attributeMappings = FieldMappingJsonCodec.decodeAttributeMappings(entity.attribute_mappings_json),
             rowPreprocessingRules = FieldMappingJsonCodec.decodeRowRules(entity.row_rules_json),
             companionTransactionRules = FieldMappingJsonCodec.decodeCompanionRules(entity.companion_rules_json),
+            contentMatchRules = FieldMappingJsonCodec.decodeContentRules(entity.content_match_rules_json),
             createdAt = Instant.fromEpochMilliseconds(entity.created_at),
             updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
         )

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
@@ -168,6 +168,7 @@ class CsvStrategyExportService(
                     }.orEmpty(),
             rowPreprocessingRules = strategy.rowPreprocessingRules,
             companionTransactionRules = strategy.companionTransactionRules,
+            contentMatchRules = strategy.contentMatchRules,
         )
     }
 
@@ -380,6 +381,7 @@ class CsvStrategyExportService(
             attributeMappings = export.attributeMappings,
             rowPreprocessingRules = export.rowPreprocessingRules,
             companionTransactionRules = export.companionTransactionRules,
+            contentMatchRules = export.contentMatchRules,
             createdAt = now,
             updatedAt = now,
         )
@@ -447,6 +449,7 @@ class CsvStrategyExportService(
                     fieldType = fieldType,
                     columnName = columnName,
                     fallbackColumns = fallbackColumns,
+                    extraction = extraction,
                 )
             is AmountParsingMapping ->
                 AmountParsingExport(
@@ -555,6 +558,7 @@ class CsvStrategyExportService(
                     fieldType = fieldType,
                     columnName = columnName,
                     fallbackColumns = fallbackColumns,
+                    extraction = extraction,
                 )
             is AmountParsingExport ->
                 AmountParsingMapping(

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/ApiImportStrategy.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/ApiImportStrategy.sq
@@ -5,8 +5,8 @@ CREATE TABLE api_import_strategy (
     revision_id INTEGER NOT NULL DEFAULT 1,
     name TEXT NOT NULL UNIQUE,
     config_json TEXT NOT NULL,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
+    created_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    updated_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000)
 );
 
 CREATE INDEX idx_api_import_strategy_name ON api_import_strategy(name);
@@ -23,10 +23,10 @@ SELECT * FROM api_import_strategy WHERE id = ?;
 selectByName:
 SELECT * FROM api_import_strategy WHERE name = ?;
 
--- Insert a new strategy
+-- Insert a new strategy. created_at/updated_at are filled by their column DEFAULTs (current time).
 insert:
-INSERT INTO api_import_strategy (id, name, config_json, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?);
+INSERT INTO api_import_strategy (id, name, config_json)
+VALUES (?, ?, ?);
 
 -- Update an existing strategy
 update:

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/CsvImportStrategy.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/CsvImportStrategy.sq
@@ -8,6 +8,7 @@ CREATE TABLE csv_import_strategy (
     attribute_mappings_json TEXT NOT NULL,
     row_rules_json TEXT NOT NULL DEFAULT '[]',
     companion_rules_json TEXT NOT NULL DEFAULT '[]',
+    content_match_rules_json TEXT NOT NULL DEFAULT '[]',
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
 );
@@ -28,13 +29,13 @@ SELECT * FROM csv_import_strategy WHERE name = ?;
 
 -- Insert a new strategy
 insert:
-INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- Update an existing strategy
 update:
 UPDATE csv_import_strategy
-SET revision_id = revision_id + 1, name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, updated_at = ?
+SET revision_id = revision_id + 1, name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, content_match_rules_json = ?, updated_at = ?
 WHERE id = ?;
 
 -- Delete a strategy by ID

--- a/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/CsvImportStrategy.sq
+++ b/app/db/core/src/commonMain/sqldelight/com/moneymanager/database/sql/CsvImportStrategy.sq
@@ -9,8 +9,8 @@ CREATE TABLE csv_import_strategy (
     row_rules_json TEXT NOT NULL DEFAULT '[]',
     companion_rules_json TEXT NOT NULL DEFAULT '[]',
     content_match_rules_json TEXT NOT NULL DEFAULT '[]',
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
+    created_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    updated_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000)
 );
 
 CREATE INDEX idx_csv_import_strategy_name ON csv_import_strategy(name);
@@ -27,10 +27,10 @@ SELECT * FROM csv_import_strategy WHERE id = ?;
 selectByName:
 SELECT * FROM csv_import_strategy WHERE name = ?;
 
--- Insert a new strategy
+-- Insert a new strategy. created_at/updated_at are filled by their column DEFAULTs (current time).
 insert:
-INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?);
 
 -- Update an existing strategy
 update:

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/SantanderQifMapperTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/SantanderQifMapperTest.kt
@@ -1,0 +1,157 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.database.csv
+
+import com.moneymanager.csvimporter.CsvTransferMapper
+import com.moneymanager.csvimporter.MappingResult
+import com.moneymanager.database.DatabaseConfig
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.csv.CsvRow
+import com.moneymanager.qifimporter.QifCsvAdapter
+import com.moneymanager.qifimporter.qifCompatible
+import com.moneymanager.qifimporter.selectForQifContent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+
+/**
+ * Exercises the built-in Santander QIF strategy ([DatabaseConfig.buildSantanderQifStrategy]) — which
+ * is pure config — against the real Santander Payee formats. Verifies the config-driven parsing
+ * extracts a clean counterparty (target account), tags transaction-type / reference / mandate / date
+ * attributes, cleans the description, and flags person-to-person counterparties.
+ */
+class SantanderQifMapperTest {
+    private val now = Clock.System.now()
+    private val strategy = DatabaseConfig.buildSantanderQifStrategy(now)
+
+    private val gbp = Currency(id = CurrencyId(1), code = "GBP", name = "British Pound")
+    private val santander = Account(id = AccountId(1), name = "Santander", openingDate = now)
+
+    private fun mapper(): CsvTransferMapper =
+        CsvTransferMapper(
+            strategy = strategy,
+            columns = QifCsvAdapter.columns,
+            existingAccounts = mapOf(santander.name to santander),
+            existingCurrencies = mapOf(gbp.id to gbp),
+            existingCurrenciesByCode = mapOf(gbp.code to gbp),
+            sourceAccountOverride = santander.id,
+        )
+
+    /** Builds a QIF-shaped row (columns in [QifCsvAdapter] order) with the given payee and amount. */
+    private fun row(
+        payee: String,
+        amount: String,
+        date: String = "27/03/2021",
+    ): CsvRow =
+        CsvRow(
+            rowIndex = 1,
+            values = listOf(date, amount, payee, "", "", "", "", "", ""),
+        )
+
+    private fun map(
+        payee: String,
+        amount: String,
+    ): MappingResult.Success {
+        val result = mapper().mapRow(row(payee, amount))
+        return assertIs<MappingResult.Success>(result, "mapping failed: $result")
+    }
+
+    private fun MappingResult.Success.attrs(): Map<String, String> = attributes.toMap()
+
+    @Test
+    fun `card payment extracts merchant as target account and tags type`() {
+        val r = map("CARD PAYMENT TO VANGUARD,7.32 GBP, RATE 1.00/GBP ON 27-03-2021, 7.32", "-7.32")
+        // Outgoing (negative): target is the counterparty.
+        assertEquals("VANGUARD", newTargetName(r))
+        assertEquals("CARD_PAYMENT", r.attrs()["santander-transaction-type"])
+        assertEquals("27-03-2021", r.attrs()["santander-posted-date"])
+        assertNull(r.personalCounterpartyName)
+    }
+
+    @Test
+    fun `direct debit extracts payee, reference and mandate`() {
+        val r = map("DIRECT DEBIT PAYMENT TO AMERICAN EXPRESS REF 3746-935125-04002, MANDATE NO 0013, 1352.23", "-1352.23")
+        assertEquals("AMERICAN EXPRESS", newTargetName(r))
+        assertEquals("DIRECT_DEBIT", r.attrs()["santander-transaction-type"])
+        assertEquals("3746-935125-04002", r.attrs()["santander-reference"])
+        assertEquals("0013", r.attrs()["santander-mandate"])
+        assertNull(r.personalCounterpartyName)
+    }
+
+    @Test
+    fun `faster payment receipt flags the sender as a person`() {
+        val r = map("FASTER PAYMENTS RECEIPT REF.OLGA FROM ZAKHARENKO O, 250.00", "250.00")
+        // Incoming (positive) flips accounts, but the counterparty is still detected as a person.
+        assertEquals("ZAKHARENKO O", r.personalCounterpartyName)
+        assertEquals("FASTER_PAYMENT_IN", r.attrs()["santander-transaction-type"])
+    }
+
+    @Test
+    fun `faster payment receipt without reference still parses sender`() {
+        val r = map("FASTER PAYMENTS RECEIPT  FROM NIKOLAY METCHEV, 1000.00", "1000.00")
+        assertEquals("NIKOLAY METCHEV", r.personalCounterpartyName)
+    }
+
+    @Test
+    fun `bill payment via faster payment flags recipient as a person with reference`() {
+        val r = map("BILL PAYMENT VIA FASTER PAYMENT TO JASMINA KRUMOVA REFERENCE CLEANING , MANDATE NO 1, 27.00GBP", "-27.00")
+        assertEquals("JASMINA KRUMOVA", newTargetName(r))
+        assertEquals("JASMINA KRUMOVA", r.personalCounterpartyName)
+        assertEquals("BILL_PAYMENT", r.attrs()["santander-transaction-type"])
+        assertEquals("CLEANING", r.attrs()["santander-reference"])
+        assertEquals("1", r.attrs()["santander-mandate"])
+    }
+
+    @Test
+    fun `bank giro credit extracts reference as counterparty (not a person)`() {
+        val r = map("BANK GIRO CREDIT REF HMRC CHILD BENEFIT, METCHEVNIKOL850001, 84.60", "84.60")
+        assertEquals("HMRC CHILD BENEFIT", newTargetName(r))
+        assertEquals("BANK_GIRO_CREDIT", r.attrs()["santander-transaction-type"])
+        assertNull(r.personalCounterpartyName)
+    }
+
+    @Test
+    fun `monthly account fee maps to a fixed counterparty via a non-template rule`() {
+        val r = map("MONTHLY ACCOUNT FEE, 5.00GBP", "-5.00")
+        assertEquals("Santander Fees", newTargetName(r))
+        assertEquals("ACCOUNT_FEE", r.attrs()["santander-transaction-type"])
+    }
+
+    @Test
+    fun `description is cleaned of the trailing amount`() {
+        val r = map("FASTER PAYMENTS RECEIPT REF.OLGA FROM ZAKHARENKO O, 250.00", "250.00")
+        assertEquals("FASTER PAYMENTS RECEIPT REF.OLGA FROM ZAKHARENKO O", r.transfer.description)
+    }
+
+    @Test
+    fun `unmatched payee falls back to the raw payee as the counterparty`() {
+        // No leading Santander keyword -> regex rules don't match -> fallback uses the raw payee.
+        val r = map("SOME UNKNOWN NARRATIVE", "-10.00")
+        assertEquals("SOME UNKNOWN NARRATIVE", newTargetName(r))
+        assertNull(r.attrs()["santander-transaction-type"])
+        assertNull(r.personalCounterpartyName)
+    }
+
+    @Test
+    fun `content auto-detect picks Santander for santander rows and the generic QIF strategy otherwise`() {
+        val strategies = DatabaseConfig.builtInCsvStrategies(now).qifCompatible()
+        val santanderRows =
+            listOf(row("DIRECT DEBIT PAYMENT TO AMERICAN EXPRESS REF X, MANDATE NO 1, 5.00", "-5.00"))
+        val genericRows = listOf(row("Tesco", "-5.00"))
+
+        assertEquals("Santander (QIF)", strategies.selectForQifContent(santanderRows, QifCsvAdapter.columns)?.name)
+        assertEquals("QIF", strategies.selectForQifContent(genericRows, QifCsvAdapter.columns)?.name)
+    }
+
+    /** The new (counterparty) account discovered on the target side, regardless of flip. */
+    private fun newTargetName(r: MappingResult.Success): String {
+        assertTrue(r.newAccounts.isNotEmpty(), "expected a discovered counterparty account")
+        return r.newAccounts.first().name
+    }
+}

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/qif/SantanderQifE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/qif/SantanderQifE2ETest.kt
@@ -1,0 +1,214 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.database.qif
+
+import com.moneymanager.domain.Maintenance
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AuditType
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.qif.QifImport
+import com.moneymanager.domain.model.qif.QifImportRecord
+import com.moneymanager.qifimporter.bulkApplyQif
+import com.moneymanager.test.database.DbTest
+import com.moneymanager.test.database.createAccount
+import com.moneymanager.test.database.upsertCurrencyByCode
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.time.Clock
+import kotlin.time.Duration
+
+/**
+ * End-to-end regression guard for the Santander QIF import. Drives the full pipeline (auto-detect the
+ * seeded Santander strategy, parse Payee sub-components, pre-create counterparty accounts, run the
+ * import engine) and asserts the account explosion is gone: one source account + one account per
+ * distinct clean counterparty (not one per transaction), with person-to-person payees additionally
+ * modelled as People + ownership links. Re-importing the same file produces only duplicates.
+ */
+class SantanderQifE2ETest : DbTest() {
+    private val now = Clock.System.now()
+
+    // Maintenance is a thin domain interface; the entities asserted here don't depend on view refresh.
+    private val maintenance =
+        object : Maintenance {
+            override suspend fun reindex(): Duration = Duration.ZERO
+
+            override suspend fun vacuum(): Duration = Duration.ZERO
+
+            override suspend fun analyze(): Duration = Duration.ZERO
+
+            override suspend fun refreshMaterializedViews(): Duration = Duration.ZERO
+
+            override suspend fun fullRefreshMaterializedViews(): Duration = Duration.ZERO
+        }
+
+    private suspend fun createImport(): QifImport {
+        // Two VANGUARD rows prove merchant consolidation; three person payees prove Person creation.
+        val records =
+            listOf(
+                rec(0, "27/03/2021", "-7.32", "CARD PAYMENT TO VANGUARD,7.32 GBP, RATE 1.00/GBP ON 27-03-2021, 7.32"),
+                rec(1, "28/03/2021", "-10.00", "CARD PAYMENT TO VANGUARD,10.00 GBP, RATE 1.00/GBP ON 28-03-2021, 10.00"),
+                rec(
+                    2,
+                    "01/03/2021",
+                    "-1352.23",
+                    "DIRECT DEBIT PAYMENT TO AMERICAN EXPRESS REF 3746-935125-04002, MANDATE NO 0013, 1352.23",
+                ),
+                rec(3, "02/03/2021", "250.00", "FASTER PAYMENTS RECEIPT REF.OLGA FROM ZAKHARENKO O, 250.00"),
+                rec(4, "03/03/2021", "1000.00", "FASTER PAYMENTS RECEIPT  FROM NIKOLAY METCHEV, 1000.00"),
+                rec(
+                    5,
+                    "04/03/2021",
+                    "-27.00",
+                    "BILL PAYMENT VIA FASTER PAYMENT TO JASMINA KRUMOVA REFERENCE CLEANING , MANDATE NO 1, 27.00",
+                ),
+            )
+        val id =
+            repositories.qifImportRepository.createImport(
+                fileName = "santander.qif",
+                records = records,
+                accountType = "BANK",
+                fileChecksum = "santander-checksum",
+                fileLastModified = now,
+            )
+        return repositories.qifImportRepository.getImport(id).first()!!
+    }
+
+    private fun rec(
+        index: Long,
+        date: String,
+        amount: String,
+        payee: String,
+    ) = QifImportRecord(
+        recordIndex = index,
+        sectionType = "BANK",
+        accountName = "Santander",
+        supported = true,
+        rawText = "",
+        date = date,
+        amount = amount,
+        payee = payee,
+    )
+
+    private suspend fun apply(qifImport: QifImport) {
+        val currencyId = repositories.currencyRepository.upsertCurrencyByCode("GBP", "British Pound")
+        val sourceId =
+            repositories.accountRepository
+                .getAllAccounts()
+                .first()
+                .firstOrNull { it.name == "Santander" }
+                ?.id
+                ?: repositories.accountRepository.createAccount(Account(id = AccountId(0), name = "Santander", openingDate = now))
+        bulkApplyQif(
+            imports = listOf(qifImport),
+            sourceAccountId = sourceId,
+            currencyId = currencyId,
+            strategies = repositories.csvImportStrategyRepository.getAllStrategies().first(),
+            currencies = repositories.currencyRepository.getAllCurrencies().first(),
+            csvAccountMappingRepository = repositories.csvAccountMappingRepository,
+            accountRepository = repositories.accountRepository,
+            qifImportRepository = repositories.qifImportRepository,
+            attributeTypeRepository = repositories.attributeTypeRepository,
+            maintenance = maintenance,
+            importEngine = repositories.importEngine,
+            onProgress = { _, _ -> },
+        )
+    }
+
+    @Test
+    fun santanderImport_consolidatesCounterparties_andModelsPeople() =
+        runTest {
+            apply(createImport())
+
+            val accounts =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .map { it.name }
+                    .toSet()
+            // One source account + one account per DISTINCT clean counterparty — not one per record.
+            assertEquals(
+                setOf("Santander", "VANGUARD", "AMERICAN EXPRESS", "ZAKHARENKO O", "NIKOLAY METCHEV", "JASMINA KRUMOVA"),
+                accounts,
+            )
+
+            // Person-to-person payees become People; merchants/institutions do not.
+            val people =
+                repositories.personRepository
+                    .getAllPeople()
+                    .first()
+                    .map { it.firstName to it.lastName }
+                    .toSet()
+            assertEquals(
+                setOf("ZAKHARENKO" to "O", "NIKOLAY" to "METCHEV", "JASMINA" to "KRUMOVA"),
+                people,
+            )
+
+            // Each person owns their counterparty account.
+            assertEquals(
+                3,
+                repositories.personAccountOwnershipRepository
+                    .getAllOwnerships()
+                    .first()
+                    .size,
+            )
+
+            // Each person's creation source links back to the exact originating QIF record, so the
+            // audit UI can navigate to that row (not just the file).
+            for (person in repositories.personRepository.getAllPeople().first()) {
+                val insert =
+                    repositories.auditRepository
+                        .getAuditHistoryForPerson(person.id)
+                        .first { it.auditType == AuditType.INSERT }
+                val source = insert.source?.source
+                assertIs<Source.Qif>(source, "person ${person.fullName} should have a QIF source")
+                assertNotNull(source.recordIndex, "person ${person.fullName} should link to a specific QIF record")
+            }
+        }
+
+    @Test
+    fun reimportingSameFile_producesOnlyDuplicates() =
+        runTest {
+            val qifImport = createImport()
+            apply(qifImport)
+            val accountsAfterFirst =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .size
+            val peopleAfterFirst =
+                repositories.personRepository
+                    .getAllPeople()
+                    .first()
+                    .size
+
+            // Re-apply the same import: the engine dedups transfers, accounts (by name) and people (by name key).
+            apply(repositories.qifImportRepository.getImport(qifImport.id).first()!!)
+
+            assertEquals(
+                accountsAfterFirst,
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .size,
+            )
+            assertEquals(
+                peopleAfterFirst,
+                repositories.personRepository
+                    .getAllPeople()
+                    .first()
+                    .size,
+            )
+            assertEquals(
+                3,
+                repositories.personAccountOwnershipRepository
+                    .getAllOwnerships()
+                    .first()
+                    .size,
+            )
+        }
+}

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/qif/SantanderQifE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/qif/SantanderQifE2ETest.kt
@@ -12,7 +12,6 @@ import com.moneymanager.domain.model.qif.QifImportRecord
 import com.moneymanager.qifimporter.bulkApplyQif
 import com.moneymanager.test.database.DbTest
 import com.moneymanager.test.database.createAccount
-import com.moneymanager.test.database.upsertCurrencyByCode
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -95,7 +94,6 @@ class SantanderQifE2ETest : DbTest() {
     )
 
     private suspend fun apply(qifImport: QifImport) {
-        val currencyId = repositories.currencyRepository.upsertCurrencyByCode("GBP", "British Pound")
         val sourceId =
             repositories.accountRepository
                 .getAllAccounts()
@@ -106,7 +104,6 @@ class SantanderQifE2ETest : DbTest() {
         bulkApplyQif(
             imports = listOf(qifImport),
             sourceAccountId = sourceId,
-            currencyId = currencyId,
             strategies = repositories.csvImportStrategyRepository.getAllStrategies().first(),
             currencies = repositories.currencyRepository.getAllCurrencies().first(),
             csvAccountMappingRepository = repositories.csvAccountMappingRepository,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/AttributeColumnMapping.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/AttributeColumnMapping.kt
@@ -11,11 +11,20 @@ import kotlinx.serialization.Serializable
  *                            This will be resolved to or created as an AttributeType in the database.
  * @property isUniqueIdentifier If true, this column is used to detect duplicate transactions across
  *                             multiple CSV imports. When multiple columns are marked as unique identifiers,
- *                             all must match for a duplicate to be detected.
+ *                             all must match for a duplicate to be detected. The duplicate-detection key
+ *                             always uses the whole column value, independent of [extraction].
+ * @property extraction When set, the attribute value is a capture group extracted from the column
+ *                      (see [ColumnExtraction]) rather than the whole column value; if the pattern
+ *                      does not match, the attribute is omitted for that row.
+ * @property emitWhenMatched When set (and [extraction] matches), this fixed value is emitted as the
+ *                           attribute value instead of the extracted text. Lets a label such as
+ *                           `CARD_PAYMENT` be tagged whenever a transaction-type pattern matches.
  */
 @Serializable
 data class AttributeColumnMapping(
     val columnName: String,
     val attributeTypeName: String,
     val isUniqueIdentifier: Boolean = false,
+    val extraction: ColumnExtraction? = null,
+    val emitWhenMatched: String? = null,
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategy.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategy.kt
@@ -2,7 +2,21 @@
 
 package com.moneymanager.domain.model.csvstrategy
 
+import kotlinx.serialization.Serializable
 import kotlin.time.Instant
+
+/**
+ * A content-based match rule used to auto-detect a strategy from the data itself, for sources whose
+ * column set is fixed and therefore cannot distinguish formats (e.g. QIF, where every file has the
+ * same columns). A strategy is a content match for a file when a sampled row has a value in
+ * [columnName] matching [pattern] (case-insensitively). A strategy with no content rules never
+ * positively content-matches and so acts as the fallback.
+ */
+@Serializable
+data class ContentMatchRule(
+    val columnName: String,
+    val pattern: String,
+)
 
 /**
  * Represents a reusable CSV import strategy that defines how to map CSV columns
@@ -17,6 +31,8 @@ import kotlin.time.Instant
  *                                 before field mappings run (see [RowPreprocessingRule])
  * @property companionTransactionRules Rules flagging imported transfers that require a manually
  *                                     entered companion transaction (see [CompanionTransactionRule])
+ * @property contentMatchRules Rules that auto-detect this strategy from row content when the column
+ *                             set is fixed and cannot distinguish formats (see [ContentMatchRule]).
  * @property createdAt Timestamp when this strategy was created
  * @property updatedAt Timestamp when this strategy was last modified
  */
@@ -28,6 +44,7 @@ data class CsvImportStrategy(
     val attributeMappings: List<AttributeColumnMapping> = emptyList(),
     val rowPreprocessingRules: List<RowPreprocessingRule> = emptyList(),
     val companionTransactionRules: List<CompanionTransactionRule> = emptyList(),
+    val contentMatchRules: List<ContentMatchRule> = emptyList(),
     val createdAt: Instant,
     val updatedAt: Instant,
 ) {

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
@@ -62,12 +62,33 @@ data class AccountLookupMapping(
 }
 
 /**
- * A single regex rule that maps matched values to a specific account name.
+ * A reusable regex extraction: a [pattern] matched (case-insensitively) against a column value, and
+ * an [outputTemplate] producing the result from the match. Templates support `$0` (the whole match),
+ * `$1`..`$9` (numbered groups) and `${name}` (named groups). When the pattern does not match the
+ * caller decides the fallback. Used by regex account rules, attribute mappings and the description
+ * mapping so capture-group extraction lives in one place.
+ */
+@Serializable
+data class ColumnExtraction(
+    val pattern: String,
+    val outputTemplate: String = "$0",
+)
+
+/**
+ * A single regex rule that maps matched values to an account name.
+ *
+ * When [accountNameTemplate] is null the fixed [accountName] is used (the original behaviour). When
+ * set, the matched value is run through capture-group substitution (see [ColumnExtraction]) to derive
+ * the account name from the matched text — e.g. pattern `CARD PAYMENT TO (?<cp>.+?),` with template
+ * `${cp}` extracts the counterparty. [counterpartyIsPerson] marks the resolved counterparty as a
+ * person, so the import additionally creates a Person + ownership link rather than just an account.
  */
 @Serializable
 data class RegexRule(
     val pattern: String,
     val accountName: String,
+    val accountNameTemplate: String? = null,
+    val counterpartyIsPerson: Boolean = false,
 )
 
 /**
@@ -154,6 +175,10 @@ data class DateTimeParsingMapping(
  *
  * When [fallbackColumns] is specified, if the primary [columnName] is empty,
  * each fallback column is tried in order until a non-empty value is found.
+ *
+ * When [extraction] is set, the resolved column value is run through it to derive a cleaned
+ * description (e.g. stripping a trailing amount); if the pattern does not match, the raw value is
+ * kept so nothing is lost.
  */
 @Serializable
 data class DirectColumnMapping(
@@ -161,6 +186,7 @@ data class DirectColumnMapping(
     override val fieldType: TransferField,
     val columnName: String,
     val fallbackColumns: List<String> = emptyList(),
+    val extraction: ColumnExtraction? = null,
 ) : FieldMapping {
     /**
      * Returns all columns to check in priority order (primary first, then fallbacks).

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExport.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExport.kt
@@ -2,7 +2,9 @@ package com.moneymanager.domain.model.csvstrategy.export
 
 import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
+import com.moneymanager.domain.model.csvstrategy.ColumnExtraction
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
+import com.moneymanager.domain.model.csvstrategy.ContentMatchRule
 import com.moneymanager.domain.model.csvstrategy.RegexRule
 import com.moneymanager.domain.model.csvstrategy.RowCondition
 import com.moneymanager.domain.model.csvstrategy.RowPreprocessingRule
@@ -32,6 +34,7 @@ data class CsvStrategyExport(
     val accountMappings: List<CsvAccountMappingExport> = emptyList(),
     val rowPreprocessingRules: List<RowPreprocessingRule> = emptyList(),
     val companionTransactionRules: List<CompanionTransactionRule> = emptyList(),
+    val contentMatchRules: List<ContentMatchRule> = emptyList(),
 )
 
 /**
@@ -143,6 +146,7 @@ data class DirectColumnExport(
     override val fieldType: TransferField,
     val columnName: String,
     val fallbackColumns: List<String> = emptyList(),
+    val extraction: ColumnExtraction? = null,
 ) : FieldMappingExport
 
 /**

--- a/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifImportApplier.kt
+++ b/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifImportApplier.kt
@@ -16,6 +16,7 @@ import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.model.csv.ImportStatus
 import com.moneymanager.domain.model.csvstrategy.CsvAccountMapping
@@ -32,8 +33,13 @@ import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.DedupePolicy
 import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.ImportOwnershipIntent
+import com.moneymanager.importengineapi.ImportPersonIntent
 import com.moneymanager.importengineapi.ImportRowKey
 import com.moneymanager.importengineapi.ImportTransfer
+import com.moneymanager.importengineapi.LocalPersonKey
+import com.moneymanager.importengineapi.PersonMatchKey
+import com.moneymanager.importengineapi.normalizeNameKey
 import kotlinx.coroutines.flow.first
 import org.lighthousegames.logging.logging
 import kotlin.time.Clock
@@ -57,6 +63,50 @@ data class QifBulkResult(
 fun List<CsvImportStrategy>.qifCompatible(): List<CsvImportStrategy> {
     val qifHeaders = QifCsvAdapter.headers.toSet()
     return filter { it.identificationColumns.isNotEmpty() && it.identificationColumns.all { col -> col in qifHeaders } }
+}
+
+/** Number of leading rows sampled when content-matching a QIF file against a strategy. */
+private const val QIF_CONTENT_SAMPLE_SIZE = 50
+
+/**
+ * Picks the QIF strategy whose [CsvImportStrategy.contentMatchRules] best fit the given [rows], so a
+ * bank-specific strategy is auto-detected from the data (QIF's fixed columns can't distinguish banks).
+ * A strategy with no content rules acts as the fallback: when nothing positively matches, the
+ * rule-less strategy is returned. Ties are broken deterministically by score, then name, then id.
+ * Returns null only when the receiver is empty.
+ */
+fun List<CsvImportStrategy>.selectForQifContent(
+    rows: List<CsvRow>,
+    columns: List<CsvColumn>,
+): CsvImportStrategy? {
+    if (isEmpty()) return null
+    val indexByName = columns.associate { it.originalName to it.columnIndex }
+    val sample = rows.take(QIF_CONTENT_SAMPLE_SIZE)
+
+    fun CsvImportStrategy.contentScore(): Int {
+        if (contentMatchRules.isEmpty()) return 0
+        val compiled = contentMatchRules.map { it.columnName to Regex(it.pattern, RegexOption.IGNORE_CASE) }
+        return sample.count { row ->
+            compiled.any { (columnName, regex) ->
+                val idx = indexByName[columnName] ?: return@any false
+                row.values.getOrNull(idx)?.let { regex.containsMatchIn(it) } == true
+            }
+        }
+    }
+
+    val byScore =
+        compareByDescending<Pair<CsvImportStrategy, Int>> { it.second }
+            .thenBy { it.first.name }
+            .thenBy { it.first.id.toString() }
+    val best =
+        map { it to it.contentScore() }
+            .filter { it.second > 0 }
+            .minWithOrNull(byScore)
+    if (best != null) return best.first
+
+    return filter { it.contentMatchRules.isEmpty() }
+        .minWithOrNull(compareBy({ it.name }, { it.id.toString() }))
+        ?: first()
 }
 
 /**
@@ -88,16 +138,18 @@ suspend fun bulkApplyQif(
 
     imports.forEachIndexed { index, qifImport ->
         onProgress(index, imports.size)
-        val matched = qifStrategies.firstOrNull()
-        if (matched == null) {
-            skippedNoStrategy++
-            return@forEachIndexed
-        }
         try {
             val count = qifImportRepository.countRecords(qifImport.id)
             val records = qifImportRepository.getImportRecords(qifImport.id, count.coerceAtLeast(1), 0)
             val rows = QifCsvAdapter.toRows(records)
             if (rows.isEmpty()) return@forEachIndexed
+
+            // Auto-detect the bank strategy from the file's content (Santander vs the generic fallback).
+            val matched = qifStrategies.selectForQifContent(rows, QifCsvAdapter.columns)
+            if (matched == null) {
+                skippedNoStrategy++
+                return@forEachIndexed
+            }
 
             val strategy = matched.withQifCurrency(currencyId)
             // Re-fetch accounts so payee accounts created by earlier files are seen.
@@ -286,10 +338,46 @@ suspend fun runImport(
                 attributes = attributesFor(row.attributes),
             )
         }
+    // Personal counterparties (resolved via person-flagged strategy rules) become People with an
+    // ownership link to their counterparty account, in addition to the account itself. The engine
+    // dedups people by name key and ownerships by (person, account), so repeats across rows/files and
+    // re-imports collapse.
+    val accountIdByName = latestAccounts.associate { it.name to it.id }
+    // The first QIF record that referenced each personal counterparty, so the person's audit source
+    // links back to the exact originating row (the engine writes ImportPersonIntent.source verbatim).
+    val firstRecordByPersonName =
+        finalPrep.validTransfers
+            .mapNotNull { row -> row.personalCounterpartyName?.takeIf(String::isNotBlank)?.let { it to row.rowIndex } }
+            .groupBy({ it.first }, { it.second })
+            .mapValues { (_, indexes) -> indexes.min() }
+    val personAccounts =
+        firstRecordByPersonName.keys
+            .mapNotNull { name -> accountIdByName[name]?.let { name to it } }
+    val peopleToCreate =
+        personAccounts.map { (name, _) ->
+            val parts = name.trim().split(Regex("\\s+"))
+            ImportPersonIntent(
+                key = LocalPersonKey(name),
+                match = PersonMatchKey.ByNameKey(normalizeNameKey(name)),
+                firstName = parts.first(),
+                lastName = parts.drop(1).joinToString(" ").ifBlank { null },
+                source = Source.Qif(qifImport.id, firstRecordByPersonName[name]),
+            )
+        }
+    val ownerships =
+        personAccounts.map { (name, accountId) ->
+            ImportOwnershipIntent(
+                personKey = LocalPersonKey(name),
+                account = AccountRef.Existing(accountId),
+                source = Source.Qif(qifImport.id, firstRecordByPersonName[name]),
+            )
+        }
     val batch =
         ImportBatch(
             transfers = importTransfers,
             dedupePolicy = DedupePolicy.FuzzyAllFields(),
+            peopleToCreate = peopleToCreate,
+            ownerships = ownerships,
         )
     val importResult = importEngine.import(batch)
 

--- a/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifImportApplier.kt
+++ b/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifImportApplier.kt
@@ -110,15 +110,16 @@ fun List<CsvImportStrategy>.selectForQifContent(
 }
 
 /**
- * Applies the matching QIF strategy to every [imports] file using a single [sourceAccountId] and
- * [currencyId]. Payee/counterparty accounts are auto-created with their detected names (no per-file
- * confirmation). Refreshes materialized views once at the end. Reports progress via [onProgress].
+ * Applies the matching QIF strategy to every [imports] file using a single [sourceAccountId]. The
+ * currency comes from each file's auto-detected strategy (QIF data has none, so the strategy's
+ * configured currency is authoritative), so there is no per-import currency prompt. Payee/counterparty
+ * accounts are auto-created with their detected names (no per-file confirmation). Refreshes
+ * materialized views once at the end. Reports progress via [onProgress].
  */
 @Suppress("LongParameterList")
 suspend fun bulkApplyQif(
     imports: List<QifImport>,
     sourceAccountId: AccountId,
-    currencyId: CurrencyId,
     strategies: List<CsvImportStrategy>,
     currencies: List<Currency>,
     csvAccountMappingRepository: CsvAccountMappingRepository,
@@ -151,7 +152,8 @@ suspend fun bulkApplyQif(
                 return@forEachIndexed
             }
 
-            val strategy = matched.withQifCurrency(currencyId)
+            // The strategy's own (configured) currency is used — no per-import override.
+            val strategy = matched
             // Re-fetch accounts so payee accounts created by earlier files are seen.
             val accounts = accountRepository.getAllAccounts().first()
             val mappings = csvAccountMappingRepository.getMappingsForStrategy(matched.id).first()

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -670,6 +670,12 @@ fun MoneyManagerApp(
                                                 ),
                                             )
                                         },
+                                        onCsvSourceClick = { importId, rowIndex ->
+                                            navigationHistory.navigateTo(Screen.CsvImportDetail(importId, rowIndex))
+                                        },
+                                        onQifSourceClick = { importId, recordIndex ->
+                                            navigationHistory.navigateTo(Screen.QifImportDetail(importId, recordIndex))
+                                        },
                                         onBack = { navigationHistory.navigateBack() },
                                     )
                                 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -538,6 +538,7 @@ fun MoneyManagerApp(
                                     CsvStrategiesScreen(
                                         csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
                                         csvImportRepository = services.imports.csvImportRepository,
+                                        qifImportRepository = services.imports.qifImportRepository,
                                         csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
                                         accountRepository = services.accounts.accountRepository,
                                         categoryRepository = services.accounts.categoryRepository,
@@ -549,6 +550,9 @@ fun MoneyManagerApp(
                                         onBack = { navigationHistory.navigateBack() },
                                         onEditStrategy = { strategyId, importId ->
                                             navigationHistory.navigateTo(Screen.CsvStrategyEditor(importId, strategyId))
+                                        },
+                                        onEditQifStrategy = { strategyId, qifImportId ->
+                                            navigationHistory.navigateTo(Screen.QifStrategyEditor(qifImportId, strategyId))
                                         },
                                         onAuditHistoryClick = { strategy ->
                                             navigationHistory.navigateTo(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PersonAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PersonAuditScreen.kt
@@ -22,6 +22,8 @@ import com.moneymanager.domain.model.PersonAttributeAuditEntry
 import com.moneymanager.domain.model.PersonAuditEntry
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.SourceRecord
+import com.moneymanager.domain.model.csv.CsvImportId
+import com.moneymanager.domain.model.qif.QifImportId
 import com.moneymanager.domain.repository.AuditRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.ui.audit.AuditDiffCard
@@ -40,6 +42,8 @@ fun PersonAuditScreen(
     auditRepository: AuditRepository,
     personRepository: PersonRepository,
     onApiSourceClick: (ApiSessionId, ApiRequestId, String) -> Unit = { _, _, _ -> },
+    onCsvSourceClick: (CsvImportId, Long) -> Unit = { _, _ -> },
+    onQifSourceClick: (QifImportId, Long?) -> Unit = { _, _ -> },
     onBack: () -> Unit,
 ) {
     AuditScreen(
@@ -57,7 +61,7 @@ fun PersonAuditScreen(
         },
         diffKey = { it.id },
         onBack = onBack,
-        diffCard = { diff -> PersonAuditDiffCard(diff, onApiSourceClick) },
+        diffCard = { diff -> PersonAuditDiffCard(diff, onApiSourceClick, onCsvSourceClick, onQifSourceClick) },
     )
 }
 
@@ -153,6 +157,8 @@ private fun computePersonAuditDiffs(
 private fun PersonAuditDiffCard(
     diff: PersonAuditDiff,
     onApiSourceClick: (ApiSessionId, ApiRequestId, String) -> Unit = { _, _, _ -> },
+    onCsvSourceClick: (CsvImportId, Long) -> Unit = { _, _ -> },
+    onQifSourceClick: (QifImportId, Long?) -> Unit = { _, _ -> },
 ) {
     AuditDiffCard(
         auditType = diff.auditType,
@@ -170,7 +176,12 @@ private fun PersonAuditDiffCard(
                 FieldValueRow("Middle Name", diff.middleName.value() ?: "(none)")
                 FieldValueRow("Last Name", diff.lastName.value() ?: "(none)")
                 PersonAttributeChangesSection(diff.attributeChanges)
-                SourceInfoSection(diff.source, onApiSourceClick = onApiSourceClick)
+                SourceInfoSection(
+                    diff.source,
+                    onApiSourceClick = onApiSourceClick,
+                    onCsvSourceClick = onCsvSourceClick,
+                    onQifSourceClick = onQifSourceClick,
+                )
             }
             AuditType.UPDATE -> {
                 if (!diff.hasChanges) {
@@ -207,7 +218,12 @@ private fun PersonAuditDiffCard(
                     }
                     PersonAttributeChangesSection(diff.attributeChanges)
                 }
-                SourceInfoSection(diff.source, onApiSourceClick = onApiSourceClick)
+                SourceInfoSection(
+                    diff.source,
+                    onApiSourceClick = onApiSourceClick,
+                    onCsvSourceClick = onCsvSourceClick,
+                    onQifSourceClick = onQifSourceClick,
+                )
             }
             AuditType.DELETE -> {
                 val errorColor = MaterialTheme.colorScheme.error
@@ -220,7 +236,13 @@ private fun PersonAuditDiffCard(
                 FieldValueRow("Middle Name", diff.middleName.value() ?: "(none)", errorColor)
                 FieldValueRow("Last Name", diff.lastName.value() ?: "(none)", errorColor)
                 PersonAttributeChangesSection(diff.attributeChanges, errorColor)
-                SourceInfoSection(diff.source, labelColor = errorColor.copy(alpha = 0.8f), onApiSourceClick = onApiSourceClick)
+                SourceInfoSection(
+                    diff.source,
+                    labelColor = errorColor.copy(alpha = 0.8f),
+                    onApiSourceClick = onApiSourceClick,
+                    onCsvSourceClick = onCsvSourceClick,
+                    onQifSourceClick = onQifSourceClick,
+                )
             }
         }
     }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
@@ -49,6 +49,7 @@ import com.moneymanager.domain.model.AppVersion
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.model.qif.QifImportId
 import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CsvAccountMappingRepository
@@ -57,6 +58,8 @@ import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
+import com.moneymanager.domain.repository.QifImportRepository
+import com.moneymanager.qifimporter.QifCsvAdapter
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -66,6 +69,7 @@ import nl.jacobras.humanreadable.HumanReadable
 fun CsvStrategiesScreen(
     csvImportStrategyRepository: CsvImportStrategyRepository,
     csvImportRepository: CsvImportRepository,
+    qifImportRepository: QifImportRepository,
     csvAccountMappingRepository: CsvAccountMappingRepository,
     accountRepository: AccountRepository,
     categoryRepository: CategoryRepository,
@@ -77,15 +81,17 @@ fun CsvStrategiesScreen(
     onStrategyClick: (CsvImportStrategy) -> Unit = {},
     onBack: () -> Unit = {},
     onEditStrategy: (CsvImportStrategyId, CsvImportId) -> Unit = { _, _ -> },
+    onEditQifStrategy: (CsvImportStrategyId, QifImportId) -> Unit = { _, _ -> },
     onAuditHistoryClick: (CsvImportStrategy) -> Unit = {},
 ) {
     val strategies by csvImportStrategyRepository
         .getAllStrategies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
-    // Edit flow state: pick a CSV to edit the strategy against, then navigate to the editor screen.
+    // Edit flow state: pick a sample file to edit the strategy against, then navigate to the editor.
+    // QIF strategies (columns are the fixed QIF fields) need a QIF file as sample data, not a CSV one.
     var strategyToEdit by remember { mutableStateOf<CsvImportStrategy?>(null) }
-    var showSelectCsvDialog by remember { mutableStateOf(false) }
+    var showSelectFileDialog by remember { mutableStateOf(false) }
 
     // Export state
     var strategyPendingExportPrompt by remember { mutableStateOf<CsvImportStrategy?>(null) }
@@ -253,7 +259,7 @@ fun CsvStrategiesScreen(
                                 onEditClick = {
                                     onStrategyClick(strategy)
                                     strategyToEdit = strategy
-                                    showSelectCsvDialog = true
+                                    showSelectFileDialog = true
                                 },
                                 onExportClick = {
                                     strategyPendingExportPrompt = strategy
@@ -288,21 +294,34 @@ fun CsvStrategiesScreen(
         )
     }
 
-    // Show CSV import selector dialog, then navigate to the editor screen for the chosen CSV.
+    // Show the sample-file selector, then navigate to the editor. QIF strategies (whose identification
+    // columns are exactly the fixed QIF fields) pick a QIF file and route to the QIF editor; all other
+    // strategies pick a CSV file.
     val editingStrategy = strategyToEdit
-    if (showSelectCsvDialog && editingStrategy != null) {
-        SelectCsvImportDialog(
-            csvImportRepository = csvImportRepository,
-            onCsvSelected = { csvImport ->
-                showSelectCsvDialog = false
-                strategyToEdit = null
-                onEditStrategy(editingStrategy.id, csvImport.id)
-            },
-            onDismiss = {
-                showSelectCsvDialog = false
-                strategyToEdit = null
-            },
-        )
+    if (showSelectFileDialog && editingStrategy != null) {
+        val dismiss = {
+            showSelectFileDialog = false
+            strategyToEdit = null
+        }
+        if (editingStrategy.isQifStrategy()) {
+            SelectQifImportDialog(
+                qifImportRepository = qifImportRepository,
+                onQifSelected = { qifImport ->
+                    dismiss()
+                    onEditQifStrategy(editingStrategy.id, qifImport.id)
+                },
+                onDismiss = dismiss,
+            )
+        } else {
+            SelectCsvImportDialog(
+                csvImportRepository = csvImportRepository,
+                onCsvSelected = { csvImport ->
+                    dismiss()
+                    onEditStrategy(editingStrategy.id, csvImport.id)
+                },
+                onDismiss = dismiss,
+            )
+        }
     }
 
     // Show import dialog when a strategy file has been parsed
@@ -419,3 +438,10 @@ fun CsvStrategyCard(
         )
     }
 }
+
+/**
+ * A QIF strategy is a CSV strategy whose identification columns are (a non-empty subset of) the fixed
+ * QIF fields, so it is edited against a QIF file rather than a CSV one.
+ */
+private fun CsvImportStrategy.isQifStrategy(): Boolean =
+    identificationColumns.isNotEmpty() && identificationColumns.all { it in QifCsvAdapter.headers }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/StrategyDialogs.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/StrategyDialogs.kt
@@ -34,8 +34,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.model.qif.QifImport
 import com.moneymanager.domain.repository.CsvImportRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
+import com.moneymanager.domain.repository.QifImportRepository
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.launch
@@ -248,6 +250,100 @@ fun SelectCsvImportDialog(
                                 )
                                 Text(
                                     text = "Imported ${HumanReadable.timeAgo(csvImport.importTimestamp)}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}
+
+/**
+ * Dialog for selecting a QIF import to use as sample data when editing a QIF strategy. QIF strategies
+ * are CSV strategies over the fixed QIF columns, so they need QIF (not CSV) files as their sample data.
+ */
+@Composable
+fun SelectQifImportDialog(
+    qifImportRepository: QifImportRepository,
+    onQifSelected: (QifImport) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val imports by qifImportRepository
+        .getAllImports()
+        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Select QIF File") },
+        text = {
+            if (imports.isEmpty()) {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 100.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = "No QIF files available",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "Import a QIF file first to use as sample data",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            } else {
+                LazyColumn(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 400.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(imports) { qifImport ->
+                        Card(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable { onQifSelected(qifImport) },
+                            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+                        ) {
+                            Column(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(12.dp),
+                            ) {
+                                Text(
+                                    text = qifImport.originalFileName,
+                                    style = MaterialTheme.typography.titleSmall,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = "${qifImport.recordCount} records",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Text(
+                                    text = "Imported ${HumanReadable.timeAgo(qifImport.importTimestamp)}",
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifApplyStrategyDialog.kt
@@ -49,6 +49,7 @@ import com.moneymanager.qifimporter.QifCsvAdapter
 import com.moneymanager.qifimporter.QifImportResult
 import com.moneymanager.qifimporter.buildMapper
 import com.moneymanager.qifimporter.runImport
+import com.moneymanager.qifimporter.selectForQifContent
 import com.moneymanager.qifimporter.withQifCurrency
 import com.moneymanager.ui.components.AccountPicker
 import com.moneymanager.ui.components.CurrencyPicker
@@ -142,9 +143,11 @@ fun QifApplyStrategyDialog(
         }
     }
 
-    LaunchedEffect(qifStrategies) {
+    LaunchedEffect(qifStrategies, rows) {
         if (selectedStrategy == null) {
-            selectedStrategy = qifStrategies.firstOrNull()
+            // Auto-detect the bank strategy from the file's content (e.g. Santander), with the generic
+            // QIF strategy as the fallback. The user can still override via the selector below.
+            selectedStrategy = qifStrategies.selectForQifContent(rows, QifCsvAdapter.columns)
         }
     }
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.AccountId
-import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.qif.QifImport
 import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.AttributeTypeRepository
@@ -33,7 +32,6 @@ import com.moneymanager.domain.repository.SettingsRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.qifimporter.bulkApplyQif
 import com.moneymanager.ui.components.AccountPicker
-import com.moneymanager.ui.components.CurrencyPicker
 import com.moneymanager.ui.components.LoadingTextButton
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -42,11 +40,11 @@ import kotlinx.coroutines.launch
 
 /**
  * Applies the matching QIF strategy to every unimported file in one go, using a single source account
- * and currency chosen here. The source account defaults to (and is remembered as) the last account
- * used for QIF imports. Payee accounts auto-create with their detected names.
+ * chosen here. The currency is taken from each file's auto-detected strategy (so there is no currency
+ * prompt). The source account defaults to (and is remembered as) the last account used for QIF imports.
+ * Payee accounts auto-create with their detected names.
  */
 @Composable
-// Shares the single-file QIF apply flow's source-account/currency selection by design.
 @Suppress("LongParameterList", "LongMethod", "DuplicatedCode")
 fun QifImportAllDialog(
     unimported: List<QifImport>,
@@ -71,7 +69,6 @@ fun QifImportAllDialog(
     val accounts by accountRepository.getAllAccounts().collectAsStateWithSchemaErrorHandling(emptyList())
 
     var sourceAccountId by remember { mutableStateOf<AccountId?>(null) }
-    var selectedCurrencyId by remember { mutableStateOf<CurrencyId?>(null) }
     var isImporting by remember { mutableStateOf(false) }
     var progress by remember { mutableStateOf<Pair<Int, Int>?>(null) }
     var summary by remember { mutableStateOf<String?>(null) }
@@ -80,12 +77,6 @@ fun QifImportAllDialog(
         if (sourceAccountId == null) {
             val last = settingsRepository.getLastQifAccountId().first()
             if (last != null && accounts.any { it.id == last }) sourceAccountId = last
-        }
-    }
-    LaunchedEffect(currencies) {
-        if (selectedCurrencyId == null && currencies.isNotEmpty()) {
-            val defaultId = settingsRepository.getDefaultCurrencyId().first()
-            selectedCurrencyId = defaultId?.takeIf { id -> currencies.any { it.id == id } } ?: currencies.firstOrNull()?.id
         }
     }
 
@@ -109,15 +100,6 @@ fun QifImportAllDialog(
                         enabled = !isImporting,
                         isError = sourceAccountId == null,
                     )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    CurrencyPicker(
-                        selectedCurrencyId = selectedCurrencyId,
-                        onCurrencySelected = { selectedCurrencyId = it },
-                        label = "Currency",
-                        currencyRepository = currencyRepository,
-                        enabled = !isImporting,
-                        isError = selectedCurrencyId == null,
-                    )
                     progress?.let { (done, total) ->
                         Spacer(modifier = Modifier.height(12.dp))
                         Text("Importing ${done.coerceAtMost(total)} of $total…", style = MaterialTheme.typography.bodySmall)
@@ -132,7 +114,6 @@ fun QifImportAllDialog(
                 LoadingTextButton(
                     onClick = {
                         val source = sourceAccountId ?: return@LoadingTextButton
-                        val currency = selectedCurrencyId ?: return@LoadingTextButton
                         isImporting = true
                         scope.launch {
                             try {
@@ -140,7 +121,6 @@ fun QifImportAllDialog(
                                     bulkApplyQif(
                                         imports = unimported,
                                         sourceAccountId = source,
-                                        currencyId = currency,
                                         strategies = strategies,
                                         currencies = currencies,
                                         csvAccountMappingRepository = csvAccountMappingRepository,
@@ -158,7 +138,7 @@ fun QifImportAllDialog(
                             }
                         }
                     },
-                    enabled = !isImporting && sourceAccountId != null && selectedCurrencyId != null,
+                    enabled = !isImporting && sourceAccountId != null,
                     loading = isImporting,
                     label = "Import ${unimported.size} files",
                 )


### PR DESCRIPTION
## Problem

QIF import mapped the entire Santander `Payee` field — which packs the whole transaction description (`DIRECT DEBIT PAYMENT TO AMERICAN EXPRESS REF …, MANDATE NO 0013, 1352.23`) — straight to a target account name. The result: the DB exploded into thousands of phantom "description-as-account" rows (~3,300 on the original import).

## Approach

Parse the description into sub-components **entirely via strategy config — no bank-specific code**. New generic, serializable features are added to the existing CSV/QIF strategy engine, and "Santander (QIF)" is seeded as data.

### New strategy config features
- **`ColumnExtraction(pattern, outputTemplate)`** — reusable regex capture-group extraction (`$0`/`$1`/`${name}`), via a shared `CsvTransferMapper` helper.
- **`RegexRule.accountNameTemplate`** — extract a clean counterparty from a capture group (null keeps the legacy fixed-name behaviour); **`counterpartyIsPerson`** flags person-to-person payees so the import also creates a `Person` + ownership link.
- **`AttributeColumnMapping.extraction` + `emitWhenMatched`** — pull transaction type / reference / mandate / posted date out of one column.
- **`DirectColumnMapping.extraction`** — clean description.
- **`CsvImportStrategy.contentMatchRules`** (+ `content_match_rules_json` column) with `selectForQifContent` for config-driven bank auto-detection; the generic QIF strategy (no content rules) stays the fallback.

All new fields default null/empty ⇒ **Wise/Monzo CSV imports are byte-for-byte unaffected**.

### Santander strategy (seeded as data)
`DatabaseConfig.buildSantanderQifStrategy`, tuned against a full ~7k-record statement history to **~99.9% coverage**: clean counterparty → account, type/reference/mandate/date → attributes, cash/cheque/interest/fees/cashback consolidated, giro-credit refs cleaned. Distinct accounts drop ~1,220 → ~435 on a real statement.

### People audit link
People created from QIF now carry the originating record index, so the person audit screen links back to the **exact source row** (handlers wired through `PersonAuditScreen` + `MoneyManagerApp`).

## Tests
- `SantanderQifMapperTest` — config-level parsing of every pattern + person flag + content selection + fallback.
- `SantanderQifE2ETest` — full pipeline: account consolidation, People + ownership, per-row source provenance, re-import → duplicates.
- Export round-trip + full `./gradlew build` (tests, detekt, ktlint, buildHealth, kover) green; `verifyNoDbDependency` confirms importer modules stay DB-free.

## Note
The database is recreated from scratch on schema changes (BETA, no migrations), so the seeded Santander strategy and parsing take effect after a **wipe & re-import**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Santander QIF import strategy with automated merchant and payee extraction.
  * Implemented content-based auto-detection of import strategies based on file characteristics.
  * Added automatic peer-to-peer transfer detection that creates people entities for personal counterparties.
  * Enhanced CSV mapping with templated extraction for flexible transaction field parsing.

* **Tests**
  * Added test coverage for Santander QIF import workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->