### PR TITLE
Address CodeRabbit feedback on QIF person/ownership creation

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -883,7 +883,13 @@ class CsvTransferMapper(
         when (mapping) {
             is RegexAccountMapping -> {
                 val result = getAccountNameFromRegexWithPattern(mapping, values)
-                if (result.counterpartyIsPerson && result.accountName.isNotBlank()) result.accountName else null
+                when {
+                    !result.counterpartyIsPerson || result.accountName.isBlank() -> null
+                    // A persisted account mapping intentionally remaps this counterparty (e.g. onto an
+                    // existing account), so don't auto-create a Person/ownership from the regex name.
+                    findPersistedMapping(result.sourceColumnName, result.sourceColumnValue) != null -> null
+                    else -> result.accountName
+                }
             }
             is ConditionalAccountMapping -> resolvePersonalCounterparty(resolveConditional(mapping, values), values)
             else -> null

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/SantanderQifMapperTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/SantanderQifMapperTest.kt
@@ -10,6 +10,8 @@ import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.csv.CsvRow
+import com.moneymanager.domain.model.csvstrategy.CsvAccountMapping
+import com.moneymanager.domain.model.qif.QifColumns
 import com.moneymanager.qifimporter.QifCsvAdapter
 import com.moneymanager.qifimporter.qifCompatible
 import com.moneymanager.qifimporter.selectForQifContent
@@ -136,6 +138,40 @@ class SantanderQifMapperTest {
         assertEquals("SOME UNKNOWN NARRATIVE", newTargetName(r))
         assertNull(r.attrs()["santander-transaction-type"])
         assertNull(r.personalCounterpartyName)
+    }
+
+    @Test
+    fun `persisted account mapping suppresses person detection`() {
+        // A user-persisted mapping remaps the FASTER PAYMENTS counterparty onto an existing account.
+        val mapped = Account(id = AccountId(42), name = "My Savings", openingDate = now)
+        val mapping =
+            CsvAccountMapping(
+                id = 1L,
+                strategyId = strategy.id,
+                columnName = QifColumns.COL_PAYEE,
+                valuePattern = Regex("ZAKHARENKO O"),
+                accountId = mapped.id,
+                createdAt = now,
+                updatedAt = now,
+            )
+        val mapper =
+            CsvTransferMapper(
+                strategy = strategy,
+                columns = QifCsvAdapter.columns,
+                existingAccounts = mapOf(santander.name to santander, mapped.name to mapped),
+                existingCurrencies = mapOf(gbp.id to gbp),
+                existingCurrenciesByCode = mapOf(gbp.code to gbp),
+                accountMappings = listOf(mapping),
+                sourceAccountOverride = santander.id,
+            )
+        val r =
+            assertIs<MappingResult.Success>(
+                mapper.mapRow(row("FASTER PAYMENTS RECEIPT REF.OLGA FROM ZAKHARENKO O, 250.00", "250.00")),
+            )
+        // The persisted mapping overrode the counterparty, so no Person/ownership is created from the
+        // regex name, and no new account is discovered (it resolved to the mapped existing account).
+        assertNull(r.personalCounterpartyName)
+        assertTrue(r.newAccounts.isEmpty())
     }
 
     @Test

--- a/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifImportApplier.kt
+++ b/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifImportApplier.kt
@@ -344,34 +344,44 @@ suspend fun runImport(
     // ownership link to their counterparty account, in addition to the account itself. The engine
     // dedups people by name key and ownerships by (person, account), so repeats across rows/files and
     // re-imports collapse.
+    //
+    // The counterparty account id is read from the resolved transfer (the side that isn't the source
+    // account) rather than by name lookup, so a counterparty that resolved to an existing account with
+    // different casing/name still gets its Person + ownership. The value is paired with the first QIF
+    // record that referenced the person, so the person's audit source links back to that exact row
+    // (the engine writes ImportPersonIntent.source verbatim).
     val accountIdByName = latestAccounts.associate { it.name to it.id }
-    // The first QIF record that referenced each personal counterparty, so the person's audit source
-    // links back to the exact originating row (the engine writes ImportPersonIntent.source verbatim).
-    val firstRecordByPersonName =
-        finalPrep.validTransfers
-            .mapNotNull { row -> row.personalCounterpartyName?.takeIf(String::isNotBlank)?.let { it to row.rowIndex } }
-            .groupBy({ it.first }, { it.second })
-            .mapValues { (_, indexes) -> indexes.min() }
-    val personAccounts =
-        firstRecordByPersonName.keys
-            .mapNotNull { name -> accountIdByName[name]?.let { name to it } }
+    // name -> (counterparty account id, first referencing record index)
+    val personLinks = LinkedHashMap<String, Pair<AccountId, Long>>()
+    finalPrep.validTransfers.forEach { row ->
+        val name = row.personalCounterpartyName?.trim()?.takeIf { it.isNotEmpty() } ?: return@forEach
+        val counterpartyAccountId =
+            when (selectedSourceAccountId) {
+                row.transfer.sourceAccountId -> row.transfer.targetAccountId
+                row.transfer.targetAccountId -> row.transfer.sourceAccountId
+                else -> accountIdByName[name]
+            } ?: return@forEach
+        val previous = personLinks[name]
+        personLinks[name] =
+            (previous?.first ?: counterpartyAccountId) to minOf(previous?.second ?: row.rowIndex, row.rowIndex)
+    }
     val peopleToCreate =
-        personAccounts.map { (name, _) ->
-            val parts = name.trim().split(Regex("\\s+"))
+        personLinks.map { (name, link) ->
+            val parts = name.split(Regex("\\s+"))
             ImportPersonIntent(
                 key = LocalPersonKey(name),
                 match = PersonMatchKey.ByNameKey(normalizeNameKey(name)),
                 firstName = parts.first(),
                 lastName = parts.drop(1).joinToString(" ").ifBlank { null },
-                source = Source.Qif(qifImport.id, firstRecordByPersonName[name]),
+                source = Source.Qif(qifImport.id, link.second),
             )
         }
     val ownerships =
-        personAccounts.map { (name, accountId) ->
+        personLinks.map { (name, link) ->
             ImportOwnershipIntent(
                 personKey = LocalPersonKey(name),
-                account = AccountRef.Existing(accountId),
-                source = Source.Qif(qifImport.id, firstRecordByPersonName[name]),
+                account = AccountRef.Existing(link.first),
+                source = Source.Qif(qifImport.id, link.second),
             )
         }
     val batch =


### PR DESCRIPTION
Follow-up to #556 (merged) addressing CodeRabbit's two review comments on the QIF person/ownership logic.

## 1. Respect persisted account overrides when detecting persons
`CsvTransferMapper.resolvePersonalCounterparty` previously flagged a counterparty as a person based solely on the regex match. But account resolution can be overridden by a persisted `CsvAccountMapping`, so a user who intentionally remaps a counterparty (e.g. onto an existing account) could still get an incorrect `Person` + ownership created from the regex-derived name.

Now it returns null when a persisted mapping applies to the resolved column/value — mirroring the precedence already used by `parseAccount`/`discoverNewAccount`.

## 2. Don't drop person/ownership intents on a name mismatch
`QifImportApplier` looked up the counterparty account id by exact name in `latestAccounts`. If a counterparty resolved to an existing account with different casing/display name, the person intent was skipped even though the transfer already carried the resolved counterparty account id.

It now reads the counterparty account id directly from the resolved transfer (the side that isn't the source account), falling back to name lookup, and preserves the first-referencing record index for the audit source.

## Tests
- New `SantanderQifMapperTest` case: a persisted mapping suppresses person detection (no Person, no new account).
- Existing `SantanderQifMapperTest` / `SantanderQifE2ETest` still pass.
- Full `./gradlew build` (tests, detekt, ktlint, buildHealth, kover) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)