### PR TITLE
Multi-device cloud sync: change detection, Upload/Download, editing lock

### DIFF
--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -3,19 +3,25 @@
 package com.moneymanager.database.importer
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Category
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.importengineapi.AccountMatchKey
+import com.moneymanager.importengineapi.AccountMergeRequest
 import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.DedupePolicy
 import com.moneymanager.importengineapi.ImportAccountIntent
 import com.moneymanager.importengineapi.ImportBatch
+import com.moneymanager.importengineapi.ImportCategoryIntent
+import com.moneymanager.importengineapi.ImportOperation
 import com.moneymanager.importengineapi.ImportOwnershipIntent
 import com.moneymanager.importengineapi.ImportPersonIntent
 import com.moneymanager.importengineapi.ImportRowKey
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
+import com.moneymanager.importengineapi.LocalCategoryKey
 import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.importengineapi.PersonMatchKey
 import com.moneymanager.importer.ImportEngineImpl
@@ -25,6 +31,9 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.time.Instant
 
 class ImportEngineDbTest : DbTest() {
@@ -179,8 +188,8 @@ class ImportEngineDbTest : DbTest() {
                         ),
                     ownerships =
                         listOf(
-                            ImportOwnershipIntent(aliceKey, AccountRef.Existing(sourceId), source),
-                            ImportOwnershipIntent(bobKey, AccountRef.Existing(sourceId), source),
+                            ImportOwnershipIntent(personKey = aliceKey, account = AccountRef.Existing(sourceId), source = source),
+                            ImportOwnershipIntent(personKey = bobKey, account = AccountRef.Existing(sourceId), source = source),
                         ),
                 )
 
@@ -193,5 +202,263 @@ class ImportEngineDbTest : DbTest() {
             assertEquals(setOf("Alice Smith", "Bob Jones"), people.map { it.fullName }.toSet())
             val ownerships = repositories.personAccountOwnershipRepository.getOwnershipsByAccount(sourceId).first()
             assertEquals(2, ownerships.size)
+        }
+
+    @Test
+    fun categoryCreateUpdateDeleteViaImport() =
+        runTest {
+            val key = LocalCategoryKey("food")
+            val created =
+                engine().import(
+                    ImportBatch.manualEdits(
+                        categories = listOf(ImportCategoryIntent(key = key, source = Source.Manual, name = "Food")),
+                    ),
+                )
+            val id = created.createdCategoryIds.getValue(key)
+            assertTrue(
+                repositories.categoryRepository
+                    .getAllCategories()
+                    .first()
+                    .any { it.id == id && it.name == "Food" },
+            )
+
+            engine().import(
+                ImportBatch.manualEdits(
+                    categories =
+                        listOf(
+                            ImportCategoryIntent(
+                                key = key,
+                                source = Source.Manual,
+                                operation = ImportOperation.UPDATE,
+                                existingId = id,
+                                category = Category(id = id, name = "Groceries"),
+                            ),
+                        ),
+                ),
+            )
+            assertEquals(
+                "Groceries",
+                repositories.categoryRepository
+                    .getCategoryById(id)
+                    .first()
+                    ?.name,
+            )
+
+            engine().import(
+                ImportBatch.manualEdits(
+                    categories =
+                        listOf(
+                            ImportCategoryIntent(
+                                key = key,
+                                source = Source.Manual,
+                                operation = ImportOperation.DELETE,
+                                existingId = id,
+                            ),
+                        ),
+                ),
+            )
+            assertNull(repositories.categoryRepository.getCategoryById(id).first())
+        }
+
+    @Test
+    fun createAccountThenOwnByLocalKey() =
+        runTest {
+            val accountKey = LocalAccountKey("savings")
+            val personKey = LocalPersonKey("owner")
+            val result =
+                engine().import(
+                    ImportBatch.manualEdits(
+                        accounts =
+                            listOf(
+                                ImportAccountIntent(
+                                    key = accountKey,
+                                    source = Source.Manual,
+                                    name = "Savings",
+                                    openingDate = baseTime,
+                                ),
+                            ),
+                        people =
+                            listOf(
+                                ImportPersonIntent(key = personKey, source = Source.Manual, firstName = "Dana"),
+                            ),
+                        ownerships =
+                            listOf(
+                                ImportOwnershipIntent(
+                                    source = Source.Manual,
+                                    personKey = personKey,
+                                    account = AccountRef.Local(accountKey),
+                                ),
+                            ),
+                    ),
+                )
+            val accountId = result.createdAccountIds.getValue(accountKey)
+            val personId = result.createdPersonIds.getValue(personKey)
+            val ownerships = repositories.personAccountOwnershipRepository.getOwnershipsByAccount(accountId).first()
+            assertEquals(listOf(personId), ownerships.map { it.personId })
+        }
+
+    @Test
+    fun accountUpdateAndDeleteViaImport() =
+        runTest {
+            val key = LocalAccountKey("acct")
+            val accountId =
+                engine()
+                    .import(
+                        ImportBatch.manualEdits(
+                            accounts =
+                                listOf(
+                                    ImportAccountIntent(key = key, source = Source.Manual, name = "Old", openingDate = baseTime),
+                                ),
+                        ),
+                    ).createdAccountIds
+                    .getValue(key)
+
+            engine().import(
+                ImportBatch.manualEdits(
+                    accounts =
+                        listOf(
+                            ImportAccountIntent(
+                                key = key,
+                                source = Source.Manual,
+                                operation = ImportOperation.UPDATE,
+                                existingId = accountId,
+                                account =
+                                    repositories.accountRepository
+                                        .getAccountById(accountId)
+                                        .first()!!
+                                        .copy(name = "New"),
+                            ),
+                        ),
+                ),
+            )
+            assertEquals(
+                "New",
+                repositories.accountRepository
+                    .getAccountById(accountId)
+                    .first()
+                    ?.name,
+            )
+
+            engine().import(
+                ImportBatch.manualEdits(
+                    accounts =
+                        listOf(
+                            ImportAccountIntent(
+                                key = key,
+                                source = Source.Manual,
+                                operation = ImportOperation.DELETE,
+                                existingId = accountId,
+                            ),
+                        ),
+                ),
+            )
+            assertNull(repositories.accountRepository.getAccountById(accountId).first())
+        }
+
+    @Test
+    fun personDeleteViaImport() =
+        runTest {
+            val key = LocalPersonKey("p")
+            val personId: PersonId =
+                engine()
+                    .import(
+                        ImportBatch.manualEdits(
+                            people = listOf(ImportPersonIntent(key = key, source = Source.Manual, firstName = "Temp")),
+                        ),
+                    ).createdPersonIds
+                    .getValue(key)
+            assertTrue(
+                repositories.personRepository
+                    .getAllPeople()
+                    .first()
+                    .any { it.id == personId },
+            )
+
+            engine().import(
+                ImportBatch.manualEdits(
+                    people =
+                        listOf(
+                            ImportPersonIntent(
+                                key = key,
+                                source = Source.Manual,
+                                operation = ImportOperation.DELETE,
+                                existingId = personId,
+                            ),
+                        ),
+                ),
+            )
+            assertTrue(
+                repositories.personRepository
+                    .getAllPeople()
+                    .first()
+                    .none { it.id == personId },
+            )
+        }
+
+    @Test
+    fun accountMergeAndUnmergeViaImport() =
+        runTest {
+            val currency = gbp()
+            val keepKey = LocalAccountKey("keep")
+            val dropKey = LocalAccountKey("drop")
+            val funded = LocalAccountKey("funded")
+            // Create two accounts plus one transfer into the dropped account, so the merge reassigns it.
+            val created =
+                engine().import(
+                    ImportBatch.manualEdits(
+                        accounts =
+                            listOf(
+                                ImportAccountIntent(key = keepKey, source = Source.Manual, name = "Keep", openingDate = baseTime),
+                                ImportAccountIntent(key = dropKey, source = Source.Manual, name = "Drop", openingDate = baseTime),
+                                ImportAccountIntent(key = funded, source = Source.Manual, name = "Funder", openingDate = baseTime),
+                            ),
+                        transfers =
+                            listOf(
+                                ImportTransfer(
+                                    source = Source.Manual,
+                                    fromAccount = AccountRef.Local(funded),
+                                    toAccount = AccountRef.Local(dropKey),
+                                    timestamp = baseTime,
+                                    description = "seed",
+                                    amount = Money.fromDisplayValue("5", currency),
+                                ),
+                            ),
+                    ),
+                )
+            val keepId = created.createdAccountIds.getValue(keepKey)
+            val dropId = created.createdAccountIds.getValue(dropKey)
+
+            engine().import(
+                ImportBatch.manualEdits(accountMerges = listOf(AccountMergeRequest(deletedId = dropId, survivingId = keepId))),
+            )
+            assertNull(repositories.accountRepository.getAccountById(dropId).first())
+
+            val merge =
+                repositories.accountRepository
+                    .getReversibleMerges()
+                    .first()
+                    .first()
+            engine().import(ImportBatch.manualEdits(accountUnmerges = listOf(merge.id)))
+            assertTrue(repositories.accountRepository.getAccountById(dropId).first() != null)
+        }
+
+    @Test
+    fun updateWithoutExistingIdFailsValidation() =
+        runTest {
+            assertFailsWith<IllegalArgumentException> {
+                engine().import(
+                    ImportBatch.manualEdits(
+                        categories =
+                            listOf(
+                                ImportCategoryIntent(
+                                    key = LocalCategoryKey("x"),
+                                    source = Source.Manual,
+                                    operation = ImportOperation.UPDATE,
+                                    category = Category(id = 1, name = "X"),
+                                ),
+                            ),
+                    ),
+                )
+            }
         }
 }

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -38,6 +38,7 @@ class ImportEngineDbTest : DbTest() {
             personRepository = repositories.personRepository,
             personAttributeRepository = repositories.personAttributeRepository,
             ownershipRepository = repositories.personAccountOwnershipRepository,
+            categoryRepository = repositories.categoryRepository,
         )
 
     private suspend fun gbp(): Currency =

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/RepositoryModule.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/RepositoryModule.kt
@@ -216,6 +216,7 @@ interface RepositoryModule {
         personRepository: PersonRepository,
         personAttributeRepository: PersonAttributeRepository,
         ownershipRepository: PersonAccountOwnershipRepository,
+        categoryRepository: CategoryRepository,
     ): ImportEngine =
         ImportEngineImpl(
             transactionRepository = transactionRepository,
@@ -224,5 +225,6 @@ interface RepositoryModule {
             personRepository = personRepository,
             personAttributeRepository = personAttributeRepository,
             ownershipRepository = ownershipRepository,
+            categoryRepository = categoryRepository,
         )
 }

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/EditGate.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/EditGate.kt
@@ -1,0 +1,23 @@
+package com.moneymanager.importengineapi
+
+/**
+ * A gate the [ImportEngine] consults before performing any write. It lets the app block all edits and
+ * imports when they would be unsafe — e.g. a cloud-backed database whose remote copy has been changed
+ * by another device, where a local write would diverge from the remote (see the remote-storage sync
+ * layer). Database-free on purpose so the engine modules don't depend on the sync/DI layers; the real
+ * implementation is wired in where the sync state is available.
+ */
+fun interface EditGate {
+    /** Throws [EditingLockedException] if writes are currently blocked; returns normally otherwise. */
+    fun ensureWritable()
+
+    companion object {
+        /** A gate that never blocks — the default for imports/tests with no remote lock in play. */
+        val AlwaysWritable: EditGate = EditGate {}
+    }
+}
+
+/** Thrown by [EditGate.ensureWritable] when editing is locked (e.g. the remote copy is ahead). */
+class EditingLockedException(
+    message: String = "Editing is locked: download the latest changes from cloud storage first.",
+) : Exception(message)

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
@@ -2,19 +2,35 @@
 
 package com.moneymanager.importengineapi
 
+import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.ApiRequestId
 import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.Auditable
 import com.moneymanager.domain.model.Category
+import com.moneymanager.domain.model.MergeId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.NewRelationship
+import com.moneymanager.domain.model.Person
+import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.RelationshipTypeId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
 import kotlin.jvm.JvmInline
 import kotlin.time.Instant
+
+/**
+ * The kind of write an intent describes. Defaults to [CREATE] everywhere so the import producers
+ * (CSV/QIF/API), which only ever create, are unaffected; manual edits set [UPDATE]/[DELETE].
+ */
+enum class ImportOperation { CREATE, UPDATE, DELETE }
+
+/** An intent declaring one write on an entity; [operation] selects create/update/delete. */
+interface WriteIntent {
+    val operation: ImportOperation
+}
 
 /**
  * Computes the unique-identifier dedupe key for an existing (database) transfer, so the engine can
@@ -43,6 +59,12 @@ value class LocalAccountKey(
 /** Builder-chosen placeholder identity for a person created in this batch, before DB ids exist. */
 @JvmInline
 value class LocalPersonKey(
+    val value: String,
+)
+
+/** Builder-chosen placeholder identity for a category created in this batch, before DB ids exist. */
+@JvmInline
+value class LocalCategoryKey(
     val value: String,
 )
 
@@ -91,11 +113,11 @@ sealed interface AccountMatchKey {
  */
 data class ImportAccountIntent(
     val key: LocalAccountKey,
-    val match: AccountMatchKey,
-    val name: String,
-    val openingDate: Instant,
-    /** Where this account came from (e.g. the import as a whole, or the API `$.accounts[i]` node). */
+    /** Where this account came from (e.g. the import as a whole, or the API accounts node). */
     override val source: Source,
+    val match: AccountMatchKey = AccountMatchKey.AlwaysCreate,
+    val name: String? = null,
+    val openingDate: Instant? = null,
     val categoryId: Long = Category.UNCATEGORIZED_ID,
     val attributes: List<NewAttribute> = emptyList(),
     /**
@@ -106,7 +128,18 @@ data class ImportAccountIntent(
      * renaming the account they merge into.
      */
     val adoptOnBankMatch: Boolean = false,
-) : Auditable
+    /** [ImportOperation.CREATE] (default), or UPDATE/DELETE of [existingId]. */
+    override val operation: ImportOperation = ImportOperation.CREATE,
+    /** The account to UPDATE/DELETE (required for those operations). */
+    val existingId: AccountId? = null,
+    /** UPDATE: the new account row (null to change only attributes), passed straight to the repository. */
+    val account: Account? = null,
+    /** UPDATE: attribute rows to remove. */
+    val deletedAttributeIds: Set<Long> = emptySet(),
+    /** UPDATE: existing attribute rows to change (id -> new value). */
+    val updatedAttributes: Map<Long, NewAttribute> = emptyMap(),
+) : Auditable,
+    WriteIntent
 
 /** How the engine decides whether a person already exists before creating them. */
 sealed interface PersonMatchKey {
@@ -130,21 +163,63 @@ sealed interface PersonMatchKey {
 
 data class ImportPersonIntent(
     val key: LocalPersonKey,
-    val match: PersonMatchKey,
-    val firstName: String,
     /** Where this person came from (e.g. the import as a whole, or the API node the holder came from). */
     override val source: Source,
+    val match: PersonMatchKey = PersonMatchKey.ByNameKey(""),
+    val firstName: String? = null,
     val middleName: String? = null,
     val lastName: String? = null,
     val attributes: List<NewAttribute> = emptyList(),
-) : Auditable
+    /** [ImportOperation.CREATE] (default), or UPDATE/DELETE of [existingId]. */
+    override val operation: ImportOperation = ImportOperation.CREATE,
+    /** The person to UPDATE/DELETE (required for those operations). */
+    val existingId: PersonId? = null,
+    /** UPDATE: the new person row (null to change only attributes), passed straight to the repository. */
+    val person: Person? = null,
+    /** UPDATE: attribute rows to remove. */
+    val deletedAttributeIds: Set<Long> = emptySet(),
+    /** UPDATE: existing attribute rows to change (id -> new value). */
+    val updatedAttributes: Map<Long, NewAttribute> = emptyMap(),
+) : Auditable,
+    WriteIntent
 
 data class ImportOwnershipIntent(
-    val personKey: LocalPersonKey,
-    val account: AccountRef,
     /** Where this ownership link came from (e.g. the import as a whole, or the API node it came from). */
     override val source: Source,
-) : Auditable
+    /** CREATE: the person, as a batch-local key (resolved against created people). */
+    val personKey: LocalPersonKey? = null,
+    /** CREATE: the person, when already persisted (the UI add-owner case). */
+    val existingPersonId: PersonId? = null,
+    /** CREATE: the account (an existing id, or a batch-local key). */
+    val account: AccountRef? = null,
+    /** [ImportOperation.CREATE] (default) or DELETE of [existingId]. Ownerships have no UPDATE. */
+    override val operation: ImportOperation = ImportOperation.CREATE,
+    /** DELETE: the ownership row id. */
+    val existingId: Long? = null,
+) : Auditable,
+    WriteIntent
+
+/**
+ * A category to create/update/delete. [key] lets a CREATE's generated id be read back from
+ * [ImportResult.createdCategoryIds]; [existingId] targets the row for UPDATE/DELETE.
+ */
+data class ImportCategoryIntent(
+    val key: LocalCategoryKey,
+    override val source: Source,
+    val name: String? = null,
+    val parentId: Long? = null,
+    override val operation: ImportOperation = ImportOperation.CREATE,
+    val existingId: Long? = null,
+    /** UPDATE: the new category row, passed straight to the repository. */
+    val category: Category? = null,
+) : Auditable,
+    WriteIntent
+
+/** A request to merge [deletedId] into [survivingId] (reassign its transfers, then delete it). */
+data class AccountMergeRequest(
+    val deletedId: AccountId,
+    val survivingId: AccountId,
+)
 
 /**
  * A fee charged on a transaction, modelled as its own movement linked to the main transfer via a
@@ -188,13 +263,13 @@ data class ImportFee(
  * @property fee An optional fee charged on this transaction, expanded by the engine into a linked transfer.
  */
 data class ImportTransfer(
-    val rowKey: ImportRowKey,
-    val fromAccount: AccountRef,
-    val toAccount: AccountRef,
     override val source: Source,
-    val timestamp: Instant,
-    val description: String,
-    val amount: Money,
+    val rowKey: ImportRowKey? = null,
+    val fromAccount: AccountRef? = null,
+    val toAccount: AccountRef? = null,
+    val timestamp: Instant? = null,
+    val description: String = "",
+    val amount: Money? = null,
     val attributes: List<NewAttribute> = emptyList(),
     val relationships: List<NewRelationship> = emptyList(),
     val uniqueKey: Map<String, String>? = null,
@@ -202,7 +277,16 @@ data class ImportTransfer(
     val apiId: String? = null,
     val excludedFromBalances: Boolean = false,
     val fee: ImportFee? = null,
-) : Auditable
+    /** [ImportOperation.CREATE] (default), or UPDATE/DELETE of [existingId]. */
+    override val operation: ImportOperation = ImportOperation.CREATE,
+    /** The transfer to UPDATE/DELETE (required for those operations). */
+    val existingId: TransferId? = null,
+    /** UPDATE: attribute rows to remove. */
+    val deletedAttributeIds: Set<Long> = emptySet(),
+    /** UPDATE: existing attribute rows to change (id -> new value). */
+    val updatedAttributes: Map<Long, NewAttribute> = emptyMap(),
+) : Auditable,
+    WriteIntent
 
 /** Opaque per-row provenance + status-writeback key, identifying the source row of a transfer. */
 sealed interface ImportRowKey {
@@ -221,6 +305,11 @@ sealed interface ImportRowKey {
         val requestId: ApiRequestId,
         val jsonPath: String,
     ) : ImportRowKey
+
+    /** Provenance key for a manually-entered transfer (no source row); [index] keeps a batch's keys unique. */
+    data class Manual(
+        val index: Long,
+    ) : ImportRowKey
 }
 
 /**
@@ -228,13 +317,43 @@ sealed interface ImportRowKey {
  * import engine, which creates accounts/people/ownerships, dedupes, and bulk-writes transfers.
  */
 data class ImportBatch(
-    val transfers: List<ImportTransfer>,
-    val dedupePolicy: DedupePolicy,
+    val transfers: List<ImportTransfer> = emptyList(),
+    val dedupePolicy: DedupePolicy = DedupePolicy.None,
     val accountsToCreate: List<ImportAccountIntent> = emptyList(),
     val peopleToCreate: List<ImportPersonIntent> = emptyList(),
     val ownerships: List<ImportOwnershipIntent> = emptyList(),
+    val categories: List<ImportCategoryIntent> = emptyList(),
+    val accountMerges: List<AccountMergeRequest> = emptyList(),
+    val accountUnmerges: List<MergeId> = emptyList(),
     /** Required when [dedupePolicy] is [DedupePolicy.UniqueIdentifier] or [DedupePolicy.ApiMultiKey]. */
     val uniqueKeyExtractor: ExistingUniqueKeyExtractor? = null,
     /** Required when [dedupePolicy] is [DedupePolicy.ApiMultiKey]. */
     val apiIdExtractor: ExistingApiIdExtractor? = null,
-)
+) {
+    companion object {
+        /**
+         * Builds a batch of direct edits (no dedup): the UI describes the exact writes it wants. Each
+         * list may carry create/update/delete intents (per their [ImportOperation]); merges/unmerges are
+         * their own lists.
+         */
+        fun manualEdits(
+            transfers: List<ImportTransfer> = emptyList(),
+            accounts: List<ImportAccountIntent> = emptyList(),
+            people: List<ImportPersonIntent> = emptyList(),
+            ownerships: List<ImportOwnershipIntent> = emptyList(),
+            categories: List<ImportCategoryIntent> = emptyList(),
+            accountMerges: List<AccountMergeRequest> = emptyList(),
+            accountUnmerges: List<MergeId> = emptyList(),
+        ): ImportBatch =
+            ImportBatch(
+                transfers = transfers,
+                dedupePolicy = DedupePolicy.None,
+                accountsToCreate = accounts,
+                peopleToCreate = people,
+                ownerships = ownerships,
+                categories = categories,
+                accountMerges = accountMerges,
+                accountUnmerges = accountUnmerges,
+            )
+    }
+}

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngine.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngine.kt
@@ -1,15 +1,27 @@
 package com.moneymanager.importengineapi
 
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Category
+import com.moneymanager.domain.model.MergeId
+import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.Person
+import com.moneymanager.domain.model.PersonId
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
+
 /**
- * The central import engine: takes a fully-built [ImportBatch] and performs the entire import —
- * creates (or reuses) accounts, people and ownerships, resolves transfer account references,
- * deduplicates against existing transfers, bulk-creates new transfers, applies updates for changed
- * duplicates, and records the source of every entity/transfer it writes.
+ * The central write engine. It performs bulk [import]s and is also the **single entry point for every
+ * manual edit** (create/update/delete of transfers, accounts, categories, people and ownerships) — the
+ * UI never writes through repositories directly. Every write first consults an [EditGate], so the app
+ * can block all edits at one place when they would be unsafe (e.g. a cloud-backed database whose remote
+ * copy is ahead).
  *
- * This is the **only** component that writes imported entities, transfers and their sources to the
- * database. CSV/QIF/API importers live in modules that depend solely on this interface (never on the
- * database) and only build an [ImportBatch]; the binding to the database-backed implementation
- * ([com.moneymanager.importer.ImportEngineImpl]) happens exclusively in the DI module.
+ * Import logic and the source/provenance recording for imported entities live in the database-backed
+ * implementation ([com.moneymanager.importer.ImportEngineImpl]); CSV/QIF/API importers depend only on
+ * this interface and build an [ImportBatch]. The binding to the implementation happens where services
+ * are assembled.
  */
 interface ImportEngine {
     /**
@@ -24,4 +36,84 @@ interface ImportEngine {
         onProgress: (suspend (ImportProgress) -> Unit)? = null,
         batchSize: Int = Int.MAX_VALUE,
     ): ImportResult
+
+    // region Manual edits — the UI routes every create/update/delete through these gated methods.
+
+    suspend fun createTransfers(
+        transfers: List<Transfer>,
+        newAttributes: Map<TransferId, List<NewAttribute>> = emptyMap(),
+        sources: List<Source>,
+    ): List<TransferId>
+
+    suspend fun updateTransfer(
+        transfer: Transfer?,
+        deletedAttributeIds: Set<Long>,
+        updatedAttributes: Map<Long, NewAttribute>,
+        newAttributes: List<NewAttribute>,
+        transactionId: TransferId,
+        source: Source,
+    )
+
+    suspend fun deleteTransaction(id: Long)
+
+    suspend fun createAccount(
+        account: Account,
+        source: Source,
+    ): AccountId
+
+    suspend fun updateAccountWithAttributes(
+        account: Account?,
+        accountId: AccountId,
+        deletedAttributeIds: Set<Long>,
+        updatedAttributes: Map<Long, NewAttribute>,
+        newAttributes: List<NewAttribute>,
+        source: Source,
+    ): Long
+
+    suspend fun deleteAccount(id: AccountId)
+
+    suspend fun mergeAccounts(
+        deletedAccount: AccountId,
+        survivingAccount: AccountId,
+    ): MergeId
+
+    suspend fun unmergeAccount(mergeId: MergeId)
+
+    suspend fun createCategory(
+        category: Category,
+        source: Source,
+    ): Long
+
+    suspend fun updateCategory(
+        category: Category,
+        source: Source,
+    )
+
+    suspend fun deleteCategory(id: Long)
+
+    suspend fun createPerson(
+        person: Person,
+        source: Source,
+    ): PersonId
+
+    suspend fun updatePersonWithAttributes(
+        person: Person?,
+        personId: PersonId,
+        deletedAttributeIds: Set<Long>,
+        updatedAttributes: Map<Long, NewAttribute>,
+        newAttributes: List<NewAttribute>,
+        source: Source,
+    ): Long
+
+    suspend fun deletePerson(id: PersonId)
+
+    suspend fun createOwnership(
+        personId: PersonId,
+        accountId: AccountId,
+        source: Source,
+    ): Long
+
+    suspend fun deleteOwnership(id: Long)
+
+    // endregion
 }

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngine.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngine.kt
@@ -1,119 +1,30 @@
 package com.moneymanager.importengineapi
 
-import com.moneymanager.domain.model.Account
-import com.moneymanager.domain.model.AccountId
-import com.moneymanager.domain.model.Category
-import com.moneymanager.domain.model.MergeId
-import com.moneymanager.domain.model.NewAttribute
-import com.moneymanager.domain.model.Person
-import com.moneymanager.domain.model.PersonId
-import com.moneymanager.domain.model.Source
-import com.moneymanager.domain.model.Transfer
-import com.moneymanager.domain.model.TransferId
-
 /**
- * The central write engine. It performs bulk [import]s and is also the **single entry point for every
- * manual edit** (create/update/delete of transfers, accounts, categories, people and ownerships) — the
- * UI never writes through repositories directly. Every write first consults an [EditGate], so the app
- * can block all edits at one place when they would be unsafe (e.g. a cloud-backed database whose remote
- * copy is ahead).
+ * The central write engine. It has a **single** entry point, [import], which applies a declarative
+ * [ImportBatch]: bulk imports (CSV/QIF/API) and every manual edit (create/update/delete of transfers,
+ * accounts, categories, people and ownerships, plus account merge/unmerge) are all expressed as data in
+ * the batch — the UI never writes through repositories directly. [import] consults an [EditGate] once, so
+ * the app can block all writes at one place when they would be unsafe (e.g. a cloud-backed database whose
+ * remote copy is ahead).
  *
- * Import logic and the source/provenance recording for imported entities live in the database-backed
- * implementation ([com.moneymanager.importer.ImportEngineImpl]); CSV/QIF/API importers depend only on
- * this interface and build an [ImportBatch]. The binding to the implementation happens where services
- * are assembled.
+ * The database-backed implementation ([com.moneymanager.importer.ImportEngineImpl]) owns the import logic
+ * and source/provenance recording; CSV/QIF/API importers depend only on this interface and build an
+ * [ImportBatch]. The binding to the implementation happens where services are assembled.
  */
 interface ImportEngine {
     /**
-     * @param batchSize How many transfers to write per database transaction. The default writes the
-     *   whole batch in a single transaction (the behaviour all importers relied on historically). Large
-     *   producers (e.g. the sample-data generator, which creates hundreds of thousands of transfers) pass
-     *   a smaller value so the write is chunked into several transactions and [onProgress] reports
-     *   fine-grained progress instead of freezing on one giant transaction.
+     * Applies [batch] and returns the outcome (counts, per-row outcomes, and the real ids generated for
+     * the batch's create intents — see [ImportResult.createdAccountIds]/`createdCategoryIds`/`createdPersonIds`).
+     *
+     * @param batchSize How many transfers to write per database transaction. The default writes the whole
+     *   batch in a single transaction (the behaviour all importers relied on historically). Large producers
+     *   (e.g. the sample-data generator) pass a smaller value so the write is chunked and [onProgress]
+     *   reports fine-grained progress instead of freezing on one giant transaction.
      */
     suspend fun import(
         batch: ImportBatch,
         onProgress: (suspend (ImportProgress) -> Unit)? = null,
         batchSize: Int = Int.MAX_VALUE,
     ): ImportResult
-
-    // region Manual edits — the UI routes every create/update/delete through these gated methods.
-
-    suspend fun createTransfers(
-        transfers: List<Transfer>,
-        newAttributes: Map<TransferId, List<NewAttribute>> = emptyMap(),
-        sources: List<Source>,
-    ): List<TransferId>
-
-    suspend fun updateTransfer(
-        transfer: Transfer?,
-        deletedAttributeIds: Set<Long>,
-        updatedAttributes: Map<Long, NewAttribute>,
-        newAttributes: List<NewAttribute>,
-        transactionId: TransferId,
-        source: Source,
-    )
-
-    suspend fun deleteTransaction(id: Long)
-
-    suspend fun createAccount(
-        account: Account,
-        source: Source,
-    ): AccountId
-
-    suspend fun updateAccountWithAttributes(
-        account: Account?,
-        accountId: AccountId,
-        deletedAttributeIds: Set<Long>,
-        updatedAttributes: Map<Long, NewAttribute>,
-        newAttributes: List<NewAttribute>,
-        source: Source,
-    ): Long
-
-    suspend fun deleteAccount(id: AccountId)
-
-    suspend fun mergeAccounts(
-        deletedAccount: AccountId,
-        survivingAccount: AccountId,
-    ): MergeId
-
-    suspend fun unmergeAccount(mergeId: MergeId)
-
-    suspend fun createCategory(
-        category: Category,
-        source: Source,
-    ): Long
-
-    suspend fun updateCategory(
-        category: Category,
-        source: Source,
-    )
-
-    suspend fun deleteCategory(id: Long)
-
-    suspend fun createPerson(
-        person: Person,
-        source: Source,
-    ): PersonId
-
-    suspend fun updatePersonWithAttributes(
-        person: Person?,
-        personId: PersonId,
-        deletedAttributeIds: Set<Long>,
-        updatedAttributes: Map<Long, NewAttribute>,
-        newAttributes: List<NewAttribute>,
-        source: Source,
-    ): Long
-
-    suspend fun deletePerson(id: PersonId)
-
-    suspend fun createOwnership(
-        personId: PersonId,
-        accountId: AccountId,
-        source: Source,
-    ): Long
-
-    suspend fun deleteOwnership(id: Long)
-
-    // endregion
 }

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportResult.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportResult.kt
@@ -1,6 +1,7 @@
 package com.moneymanager.importengineapi
 
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.ImportStatus
 
@@ -23,6 +24,8 @@ data class RowOutcome(
  * @property rowOutcomes Per-row classification + resulting transfer id for every non-error transfer row.
  * @property createdAccountIds Real ids of accounts created (or matched/reused) for each
  *   [LocalAccountKey] in the batch's `accountsToCreate`.
+ * @property createdCategoryIds Real ids of categories created for each [LocalCategoryKey] in `categories`.
+ * @property createdPersonIds Real ids of people created (or matched) for each [LocalPersonKey] in `peopleToCreate`.
  */
 data class ImportResult(
     val accountsCreated: Int = 0,
@@ -39,6 +42,8 @@ data class ImportResult(
     // keyed rowOutcomes) when row keys are not unique per transfer (e.g. API pages, QIF splits).
     val orderedRowOutcomes: List<RowOutcome> = emptyList(),
     val createdAccountIds: Map<LocalAccountKey, AccountId> = emptyMap(),
+    val createdCategoryIds: Map<LocalCategoryKey, Long> = emptyMap(),
+    val createdPersonIds: Map<LocalPersonKey, PersonId> = emptyMap(),
 )
 
 /**

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
@@ -170,7 +170,7 @@ class ImportDeduper(
         if (transfer.amount != existing.amount) return false
         if (transfer.fromAccount.requireId() != existing.sourceAccountId) return false
         if (transfer.toAccount.requireId() != existing.targetAccountId) return false
-        val delta = (transfer.timestamp - existing.timestamp).absoluteValue
+        val delta = (requireNotNull(transfer.timestamp) - existing.timestamp).absoluteValue
         return delta <= window
     }
 
@@ -188,11 +188,11 @@ class ImportDeduper(
     private fun ImportTransfer.toComparableTransfer(id: TransferId): Transfer =
         Transfer(
             id = id,
-            timestamp = timestamp,
+            timestamp = requireNotNull(timestamp),
             description = description,
             sourceAccountId = fromAccount.requireId(),
             targetAccountId = toAccount.requireId(),
-            amount = amount,
+            amount = requireNotNull(amount),
         )
 
     private fun classifyByUniqueId(transfer: ImportTransfer): Classified {
@@ -268,15 +268,17 @@ class ImportDeduper(
                 transfer.toAccount.requireId() == existing.targetAccountId
         if (!sharesAccount) return false
         val withinDateTolerance =
-            (transfer.timestamp - existing.timestamp).absoluteValue <= policy.dateTolerance
+            (requireNotNull(transfer.timestamp) - existing.timestamp).absoluteValue <= policy.dateTolerance
         if (!withinDateTolerance) return false
         return StringSimilarity.similarity(transfer.description, existing.description) >= policy.similarityThreshold
     }
 
-    private fun AccountRef.requireId(): AccountId =
+    // Dedupe runs on resolved CREATE transfers, whose fields are present; null indicates a builder error.
+    private fun AccountRef?.requireId(): AccountId =
         when (this) {
             is AccountRef.Existing -> id
             is AccountRef.Local ->
                 error("ImportDeduper requires resolved account references; got unresolved $key")
+            null -> error("ImportDeduper requires a resolved account reference; got null")
         }
 }

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -6,7 +6,6 @@ import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.Category
-import com.moneymanager.domain.model.MergeId
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.NewRelationship
 import com.moneymanager.domain.model.Person
@@ -31,14 +30,18 @@ import com.moneymanager.importengineapi.EditGate
 import com.moneymanager.importengineapi.ImportAccountIntent
 import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.ImportOperation
 import com.moneymanager.importengineapi.ImportOwnershipIntent
 import com.moneymanager.importengineapi.ImportProgress
 import com.moneymanager.importengineapi.ImportResult
+import com.moneymanager.importengineapi.ImportRowKey
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
+import com.moneymanager.importengineapi.LocalCategoryKey
 import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.importengineapi.PersonMatchKey
 import com.moneymanager.importengineapi.RowOutcome
+import com.moneymanager.importengineapi.WriteIntent
 import com.moneymanager.importengineapi.bankKeyFromExternalId
 import com.moneymanager.importengineapi.forRow
 import com.moneymanager.importengineapi.normalizeNameKey
@@ -70,28 +73,207 @@ class ImportEngineImpl(
         batchSize: Int,
     ): ImportResult {
         editGate.ensureWritable()
+        validate(batch)
+
+        // ----- CREATE phase (first, so batch-local keys resolve for dependents) -----
+        val createdCategoryIds = mutableMapOf<LocalCategoryKey, Long>()
+        for (intent in batch.categories.creates()) {
+            createdCategoryIds[intent.key] =
+                categoryRepository.createCategory(
+                    Category(name = requireNotNull(intent.name), parentId = intent.parentId),
+                    intent.source,
+                )
+        }
+
         onProgress?.invoke(ImportProgress("Resolving accounts"))
-        val accountResolution = resolveAccounts(batch)
+        val accountResolution = resolveAccounts(batch.copy(accountsToCreate = batch.accountsToCreate.creates()))
 
         onProgress?.invoke(ImportProgress("Resolving people"))
-        val personKeyToId = resolvePeople(batch)
+        val personResolution = resolvePeople(batch.copy(peopleToCreate = batch.peopleToCreate.creates()))
 
         onProgress?.invoke(ImportProgress("Linking ownerships"))
-        val ownershipsCreated = createOwnerships(batch, personKeyToId, accountResolution.keyToId)
+        val ownershipsCreated =
+            createOwnerships(
+                batch.copy(ownerships = batch.ownerships.creates()),
+                personResolution,
+                accountResolution.keyToId,
+            )
 
-        // Resolve every transfer's account references to real ids, including a fee's own source/target
-        // (an API fee pays from the own account into the consolidated fee account, both of which may be
-        // batch-local accounts created in this same import).
+        val transfers = importTransferCreates(batch.transfers.creates(), batch, accountResolution.keyToId, batchSize, onProgress)
+
+        // ----- UPDATE phase -----
+        for (intent in batch.transfers.updates()) {
+            transactionRepository.updateTransfer(
+                transfer = intent.toUpdatedTransfer(),
+                deletedAttributeIds = intent.deletedAttributeIds,
+                updatedAttributes = intent.updatedAttributes,
+                newAttributes = intent.attributes,
+                transactionId = requireNotNull(intent.existingId),
+                source = intent.source,
+            )
+        }
+        for (intent in batch.accountsToCreate.updates()) {
+            accountRepository.updateAccountWithAttributes(
+                account = intent.account,
+                accountId = requireNotNull(intent.existingId),
+                deletedAttributeIds = intent.deletedAttributeIds,
+                updatedAttributes = intent.updatedAttributes,
+                newAttributes = intent.attributes,
+                source = intent.source,
+            )
+        }
+        for (intent in batch.categories.updates()) {
+            categoryRepository.updateCategory(requireNotNull(intent.category), intent.source)
+        }
+        for (intent in batch.peopleToCreate.updates()) {
+            personRepository.updatePersonWithAttributes(
+                person = intent.person,
+                personId = requireNotNull(intent.existingId),
+                deletedAttributeIds = intent.deletedAttributeIds,
+                updatedAttributes = intent.updatedAttributes,
+                newAttributes = intent.attributes,
+                source = intent.source,
+            )
+        }
+
+        // ----- MERGE / UNMERGE (before deletes: a merge already removes the absorbed account) -----
+        batch.accountMerges.forEach { accountRepository.mergeAccounts(it.deletedId, it.survivingId) }
+        batch.accountUnmerges.forEach { accountRepository.unmergeAccount(it) }
+
+        // ----- DELETE phase (dependents first) -----
+        batch.ownerships.deletes().forEach { ownershipRepository.deleteOwnership(requireNotNull(it.existingId)) }
+        batch.transfers.deletes().forEach { transactionRepository.deleteTransaction(requireNotNull(it.existingId).id) }
+        batch.accountsToCreate.deletes().forEach { accountRepository.deleteAccount(requireNotNull(it.existingId)) }
+        batch.categories.deletes().forEach { categoryRepository.deleteCategory(requireNotNull(it.existingId)) }
+        batch.peopleToCreate.deletes().forEach { personRepository.deletePerson(requireNotNull(it.existingId)) }
+
+        return ImportResult(
+            accountsCreated = accountResolution.created,
+            peopleCreated = personResolution.createdCount,
+            ownershipsCreated = ownershipsCreated,
+            transfersImported = transfers.imported,
+            duplicates = transfers.duplicates,
+            updated = transfers.updated,
+            excluded = transfers.excluded,
+            createdTransferIds = transfers.createdTransferIds,
+            rowOutcomes = transfers.rowOutcomes,
+            orderedRowOutcomes = transfers.orderedRowOutcomes,
+            createdAccountIds = accountResolution.keyToId,
+            createdCategoryIds = createdCategoryIds,
+            createdPersonIds = personResolution.keyToId,
+        )
+    }
+
+    // region Operation dispatch
+
+    private fun <T : WriteIntent> List<T>.creates() = filter { it.operation == ImportOperation.CREATE }
+
+    private fun <T : WriteIntent> List<T>.updates() = filter { it.operation == ImportOperation.UPDATE }
+
+    private fun <T : WriteIntent> List<T>.deletes() = filter { it.operation == ImportOperation.DELETE }
+
+    /** Fails loudly when an intent omits the fields its [ImportOperation] requires (nullable-by-design). */
+    private fun validate(batch: ImportBatch) {
+        batch.transfers.forEach {
+            when (it.operation) {
+                ImportOperation.CREATE ->
+                    require(it.fromAccount != null && it.toAccount != null && it.timestamp != null && it.amount != null) {
+                        "CREATE transfer requires fromAccount/toAccount/timestamp/amount"
+                    }
+                ImportOperation.UPDATE, ImportOperation.DELETE ->
+                    require(it.existingId != null) { "${it.operation} transfer requires existingId" }
+            }
+        }
+        batch.accountsToCreate.forEach {
+            when (it.operation) {
+                ImportOperation.CREATE ->
+                    require(it.name != null && it.openingDate != null) { "CREATE account requires name/openingDate" }
+                ImportOperation.UPDATE, ImportOperation.DELETE ->
+                    require(it.existingId != null) { "${it.operation} account requires existingId" }
+            }
+        }
+        batch.categories.forEach {
+            when (it.operation) {
+                ImportOperation.CREATE -> require(it.name != null) { "CREATE category requires name" }
+                ImportOperation.UPDATE ->
+                    require(it.existingId != null && it.category != null) { "UPDATE category requires existingId and category" }
+                ImportOperation.DELETE -> require(it.existingId != null) { "DELETE category requires existingId" }
+            }
+        }
+        batch.peopleToCreate.forEach {
+            when (it.operation) {
+                ImportOperation.CREATE -> require(it.firstName != null) { "CREATE person requires firstName" }
+                ImportOperation.UPDATE, ImportOperation.DELETE ->
+                    require(it.existingId != null) { "${it.operation} person requires existingId" }
+            }
+        }
+        batch.ownerships.forEach {
+            when (it.operation) {
+                ImportOperation.CREATE ->
+                    require((it.personKey != null || it.existingPersonId != null) && it.account != null) {
+                        "CREATE ownership requires a person and an account"
+                    }
+                ImportOperation.DELETE -> require(it.existingId != null) { "DELETE ownership requires existingId" }
+                ImportOperation.UPDATE -> error("Ownerships have no UPDATE operation")
+            }
+        }
+    }
+
+    /** Builds the [Transfer] for an UPDATE intent, or null for an attribute-only update. */
+    private fun ImportTransfer.toUpdatedTransfer(): Transfer? =
+        if (fromAccount == null && toAccount == null && amount == null && timestamp == null) {
+            null
+        } else {
+            Transfer(
+                id = requireNotNull(existingId),
+                timestamp = requireNotNull(timestamp),
+                description = description,
+                sourceAccountId = requireId(fromAccount),
+                targetAccountId = requireId(toAccount),
+                amount = requireNotNull(amount),
+            )
+        }
+
+    // endregion
+
+    // region Transfer creates
+
+    /** The transfer-related portion of an [ImportResult], produced by [importTransferCreates]. */
+    private class TransferOutcome(
+        val imported: Int,
+        val duplicates: Int,
+        val updated: Int,
+        val excluded: Int,
+        val createdTransferIds: Map<ImportRowKey, TransferId>,
+        val rowOutcomes: Map<ImportRowKey, RowOutcome>,
+        val orderedRowOutcomes: List<RowOutcome>,
+    )
+
+    /**
+     * Runs the existing dedupe + write path over the CREATE transfers, resolving account references and
+     * synthesising a [ImportRowKey.Manual] for manually-entered transfers that carry no source row.
+     */
+    private suspend fun importTransferCreates(
+        creates: List<ImportTransfer>,
+        batch: ImportBatch,
+        accountKeyToId: Map<LocalAccountKey, AccountId>,
+        batchSize: Int,
+        onProgress: (suspend (ImportProgress) -> Unit)?,
+    ): TransferOutcome {
+        if (creates.isEmpty()) return TransferOutcome(0, 0, 0, 0, emptyMap(), emptyMap(), emptyList())
+
+        var manualRowIndex = 0L
         val resolvedTransfers =
-            batch.transfers.map { transfer ->
+            creates.map { transfer ->
                 val fee = transfer.fee
                 transfer.copy(
-                    fromAccount = resolveRef(transfer.fromAccount, accountResolution.keyToId),
-                    toAccount = resolveRef(transfer.toAccount, accountResolution.keyToId),
+                    rowKey = transfer.rowKey ?: ImportRowKey.Manual(manualRowIndex++),
+                    fromAccount = resolveRef(requireNotNull(transfer.fromAccount), accountKeyToId),
+                    toAccount = resolveRef(requireNotNull(transfer.toAccount), accountKeyToId),
                     fee =
                         fee?.copy(
-                            source = resolveRef(fee.source, accountResolution.keyToId),
-                            target = resolveRef(fee.target, accountResolution.keyToId),
+                            source = resolveRef(fee.source, accountKeyToId),
+                            target = resolveRef(fee.target, accountKeyToId),
                         ),
                 )
             }
@@ -108,7 +290,7 @@ class ImportEngineImpl(
         onProgress?.invoke(ImportProgress("Importing transactions", fraction = 0f, processed = 0, total = toImport.size))
         val createdIds = writeTransfers(toImport, toUpdate, batchSize, onProgress)
 
-        val createdTransferIds = toImport.zip(createdIds).associate { (classified, id) -> classified.transfer.rowKey to id }
+        val createdTransferIds = toImport.zip(createdIds).associate { (c, id) -> requireNotNull(c.transfer.rowKey) to id }
 
         // Build per-transfer outcomes in input order; IMPORTED rows pull their created id in turn.
         val createdIdByIndex = mutableMapOf<Int, TransferId>()
@@ -126,127 +308,19 @@ class ImportEngineImpl(
                     else -> RowOutcome(c.status, c.existing ?: c.inBatchMatchIndex?.let { createdIdByIndex[it] })
                 }
             }
-        val rowOutcomes = classified.zip(orderedRowOutcomes).associate { (c, outcome) -> c.transfer.rowKey to outcome }
+        val rowOutcomes =
+            classified.zip(orderedRowOutcomes).associate { (c, outcome) -> requireNotNull(c.transfer.rowKey) to outcome }
 
-        return ImportResult(
-            accountsCreated = accountResolution.created,
-            peopleCreated = personKeyToId.createdCount,
-            ownershipsCreated = ownershipsCreated,
-            transfersImported = toImport.size,
+        return TransferOutcome(
+            imported = toImport.size,
             duplicates = duplicates,
             updated = toUpdate.size,
             excluded = excluded,
             createdTransferIds = createdTransferIds,
             rowOutcomes = rowOutcomes,
             orderedRowOutcomes = orderedRowOutcomes,
-            createdAccountIds = accountResolution.keyToId,
         )
     }
-
-    // region Manual edits — every method is gated, then delegates to the matching repository.
-
-    private inline fun <T> gated(block: () -> T): T {
-        editGate.ensureWritable()
-        return block()
-    }
-
-    override suspend fun createTransfers(
-        transfers: List<Transfer>,
-        newAttributes: Map<TransferId, List<NewAttribute>>,
-        sources: List<Source>,
-    ): List<TransferId> = gated { transactionRepository.createTransfers(transfers, newAttributes, sources) }
-
-    override suspend fun updateTransfer(
-        transfer: Transfer?,
-        deletedAttributeIds: Set<Long>,
-        updatedAttributes: Map<Long, NewAttribute>,
-        newAttributes: List<NewAttribute>,
-        transactionId: TransferId,
-        source: Source,
-    ) = gated {
-        transactionRepository.updateTransfer(transfer, deletedAttributeIds, updatedAttributes, newAttributes, transactionId, source)
-    }
-
-    override suspend fun deleteTransaction(id: Long) = gated { transactionRepository.deleteTransaction(id) }
-
-    override suspend fun createAccount(
-        account: Account,
-        source: Source,
-    ): AccountId = gated { accountRepository.createAccount(account, source) }
-
-    override suspend fun updateAccountWithAttributes(
-        account: Account?,
-        accountId: AccountId,
-        deletedAttributeIds: Set<Long>,
-        updatedAttributes: Map<Long, NewAttribute>,
-        newAttributes: List<NewAttribute>,
-        source: Source,
-    ): Long =
-        gated {
-            accountRepository.updateAccountWithAttributes(
-                account,
-                accountId,
-                deletedAttributeIds,
-                updatedAttributes,
-                newAttributes,
-                source,
-            )
-        }
-
-    override suspend fun deleteAccount(id: AccountId) = gated { accountRepository.deleteAccount(id) }
-
-    override suspend fun mergeAccounts(
-        deletedAccount: AccountId,
-        survivingAccount: AccountId,
-    ): MergeId = gated { accountRepository.mergeAccounts(deletedAccount, survivingAccount) }
-
-    override suspend fun unmergeAccount(mergeId: MergeId) = gated { accountRepository.unmergeAccount(mergeId) }
-
-    override suspend fun createCategory(
-        category: Category,
-        source: Source,
-    ): Long = gated { categoryRepository.createCategory(category, source) }
-
-    override suspend fun updateCategory(
-        category: Category,
-        source: Source,
-    ) = gated { categoryRepository.updateCategory(category, source) }
-
-    override suspend fun deleteCategory(id: Long) = gated { categoryRepository.deleteCategory(id) }
-
-    override suspend fun createPerson(
-        person: Person,
-        source: Source,
-    ): PersonId = gated { personRepository.createPerson(person, source) }
-
-    override suspend fun updatePersonWithAttributes(
-        person: Person?,
-        personId: PersonId,
-        deletedAttributeIds: Set<Long>,
-        updatedAttributes: Map<Long, NewAttribute>,
-        newAttributes: List<NewAttribute>,
-        source: Source,
-    ): Long =
-        gated {
-            personRepository.updatePersonWithAttributes(
-                person,
-                personId,
-                deletedAttributeIds,
-                updatedAttributes,
-                newAttributes,
-                source,
-            )
-        }
-
-    override suspend fun deletePerson(id: PersonId) = gated { personRepository.deletePerson(id) }
-
-    override suspend fun createOwnership(
-        personId: PersonId,
-        accountId: AccountId,
-        source: Source,
-    ): Long = gated { ownershipRepository.createOwnership(personId, accountId, source) }
-
-    override suspend fun deleteOwnership(id: Long) = gated { ownershipRepository.deleteOwnership(id) }
 
     // endregion
 
@@ -328,9 +402,10 @@ class ImportEngineImpl(
         byAttr: MutableMap<Pair<AttributeTypeId, String>, AccountId>,
     ) {
         val existing = accountRepository.getAccountById(id).first() ?: return
-        if (existing.name != intent.name) {
-            accountRepository.updateAccount(existing.copy(name = intent.name), intent.source)
-            byName.getOrPut(intent.name) { id }
+        val intentName = requireNotNull(intent.name)
+        if (existing.name != intentName) {
+            accountRepository.updateAccount(existing.copy(name = intentName), intent.source)
+            byName.getOrPut(intentName) { id }
         }
         val currentAttrs = accountAttributeRepository.getByAccount(id).first()
         for (attr in intent.attributes) {
@@ -356,8 +431,8 @@ class ImportEngineImpl(
             accountRepository.createAccount(
                 Account(
                     id = AccountId(0),
-                    name = intent.name,
-                    openingDate = intent.openingDate,
+                    name = requireNotNull(intent.name),
+                    openingDate = requireNotNull(intent.openingDate),
                     categoryId = intent.categoryId,
                 ),
                 intent.source,
@@ -375,7 +450,7 @@ class ImportEngineImpl(
         byAttr: MutableMap<Pair<AttributeTypeId, String>, AccountId>,
         byPersonalKey: MutableMap<String, AccountId>,
     ) {
-        byName.getOrPut(intent.name) { id }
+        byName.getOrPut(requireNotNull(intent.name)) { id }
         intent.attributes.forEach { attr -> byAttr.getOrPut(attr.typeId to attr.value) { id } }
         when (val match = intent.match) {
             is AccountMatchKey.ByPersonalCounterparty -> byPersonalKey.getOrPut(match.key) { id }
@@ -499,11 +574,12 @@ class ImportEngineImpl(
                 keyToId[intent.key] = existingId
                 continue
             }
+            val firstName = requireNotNull(intent.firstName)
             val newId =
                 personRepository.createPerson(
                     Person(
                         id = PersonId(0),
-                        firstName = intent.firstName,
+                        firstName = firstName,
                         middleName = intent.middleName,
                         lastName = intent.lastName,
                     ),
@@ -515,7 +591,7 @@ class ImportEngineImpl(
             created++
             keyToId[intent.key] = newId
             byNameKey.getOrPut(
-                normalizeNameKey(personFullName(intent.firstName, intent.middleName, intent.lastName)),
+                normalizeNameKey(personFullName(firstName, intent.middleName, intent.lastName)),
             ) { newId }
             when (match) {
                 is PersonMatchKey.ByExternalId -> {
@@ -571,11 +647,12 @@ class ImportEngineImpl(
         accountKeyToId: Map<LocalAccountKey, AccountId>,
         seen: MutableSet<Pair<PersonId, AccountId>>,
     ): Boolean {
-        val personId = personKeyToId[intent.personKey] ?: return false
+        val personId = intent.existingPersonId ?: intent.personKey?.let { personKeyToId[it] } ?: return false
         val accountId =
             when (val ref = intent.account) {
                 is AccountRef.Existing -> ref.id
                 is AccountRef.Local -> accountKeyToId[ref.key] ?: return false
+                null -> return false
             }
         if (!seen.add(personId to accountId)) return false
         val alreadyLinked =
@@ -603,8 +680,8 @@ class ImportEngineImpl(
         val rawTransfers =
             when (batch.dedupePolicy) {
                 is DedupePolicy.FuzzyAllFields -> {
-                    val minTs = transfers.minOf { it.timestamp }
-                    val maxTs = transfers.maxOf { it.timestamp }
+                    val minTs = transfers.minOf { requireNotNull(it.timestamp) }
+                    val maxTs = transfers.maxOf { requireNotNull(it.timestamp) }
                     accountIds
                         .flatMap {
                             transactionRepository.getTransactionsByAccountAndDateRange(it, minTs, maxTs).first()
@@ -743,24 +820,25 @@ class ImportEngineImpl(
                 } else {
                     t.relationships
                 }
+            val rowKey = requireNotNull(t.rowKey)
             mainResultIndices += transfersToCreate.size
             transfersToCreate +=
                 Transfer(
                     id = mainTempId,
-                    timestamp = t.timestamp,
+                    timestamp = requireNotNull(t.timestamp),
                     description = t.description,
                     sourceAccountId = requireId(t.fromAccount),
                     targetAccountId = requireId(t.toAccount),
-                    amount = t.amount,
+                    amount = requireNotNull(t.amount),
                 )
             if (t.attributes.isNotEmpty()) newAttributes[mainTempId] = t.attributes
             if (relationships.isNotEmpty()) newRelationships[mainTempId] = relationships
-            orderedSources += t.source.forRow(t.rowKey)
+            orderedSources += t.source.forRow(rowKey)
             if (fee != null && feeTempId != null) {
                 transfersToCreate +=
                     Transfer(
                         id = feeTempId,
-                        timestamp = t.timestamp,
+                        timestamp = requireNotNull(t.timestamp),
                         description = fee.description,
                         sourceAccountId = requireId(fee.source),
                         targetAccountId = requireId(fee.target),
@@ -768,7 +846,7 @@ class ImportEngineImpl(
                     )
                 // The fee inherits the main transfer's provenance source, resolved against its own row
                 // key when provided (so the audit trail points at the fee's source node), else the main's.
-                orderedSources += t.source.forRow(fee.rowKey ?: t.rowKey)
+                orderedSources += t.source.forRow(fee.rowKey ?: rowKey)
             }
         }
         return CreatePayload(transfersToCreate, newAttributes, newRelationships, orderedSources, mainResultIndices)
@@ -785,15 +863,15 @@ class ImportEngineImpl(
                     transfer =
                         Transfer(
                             id = existingId,
-                            timestamp = t.timestamp,
+                            timestamp = requireNotNull(t.timestamp),
                             description = t.description,
                             sourceAccountId = requireId(t.fromAccount),
                             targetAccountId = requireId(t.toAccount),
-                            amount = t.amount,
+                            amount = requireNotNull(t.amount),
                         ),
                     newAttributes = t.attributes,
                 )
-            orderedUpdateSources += t.source.forRow(t.rowKey)
+            orderedUpdateSources += t.source.forRow(requireNotNull(t.rowKey))
         }
         return updates to orderedUpdateSources
     }
@@ -812,10 +890,11 @@ class ImportEngineImpl(
                 )
         }
 
-    private fun requireId(ref: AccountRef): AccountId =
+    private fun requireId(ref: AccountRef?): AccountId =
         when (ref) {
             is AccountRef.Existing -> ref.id
             is AccountRef.Local -> error("Unresolved account reference: ${ref.key}")
+            null -> error("Missing account reference")
         }
 
     private fun personFullName(

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -5,6 +5,8 @@ package com.moneymanager.importer
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AttributeTypeId
+import com.moneymanager.domain.model.Category
+import com.moneymanager.domain.model.MergeId
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.NewRelationship
 import com.moneymanager.domain.model.Person
@@ -16,6 +18,7 @@ import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.model.csv.ImportStatus
 import com.moneymanager.domain.repository.AccountAttributeRepository
 import com.moneymanager.domain.repository.AccountRepository
+import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
@@ -24,6 +27,7 @@ import com.moneymanager.domain.repository.TransferUpdate
 import com.moneymanager.importengineapi.AccountMatchKey
 import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.DedupePolicy
+import com.moneymanager.importengineapi.EditGate
 import com.moneymanager.importengineapi.ImportAccountIntent
 import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportEngine
@@ -57,12 +61,15 @@ class ImportEngineImpl(
     private val personRepository: PersonRepository,
     private val personAttributeRepository: PersonAttributeRepository,
     private val ownershipRepository: PersonAccountOwnershipRepository,
+    private val categoryRepository: CategoryRepository,
+    private val editGate: EditGate = EditGate.AlwaysWritable,
 ) : ImportEngine {
     override suspend fun import(
         batch: ImportBatch,
         onProgress: (suspend (ImportProgress) -> Unit)?,
         batchSize: Int,
     ): ImportResult {
+        editGate.ensureWritable()
         onProgress?.invoke(ImportProgress("Resolving accounts"))
         val accountResolution = resolveAccounts(batch)
 
@@ -135,6 +142,113 @@ class ImportEngineImpl(
             createdAccountIds = accountResolution.keyToId,
         )
     }
+
+    // region Manual edits — every method is gated, then delegates to the matching repository.
+
+    private inline fun <T> gated(block: () -> T): T {
+        editGate.ensureWritable()
+        return block()
+    }
+
+    override suspend fun createTransfers(
+        transfers: List<Transfer>,
+        newAttributes: Map<TransferId, List<NewAttribute>>,
+        sources: List<Source>,
+    ): List<TransferId> = gated { transactionRepository.createTransfers(transfers, newAttributes, sources) }
+
+    override suspend fun updateTransfer(
+        transfer: Transfer?,
+        deletedAttributeIds: Set<Long>,
+        updatedAttributes: Map<Long, NewAttribute>,
+        newAttributes: List<NewAttribute>,
+        transactionId: TransferId,
+        source: Source,
+    ) = gated {
+        transactionRepository.updateTransfer(transfer, deletedAttributeIds, updatedAttributes, newAttributes, transactionId, source)
+    }
+
+    override suspend fun deleteTransaction(id: Long) = gated { transactionRepository.deleteTransaction(id) }
+
+    override suspend fun createAccount(
+        account: Account,
+        source: Source,
+    ): AccountId = gated { accountRepository.createAccount(account, source) }
+
+    override suspend fun updateAccountWithAttributes(
+        account: Account?,
+        accountId: AccountId,
+        deletedAttributeIds: Set<Long>,
+        updatedAttributes: Map<Long, NewAttribute>,
+        newAttributes: List<NewAttribute>,
+        source: Source,
+    ): Long =
+        gated {
+            accountRepository.updateAccountWithAttributes(
+                account,
+                accountId,
+                deletedAttributeIds,
+                updatedAttributes,
+                newAttributes,
+                source,
+            )
+        }
+
+    override suspend fun deleteAccount(id: AccountId) = gated { accountRepository.deleteAccount(id) }
+
+    override suspend fun mergeAccounts(
+        deletedAccount: AccountId,
+        survivingAccount: AccountId,
+    ): MergeId = gated { accountRepository.mergeAccounts(deletedAccount, survivingAccount) }
+
+    override suspend fun unmergeAccount(mergeId: MergeId) = gated { accountRepository.unmergeAccount(mergeId) }
+
+    override suspend fun createCategory(
+        category: Category,
+        source: Source,
+    ): Long = gated { categoryRepository.createCategory(category, source) }
+
+    override suspend fun updateCategory(
+        category: Category,
+        source: Source,
+    ) = gated { categoryRepository.updateCategory(category, source) }
+
+    override suspend fun deleteCategory(id: Long) = gated { categoryRepository.deleteCategory(id) }
+
+    override suspend fun createPerson(
+        person: Person,
+        source: Source,
+    ): PersonId = gated { personRepository.createPerson(person, source) }
+
+    override suspend fun updatePersonWithAttributes(
+        person: Person?,
+        personId: PersonId,
+        deletedAttributeIds: Set<Long>,
+        updatedAttributes: Map<Long, NewAttribute>,
+        newAttributes: List<NewAttribute>,
+        source: Source,
+    ): Long =
+        gated {
+            personRepository.updatePersonWithAttributes(
+                person,
+                personId,
+                deletedAttributeIds,
+                updatedAttributes,
+                newAttributes,
+                source,
+            )
+        }
+
+    override suspend fun deletePerson(id: PersonId) = gated { personRepository.deletePerson(id) }
+
+    override suspend fun createOwnership(
+        personId: PersonId,
+        accountId: AccountId,
+        source: Source,
+    ): Long = gated { ownershipRepository.createOwnership(personId, accountId, source) }
+
+    override suspend fun deleteOwnership(id: Long) = gated { ownershipRepository.deleteOwnership(id) }
+
+    // endregion
 
     // region Accounts
 

--- a/app/main/android/build.gradle.kts
+++ b/app/main/android/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(libs.play.services.auth)
     implementation(projects.app.db.core)
     implementation(projects.app.di.core)
+    implementation(projects.app.importengineapi)
     implementation(projects.app.model.core)
     implementation(projects.app.remotestorage.core)
     // Native Android Google Drive auth (AndroidGoogleAccessTokenSource) implements the googledrive seam.

--- a/app/main/android/src/main/kotlin/com/moneymanager/android/MainActivity.kt
+++ b/app/main/android/src/main/kotlin/com/moneymanager/android/MainActivity.kt
@@ -13,7 +13,9 @@ import com.moneymanager.di.AppComponentParams
 import com.moneymanager.di.database.DatabaseComponent
 import com.moneymanager.di.database.toApplication
 import com.moneymanager.di.initializeVersionReader
+import com.moneymanager.importengineapi.EditingLockedException
 import com.moneymanager.remotestorage.sync.RemoteDatabaseController
+import com.moneymanager.remotestorage.sync.SyncResult
 import com.moneymanager.ui.AppStartupHost
 import com.moneymanager.ui.error.GlobalSchemaErrorState
 import com.moneymanager.ui.error.SchemaErrorDetector
@@ -40,11 +42,11 @@ class MainActivity : ComponentActivity() {
         if (!controller.hasActiveSession()) return false
         return runCatching {
             runBlocking {
-                if (controller.hasUnsyncedChanges(database)) {
-                    controller.syncNow(database)
-                }
+                // Guarded push: a BLOCKED result (another device pushed) means the remote is NOT up to
+                // date from our side, so the local copy must be kept rather than deleted.
+                !controller.hasUnsyncedChanges(database) || controller.syncNow(database) == SyncResult.UPLOADED
             }
-        }.onFailure { Log.e(TAG, "Failed to sync database", it) }.isSuccess
+        }.onFailure { Log.e(TAG, "Failed to sync database", it) }.getOrDefault(false)
     }
 
     override fun onStop() {
@@ -109,7 +111,11 @@ class MainActivity : ComponentActivity() {
                 appVersion = component.appVersion,
                 localSettings = component.localSettings,
                 createAppServices = { database ->
-                    DatabaseComponent.create(database).toApplication().toAppServices()
+                    DatabaseComponent.create(database).toApplication().toAppServices(
+                        editGate = {
+                            if (controller.syncState.value.editingLocked) throw EditingLockedException()
+                        },
+                    )
                 },
                 onInfoLog = { message -> Log.i(TAG, message) },
                 onErrorLog = { message, error -> Log.e(TAG, message, error) },

--- a/app/main/jvm/build.gradle.kts
+++ b/app/main/jvm/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.swing)
     implementation(projects.app.db.core)
     implementation(projects.app.di.core)
+    implementation(projects.app.importengineapi)
     implementation(projects.app.model.core)
     implementation(projects.app.remotestorage.sync)
     implementation(projects.app.ui.core)

--- a/app/main/jvm/src/main/kotlin/com/moneymanager/Main.kt
+++ b/app/main/jvm/src/main/kotlin/com/moneymanager/Main.kt
@@ -16,6 +16,8 @@ import com.moneymanager.di.AppComponent
 import com.moneymanager.di.AppComponentParams
 import com.moneymanager.di.database.DatabaseComponent
 import com.moneymanager.di.database.toApplication
+import com.moneymanager.importengineapi.EditingLockedException
+import com.moneymanager.remotestorage.sync.SyncResult
 import com.moneymanager.ui.AppStartupHost
 import com.moneymanager.ui.components.DatabaseStartupProgressScreen
 import com.moneymanager.ui.error.GlobalSchemaErrorState
@@ -103,12 +105,15 @@ private fun MainWindow(onExit: () -> Unit) {
                         val changed = runCatching { remoteController.hasUnsyncedChanges(database) }.getOrDefault(true)
                         val remoteUpToDate =
                             if (changed) {
+                                // Guarded push: if another device pushed since our last sync the upload is
+                                // refused (BLOCKED) rather than clobbering it — then we keep the local copy.
                                 runCatching {
                                     remoteController.syncNow(database, rebuildViews = false) { progress ->
                                         closeProgress =
                                             DatabaseInitializationProgress(progress.message, (progress.fraction * 100).toInt(), 100)
                                     }
-                                }.onFailure { logger.error(it) { "Failed to sync database on close" } }.isSuccess
+                                }.onFailure { logger.error(it) { "Failed to sync database on close" } }
+                                    .getOrNull() == SyncResult.UPLOADED
                             } else {
                                 logger.info { "No changes since last sync; skipping upload on close" }
                                 true
@@ -139,7 +144,11 @@ private fun MainWindow(onExit: () -> Unit) {
                 appVersion = appVersion,
                 localSettings = localSettings,
                 createAppServices = { database ->
-                    DatabaseComponent.create(database).toApplication().toAppServices()
+                    DatabaseComponent.create(database).toApplication().toAppServices(
+                        editGate = {
+                            if (remoteController.syncState.value.editingLocked) throw EditingLockedException()
+                        },
+                    )
                 },
                 onInfoLog = { message -> logger.info { message } },
                 onErrorLog = { message, error -> logger.error(error) { message } },

--- a/app/remotestorage/core/src/commonMain/kotlin/com/moneymanager/remotestorage/RemoteStorageProvider.kt
+++ b/app/remotestorage/core/src/commonMain/kotlin/com/moneymanager/remotestorage/RemoteStorageProvider.kt
@@ -73,4 +73,12 @@ data class RemoteFile(
     val name: String,
     val sizeBytes: Long? = null,
     val modifiedAtEpochMs: Long? = null,
+    /**
+     * An opaque identifier that changes whenever the file's content changes (e.g. Drive's
+     * `headRevisionId`). Used to detect that another device pushed a newer version. Null if the
+     * backend doesn't expose one.
+     */
+    val revisionId: String? = null,
+    /** Content checksum (e.g. Drive's `md5Checksum`), for content-equality fallback. Null if unknown. */
+    val md5: String? = null,
 )

--- a/app/remotestorage/googledrive/src/jvmAndroidMain/kotlin/com/moneymanager/remotestorage/googledrive/GoogleDriveProvider.kt
+++ b/app/remotestorage/googledrive/src/jvmAndroidMain/kotlin/com/moneymanager/remotestorage/googledrive/GoogleDriveProvider.kt
@@ -179,6 +179,8 @@ class GoogleDriveProvider(
             name = name,
             sizeBytes = size?.toLongOrNull(),
             modifiedAtEpochMs = modifiedTime?.let { runCatching { Instant.parse(it).toEpochMilliseconds() }.getOrNull() },
+            revisionId = headRevisionId,
+            md5 = md5Checksum,
         )
 
     @Serializable
@@ -187,6 +189,8 @@ class GoogleDriveProvider(
         val name: String = "",
         val size: String? = null,
         val modifiedTime: String? = null,
+        val headRevisionId: String? = null,
+        val md5Checksum: String? = null,
     )
 
     @Serializable
@@ -208,7 +212,7 @@ class GoogleDriveProvider(
         const val UPLOAD_ENDPOINT = "https://www.googleapis.com/upload/drive/v3/files"
         const val APP_PROPERTY_KEY = "moneymanagerDb"
         const val FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
-        const val FILE_FIELDS = "id,name,size,modifiedTime"
+        const val FILE_FIELDS = "id,name,size,modifiedTime,headRevisionId,md5Checksum"
         const val HTTP_NOT_FOUND = 404
         val APP_PROPERTIES = mapOf(APP_PROPERTY_KEY to "true")
         val json = JsonFormat { ignoreUnknownKeys = true }

--- a/app/remotestorage/sync/build.gradle.kts
+++ b/app/remotestorage/sync/build.gradle.kts
@@ -19,23 +19,23 @@ kotlin {
         // KMP ABI deps must be re-declared per platform source set for dependency-analysis.
         jvmMain {
             dependencies {
+                // api: StateFlow appears in RemoteDatabaseController's public API (syncState).
+                api(libs.kotlinx.coroutines.core)
                 api(projects.app.db.core)
                 api(projects.app.model.core)
                 api(projects.app.remotestorage.core)
                 api(projects.utils.localsettings)
-
-                implementation(libs.kotlinx.coroutines.core)
             }
         }
 
         androidMain {
             dependencies {
+                // api: StateFlow appears in RemoteDatabaseController's public API (syncState).
+                api(libs.kotlinx.coroutines.core)
                 api(projects.app.db.core)
                 api(projects.app.model.core)
                 api(projects.app.remotestorage.core)
                 api(projects.utils.localsettings)
-
-                implementation(libs.kotlinx.coroutines.core)
             }
         }
 

--- a/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseBinding.kt
+++ b/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseBinding.kt
@@ -11,6 +11,8 @@ import com.moneymanager.localsettings.LocalSettings
  * @property remoteName the archive's display name on the remote (kept stable across syncs)
  * @property localCachePath where the hydrated working copy lives locally ([com.moneymanager.domain.model.DbLocation] string)
  * @property providerConfig provider-specific reconstruction config (e.g. a folder path); null when unused
+ * @property syncedRevision the remote [com.moneymanager.remotestorage.RemoteFile.revisionId] this device last
+ *   synced to; persisted so remote-change detection survives app restarts. Null until the first sync.
  */
 data class RemoteDatabaseBinding(
     val providerId: String,
@@ -18,6 +20,7 @@ data class RemoteDatabaseBinding(
     val remoteName: String,
     val localCachePath: String,
     val providerConfig: String? = null,
+    val syncedRevision: String? = null,
 )
 
 private const val KEY_PROVIDER_ID = "remoteDb.providerId"
@@ -25,6 +28,7 @@ private const val KEY_FILE_ID = "remoteDb.fileId"
 private const val KEY_NAME = "remoteDb.name"
 private const val KEY_LOCAL_PATH = "remoteDb.localPath"
 private const val KEY_PROVIDER_CONFIG = "remoteDb.providerConfig"
+private const val KEY_SYNCED_REVISION = "remoteDb.syncedRevision"
 
 /** Persists the [RemoteDatabaseBinding] for the active database in [LocalSettings]. */
 class RemoteDatabaseBindingStore(
@@ -35,7 +39,14 @@ class RemoteDatabaseBindingStore(
         val fileId = localSettings.getString(KEY_FILE_ID) ?: return null
         val name = localSettings.getString(KEY_NAME) ?: return null
         val localPath = localSettings.getString(KEY_LOCAL_PATH) ?: return null
-        return RemoteDatabaseBinding(providerId, fileId, name, localPath, localSettings.getString(KEY_PROVIDER_CONFIG))
+        return RemoteDatabaseBinding(
+            providerId,
+            fileId,
+            name,
+            localPath,
+            localSettings.getString(KEY_PROVIDER_CONFIG),
+            localSettings.getString(KEY_SYNCED_REVISION),
+        )
     }
 
     fun save(binding: RemoteDatabaseBinding) {
@@ -44,6 +55,7 @@ class RemoteDatabaseBindingStore(
         localSettings.putString(KEY_NAME, binding.remoteName)
         localSettings.putString(KEY_LOCAL_PATH, binding.localCachePath)
         binding.providerConfig?.let { localSettings.putString(KEY_PROVIDER_CONFIG, it) } ?: localSettings.remove(KEY_PROVIDER_CONFIG)
+        binding.syncedRevision?.let { localSettings.putString(KEY_SYNCED_REVISION, it) } ?: localSettings.remove(KEY_SYNCED_REVISION)
     }
 
     fun clear() {
@@ -52,5 +64,6 @@ class RemoteDatabaseBindingStore(
         localSettings.remove(KEY_NAME)
         localSettings.remove(KEY_LOCAL_PATH)
         localSettings.remove(KEY_PROVIDER_CONFIG)
+        localSettings.remove(KEY_SYNCED_REVISION)
     }
 }

--- a/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseController.kt
+++ b/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseController.kt
@@ -7,13 +7,32 @@ import com.moneymanager.remotestorage.RemoteFile
 import com.moneymanager.remotestorage.RemoteStorageProvider
 import com.moneymanager.remotestorage.RemoteStorageProviderFactory
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
+
+/** The outcome of a guarded [RemoteDatabaseController.syncNow] (upload) attempt. */
+enum class SyncResult {
+    /** No active remote session; nothing was attempted. */
+    NO_SESSION,
+
+    /** The local database was pushed to the remote. */
+    UPLOADED,
+
+    /** The remote moved since the last sync, so the push was refused to avoid clobbering it. */
+    BLOCKED,
+}
 
 /**
  * Session-scoped coordinator the UI/startup layer drives to put the active database under remote
  * storage. Wraps [RemoteDatabaseSyncService] with the provider reconstruction ([RemoteStorageProviderFactory])
  * and the in-memory password for the current run (never persisted), so "Sync now" and push-on-close
  * have everything they need without re-prompting.
+ *
+ * It also tracks the multi-device [syncState]: the local change baseline ([syncedToken]) and the remote
+ * revision baseline ([syncedRevision], persisted in the binding). Remote-change detection is on demand
+ * ([checkRemote] and the [syncNow] upload guard), never polled.
  *
  * Deliberately free of Compose so it stays unit-testable.
  */
@@ -29,6 +48,12 @@ class RemoteDatabaseController(
 
     private var session: Session? = null
     private var syncedToken: Long? = null
+    private var syncedRevision: String? = null
+
+    private val _syncState = MutableStateFlow(SyncState())
+
+    /** Reactive view of how the local copy stands relative to the remote (drives the sync UI + lock). */
+    val syncState: StateFlow<SyncState> = _syncState.asStateFlow()
 
     /** The persisted binding for the active database, if it is remote-backed. */
     fun activeBinding(): RemoteDatabaseBinding? = syncService.activeBinding()
@@ -42,6 +67,7 @@ class RemoteDatabaseController(
     /** Records the current database state as "fully synced" (call when the live DB matches the remote). */
     suspend fun markSynced(database: MoneyManagerDatabaseWrapper) {
         syncedToken = currentToken(database)
+        publish(localDirty = false, remoteChanged = false)
     }
 
     /** True if [database] has logical changes that haven't been pushed since the last [markSynced]. */
@@ -52,6 +78,62 @@ class RemoteDatabaseController(
 
     private suspend fun currentToken(database: MoneyManagerDatabaseWrapper): Long =
         withContext(Dispatchers.Default) { database.dataChangeToken() }
+
+    /** Republishes [syncState] from the two change flags (status is NO_SESSION when no session is armed). */
+    private fun publish(
+        localDirty: Boolean,
+        remoteChanged: Boolean,
+    ) {
+        val status =
+            if (session == null) SyncStatus.NO_SESSION else SyncState.statusFor(localDirty, remoteChanged)
+        _syncState.value = SyncState(status, localDirty, remoteChanged)
+    }
+
+    /**
+     * Synchronously marks [syncState] busy so the UI can disable the upload/download actions the instant
+     * one is triggered (before the longer async work and the switch to the loading screen). Cleared by the
+     * next [publish] (e.g. once the download completes and the database is re-baselined).
+     */
+    fun beginBusy() {
+        _syncState.value = _syncState.value.copy(busy = true)
+    }
+
+    /**
+     * Recomputes the local-dirty flag (cheap, no network) and republishes [syncState], keeping the last
+     * known remote-changed flag. Call this on a light cadence while a session is active.
+     */
+    suspend fun refreshLocalDirty(database: MoneyManagerDatabaseWrapper) {
+        if (session == null) {
+            publish(localDirty = false, remoteChanged = false)
+            return
+        }
+        publish(localDirty = hasUnsyncedChanges(database), remoteChanged = _syncState.value.remoteChanged)
+    }
+
+    /**
+     * Checks the remote for changes (a network `stat`) and republishes [syncState]. Invoked on demand
+     * (the "Check remote for changes" button), on session arm, and after a download — never on a timer.
+     * Propagates network/auth failures to the caller so the UI can report them.
+     */
+    suspend fun checkRemote(database: MoneyManagerDatabaseWrapper) {
+        if (session == null) {
+            publish(localDirty = false, remoteChanged = false)
+            return
+        }
+        val changed = remoteChanged()
+        publish(localDirty = hasUnsyncedChanges(database), remoteChanged = changed)
+    }
+
+    /**
+     * Whether the remote head revision differs from the baseline this device last synced to. False when
+     * there is no session or no baseline revision is known (can't tell → don't claim a change).
+     */
+    suspend fun remoteChanged(): Boolean {
+        val current = session ?: return false
+        val baseline = syncedRevision ?: return false
+        val rev = current.provider.stat(current.binding.remoteFileId)?.revisionId
+        return rev != null && rev != baseline
+    }
 
     /**
      * Ensures there is a usable session with [providerId] for the given [config], performing interactive
@@ -87,6 +169,7 @@ class RemoteDatabaseController(
         val provider = resolve(providerId, config)
         val binding = syncService.createRemote(provider, remoteName, localCachePath, database, password, config, onProgress)
         session = Session(provider, binding, password)
+        syncedRevision = binding.syncedRevision
         markSynced(database)
         return binding
     }
@@ -104,11 +187,14 @@ class RemoteDatabaseController(
         onProgress: (SyncProgress) -> Unit = {},
     ): DbLocation {
         val provider = resolve(providerId, config)
-        val binding = RemoteDatabaseBinding(providerId, remoteFile.id, remoteFile.name, localCachePath.toString(), config)
-        val location = syncService.hydrate(provider, binding, password, onProgress)
+        val initial = RemoteDatabaseBinding(providerId, remoteFile.id, remoteFile.name, localCachePath.toString(), config)
+        val result = syncService.hydrate(provider, initial, password, onProgress)
+        val binding = initial.copy(syncedRevision = result.revisionId)
         syncService.bind(binding)
         session = Session(provider, binding, password)
-        return location
+        syncedRevision = result.revisionId
+        publish(localDirty = false, remoteChanged = false)
+        return result.location
     }
 
     /**
@@ -121,9 +207,13 @@ class RemoteDatabaseController(
         onProgress: (SyncProgress) -> Unit = {},
     ): DbLocation {
         val provider = resolve(binding.providerId, binding.providerConfig)
-        val location = syncService.hydrate(provider, binding, password, onProgress)
-        session = Session(provider, binding, password)
-        return location
+        val result = syncService.hydrate(provider, binding, password, onProgress)
+        val updated = binding.copy(syncedRevision = result.revisionId)
+        syncService.bind(updated)
+        session = Session(provider, updated, password)
+        syncedRevision = result.revisionId
+        publish(localDirty = false, remoteChanged = false)
+        return result.location
     }
 
     /**
@@ -135,21 +225,57 @@ class RemoteDatabaseController(
         val provider = resolve(binding.providerId, binding.providerConfig)
         if (!syncService.verify(provider, binding, password)) return false
         session = Session(provider, binding, password)
+        syncedRevision = binding.syncedRevision
+        publish(localDirty = false, remoteChanged = false)
         return true
     }
 
     /**
-     * Pushes the open [database] to the bound remote file. No-op if there is no active session. Set
-     * [rebuildViews] false on close (the local copy is about to be discarded) to skip the rebuild.
+     * Pushes the open [database] to the bound remote file. Returns [SyncResult.NO_SESSION] when not
+     * remote-backed. Unless [force] is true, it first re-checks the remote and returns
+     * [SyncResult.BLOCKED] (without uploading) if another device pushed since the last sync, so an
+     * upload can never silently clobber remote changes. Set [rebuildViews] false on close (the local
+     * copy is about to be discarded) to skip the materialized-view rebuild.
      */
     suspend fun syncNow(
         database: MoneyManagerDatabaseWrapper,
+        force: Boolean = false,
         rebuildViews: Boolean = true,
         onProgress: (SyncProgress) -> Unit = {},
-    ) {
-        val current = session ?: return
-        syncService.push(current.provider, current.binding, database, current.password, rebuildViews, onProgress)
+    ): SyncResult {
+        val current = session ?: return SyncResult.NO_SESSION
+        if (!force && remoteChanged()) {
+            publish(localDirty = hasUnsyncedChanges(database), remoteChanged = true)
+            return SyncResult.BLOCKED
+        }
+        val file = syncService.push(current.provider, current.binding, database, current.password, rebuildViews, onProgress)
+        recordSyncedRevision(file.revisionId)
         markSynced(database)
+        return SyncResult.UPLOADED
+    }
+
+    /**
+     * Downloads the remote into the local working copy and returns the [DbLocation] to switch to. The
+     * caller must route this through the database-switch path so the working copy is reopened; the local
+     * change baseline is invalidated here and re-captured on the reopened handle (via [markSynced]).
+     */
+    suspend fun download(onProgress: (SyncProgress) -> Unit = {}): DbLocation {
+        val current = session ?: error("download requires an active remote session")
+        val result = syncService.hydrate(current.provider, current.binding, current.password, onProgress)
+        recordSyncedRevision(result.revisionId)
+        // Invalidate the local baseline so AppStartupHost re-captures it on the reopened database handle.
+        syncedToken = null
+        publish(localDirty = false, remoteChanged = false)
+        return result.location
+    }
+
+    /** Updates the in-memory + persisted remote-revision baseline after a successful upload/download. */
+    private fun recordSyncedRevision(revisionId: String?) {
+        syncedRevision = revisionId
+        val current = session ?: return
+        val updated = current.binding.copy(syncedRevision = revisionId)
+        session = current.copy(binding = updated)
+        syncService.bind(updated)
     }
 
     /**
@@ -183,6 +309,8 @@ class RemoteDatabaseController(
         syncService.clearBinding()
         session = null
         syncedToken = null
+        syncedRevision = null
+        _syncState.value = SyncState()
     }
 
     private suspend fun resolve(

--- a/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseController.kt
+++ b/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseController.kt
@@ -187,12 +187,22 @@ class RemoteDatabaseController(
         onProgress: (SyncProgress) -> Unit = {},
     ): DbLocation {
         val provider = resolve(providerId, config)
-        val initial = RemoteDatabaseBinding(providerId, remoteFile.id, remoteFile.name, localCachePath.toString(), config)
+        // Seed the baseline from the picked file so detection still works if hydrate can't fetch a revision.
+        val initial =
+            RemoteDatabaseBinding(
+                providerId = providerId,
+                remoteFileId = remoteFile.id,
+                remoteName = remoteFile.name,
+                localCachePath = localCachePath.toString(),
+                providerConfig = config,
+                syncedRevision = remoteFile.revisionId,
+            )
         val result = syncService.hydrate(provider, initial, password, onProgress)
-        val binding = initial.copy(syncedRevision = result.revisionId)
+        val revision = result.revisionId ?: remoteFile.revisionId
+        val binding = initial.copy(syncedRevision = revision)
         syncService.bind(binding)
         session = Session(provider, binding, password)
-        syncedRevision = result.revisionId
+        syncedRevision = revision
         publish(localDirty = false, remoteChanged = false)
         return result.location
     }
@@ -208,10 +218,12 @@ class RemoteDatabaseController(
     ): DbLocation {
         val provider = resolve(binding.providerId, binding.providerConfig)
         val result = syncService.hydrate(provider, binding, password, onProgress)
-        val updated = binding.copy(syncedRevision = result.revisionId)
+        // Keep the persisted baseline if this run couldn't fetch a revision.
+        val revision = result.revisionId ?: binding.syncedRevision
+        val updated = binding.copy(syncedRevision = revision)
         syncService.bind(updated)
         session = Session(provider, updated, password)
-        syncedRevision = result.revisionId
+        syncedRevision = revision
         publish(localDirty = false, remoteChanged = false)
         return result.location
     }
@@ -233,9 +245,13 @@ class RemoteDatabaseController(
     /**
      * Pushes the open [database] to the bound remote file. Returns [SyncResult.NO_SESSION] when not
      * remote-backed. Unless [force] is true, it first re-checks the remote and returns
-     * [SyncResult.BLOCKED] (without uploading) if another device pushed since the last sync, so an
-     * upload can never silently clobber remote changes. Set [rebuildViews] false on close (the local
-     * copy is about to be discarded) to skip the materialized-view rebuild.
+     * [SyncResult.BLOCKED] (without uploading) if another device pushed since the last sync.
+     *
+     * Note this is a best-effort guard, not an atomic conditional write: the Google Drive REST API v3 has
+     * no If-Match/ETag/revision precondition, so a push that lands between this check and the upload is
+     * still last-writer-wins. The check shrinks the window to near-zero for human-paced multi-device use;
+     * it does not eliminate it. Set [rebuildViews] false on close (the local copy is about to be
+     * discarded) to skip the materialized-view rebuild.
      */
     suspend fun syncNow(
         database: MoneyManagerDatabaseWrapper,
@@ -269,11 +285,16 @@ class RemoteDatabaseController(
         return result.location
     }
 
-    /** Updates the in-memory + persisted remote-revision baseline after a successful upload/download. */
+    /**
+     * Updates the in-memory + persisted remote-revision baseline after a successful upload/download.
+     * A null [revisionId] (provider didn't return one this run) keeps the previous baseline rather than
+     * wiping it, so remote-change detection isn't disabled by a missing revision.
+     */
     private fun recordSyncedRevision(revisionId: String?) {
-        syncedRevision = revisionId
+        val effective = revisionId ?: syncedRevision ?: return
+        syncedRevision = effective
         val current = session ?: return
-        val updated = current.binding.copy(syncedRevision = revisionId)
+        val updated = current.binding.copy(syncedRevision = effective)
         session = current.copy(binding = updated)
         syncService.bind(updated)
     }

--- a/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseController.kt
+++ b/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseController.kt
@@ -198,12 +198,7 @@ class RemoteDatabaseController(
                 syncedRevision = remoteFile.revisionId,
             )
         val result = syncService.hydrate(provider, initial, password, onProgress)
-        val revision = result.revisionId ?: remoteFile.revisionId
-        val binding = initial.copy(syncedRevision = revision)
-        syncService.bind(binding)
-        session = Session(provider, binding, password)
-        syncedRevision = revision
-        publish(localDirty = false, remoteChanged = false)
+        armHydratedSession(provider, initial, password, result.revisionId ?: remoteFile.revisionId)
         return result.location
     }
 
@@ -219,13 +214,25 @@ class RemoteDatabaseController(
         val provider = resolve(binding.providerId, binding.providerConfig)
         val result = syncService.hydrate(provider, binding, password, onProgress)
         // Keep the persisted baseline if this run couldn't fetch a revision.
-        val revision = result.revisionId ?: binding.syncedRevision
-        val updated = binding.copy(syncedRevision = revision)
-        syncService.bind(updated)
-        session = Session(provider, updated, password)
+        armHydratedSession(provider, binding, password, result.revisionId ?: binding.syncedRevision)
+        return result.location
+    }
+
+    /**
+     * Persists [revision] onto [binding], arms the session for [provider]/[password], and publishes the
+     * in-sync state. Shared by [openRemote] and [restore] after a successful hydrate.
+     */
+    private fun armHydratedSession(
+        provider: RemoteStorageProvider,
+        binding: RemoteDatabaseBinding,
+        password: String,
+        revision: String?,
+    ) {
+        val armed = binding.copy(syncedRevision = revision)
+        syncService.bind(armed)
+        session = Session(provider, armed, password)
         syncedRevision = revision
         publish(localDirty = false, remoteChanged = false)
-        return result.location
     }
 
     /**

--- a/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseSyncService.kt
+++ b/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseSyncService.kt
@@ -8,6 +8,7 @@ import com.moneymanager.database.MoneyManagerDatabaseWrapper
 import com.moneymanager.domain.model.DbLocation
 import com.moneymanager.domain.model.dbLocationFromString
 import com.moneymanager.localsettings.LocalSettings
+import com.moneymanager.remotestorage.RemoteFile
 import com.moneymanager.remotestorage.RemoteStorageProvider
 
 /**
@@ -49,7 +50,15 @@ class RemoteDatabaseSyncService(
         onProgress(SyncProgress("Uploading to cloud…", UPLOAD_FRACTION))
         val file = provider.upload(fileId = null, name = remoteName, bytes = archive)
         onProgress(SyncProgress("Done", 1f))
-        val binding = RemoteDatabaseBinding(provider.id, file.id, remoteName, localCachePath.toString(), providerConfig)
+        val binding =
+            RemoteDatabaseBinding(
+                provider.id,
+                file.id,
+                remoteName,
+                localCachePath.toString(),
+                providerConfig,
+                syncedRevision = file.revisionId,
+            )
         bindingStore.save(binding)
         return binding
     }
@@ -92,24 +101,28 @@ class RemoteDatabaseSyncService(
         password: String,
         rebuildAfter: Boolean = true,
         onProgress: (SyncProgress) -> Unit = {},
-    ) {
+    ): RemoteFile {
         val archive = shrinkAndPack(database, password, rebuildAfter, onProgress)
         onProgress(SyncProgress("Uploading to cloud…", UPLOAD_FRACTION))
-        provider.upload(fileId = binding.remoteFileId, name = binding.remoteName, bytes = archive)
+        val file = provider.upload(fileId = binding.remoteFileId, name = binding.remoteName, bytes = archive)
         onProgress(SyncProgress("Done", 1f))
+        return file
     }
 
     /**
      * Downloads and rehydrates the bound database into its local cache path (rebuilding its
-     * materialized views), returning the [DbLocation] to open.
+     * materialized views), returning the [DbLocation] to open and the remote [RemoteFile.revisionId]
+     * that was downloaded (so the caller can record it as the new synced baseline).
      */
     suspend fun hydrate(
         provider: RemoteStorageProvider,
         binding: RemoteDatabaseBinding,
         password: String,
         onProgress: (SyncProgress) -> Unit = {},
-    ): DbLocation {
+    ): HydrateResult {
         onProgress(SyncProgress("Downloading from cloud…", 0.1f))
+        // Capture the head revision we are about to fetch so the caller can baseline against it.
+        val revisionId = provider.stat(binding.remoteFileId)?.revisionId
         val archive = provider.download(binding.remoteFileId)
         onProgress(SyncProgress("Decrypting and decompressing…", 0.45f))
         val databaseBytes = ArchiveCodec.unpack(archive, password)
@@ -126,7 +139,7 @@ class RemoteDatabaseSyncService(
             opened.close()
         }
         onProgress(SyncProgress("Done", 1f))
-        return location
+        return HydrateResult(location, revisionId)
     }
 
     /**
@@ -164,3 +177,12 @@ class RemoteDatabaseSyncService(
         const val UPLOAD_FRACTION = 0.8f
     }
 }
+
+/**
+ * The outcome of [RemoteDatabaseSyncService.hydrate]: where the working copy was written and the
+ * remote revision it was downloaded from (null if the backend doesn't expose revisions).
+ */
+data class HydrateResult(
+    val location: DbLocation,
+    val revisionId: String?,
+)

--- a/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/SyncState.kt
+++ b/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/SyncState.kt
@@ -1,0 +1,49 @@
+package com.moneymanager.remotestorage.sync
+
+/**
+ * Where the local working copy stands relative to the remote archive, for a remote-backed database.
+ *
+ * - [NO_SESSION] – not remote-backed, or no password entered this run.
+ * - [IN_SYNC] – local matches remote; nothing to do.
+ * - [LOCAL_AHEAD] – local has unpushed edits; remote unchanged → safe to upload.
+ * - [REMOTE_AHEAD] – another device pushed; local has no edits → download to catch up, editing locked.
+ * - [CONFLICT] – both sides changed since the last sync → editing locked; uploading or downloading
+ *   discards one side's changes (the UI confirms before either).
+ */
+enum class SyncStatus { NO_SESSION, IN_SYNC, LOCAL_AHEAD, REMOTE_AHEAD, CONFLICT }
+
+/**
+ * Reactive snapshot of the active remote-backed database's sync standing, published by
+ * [RemoteDatabaseController.syncState]. Detection is on demand (a "Check remote for changes" button
+ * and the upload guard), not polled.
+ */
+data class SyncState(
+    val status: SyncStatus = SyncStatus.NO_SESSION,
+    val localDirty: Boolean = false,
+    val remoteChanged: Boolean = false,
+    /** True while a remote check / sync operation is in flight (for spinners and disabling buttons). */
+    val busy: Boolean = false,
+) {
+    /** Editing must be blocked while the remote is ahead, until the user downloads. */
+    val editingLocked: Boolean get() = status == SyncStatus.REMOTE_AHEAD || status == SyncStatus.CONFLICT
+
+    /** The Upload button is meaningful only when there are local changes to push. */
+    val canUpload: Boolean get() = status == SyncStatus.LOCAL_AHEAD || status == SyncStatus.CONFLICT
+
+    /** The Download button is meaningful only when the remote has moved ahead. */
+    val canDownload: Boolean get() = status == SyncStatus.REMOTE_AHEAD || status == SyncStatus.CONFLICT
+
+    companion object {
+        /** Derives the [SyncStatus] from the two change flags (assuming an active session). */
+        fun statusFor(
+            localDirty: Boolean,
+            remoteChanged: Boolean,
+        ): SyncStatus =
+            when {
+                localDirty && remoteChanged -> SyncStatus.CONFLICT
+                remoteChanged -> SyncStatus.REMOTE_AHEAD
+                localDirty -> SyncStatus.LOCAL_AHEAD
+                else -> SyncStatus.IN_SYNC
+            }
+    }
+}

--- a/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseControllerTest.kt
+++ b/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseControllerTest.kt
@@ -1,5 +1,7 @@
 package com.moneymanager.remotestorage.sync
 
+import com.moneymanager.database.MoneyManagerDatabaseWrapper
+import com.moneymanager.domain.model.DbLocation
 import com.moneymanager.test.database.createTestDatabaseLocation
 import com.moneymanager.test.database.createTestDatabaseManager
 import com.moneymanager.test.database.deleteTestDatabase
@@ -72,4 +74,147 @@ class RemoteDatabaseControllerTest {
                 deleteTestDatabase(targetLocation)
             }
         }
+
+    @Test
+    fun uploadDoesNotReportRemoteChanged() =
+        runTest {
+            withController { controller, _, database, location ->
+                controller.createRemote("in-memory", null, "db.mmdb", location, database, "pw")
+                database.bumpDataChange()
+                controller.refreshLocalDirty(database)
+                assertEquals(SyncStatus.LOCAL_AHEAD, controller.syncState.value.status)
+
+                assertEquals(SyncResult.UPLOADED, controller.syncNow(database))
+
+                // Our own upload must not look like an external change on the next check.
+                assertFalse(controller.remoteChanged(), "our own push should not register as a remote change")
+                controller.checkRemote(database)
+                assertEquals(SyncStatus.IN_SYNC, controller.syncState.value.status)
+            }
+        }
+
+    @Test
+    fun checkRemoteDetectsExternalPush() =
+        runTest {
+            withController { controller, provider, database, location ->
+                val binding = controller.createRemote("in-memory", null, "db.mmdb", location, database, "pw")
+                provider.externalPush(binding.remoteFileId, byteArrayOf(1, 2, 3))
+
+                controller.checkRemote(database)
+
+                val state = controller.syncState.value
+                assertEquals(SyncStatus.REMOTE_AHEAD, state.status)
+                assertTrue(state.editingLocked)
+                assertTrue(state.canDownload)
+                assertFalse(state.canUpload)
+            }
+        }
+
+    @Test
+    fun localEditMakesLocalAhead() =
+        runTest {
+            withController { controller, _, database, location ->
+                controller.createRemote("in-memory", null, "db.mmdb", location, database, "pw")
+                database.bumpDataChange()
+
+                controller.refreshLocalDirty(database)
+
+                val state = controller.syncState.value
+                assertEquals(SyncStatus.LOCAL_AHEAD, state.status)
+                assertTrue(state.canUpload)
+                assertFalse(state.canDownload)
+                assertFalse(state.editingLocked)
+            }
+        }
+
+    @Test
+    fun localEditPlusExternalPushIsConflict() =
+        runTest {
+            withController { controller, provider, database, location ->
+                val binding = controller.createRemote("in-memory", null, "db.mmdb", location, database, "pw")
+                database.bumpDataChange()
+                provider.externalPush(binding.remoteFileId, byteArrayOf(9))
+
+                controller.checkRemote(database)
+
+                val state = controller.syncState.value
+                assertEquals(SyncStatus.CONFLICT, state.status)
+                assertTrue(state.editingLocked)
+                assertTrue(state.canUpload)
+                assertTrue(state.canDownload)
+            }
+        }
+
+    @Test
+    fun guardedUploadAbortsWhenRemoteMoved() =
+        runTest {
+            withController { controller, provider, database, location ->
+                val binding = controller.createRemote("in-memory", null, "db.mmdb", location, database, "pw")
+                database.bumpDataChange()
+                val externalBytes = byteArrayOf(7, 7, 7)
+                provider.externalPush(binding.remoteFileId, externalBytes)
+
+                // Guarded upload must refuse rather than clobber the external content.
+                assertEquals(SyncResult.BLOCKED, controller.syncNow(database))
+                assertEquals(externalBytes.toList(), provider.download(binding.remoteFileId).toList())
+
+                // Forcing overwrites the remote with our copy.
+                assertEquals(SyncResult.UPLOADED, controller.syncNow(database, force = true))
+                assertFalse(externalBytes.toList() == provider.download(binding.remoteFileId).toList())
+            }
+        }
+
+    @Test
+    fun revisionBaselineSurvivesRestart() =
+        runTest {
+            val manager = createTestDatabaseManager()
+            val location = createTestDatabaseLocation()
+            try {
+                val database = manager.openDatabase(location)
+                val provider = InMemoryStorageProvider()
+                // A shared settings store is what carries the synced-revision baseline across "restarts".
+                val sync = RemoteDatabaseSyncService(manager, InMemoryLocalSettings())
+                val controller = RemoteDatabaseController(sync, SingleProviderFactory(provider))
+                val binding = controller.createRemote("in-memory", null, "db.mmdb", location, database, "pw")
+
+                // Another device pushes while we are "closed". Re-push the existing (valid) encrypted
+                // archive so resume's password check still passes; only the revision id changes.
+                provider.externalPush(binding.remoteFileId, provider.download(binding.remoteFileId))
+
+                // A fresh controller over the same persisted settings resumes and still detects the change.
+                val fresh = RemoteDatabaseController(sync, SingleProviderFactory(provider))
+                assertTrue(fresh.resume("pw"))
+                fresh.checkRemote(database)
+                assertEquals(SyncStatus.REMOTE_AHEAD, fresh.syncState.value.status)
+
+                database.close()
+            } finally {
+                deleteTestDatabase(location)
+            }
+        }
+
+    private suspend fun withController(
+        block: suspend (
+            controller: RemoteDatabaseController,
+            provider: InMemoryStorageProvider,
+            database: MoneyManagerDatabaseWrapper,
+            location: DbLocation,
+        ) -> Unit,
+    ) {
+        val manager = createTestDatabaseManager()
+        val location = createTestDatabaseLocation()
+        try {
+            val database = manager.openDatabase(location)
+            val provider = InMemoryStorageProvider()
+            val sync = RemoteDatabaseSyncService(manager, InMemoryLocalSettings())
+            val controller = RemoteDatabaseController(sync, SingleProviderFactory(provider))
+            try {
+                block(controller, provider, database, location)
+            } finally {
+                database.close()
+            }
+        } finally {
+            deleteTestDatabase(location)
+        }
+    }
 }

--- a/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseControllerTest.kt
+++ b/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseControllerTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -160,7 +161,7 @@ class RemoteDatabaseControllerTest {
 
                 // Forcing overwrites the remote with our copy.
                 assertEquals(SyncResult.UPLOADED, controller.syncNow(database, force = true))
-                assertFalse(externalBytes.toList() == provider.download(binding.remoteFileId).toList())
+                assertNotEquals(externalBytes.toList(), provider.download(binding.remoteFileId).toList())
             }
         }
 

--- a/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseSyncServiceTest.kt
+++ b/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseSyncServiceTest.kt
@@ -30,9 +30,19 @@ class RemoteDatabaseSyncServiceTest {
                 val binding = sync.createRemote(provider, "test.mmdb", cacheLocation, database, "pw")
                 assertEquals(binding, sync.activeBinding(), "binding should be persisted")
                 assertEquals(1, provider.list().size, "archive should be uploaded")
+                assertEquals(
+                    provider.stat(binding.remoteFileId)?.revisionId,
+                    binding.syncedRevision,
+                    "createRemote should record the uploaded revision as the synced baseline",
+                )
 
                 val hydrated = sync.hydrate(provider, binding.copy(localCachePath = targetLocation.toString()), "pw")
-                val restored = manager.openDatabase(hydrated)
+                assertEquals(
+                    provider.stat(binding.remoteFileId)?.revisionId,
+                    hydrated.revisionId,
+                    "hydrate should report the downloaded revision",
+                )
+                val restored = manager.openDatabase(hydrated.location)
                 try {
                     assertEquals(originalCurrencies, restored.countRows("currency"), "data should survive the round trip")
                 } finally {

--- a/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/TestDoubles.kt
+++ b/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/TestDoubles.kt
@@ -14,7 +14,8 @@ class InMemoryStorageProvider(
     override val id: String = "in-memory",
     override val displayName: String = "In-Memory",
 ) : RemoteStorageProvider {
-    private data class Entry(
+    // Not a data class: a ByteArray member would need custom equals/hashCode, which we don't rely on.
+    private class Entry(
         val name: String,
         val bytes: ByteArray,
         val revision: Int,
@@ -67,7 +68,7 @@ class InMemoryStorageProvider(
         bytes: ByteArray,
     ) {
         val existing = files[fileId] ?: error("No such file to externally push: $fileId")
-        files[fileId] = existing.copy(bytes = bytes.copyOf(), revision = revisionCounter++)
+        files[fileId] = Entry(existing.name, bytes.copyOf(), revisionCounter++)
     }
 
     private fun Entry.toRemoteFile(id: String) = RemoteFile(id, name, bytes.size.toLong(), revisionId = "rev-$revision")

--- a/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/TestDoubles.kt
+++ b/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/TestDoubles.kt
@@ -14,8 +14,17 @@ class InMemoryStorageProvider(
     override val id: String = "in-memory",
     override val displayName: String = "In-Memory",
 ) : RemoteStorageProvider {
-    private val files = mutableMapOf<String, Pair<String, ByteArray>>()
+    private data class Entry(
+        val name: String,
+        val bytes: ByteArray,
+        val revision: Int,
+    )
+
+    private val files = mutableMapOf<String, Entry>()
     private var counter = 0
+
+    // Monotonic, like Drive's headRevisionId: every content write yields a brand-new revision id.
+    private var revisionCounter = 0
     private var signedIn = true
 
     override suspend fun isSignedIn(): Boolean = signedIn
@@ -28,10 +37,11 @@ class InMemoryStorageProvider(
         signedIn = false
     }
 
-    override suspend fun list(): List<RemoteFile> = files.map { (id, value) -> RemoteFile(id, value.first, value.second.size.toLong()) }
+    override suspend fun list(): List<RemoteFile> = files.map { (id, entry) -> entry.toRemoteFile(id) }
 
-    override suspend fun download(fileId: String): ByteArray =
-        files[fileId]?.second ?: throw RemoteStorageException("No such file: $fileId")
+    override suspend fun stat(fileId: String): RemoteFile? = files[fileId]?.toRemoteFile(fileId)
+
+    override suspend fun download(fileId: String): ByteArray = files[fileId]?.bytes ?: throw RemoteStorageException("No such file: $fileId")
 
     override suspend fun upload(
         fileId: String?,
@@ -39,13 +49,25 @@ class InMemoryStorageProvider(
         bytes: ByteArray,
     ): RemoteFile {
         val id = fileId ?: "file-${counter++}"
-        files[id] = name to bytes
-        return RemoteFile(id, name, bytes.size.toLong())
+        val entry = Entry(name, bytes, revisionCounter++)
+        files[id] = entry
+        return entry.toRemoteFile(id)
     }
 
     override suspend fun delete(fileId: String) {
         files.remove(fileId)
     }
+
+    /** Test seam: simulate another device pushing new content to [fileId] (bumps its revision). */
+    fun externalPush(
+        fileId: String,
+        bytes: ByteArray,
+    ) {
+        val existing = files[fileId] ?: error("No such file to externally push: $fileId")
+        files[fileId] = existing.copy(bytes = bytes, revision = revisionCounter++)
+    }
+
+    private fun Entry.toRemoteFile(id: String) = RemoteFile(id, name, bytes.size.toLong(), revisionId = "rev-$revision")
 }
 
 /** A [RemoteStorageProviderFactory] that always hands back the same [provider] instance. */
@@ -74,6 +96,20 @@ fun MoneyManagerDatabaseWrapper.countRows(table: String): Long =
         },
         parameters = 0,
     ).value
+
+/**
+ * Appends an audit row so [MoneyManagerDatabaseWrapper.dataChangeToken] advances, simulating a local
+ * edit (the controller's "local dirty" signal) without going through the repositories.
+ */
+fun MoneyManagerDatabaseWrapper.bumpDataChange() {
+    execute(
+        identifier = null,
+        sql =
+            "INSERT INTO category_audit (audit_timestamp, audit_type_id, category_id, revision_id, name) " +
+                "VALUES (0, (SELECT id FROM audit_type LIMIT 1), 1, 1, 'dirty')",
+        parameters = 0,
+    )
+}
 
 /** In-memory [LocalSettings] for tests. */
 class InMemoryLocalSettings : LocalSettings {

--- a/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/TestDoubles.kt
+++ b/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/TestDoubles.kt
@@ -41,7 +41,10 @@ class InMemoryStorageProvider(
 
     override suspend fun stat(fileId: String): RemoteFile? = files[fileId]?.toRemoteFile(fileId)
 
-    override suspend fun download(fileId: String): ByteArray = files[fileId]?.bytes ?: throw RemoteStorageException("No such file: $fileId")
+    // Copy on the way in/out so a caller mutating its array can't silently change stored content (which
+    // would otherwise alter a file without bumping its revision and break the sync tests).
+    override suspend fun download(fileId: String): ByteArray =
+        files[fileId]?.bytes?.copyOf() ?: throw RemoteStorageException("No such file: $fileId")
 
     override suspend fun upload(
         fileId: String?,
@@ -49,7 +52,7 @@ class InMemoryStorageProvider(
         bytes: ByteArray,
     ): RemoteFile {
         val id = fileId ?: "file-${counter++}"
-        val entry = Entry(name, bytes, revisionCounter++)
+        val entry = Entry(name, bytes.copyOf(), revisionCounter++)
         files[id] = entry
         return entry.toRemoteFile(id)
     }
@@ -64,7 +67,7 @@ class InMemoryStorageProvider(
         bytes: ByteArray,
     ) {
         val existing = files[fileId] ?: error("No such file to externally push: $fileId")
-        files[fileId] = existing.copy(bytes = bytes, revision = revisionCounter++)
+        files[fileId] = existing.copy(bytes = bytes.copyOf(), revision = revisionCounter++)
     }
 
     private fun Entry.toRemoteFile(id: String) = RemoteFile(id, name, bytes.size.toLong(), revisionId = "rev-$revision")

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppServices.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppServices.kt
@@ -24,6 +24,7 @@ import com.moneymanager.domain.repository.QifImportRepository
 import com.moneymanager.domain.repository.SettingsRepository
 import com.moneymanager.domain.repository.TransactionRepository
 import com.moneymanager.domain.repository.TransferSourceRepository
+import com.moneymanager.importengineapi.EditGate
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importer.ImportEngineImpl
 
@@ -78,7 +79,7 @@ data class AuditDomain(
     val auditRepository: AuditRepository,
 )
 
-fun Application.toAppServices() =
+fun Application.toAppServices(editGate: EditGate = EditGate.AlwaysWritable) =
     AppServices(
         accounts =
             AccountsDomain(
@@ -112,6 +113,8 @@ fun Application.toAppServices() =
                         personRepository = people.personRepository,
                         personAttributeRepository = people.personAttributeRepository,
                         ownershipRepository = people.personAccountOwnershipRepository,
+                        categoryRepository = accounts.categoryRepository,
+                        editGate = editGate,
                     ),
             ),
         people =

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppStartupHost.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppStartupHost.kt
@@ -156,10 +156,12 @@ fun AppStartupHost(
                             val loaded = databaseState as? AppDatabaseState.Loaded ?: return@launch
                             databaseState =
                                 AppDatabaseState.Loading(DatabaseInitializationProgress("Downloading from cloud…", 0, 100))
-                            // Release the file lock so restore can overwrite the working copy.
-                            runCatching { loaded.database.close() }
                             onDatabaseReady(null, null)
                             try {
+                                // Release the file lock so restore can overwrite the working copy. If the
+                                // close fails we must NOT proceed — restoring over a still-open handle is the
+                                // file-busy case this flow exists to avoid — so let it abort into the catch.
+                                loaded.database.close()
                                 val location =
                                     controller.download { progress ->
                                         databaseState =

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppStartupHost.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppStartupHost.kt
@@ -147,11 +147,10 @@ fun AppStartupHost(
                 // overwrites the *currently open* working copy, so the live connection must be closed
                 // first — otherwise SQLite reports the database as busy/locked (notably on Android).
                 onReloadFromRemote = {
-                    val controller = remoteController
-                    if (controller != null) {
+                    if (remoteController != null) {
                         // Disable the download/upload actions immediately (before the loading screen takes
                         // over), so a second click can't kick off a concurrent reload.
-                        controller.beginBusy()
+                        remoteController.beginBusy()
                         scope.launch {
                             val loaded = databaseState as? AppDatabaseState.Loaded ?: return@launch
                             databaseState =
@@ -163,7 +162,7 @@ fun AppStartupHost(
                                 // file-busy case this flow exists to avoid — so let it abort into the catch.
                                 loaded.database.close()
                                 val location =
-                                    controller.download { progress ->
+                                    remoteController.download { progress ->
                                         databaseState =
                                             AppDatabaseState.Loading(
                                                 DatabaseInitializationProgress(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppStartupHost.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppStartupHost.kt
@@ -143,6 +143,53 @@ fun AppStartupHost(
                         )
                     }
                 },
+                // Re-hydrate the bound cloud database in place. Unlike a switch (different file), this
+                // overwrites the *currently open* working copy, so the live connection must be closed
+                // first — otherwise SQLite reports the database as busy/locked (notably on Android).
+                onReloadFromRemote = {
+                    val controller = remoteController
+                    if (controller != null) {
+                        // Disable the download/upload actions immediately (before the loading screen takes
+                        // over), so a second click can't kick off a concurrent reload.
+                        controller.beginBusy()
+                        scope.launch {
+                            val loaded = databaseState as? AppDatabaseState.Loaded ?: return@launch
+                            databaseState =
+                                AppDatabaseState.Loading(DatabaseInitializationProgress("Downloading from cloud…", 0, 100))
+                            // Release the file lock so restore can overwrite the working copy.
+                            runCatching { loaded.database.close() }
+                            onDatabaseReady(null, null)
+                            try {
+                                val location =
+                                    controller.download { progress ->
+                                        databaseState =
+                                            AppDatabaseState.Loading(
+                                                DatabaseInitializationProgress(
+                                                    progress.message,
+                                                    (progress.fraction * 100).toInt(),
+                                                    100,
+                                                ),
+                                            )
+                                    }
+                                val error =
+                                    openAndLoad(
+                                        location = location,
+                                        databaseManager = databaseManager,
+                                        createAppServices = createAppServices,
+                                        databaseStateUpdater = { databaseState = it },
+                                        onInfoLog = onInfoLog,
+                                        onErrorLog = onErrorLog,
+                                    )
+                                if (error == null) localSettings.putString(KEY_LAST_DATABASE, location.toString())
+                            } catch (expected: CancellationException) {
+                                throw expected
+                            } catch (expected: Exception) {
+                                onErrorLog("Failed to download database from cloud", expected)
+                                databaseState = AppDatabaseState.Error(loaded.location, expected)
+                            }
+                        }
+                    }
+                },
             )
         }
         is AppDatabaseState.Loading -> DatabaseStartupProgressScreen(state.progress)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/LocalImportEngine.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/LocalImportEngine.kt
@@ -1,16 +1,6 @@
 package com.moneymanager.ui
 
 import androidx.compose.runtime.staticCompositionLocalOf
-import com.moneymanager.domain.model.Account
-import com.moneymanager.domain.model.AccountId
-import com.moneymanager.domain.model.Category
-import com.moneymanager.domain.model.MergeId
-import com.moneymanager.domain.model.NewAttribute
-import com.moneymanager.domain.model.Person
-import com.moneymanager.domain.model.PersonId
-import com.moneymanager.domain.model.Source
-import com.moneymanager.domain.model.Transfer
-import com.moneymanager.domain.model.TransferId
 import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.ImportProgress
@@ -18,102 +8,24 @@ import com.moneymanager.importengineapi.ImportResult
 
 /**
  * The [ImportEngine] for the active database, provided once at the app root
- * ([com.moneymanager.ui.MoneyManagerApp]). It is the single entry point for every manual edit
- * (create/update/delete of transfers, accounts, categories, people, ownerships), so the write can be
- * blocked centrally when editing is locked (e.g. a cloud-backed database whose remote copy is ahead).
+ * ([com.moneymanager.ui.MoneyManagerApp]). It is the single entry point for every edit (described
+ * declaratively as an [ImportBatch]), so writes can be blocked centrally when editing is locked (e.g. a
+ * cloud-backed database whose remote copy is ahead).
  *
  * Exposed as a composition local rather than threaded through every screen because the editing dialogs
  * are deeply nested (e.g. an account picker inside a transaction dialog). The default is a stub that
- * throws only if a write is *invoked* without a provider — so render-only previews/tests work, while a
- * test that exercises an edit must provide a real or fake engine via
+ * throws only if [ImportEngine.import] is *invoked* without a provider — so render-only previews/tests
+ * work, while a test that exercises an edit must provide a real or fake engine via
  * `CompositionLocalProvider(LocalImportEngine provides …)`.
  */
 val LocalImportEngine =
     staticCompositionLocalOf<ImportEngine> { UnprovidedImportEngine }
 
-/** Stub used only when no engine is provided; every write fails loudly so missing wiring is obvious. */
+/** Stub used only when no engine is provided; [import] fails loudly so missing wiring is obvious. */
 private object UnprovidedImportEngine : ImportEngine {
-    private fun fail(): Nothing = error("LocalImportEngine not provided — host this screen under MoneyManagerApp or provide it in tests")
-
     override suspend fun import(
         batch: ImportBatch,
         onProgress: (suspend (ImportProgress) -> Unit)?,
         batchSize: Int,
-    ): ImportResult = fail()
-
-    override suspend fun createTransfers(
-        transfers: List<Transfer>,
-        newAttributes: Map<TransferId, List<NewAttribute>>,
-        sources: List<Source>,
-    ): List<TransferId> = fail()
-
-    override suspend fun updateTransfer(
-        transfer: Transfer?,
-        deletedAttributeIds: Set<Long>,
-        updatedAttributes: Map<Long, NewAttribute>,
-        newAttributes: List<NewAttribute>,
-        transactionId: TransferId,
-        source: Source,
-    ) = fail()
-
-    override suspend fun deleteTransaction(id: Long) = fail()
-
-    override suspend fun createAccount(
-        account: Account,
-        source: Source,
-    ): AccountId = fail()
-
-    override suspend fun updateAccountWithAttributes(
-        account: Account?,
-        accountId: AccountId,
-        deletedAttributeIds: Set<Long>,
-        updatedAttributes: Map<Long, NewAttribute>,
-        newAttributes: List<NewAttribute>,
-        source: Source,
-    ): Long = fail()
-
-    override suspend fun deleteAccount(id: AccountId) = fail()
-
-    override suspend fun mergeAccounts(
-        deletedAccount: AccountId,
-        survivingAccount: AccountId,
-    ): MergeId = fail()
-
-    override suspend fun unmergeAccount(mergeId: MergeId) = fail()
-
-    override suspend fun createCategory(
-        category: Category,
-        source: Source,
-    ): Long = fail()
-
-    override suspend fun updateCategory(
-        category: Category,
-        source: Source,
-    ) = fail()
-
-    override suspend fun deleteCategory(id: Long) = fail()
-
-    override suspend fun createPerson(
-        person: Person,
-        source: Source,
-    ): PersonId = fail()
-
-    override suspend fun updatePersonWithAttributes(
-        person: Person?,
-        personId: PersonId,
-        deletedAttributeIds: Set<Long>,
-        updatedAttributes: Map<Long, NewAttribute>,
-        newAttributes: List<NewAttribute>,
-        source: Source,
-    ): Long = fail()
-
-    override suspend fun deletePerson(id: PersonId) = fail()
-
-    override suspend fun createOwnership(
-        personId: PersonId,
-        accountId: AccountId,
-        source: Source,
-    ): Long = fail()
-
-    override suspend fun deleteOwnership(id: Long) = fail()
+    ): ImportResult = error("LocalImportEngine not provided — host this screen under MoneyManagerApp or provide it in tests")
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/LocalImportEngine.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/LocalImportEngine.kt
@@ -1,0 +1,119 @@
+package com.moneymanager.ui
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Category
+import com.moneymanager.domain.model.MergeId
+import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.Person
+import com.moneymanager.domain.model.PersonId
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.importengineapi.ImportBatch
+import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.ImportProgress
+import com.moneymanager.importengineapi.ImportResult
+
+/**
+ * The [ImportEngine] for the active database, provided once at the app root
+ * ([com.moneymanager.ui.MoneyManagerApp]). It is the single entry point for every manual edit
+ * (create/update/delete of transfers, accounts, categories, people, ownerships), so the write can be
+ * blocked centrally when editing is locked (e.g. a cloud-backed database whose remote copy is ahead).
+ *
+ * Exposed as a composition local rather than threaded through every screen because the editing dialogs
+ * are deeply nested (e.g. an account picker inside a transaction dialog). The default is a stub that
+ * throws only if a write is *invoked* without a provider — so render-only previews/tests work, while a
+ * test that exercises an edit must provide a real or fake engine via
+ * `CompositionLocalProvider(LocalImportEngine provides …)`.
+ */
+val LocalImportEngine =
+    staticCompositionLocalOf<ImportEngine> { UnprovidedImportEngine }
+
+/** Stub used only when no engine is provided; every write fails loudly so missing wiring is obvious. */
+private object UnprovidedImportEngine : ImportEngine {
+    private fun fail(): Nothing = error("LocalImportEngine not provided — host this screen under MoneyManagerApp or provide it in tests")
+
+    override suspend fun import(
+        batch: ImportBatch,
+        onProgress: (suspend (ImportProgress) -> Unit)?,
+        batchSize: Int,
+    ): ImportResult = fail()
+
+    override suspend fun createTransfers(
+        transfers: List<Transfer>,
+        newAttributes: Map<TransferId, List<NewAttribute>>,
+        sources: List<Source>,
+    ): List<TransferId> = fail()
+
+    override suspend fun updateTransfer(
+        transfer: Transfer?,
+        deletedAttributeIds: Set<Long>,
+        updatedAttributes: Map<Long, NewAttribute>,
+        newAttributes: List<NewAttribute>,
+        transactionId: TransferId,
+        source: Source,
+    ) = fail()
+
+    override suspend fun deleteTransaction(id: Long) = fail()
+
+    override suspend fun createAccount(
+        account: Account,
+        source: Source,
+    ): AccountId = fail()
+
+    override suspend fun updateAccountWithAttributes(
+        account: Account?,
+        accountId: AccountId,
+        deletedAttributeIds: Set<Long>,
+        updatedAttributes: Map<Long, NewAttribute>,
+        newAttributes: List<NewAttribute>,
+        source: Source,
+    ): Long = fail()
+
+    override suspend fun deleteAccount(id: AccountId) = fail()
+
+    override suspend fun mergeAccounts(
+        deletedAccount: AccountId,
+        survivingAccount: AccountId,
+    ): MergeId = fail()
+
+    override suspend fun unmergeAccount(mergeId: MergeId) = fail()
+
+    override suspend fun createCategory(
+        category: Category,
+        source: Source,
+    ): Long = fail()
+
+    override suspend fun updateCategory(
+        category: Category,
+        source: Source,
+    ) = fail()
+
+    override suspend fun deleteCategory(id: Long) = fail()
+
+    override suspend fun createPerson(
+        person: Person,
+        source: Source,
+    ): PersonId = fail()
+
+    override suspend fun updatePersonWithAttributes(
+        person: Person?,
+        personId: PersonId,
+        deletedAttributeIds: Set<Long>,
+        updatedAttributes: Map<Long, NewAttribute>,
+        newAttributes: List<NewAttribute>,
+        source: Source,
+    ): Long = fail()
+
+    override suspend fun deletePerson(id: PersonId) = fail()
+
+    override suspend fun createOwnership(
+        personId: PersonId,
+        accountId: AccountId,
+        source: Source,
+    ): Long = fail()
+
+    override suspend fun deleteOwnership(id: Long) = fail()
+}

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -20,6 +21,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -109,6 +111,7 @@ fun MoneyManagerApp(
         // Multi-device sync state: when the remote is ahead, editing is locked until the user downloads.
         val syncState by (remoteController?.syncState ?: remember { MutableStateFlow(SyncState()) }).collectAsState()
         val editingLocked = syncState.editingLocked
+        var showConflictDownloadConfirm by remember { mutableStateOf(false) }
 
         var defaultCurrencyLoaded by remember { mutableStateOf(false) }
         val defaultCurrencyId by services.settings.settingsRepository
@@ -281,7 +284,15 @@ fun MoneyManagerApp(
                             EditingLockedBanner(
                                 conflict = syncState.status == SyncStatus.CONFLICT,
                                 enabled = !syncState.busy,
-                                onDownload = onReloadFromRemote,
+                                // In a conflict, downloading discards local edits — confirm first (matching
+                                // the Settings sync UI). Otherwise the remote is simply ahead: download directly.
+                                onDownload = {
+                                    if (syncState.status == SyncStatus.CONFLICT) {
+                                        showConflictDownloadConfirm = true
+                                    } else {
+                                        onReloadFromRemote()
+                                    }
+                                },
                             )
                         }
                         Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
@@ -809,6 +820,28 @@ fun MoneyManagerApp(
                         },
                         onSaved = {
                             transactionRefreshTrigger++
+                        },
+                    )
+                }
+
+                if (showConflictDownloadConfirm) {
+                    AlertDialog(
+                        onDismissRequest = { showConflictDownloadConfirm = false },
+                        title = { Text("Discard local changes?") },
+                        text = {
+                            Text(
+                                "Another device changed this database since your last sync. Downloading now will " +
+                                    "discard your local unsynced changes. This can't be undone.",
+                            )
+                        },
+                        confirmButton = {
+                            TextButton(onClick = {
+                                showConflictDownloadConfirm = false
+                                onReloadFromRemote()
+                            }) { Text("Discard local") }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showConflictDownloadConfirm = false }) { Text("Cancel") }
                         },
                     )
                 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -460,7 +460,6 @@ fun MoneyManagerApp(
                                             transactionRepository = services.transactions.transactionRepository,
                                             maintenance = services.imports.maintenance,
                                             personRepository = services.people.personRepository,
-                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
                                             importEngine = services.transactions.importEngine,
                                             deviceId = services.deviceId,
                                             onCsvImportClick = { importId ->
@@ -531,7 +530,6 @@ fun MoneyManagerApp(
                                             currencyRepository = services.accounts.currencyRepository,
                                             attributeTypeRepository = services.transactions.attributeTypeRepository,
                                             personRepository = services.people.personRepository,
-                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
                                             maintenance = services.imports.maintenance,
                                             transferSourceRepository = services.transactions.transferSourceRepository,
                                             importEngine = services.transactions.importEngine,
@@ -557,7 +555,6 @@ fun MoneyManagerApp(
                                             categoryRepository = services.accounts.categoryRepository,
                                             currencyRepository = services.accounts.currencyRepository,
                                             personRepository = services.people.personRepository,
-                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
                                             attributeTypeRepository = services.transactions.attributeTypeRepository,
                                             settingsRepository = services.settings.settingsRepository,
                                             maintenance = services.imports.maintenance,
@@ -584,7 +581,6 @@ fun MoneyManagerApp(
                                             categoryRepository = services.accounts.categoryRepository,
                                             currencyRepository = services.accounts.currencyRepository,
                                             personRepository = services.people.personRepository,
-                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
                                             csvStrategyImportExport = services.imports.csvStrategyImportExport,
                                             appVersion = appVersion,
                                             onBack = { navigationHistory.navigateBack() },
@@ -613,7 +609,6 @@ fun MoneyManagerApp(
                                             currencyRepository = services.accounts.currencyRepository,
                                             attributeTypeRepository = services.transactions.attributeTypeRepository,
                                             personRepository = services.people.personRepository,
-                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
                                             onBack = { navigationHistory.navigateBack() },
                                         )
                                     }
@@ -630,7 +625,6 @@ fun MoneyManagerApp(
                                             currencyRepository = services.accounts.currencyRepository,
                                             attributeTypeRepository = services.transactions.attributeTypeRepository,
                                             personRepository = services.people.personRepository,
-                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
                                             onBack = { navigationHistory.navigateBack() },
                                         )
                                     }
@@ -809,7 +803,6 @@ fun MoneyManagerApp(
                         currencyRepository = services.accounts.currencyRepository,
                         attributeTypeRepository = services.transactions.attributeTypeRepository,
                         personRepository = services.people.personRepository,
-                        personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
                         maintenance = services.imports.maintenance,
                         preSelectedSourceAccountId = preSelectedAccountId,
                         preSelectedCurrencyId = preSelectedCurrencyId,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -2,24 +2,30 @@
 
 package com.moneymanager.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,6 +40,8 @@ import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.DbLocation
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.remotestorage.sync.RemoteDatabaseController
+import com.moneymanager.remotestorage.sync.SyncState
+import com.moneymanager.remotestorage.sync.SyncStatus
 import com.moneymanager.ui.background.BackgroundTaskPanel
 import com.moneymanager.ui.background.LocalBackgroundTaskManager
 import com.moneymanager.ui.background.rememberBackgroundTaskManager
@@ -70,6 +78,7 @@ import com.moneymanager.ui.screens.qif.QifStrategyEditorScreen
 import com.moneymanager.ui.screens.transactions.AccountTransactionsScreen
 import com.moneymanager.ui.screens.transactions.TransactionAuditScreen
 import com.moneymanager.ui.screens.transactions.TransactionEditDialog
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -81,6 +90,7 @@ fun MoneyManagerApp(
     databaseLocation: DbLocation,
     services: AppServices,
     onRequestSwitchDatabase: (DbLocation) -> Unit,
+    onReloadFromRemote: () -> Unit = {},
     remoteController: RemoteDatabaseController? = null,
     database: MoneyManagerDatabaseWrapper? = null,
 ) {
@@ -95,6 +105,10 @@ fun MoneyManagerApp(
         var preSelectedCurrencyId by remember { mutableStateOf<CurrencyId?>(null) }
         var currentlyViewedCurrencyId by remember { mutableStateOf<CurrencyId?>(null) }
         var transactionRefreshTrigger by remember { mutableStateOf(0) }
+
+        // Multi-device sync state: when the remote is ahead, editing is locked until the user downloads.
+        val syncState by (remoteController?.syncState ?: remember { MutableStateFlow(SyncState()) }).collectAsState()
+        val editingLocked = syncState.editingLocked
 
         var defaultCurrencyLoaded by remember { mutableStateOf(false) }
         val defaultCurrencyId by services.settings.settingsRepository
@@ -135,6 +149,7 @@ fun MoneyManagerApp(
             CompositionLocalProvider(
                 LocalBackgroundTaskManager provides backgroundTaskManager,
                 LocalDeviceId provides services.deviceId,
+                LocalImportEngine provides services.transactions.importEngine,
             ) {
                 // Handle system back button (Android) when there's navigation history
                 PlatformBackHandler(enabled = navigationHistory.canGoBack) {
@@ -248,7 +263,7 @@ fun MoneyManagerApp(
                             currentScreen is Screen.Accounts ||
                                 currentScreen is Screen.AccountTransactions ||
                                 currentScreen is Screen.Categories
-                        if (showTransactionFab) {
+                        if (showTransactionFab && !editingLocked) {
                             FloatingActionButton(
                                 onClick = {
                                     preSelectedAccountId = currentlyViewedAccountId
@@ -261,502 +276,511 @@ fun MoneyManagerApp(
                         }
                     },
                 ) { paddingValues ->
-                    Box(modifier = Modifier.padding(paddingValues)) {
-                        currentScreen.let { screen ->
-                            when (screen) {
-                                is Screen.Accounts -> {
-                                    // Reset currentlyViewedAccountId and currentlyViewedCurrencyId when on other screens
-                                    LaunchedEffect(Unit) {
-                                        currentlyViewedAccountId = null
-                                        currentlyViewedCurrencyId = null
+                    Column(modifier = Modifier.padding(paddingValues)) {
+                        if (editingLocked) {
+                            EditingLockedBanner(
+                                conflict = syncState.status == SyncStatus.CONFLICT,
+                                enabled = !syncState.busy,
+                                onDownload = onReloadFromRemote,
+                            )
+                        }
+                        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                            currentScreen.let { screen ->
+                                when (screen) {
+                                    is Screen.Accounts -> {
+                                        // Reset currentlyViewedAccountId and currentlyViewedCurrencyId when on other screens
+                                        LaunchedEffect(Unit) {
+                                            currentlyViewedAccountId = null
+                                            currentlyViewedCurrencyId = null
+                                        }
+                                        AccountsScreen(
+                                            accountRepository = services.accounts.accountRepository,
+                                            accountAttributeRepository = services.accounts.accountAttributeRepository,
+                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
+                                            categoryRepository = services.accounts.categoryRepository,
+                                            transactionRepository = services.transactions.transactionRepository,
+                                            personRepository = services.people.personRepository,
+                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
+                                            maintenance = services.imports.maintenance,
+                                            scrollToAccountId = screen.scrollToAccountId,
+                                            onAccountClick = { account ->
+                                                // Replace current screen with one that remembers the clicked account
+                                                // so that navigating back will scroll to this account
+                                                navigationHistory.replaceCurrentScreen(Screen.Accounts(scrollToAccountId = account.id))
+                                                navigationHistory.navigateTo(Screen.AccountTransactions(account.id, account.name))
+                                            },
+                                            onAuditClick = { account ->
+                                                navigationHistory.navigateTo(Screen.AccountAuditHistory(account.id, account.name))
+                                            },
+                                        )
                                     }
-                                    AccountsScreen(
-                                        accountRepository = services.accounts.accountRepository,
-                                        accountAttributeRepository = services.accounts.accountAttributeRepository,
-                                        attributeTypeRepository = services.transactions.attributeTypeRepository,
-                                        categoryRepository = services.accounts.categoryRepository,
-                                        transactionRepository = services.transactions.transactionRepository,
-                                        personRepository = services.people.personRepository,
-                                        personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
-                                        maintenance = services.imports.maintenance,
-                                        scrollToAccountId = screen.scrollToAccountId,
-                                        onAccountClick = { account ->
-                                            // Replace current screen with one that remembers the clicked account
-                                            // so that navigating back will scroll to this account
-                                            navigationHistory.replaceCurrentScreen(Screen.Accounts(scrollToAccountId = account.id))
-                                            navigationHistory.navigateTo(Screen.AccountTransactions(account.id, account.name))
-                                        },
-                                        onAuditClick = { account ->
-                                            navigationHistory.navigateTo(Screen.AccountAuditHistory(account.id, account.name))
-                                        },
-                                    )
-                                }
-                                is Screen.Currencies -> {
-                                    // Reset currentlyViewedAccountId and currentlyViewedCurrencyId when on other screens
-                                    LaunchedEffect(Unit) {
-                                        currentlyViewedAccountId = null
-                                        currentlyViewedCurrencyId = null
+                                    is Screen.Currencies -> {
+                                        // Reset currentlyViewedAccountId and currentlyViewedCurrencyId when on other screens
+                                        LaunchedEffect(Unit) {
+                                            currentlyViewedAccountId = null
+                                            currentlyViewedCurrencyId = null
+                                        }
+                                        CurrenciesScreen(
+                                            currencyRepository = services.accounts.currencyRepository,
+                                            onAuditClick = { currency ->
+                                                navigationHistory.navigateTo(Screen.CurrencyAuditHistory(currency.id, currency.code))
+                                            },
+                                        )
                                     }
-                                    CurrenciesScreen(
-                                        currencyRepository = services.accounts.currencyRepository,
-                                        onAuditClick = { currency ->
-                                            navigationHistory.navigateTo(Screen.CurrencyAuditHistory(currency.id, currency.code))
-                                        },
-                                    )
-                                }
-                                is Screen.Categories -> {
-                                    // Reset currentlyViewedAccountId and currentlyViewedCurrencyId when on other screens
-                                    LaunchedEffect(Unit) {
-                                        currentlyViewedAccountId = null
-                                        currentlyViewedCurrencyId = null
+                                    is Screen.Categories -> {
+                                        // Reset currentlyViewedAccountId and currentlyViewedCurrencyId when on other screens
+                                        LaunchedEffect(Unit) {
+                                            currentlyViewedAccountId = null
+                                            currentlyViewedCurrencyId = null
+                                        }
+                                        CategoriesScreen(
+                                            categoryRepository = services.accounts.categoryRepository,
+                                            currencyRepository = services.accounts.currencyRepository,
+                                            onAuditClick = { category ->
+                                                navigationHistory.navigateTo(Screen.CategoryAuditHistory(category.id, category.name))
+                                            },
+                                        )
                                     }
-                                    CategoriesScreen(
-                                        categoryRepository = services.accounts.categoryRepository,
-                                        currencyRepository = services.accounts.currencyRepository,
-                                        onAuditClick = { category ->
-                                            navigationHistory.navigateTo(Screen.CategoryAuditHistory(category.id, category.name))
-                                        },
-                                    )
-                                }
-                                is Screen.People,
-                                is Screen.PeopleScroll,
-                                -> {
-                                    // Reset currentlyViewedAccountId and currentlyViewedCurrencyId when on other screens
-                                    LaunchedEffect(Unit) {
-                                        currentlyViewedAccountId = null
-                                        currentlyViewedCurrencyId = null
+                                    is Screen.People,
+                                    is Screen.PeopleScroll,
+                                    -> {
+                                        // Reset currentlyViewedAccountId and currentlyViewedCurrencyId when on other screens
+                                        LaunchedEffect(Unit) {
+                                            currentlyViewedAccountId = null
+                                            currentlyViewedCurrencyId = null
+                                        }
+                                        PeopleScreen(
+                                            personRepository = services.people.personRepository,
+                                            personAttributeRepository = services.people.personAttributeRepository,
+                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
+                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
+                                            scrollToPersonId = (screen as? Screen.PeopleScroll)?.personId,
+                                            onAuditClick = { person ->
+                                                navigationHistory.navigateTo(Screen.PersonAuditHistory(person.id, person.fullName))
+                                            },
+                                        )
                                     }
-                                    PeopleScreen(
-                                        personRepository = services.people.personRepository,
-                                        personAttributeRepository = services.people.personAttributeRepository,
-                                        personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
-                                        attributeTypeRepository = services.transactions.attributeTypeRepository,
-                                        scrollToPersonId = (screen as? Screen.PeopleScroll)?.personId,
-                                        onAuditClick = { person ->
-                                            navigationHistory.navigateTo(Screen.PersonAuditHistory(person.id, person.fullName))
-                                        },
-                                    )
-                                }
-                                is Screen.Settings -> {
-                                    // Reset currentlyViewedAccountId and currentlyViewedCurrencyId when on other screens
-                                    LaunchedEffect(Unit) {
-                                        currentlyViewedAccountId = null
-                                        currentlyViewedCurrencyId = null
+                                    is Screen.Settings -> {
+                                        // Reset currentlyViewedAccountId and currentlyViewedCurrencyId when on other screens
+                                        LaunchedEffect(Unit) {
+                                            currentlyViewedAccountId = null
+                                            currentlyViewedCurrencyId = null
+                                        }
+                                        SettingsScreen(
+                                            currencyRepository = services.accounts.currencyRepository,
+                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
+                                            importEngine = services.transactions.importEngine,
+                                            settingsRepository = services.settings.settingsRepository,
+                                            maintenance = services.imports.maintenance,
+                                            currentDatabaseLocation = databaseLocation,
+                                            onRequestSwitchDatabase = onRequestSwitchDatabase,
+                                            onReloadFromRemote = onReloadFromRemote,
+                                            remoteController = remoteController,
+                                            database = database,
+                                        )
                                     }
-                                    SettingsScreen(
-                                        currencyRepository = services.accounts.currencyRepository,
-                                        categoryRepository = services.accounts.categoryRepository,
-                                        attributeTypeRepository = services.transactions.attributeTypeRepository,
-                                        importEngine = services.transactions.importEngine,
-                                        settingsRepository = services.settings.settingsRepository,
-                                        maintenance = services.imports.maintenance,
-                                        currentDatabaseLocation = databaseLocation,
-                                        onRequestSwitchDatabase = onRequestSwitchDatabase,
-                                        remoteController = remoteController,
-                                        database = database,
-                                    )
-                                }
-                                is Screen.AccountTransactions -> {
-                                    // Initialize currentlyViewedAccountId when first entering the screen
-                                    LaunchedEffect(screen.accountId) {
-                                        currentlyViewedAccountId = screen.accountId
+                                    is Screen.AccountTransactions -> {
+                                        // Initialize currentlyViewedAccountId when first entering the screen
+                                        LaunchedEffect(screen.accountId) {
+                                            currentlyViewedAccountId = screen.accountId
+                                        }
+                                        AccountTransactionsScreen(
+                                            accountId = currentlyViewedAccountId ?: screen.accountId,
+                                            transactionRepository = services.transactions.transactionRepository,
+                                            accountRepository = services.accounts.accountRepository,
+                                            accountAttributeRepository = services.accounts.accountAttributeRepository,
+                                            categoryRepository = services.accounts.categoryRepository,
+                                            currencyRepository = services.accounts.currencyRepository,
+                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
+                                            personRepository = services.people.personRepository,
+                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
+                                            maintenance = services.imports.maintenance,
+                                            onAccountIdChange = { accountId ->
+                                                currentlyViewedAccountId = accountId
+                                            },
+                                            onCurrencyIdChange = { currencyId ->
+                                                currentlyViewedCurrencyId = currencyId
+                                            },
+                                            onAccountClick = { accountId, accountName, currencyId, transferId ->
+                                                navigationHistory.navigateTo(
+                                                    Screen.AccountTransactions(
+                                                        accountId = accountId,
+                                                        accountName = accountName,
+                                                        selectedCurrencyId = currencyId,
+                                                        scrollToTransferId = transferId,
+                                                    ),
+                                                )
+                                            },
+                                            onAuditClick = { transferId ->
+                                                navigationHistory.navigateTo(Screen.AuditHistory(transferId))
+                                            },
+                                            // Clicking a fee badge jumps to the linked transfer, landing on its
+                                            // (own) account scrolled to it.
+                                            onFeeLinkClick = { transferId ->
+                                                navigateToTransferAccount(transferId, isPositiveAmount = false)
+                                            },
+                                            scrollToTransferId = screen.scrollToTransferId,
+                                            initialCurrencyId = screen.selectedCurrencyId,
+                                            externalRefreshTrigger = transactionRefreshTrigger,
+                                        )
                                     }
-                                    AccountTransactionsScreen(
-                                        accountId = currentlyViewedAccountId ?: screen.accountId,
-                                        transactionRepository = services.transactions.transactionRepository,
-                                        accountRepository = services.accounts.accountRepository,
-                                        accountAttributeRepository = services.accounts.accountAttributeRepository,
-                                        categoryRepository = services.accounts.categoryRepository,
-                                        currencyRepository = services.accounts.currencyRepository,
-                                        attributeTypeRepository = services.transactions.attributeTypeRepository,
-                                        personRepository = services.people.personRepository,
-                                        personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
-                                        maintenance = services.imports.maintenance,
-                                        onAccountIdChange = { accountId ->
-                                            currentlyViewedAccountId = accountId
-                                        },
-                                        onCurrencyIdChange = { currencyId ->
-                                            currentlyViewedCurrencyId = currencyId
-                                        },
-                                        onAccountClick = { accountId, accountName, currencyId, transferId ->
-                                            navigationHistory.navigateTo(
-                                                Screen.AccountTransactions(
-                                                    accountId = accountId,
-                                                    accountName = accountName,
-                                                    selectedCurrencyId = currencyId,
-                                                    scrollToTransferId = transferId,
-                                                ),
-                                            )
-                                        },
-                                        onAuditClick = { transferId ->
-                                            navigationHistory.navigateTo(Screen.AuditHistory(transferId))
-                                        },
-                                        // Clicking a fee badge jumps to the linked transfer, landing on its
-                                        // (own) account scrolled to it.
-                                        onFeeLinkClick = { transferId ->
-                                            navigateToTransferAccount(transferId, isPositiveAmount = false)
-                                        },
-                                        scrollToTransferId = screen.scrollToTransferId,
-                                        initialCurrencyId = screen.selectedCurrencyId,
-                                        externalRefreshTrigger = transactionRefreshTrigger,
-                                    )
-                                }
-                                is Screen.Imports -> {
-                                    LaunchedEffect(Unit) {
-                                        currentlyViewedAccountId = null
-                                        currentlyViewedCurrencyId = null
+                                    is Screen.Imports -> {
+                                        LaunchedEffect(Unit) {
+                                            currentlyViewedAccountId = null
+                                            currentlyViewedCurrencyId = null
+                                        }
+                                        ImportsScreen(
+                                            selectedTab = screen.tab,
+                                            onTabSelected = { tab ->
+                                                navigationHistory.replaceCurrentScreen(Screen.Imports(tab))
+                                            },
+                                            csvImportRepository = services.imports.csvImportRepository,
+                                            csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
+                                            csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
+                                            qifImportRepository = services.imports.qifImportRepository,
+                                            categoryRepository = services.accounts.categoryRepository,
+                                            settingsRepository = services.settings.settingsRepository,
+                                            apiSessionRepository = services.imports.apiSessionRepository,
+                                            apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
+                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
+                                            accountAttributeRepository = services.accounts.accountAttributeRepository,
+                                            accountRepository = services.accounts.accountRepository,
+                                            currencyRepository = services.accounts.currencyRepository,
+                                            transactionRepository = services.transactions.transactionRepository,
+                                            maintenance = services.imports.maintenance,
+                                            personRepository = services.people.personRepository,
+                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
+                                            importEngine = services.transactions.importEngine,
+                                            deviceId = services.deviceId,
+                                            onCsvImportClick = { importId ->
+                                                navigationHistory.navigateTo(Screen.CsvImportDetail(importId))
+                                            },
+                                            onCsvStrategiesClick = {
+                                                navigationHistory.navigateTo(Screen.CsvStrategies)
+                                            },
+                                            onQifImportClick = { importId ->
+                                                navigationHistory.navigateTo(Screen.QifImportDetail(importId))
+                                            },
+                                            onAddCredentialClick = {
+                                                navigationHistory.navigateTo(Screen.ConnectApi)
+                                            },
+                                            onApiStrategiesClick = {
+                                                navigationHistory.navigateTo(Screen.ApiStrategies)
+                                            },
+                                            onSessionClick = { session ->
+                                                navigationHistory.navigateTo(Screen.ApiSessionTraffic(session.id))
+                                            },
+                                            onTransactionsImported = {
+                                                transactionRefreshTrigger++
+                                            },
+                                        )
                                     }
-                                    ImportsScreen(
-                                        selectedTab = screen.tab,
-                                        onTabSelected = { tab ->
-                                            navigationHistory.replaceCurrentScreen(Screen.Imports(tab))
-                                        },
-                                        csvImportRepository = services.imports.csvImportRepository,
-                                        csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
-                                        csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
-                                        qifImportRepository = services.imports.qifImportRepository,
-                                        categoryRepository = services.accounts.categoryRepository,
-                                        settingsRepository = services.settings.settingsRepository,
-                                        apiSessionRepository = services.imports.apiSessionRepository,
-                                        apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
-                                        attributeTypeRepository = services.transactions.attributeTypeRepository,
-                                        accountAttributeRepository = services.accounts.accountAttributeRepository,
-                                        accountRepository = services.accounts.accountRepository,
-                                        currencyRepository = services.accounts.currencyRepository,
-                                        transactionRepository = services.transactions.transactionRepository,
-                                        maintenance = services.imports.maintenance,
-                                        personRepository = services.people.personRepository,
-                                        personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
-                                        importEngine = services.transactions.importEngine,
-                                        deviceId = services.deviceId,
-                                        onCsvImportClick = { importId ->
-                                            navigationHistory.navigateTo(Screen.CsvImportDetail(importId))
-                                        },
-                                        onCsvStrategiesClick = {
-                                            navigationHistory.navigateTo(Screen.CsvStrategies)
-                                        },
-                                        onQifImportClick = { importId ->
-                                            navigationHistory.navigateTo(Screen.QifImportDetail(importId))
-                                        },
-                                        onAddCredentialClick = {
-                                            navigationHistory.navigateTo(Screen.ConnectApi)
-                                        },
-                                        onApiStrategiesClick = {
-                                            navigationHistory.navigateTo(Screen.ApiStrategies)
-                                        },
-                                        onSessionClick = { session ->
-                                            navigationHistory.navigateTo(Screen.ApiSessionTraffic(session.id))
-                                        },
-                                        onTransactionsImported = {
-                                            transactionRefreshTrigger++
-                                        },
-                                    )
-                                }
-                                is Screen.ApiStrategies -> {
-                                    LaunchedEffect(Unit) {
-                                        currentlyViewedAccountId = null
-                                        currentlyViewedCurrencyId = null
+                                    is Screen.ApiStrategies -> {
+                                        LaunchedEffect(Unit) {
+                                            currentlyViewedAccountId = null
+                                            currentlyViewedCurrencyId = null
+                                        }
+                                        ApiStrategiesScreen(
+                                            apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
+                                            onBack = { navigationHistory.navigateBack() },
+                                            onCreateStrategy = {
+                                                navigationHistory.navigateTo(Screen.ApiStrategyEditor())
+                                            },
+                                            onEditStrategy = { strategyId ->
+                                                navigationHistory.navigateTo(Screen.ApiStrategyEditor(strategyId))
+                                            },
+                                            onAuditHistoryClick = { strategy ->
+                                                navigationHistory.navigateTo(
+                                                    Screen.ApiStrategyAuditHistory(strategy.id, strategy.name),
+                                                )
+                                            },
+                                        )
                                     }
-                                    ApiStrategiesScreen(
-                                        apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
-                                        onBack = { navigationHistory.navigateBack() },
-                                        onCreateStrategy = {
-                                            navigationHistory.navigateTo(Screen.ApiStrategyEditor())
-                                        },
-                                        onEditStrategy = { strategyId ->
-                                            navigationHistory.navigateTo(Screen.ApiStrategyEditor(strategyId))
-                                        },
-                                        onAuditHistoryClick = { strategy ->
-                                            navigationHistory.navigateTo(
-                                                Screen.ApiStrategyAuditHistory(strategy.id, strategy.name),
-                                            )
-                                        },
-                                    )
-                                }
-                                is Screen.ApiStrategyEditor -> {
-                                    LaunchedEffect(Unit) {
-                                        currentlyViewedAccountId = null
-                                        currentlyViewedCurrencyId = null
+                                    is Screen.ApiStrategyEditor -> {
+                                        LaunchedEffect(Unit) {
+                                            currentlyViewedAccountId = null
+                                            currentlyViewedCurrencyId = null
+                                        }
+                                        ApiStrategyEditorScreen(
+                                            strategyId = screen.strategyId,
+                                            apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
+                                            apiSessionRepository = services.imports.apiSessionRepository,
+                                            onBack = { navigationHistory.navigateBack() },
+                                        )
                                     }
-                                    ApiStrategyEditorScreen(
-                                        strategyId = screen.strategyId,
-                                        apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
-                                        apiSessionRepository = services.imports.apiSessionRepository,
-                                        onBack = { navigationHistory.navigateBack() },
-                                    )
-                                }
-                                is Screen.CsvImportDetail -> {
-                                    CsvImportDetailScreen(
-                                        importId = screen.importId,
-                                        scrollToRowIndex = screen.scrollToRowIndex,
-                                        csvImportRepository = services.imports.csvImportRepository,
-                                        csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
-                                        csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
-                                        accountRepository = services.accounts.accountRepository,
-                                        categoryRepository = services.accounts.categoryRepository,
-                                        currencyRepository = services.accounts.currencyRepository,
-                                        attributeTypeRepository = services.transactions.attributeTypeRepository,
-                                        personRepository = services.people.personRepository,
-                                        personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
-                                        maintenance = services.imports.maintenance,
-                                        transferSourceRepository = services.transactions.transferSourceRepository,
-                                        importEngine = services.transactions.importEngine,
-                                        onBack = { navigationHistory.navigateBack() },
-                                        onDeleted = { navigationHistory.navigateTo(Screen.Imports(ImportTab.CSV)) },
-                                        onCreateStrategy = { importId ->
-                                            navigationHistory.navigateTo(Screen.CsvStrategyEditor(importId))
-                                        },
-                                        onCsvSourceClick = { importId, rowIndex ->
-                                            navigationHistory.navigateTo(Screen.CsvImportDetail(importId, rowIndex))
-                                        },
-                                        onTransferClick = ::navigateToTransferAccount,
-                                    )
-                                }
-                                is Screen.QifImportDetail -> {
-                                    QifImportDetailScreen(
-                                        importId = screen.importId,
-                                        scrollToRecordIndex = screen.scrollToRecordIndex,
-                                        qifImportRepository = services.imports.qifImportRepository,
-                                        csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
-                                        csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
-                                        accountRepository = services.accounts.accountRepository,
-                                        categoryRepository = services.accounts.categoryRepository,
-                                        currencyRepository = services.accounts.currencyRepository,
-                                        personRepository = services.people.personRepository,
-                                        personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
-                                        attributeTypeRepository = services.transactions.attributeTypeRepository,
-                                        settingsRepository = services.settings.settingsRepository,
-                                        maintenance = services.imports.maintenance,
-                                        importEngine = services.transactions.importEngine,
-                                        onBack = { navigationHistory.navigateBack() },
-                                        onCreateStrategy = { qifImportId ->
-                                            navigationHistory.navigateTo(Screen.QifStrategyEditor(qifImportId))
-                                        },
-                                        onDeleted = { navigationHistory.navigateTo(Screen.Imports(ImportTab.QIF)) },
-                                        onTransferClick = ::navigateToTransferAccount,
-                                    )
-                                }
-                                is Screen.CsvStrategies -> {
-                                    LaunchedEffect(Unit) {
-                                        currentlyViewedAccountId = null
-                                        currentlyViewedCurrencyId = null
+                                    is Screen.CsvImportDetail -> {
+                                        CsvImportDetailScreen(
+                                            importId = screen.importId,
+                                            scrollToRowIndex = screen.scrollToRowIndex,
+                                            csvImportRepository = services.imports.csvImportRepository,
+                                            csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
+                                            csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
+                                            accountRepository = services.accounts.accountRepository,
+                                            categoryRepository = services.accounts.categoryRepository,
+                                            currencyRepository = services.accounts.currencyRepository,
+                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
+                                            personRepository = services.people.personRepository,
+                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
+                                            maintenance = services.imports.maintenance,
+                                            transferSourceRepository = services.transactions.transferSourceRepository,
+                                            importEngine = services.transactions.importEngine,
+                                            onBack = { navigationHistory.navigateBack() },
+                                            onDeleted = { navigationHistory.navigateTo(Screen.Imports(ImportTab.CSV)) },
+                                            onCreateStrategy = { importId ->
+                                                navigationHistory.navigateTo(Screen.CsvStrategyEditor(importId))
+                                            },
+                                            onCsvSourceClick = { importId, rowIndex ->
+                                                navigationHistory.navigateTo(Screen.CsvImportDetail(importId, rowIndex))
+                                            },
+                                            onTransferClick = ::navigateToTransferAccount,
+                                        )
                                     }
-                                    CsvStrategiesScreen(
-                                        csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
-                                        csvImportRepository = services.imports.csvImportRepository,
-                                        qifImportRepository = services.imports.qifImportRepository,
-                                        csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
-                                        accountRepository = services.accounts.accountRepository,
-                                        categoryRepository = services.accounts.categoryRepository,
-                                        currencyRepository = services.accounts.currencyRepository,
-                                        personRepository = services.people.personRepository,
-                                        personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
-                                        csvStrategyImportExport = services.imports.csvStrategyImportExport,
-                                        appVersion = appVersion,
-                                        onBack = { navigationHistory.navigateBack() },
-                                        onEditStrategy = { strategyId, importId ->
-                                            navigationHistory.navigateTo(Screen.CsvStrategyEditor(importId, strategyId))
-                                        },
-                                        onEditQifStrategy = { strategyId, qifImportId ->
-                                            navigationHistory.navigateTo(Screen.QifStrategyEditor(qifImportId, strategyId))
-                                        },
-                                        onAuditHistoryClick = { strategy ->
-                                            navigationHistory.navigateTo(
-                                                Screen.CsvStrategyAuditHistory(strategy.id, strategy.name),
-                                            )
-                                        },
-                                    )
-                                }
-                                is Screen.CsvStrategyEditor -> {
-                                    CsvStrategyEditorScreen(
-                                        csvImportId = screen.csvImportId,
-                                        strategyId = screen.strategyId,
-                                        csvImportRepository = services.imports.csvImportRepository,
-                                        csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
-                                        csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
-                                        accountRepository = services.accounts.accountRepository,
-                                        categoryRepository = services.accounts.categoryRepository,
-                                        currencyRepository = services.accounts.currencyRepository,
-                                        attributeTypeRepository = services.transactions.attributeTypeRepository,
-                                        personRepository = services.people.personRepository,
-                                        personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
-                                        onBack = { navigationHistory.navigateBack() },
-                                    )
-                                }
-                                is Screen.QifStrategyEditor -> {
-                                    QifStrategyEditorScreen(
-                                        qifImportId = screen.qifImportId,
-                                        strategyId = screen.strategyId,
-                                        qifImportRepository = services.imports.qifImportRepository,
-                                        csvImportRepository = services.imports.csvImportRepository,
-                                        csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
-                                        csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
-                                        accountRepository = services.accounts.accountRepository,
-                                        categoryRepository = services.accounts.categoryRepository,
-                                        currencyRepository = services.accounts.currencyRepository,
-                                        attributeTypeRepository = services.transactions.attributeTypeRepository,
-                                        personRepository = services.people.personRepository,
-                                        personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
-                                        onBack = { navigationHistory.navigateBack() },
-                                    )
-                                }
-                                is Screen.AuditHistory -> {
-                                    TransactionAuditScreen(
-                                        transferId = screen.transferId,
-                                        auditRepository = services.audit.auditRepository,
-                                        accountRepository = services.accounts.accountRepository,
-                                        transactionRepository = services.transactions.transactionRepository,
-                                        currentDeviceId = services.deviceId,
-                                        onCsvSourceClick = { importId, rowIndex ->
-                                            navigationHistory.navigateTo(Screen.CsvImportDetail(importId, rowIndex))
-                                        },
-                                        onQifSourceClick = { importId, recordIndex ->
-                                            navigationHistory.navigateTo(Screen.QifImportDetail(importId, recordIndex))
-                                        },
-                                        onApiSourceClick = { sessionId, requestId, jsonPath ->
-                                            navigationHistory.navigateTo(
-                                                Screen.ApiSessionTraffic(
-                                                    sessionId = sessionId,
-                                                    highlightRequestId = requestId,
-                                                    highlightJsonPath = jsonPath,
-                                                ),
-                                            )
-                                        },
-                                        onAccountClick = { accountId ->
-                                            val account = accounts.find { it.id == accountId }
-                                            navigationHistory.navigateTo(
-                                                Screen.AccountTransactions(
-                                                    accountId = accountId,
-                                                    accountName = account?.name ?: "#${accountId.id}",
-                                                ),
-                                            )
-                                        },
-                                        onBack = { navigationHistory.navigateBack() },
-                                    )
-                                }
-                                is Screen.AccountAuditHistory -> {
-                                    AccountAuditScreen(
-                                        accountId = screen.accountId,
-                                        auditRepository = services.audit.auditRepository,
-                                        accountRepository = services.accounts.accountRepository,
-                                        categoryRepository = services.accounts.categoryRepository,
-                                        maintenance = services.imports.maintenance,
-                                        onApiSourceClick = { sessionId, requestId, jsonPath ->
-                                            navigationHistory.navigateTo(
-                                                Screen.ApiSessionTraffic(
-                                                    sessionId = sessionId,
-                                                    highlightRequestId = requestId,
-                                                    highlightJsonPath = jsonPath,
-                                                ),
-                                            )
-                                        },
-                                        onCsvSourceClick = { importId, rowIndex ->
-                                            navigationHistory.navigateTo(Screen.CsvImportDetail(importId, rowIndex))
-                                        },
-                                        onQifSourceClick = { importId, recordIndex ->
-                                            navigationHistory.navigateTo(Screen.QifImportDetail(importId, recordIndex))
-                                        },
-                                        onOwnerClick = { personId ->
-                                            navigationHistory.navigateTo(
-                                                Screen.PeopleScroll(
-                                                    personId = personId,
-                                                ),
-                                            )
-                                        },
-                                        onBack = { navigationHistory.navigateBack() },
-                                    )
-                                }
-                                is Screen.PersonAuditHistory -> {
-                                    PersonAuditScreen(
-                                        personId = screen.personId,
-                                        auditRepository = services.audit.auditRepository,
-                                        personRepository = services.people.personRepository,
-                                        onApiSourceClick = { sessionId, requestId, jsonPath ->
-                                            navigationHistory.navigateTo(
-                                                Screen.ApiSessionTraffic(
-                                                    sessionId = sessionId,
-                                                    highlightRequestId = requestId,
-                                                    highlightJsonPath = jsonPath,
-                                                ),
-                                            )
-                                        },
-                                        onCsvSourceClick = { importId, rowIndex ->
-                                            navigationHistory.navigateTo(Screen.CsvImportDetail(importId, rowIndex))
-                                        },
-                                        onQifSourceClick = { importId, recordIndex ->
-                                            navigationHistory.navigateTo(Screen.QifImportDetail(importId, recordIndex))
-                                        },
-                                        onBack = { navigationHistory.navigateBack() },
-                                    )
-                                }
-                                is Screen.CurrencyAuditHistory -> {
-                                    CurrencyAuditScreen(
-                                        currencyId = screen.currencyId,
-                                        auditRepository = services.audit.auditRepository,
-                                        currencyRepository = services.accounts.currencyRepository,
-                                        onBack = { navigationHistory.navigateBack() },
-                                    )
-                                }
-                                is Screen.CategoryAuditHistory -> {
-                                    CategoryAuditScreen(
-                                        categoryId = screen.categoryId,
-                                        auditRepository = services.audit.auditRepository,
-                                        categoryRepository = services.accounts.categoryRepository,
-                                        onBack = { navigationHistory.navigateBack() },
-                                    )
-                                }
-                                is Screen.ApiStrategyAuditHistory -> {
-                                    ApiImportStrategyAuditScreen(
-                                        strategyId = screen.strategyId,
-                                        auditRepository = services.audit.auditRepository,
-                                        apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
-                                        onBack = { navigationHistory.navigateBack() },
-                                    )
-                                }
-                                is Screen.CsvStrategyAuditHistory -> {
-                                    CsvImportStrategyAuditScreen(
-                                        strategyId = screen.strategyId,
-                                        auditRepository = services.audit.auditRepository,
-                                        csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
-                                        onBack = { navigationHistory.navigateBack() },
-                                    )
-                                }
-                                is Screen.ConnectApi -> {
-                                    LaunchedEffect(Unit) {
-                                        currentlyViewedAccountId = null
-                                        currentlyViewedCurrencyId = null
+                                    is Screen.QifImportDetail -> {
+                                        QifImportDetailScreen(
+                                            importId = screen.importId,
+                                            scrollToRecordIndex = screen.scrollToRecordIndex,
+                                            qifImportRepository = services.imports.qifImportRepository,
+                                            csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
+                                            csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
+                                            accountRepository = services.accounts.accountRepository,
+                                            categoryRepository = services.accounts.categoryRepository,
+                                            currencyRepository = services.accounts.currencyRepository,
+                                            personRepository = services.people.personRepository,
+                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
+                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
+                                            settingsRepository = services.settings.settingsRepository,
+                                            maintenance = services.imports.maintenance,
+                                            importEngine = services.transactions.importEngine,
+                                            onBack = { navigationHistory.navigateBack() },
+                                            onCreateStrategy = { qifImportId ->
+                                                navigationHistory.navigateTo(Screen.QifStrategyEditor(qifImportId))
+                                            },
+                                            onDeleted = { navigationHistory.navigateTo(Screen.Imports(ImportTab.QIF)) },
+                                            onTransferClick = ::navigateToTransferAccount,
+                                        )
                                     }
-                                    ApiConnectScreen(
-                                        apiSessionRepository = services.imports.apiSessionRepository,
-                                        apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
-                                        onCredentialSaved = {
-                                            navigationHistory.navigateBack()
-                                        },
-                                    )
-                                }
+                                    is Screen.CsvStrategies -> {
+                                        LaunchedEffect(Unit) {
+                                            currentlyViewedAccountId = null
+                                            currentlyViewedCurrencyId = null
+                                        }
+                                        CsvStrategiesScreen(
+                                            csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
+                                            csvImportRepository = services.imports.csvImportRepository,
+                                            qifImportRepository = services.imports.qifImportRepository,
+                                            csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
+                                            accountRepository = services.accounts.accountRepository,
+                                            categoryRepository = services.accounts.categoryRepository,
+                                            currencyRepository = services.accounts.currencyRepository,
+                                            personRepository = services.people.personRepository,
+                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
+                                            csvStrategyImportExport = services.imports.csvStrategyImportExport,
+                                            appVersion = appVersion,
+                                            onBack = { navigationHistory.navigateBack() },
+                                            onEditStrategy = { strategyId, importId ->
+                                                navigationHistory.navigateTo(Screen.CsvStrategyEditor(importId, strategyId))
+                                            },
+                                            onEditQifStrategy = { strategyId, qifImportId ->
+                                                navigationHistory.navigateTo(Screen.QifStrategyEditor(qifImportId, strategyId))
+                                            },
+                                            onAuditHistoryClick = { strategy ->
+                                                navigationHistory.navigateTo(
+                                                    Screen.CsvStrategyAuditHistory(strategy.id, strategy.name),
+                                                )
+                                            },
+                                        )
+                                    }
+                                    is Screen.CsvStrategyEditor -> {
+                                        CsvStrategyEditorScreen(
+                                            csvImportId = screen.csvImportId,
+                                            strategyId = screen.strategyId,
+                                            csvImportRepository = services.imports.csvImportRepository,
+                                            csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
+                                            csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
+                                            accountRepository = services.accounts.accountRepository,
+                                            categoryRepository = services.accounts.categoryRepository,
+                                            currencyRepository = services.accounts.currencyRepository,
+                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
+                                            personRepository = services.people.personRepository,
+                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
+                                            onBack = { navigationHistory.navigateBack() },
+                                        )
+                                    }
+                                    is Screen.QifStrategyEditor -> {
+                                        QifStrategyEditorScreen(
+                                            qifImportId = screen.qifImportId,
+                                            strategyId = screen.strategyId,
+                                            qifImportRepository = services.imports.qifImportRepository,
+                                            csvImportRepository = services.imports.csvImportRepository,
+                                            csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
+                                            csvAccountMappingRepository = services.imports.csvAccountMappingRepository,
+                                            accountRepository = services.accounts.accountRepository,
+                                            categoryRepository = services.accounts.categoryRepository,
+                                            currencyRepository = services.accounts.currencyRepository,
+                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
+                                            personRepository = services.people.personRepository,
+                                            personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
+                                            onBack = { navigationHistory.navigateBack() },
+                                        )
+                                    }
+                                    is Screen.AuditHistory -> {
+                                        TransactionAuditScreen(
+                                            transferId = screen.transferId,
+                                            auditRepository = services.audit.auditRepository,
+                                            accountRepository = services.accounts.accountRepository,
+                                            transactionRepository = services.transactions.transactionRepository,
+                                            currentDeviceId = services.deviceId,
+                                            onCsvSourceClick = { importId, rowIndex ->
+                                                navigationHistory.navigateTo(Screen.CsvImportDetail(importId, rowIndex))
+                                            },
+                                            onQifSourceClick = { importId, recordIndex ->
+                                                navigationHistory.navigateTo(Screen.QifImportDetail(importId, recordIndex))
+                                            },
+                                            onApiSourceClick = { sessionId, requestId, jsonPath ->
+                                                navigationHistory.navigateTo(
+                                                    Screen.ApiSessionTraffic(
+                                                        sessionId = sessionId,
+                                                        highlightRequestId = requestId,
+                                                        highlightJsonPath = jsonPath,
+                                                    ),
+                                                )
+                                            },
+                                            onAccountClick = { accountId ->
+                                                val account = accounts.find { it.id == accountId }
+                                                navigationHistory.navigateTo(
+                                                    Screen.AccountTransactions(
+                                                        accountId = accountId,
+                                                        accountName = account?.name ?: "#${accountId.id}",
+                                                    ),
+                                                )
+                                            },
+                                            onBack = { navigationHistory.navigateBack() },
+                                        )
+                                    }
+                                    is Screen.AccountAuditHistory -> {
+                                        AccountAuditScreen(
+                                            accountId = screen.accountId,
+                                            auditRepository = services.audit.auditRepository,
+                                            accountRepository = services.accounts.accountRepository,
+                                            categoryRepository = services.accounts.categoryRepository,
+                                            maintenance = services.imports.maintenance,
+                                            onApiSourceClick = { sessionId, requestId, jsonPath ->
+                                                navigationHistory.navigateTo(
+                                                    Screen.ApiSessionTraffic(
+                                                        sessionId = sessionId,
+                                                        highlightRequestId = requestId,
+                                                        highlightJsonPath = jsonPath,
+                                                    ),
+                                                )
+                                            },
+                                            onCsvSourceClick = { importId, rowIndex ->
+                                                navigationHistory.navigateTo(Screen.CsvImportDetail(importId, rowIndex))
+                                            },
+                                            onQifSourceClick = { importId, recordIndex ->
+                                                navigationHistory.navigateTo(Screen.QifImportDetail(importId, recordIndex))
+                                            },
+                                            onOwnerClick = { personId ->
+                                                navigationHistory.navigateTo(
+                                                    Screen.PeopleScroll(
+                                                        personId = personId,
+                                                    ),
+                                                )
+                                            },
+                                            onBack = { navigationHistory.navigateBack() },
+                                        )
+                                    }
+                                    is Screen.PersonAuditHistory -> {
+                                        PersonAuditScreen(
+                                            personId = screen.personId,
+                                            auditRepository = services.audit.auditRepository,
+                                            personRepository = services.people.personRepository,
+                                            onApiSourceClick = { sessionId, requestId, jsonPath ->
+                                                navigationHistory.navigateTo(
+                                                    Screen.ApiSessionTraffic(
+                                                        sessionId = sessionId,
+                                                        highlightRequestId = requestId,
+                                                        highlightJsonPath = jsonPath,
+                                                    ),
+                                                )
+                                            },
+                                            onCsvSourceClick = { importId, rowIndex ->
+                                                navigationHistory.navigateTo(Screen.CsvImportDetail(importId, rowIndex))
+                                            },
+                                            onQifSourceClick = { importId, recordIndex ->
+                                                navigationHistory.navigateTo(Screen.QifImportDetail(importId, recordIndex))
+                                            },
+                                            onBack = { navigationHistory.navigateBack() },
+                                        )
+                                    }
+                                    is Screen.CurrencyAuditHistory -> {
+                                        CurrencyAuditScreen(
+                                            currencyId = screen.currencyId,
+                                            auditRepository = services.audit.auditRepository,
+                                            currencyRepository = services.accounts.currencyRepository,
+                                            onBack = { navigationHistory.navigateBack() },
+                                        )
+                                    }
+                                    is Screen.CategoryAuditHistory -> {
+                                        CategoryAuditScreen(
+                                            categoryId = screen.categoryId,
+                                            auditRepository = services.audit.auditRepository,
+                                            categoryRepository = services.accounts.categoryRepository,
+                                            onBack = { navigationHistory.navigateBack() },
+                                        )
+                                    }
+                                    is Screen.ApiStrategyAuditHistory -> {
+                                        ApiImportStrategyAuditScreen(
+                                            strategyId = screen.strategyId,
+                                            auditRepository = services.audit.auditRepository,
+                                            apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
+                                            onBack = { navigationHistory.navigateBack() },
+                                        )
+                                    }
+                                    is Screen.CsvStrategyAuditHistory -> {
+                                        CsvImportStrategyAuditScreen(
+                                            strategyId = screen.strategyId,
+                                            auditRepository = services.audit.auditRepository,
+                                            csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
+                                            onBack = { navigationHistory.navigateBack() },
+                                        )
+                                    }
+                                    is Screen.ConnectApi -> {
+                                        LaunchedEffect(Unit) {
+                                            currentlyViewedAccountId = null
+                                            currentlyViewedCurrencyId = null
+                                        }
+                                        ApiConnectScreen(
+                                            apiSessionRepository = services.imports.apiSessionRepository,
+                                            apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
+                                            onCredentialSaved = {
+                                                navigationHistory.navigateBack()
+                                            },
+                                        )
+                                    }
 
-                                is Screen.ApiSessionTraffic -> {
-                                    LaunchedEffect(Unit) {
-                                        currentlyViewedAccountId = null
-                                        currentlyViewedCurrencyId = null
+                                    is Screen.ApiSessionTraffic -> {
+                                        LaunchedEffect(Unit) {
+                                            currentlyViewedAccountId = null
+                                            currentlyViewedCurrencyId = null
+                                        }
+                                        ApiSessionTrafficScreen(
+                                            apiSessionRepository = services.imports.apiSessionRepository,
+                                            sessionId = screen.sessionId,
+                                            highlightRequestId = screen.highlightRequestId,
+                                            highlightJsonPath = screen.highlightJsonPath,
+                                            onBack = { navigationHistory.navigateBack() },
+                                        )
                                     }
-                                    ApiSessionTrafficScreen(
-                                        apiSessionRepository = services.imports.apiSessionRepository,
-                                        sessionId = screen.sessionId,
-                                        highlightRequestId = screen.highlightRequestId,
-                                        highlightJsonPath = screen.highlightJsonPath,
-                                        onBack = { navigationHistory.navigateBack() },
-                                    )
                                 }
                             }
+                            BackgroundTaskPanel(
+                                manager = backgroundTaskManager,
+                                modifier =
+                                    Modifier
+                                        .align(Alignment.BottomEnd)
+                                        .padding(16.dp),
+                            )
                         }
-                        BackgroundTaskPanel(
-                            manager = backgroundTaskManager,
-                            modifier =
-                                Modifier
-                                    .align(Alignment.BottomEnd)
-                                    .padding(16.dp),
-                        )
                     }
                 }
 
@@ -767,9 +791,8 @@ fun MoneyManagerApp(
                     )
                 }
 
-                if (showTransactionDialog) {
+                if (showTransactionDialog && !editingLocked) {
                     TransactionEditDialog(
-                        transactionRepository = services.transactions.transactionRepository,
                         accountRepository = services.accounts.accountRepository,
                         categoryRepository = services.accounts.categoryRepository,
                         currencyRepository = services.accounts.currencyRepository,
@@ -790,6 +813,43 @@ fun MoneyManagerApp(
                     )
                 }
             }
+        }
+    }
+}
+
+/**
+ * App-wide banner shown when the remote copy is ahead of this device, so editing is locked until the
+ * user downloads. On a [conflict] (both sides changed) downloading discards local changes, so the copy
+ * is worded as a warning.
+ */
+@Composable
+private fun EditingLockedBanner(
+    conflict: Boolean,
+    enabled: Boolean,
+    onDownload: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyMedium,
+                text =
+                    if (conflict) {
+                        "Editing is locked: this database changed on another device and here. " +
+                            "Download to continue (your local changes will be discarded)."
+                    } else {
+                        "Editing is locked: another device updated this database. Download to continue."
+                    },
+            )
+            Button(onClick = onDownload, enabled = enabled) { Text("Download") }
         }
     }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/AccountPicker.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/AccountPicker.kt
@@ -38,11 +38,14 @@ import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
  * @param accountRepository Repository to fetch accounts and create new ones
  * @param categoryRepository Repository needed for account creation (accounts have categories)
  * @param personRepository Repository needed for account creation (accounts can have owners)
- * @param personAccountOwnershipRepository Repository needed for account creation (accounts can have owners)
+ * @param personAccountOwnershipRepository Retained for call-site symmetry; account creation now writes
+ *   through the [com.moneymanager.importengineapi.ImportEngine] (see [LocalImportEngine]), so the picker
+ *   no longer touches this repository directly.
  * @param enabled Whether the picker is enabled
  * @param excludeAccountId Optional account ID to exclude from the list (e.g., the other account in a transfer)
  * @param isError Whether to show error state (red outline)
  */
+@Suppress("UnusedParameter")
 @Composable
 fun AccountPicker(
     selectedAccountId: AccountId?,
@@ -144,10 +147,8 @@ fun AccountPicker(
 
     if (showCreateAccountDialog) {
         CreateAccountDialog(
-            accountRepository = accountRepository,
             categoryRepository = categoryRepository,
             personRepository = personRepository,
-            personAccountOwnershipRepository = personAccountOwnershipRepository,
             initialName = createAccountInitialName,
             onDismiss = { showCreateAccountDialog = false },
             onAccountCreated = { accountId ->

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/AccountPicker.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/AccountPicker.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Modifier
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.CategoryRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 
@@ -38,14 +37,10 @@ import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
  * @param accountRepository Repository to fetch accounts and create new ones
  * @param categoryRepository Repository needed for account creation (accounts have categories)
  * @param personRepository Repository needed for account creation (accounts can have owners)
- * @param personAccountOwnershipRepository Retained for call-site symmetry; account creation now writes
- *   through the [com.moneymanager.importengineapi.ImportEngine] (see [LocalImportEngine]), so the picker
- *   no longer touches this repository directly.
  * @param enabled Whether the picker is enabled
  * @param excludeAccountId Optional account ID to exclude from the list (e.g., the other account in a transfer)
  * @param isError Whether to show error state (red outline)
  */
-@Suppress("UnusedParameter")
 @Composable
 fun AccountPicker(
     selectedAccountId: AccountId?,
@@ -54,7 +49,6 @@ fun AccountPicker(
     accountRepository: AccountRepository,
     categoryRepository: CategoryRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     enabled: Boolean = true,
     excludeAccountId: AccountId? = null,
     isError: Boolean = false,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
@@ -27,12 +27,11 @@ import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.Source
-import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.CategoryRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.CreateCategoryDialog
@@ -48,12 +47,10 @@ private val logger = logging()
  */
 @Composable
 fun CreateAccountDialog(
-    accountRepository: AccountRepository,
     categoryRepository: CategoryRepository,
     personRepository: PersonRepository,
     personAttributeRepository: PersonAttributeRepository? = null,
     attributeTypeRepository: AttributeTypeRepository? = null,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     onDismiss: () -> Unit,
     onAccountCreated: ((AccountId) -> Unit)? = null,
     initialName: String = "",
@@ -70,6 +67,7 @@ fun CreateAccountDialog(
         .getAllPeople()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     val scope = rememberSchemaAwareCoroutineScope()
+    val importEngine = LocalImportEngine.current
 
     AlertDialog(
         onDismissRequest = { if (!accountState.isSaving) onDismiss() },
@@ -178,9 +176,9 @@ fun CreateAccountDialog(
                                         openingDate = now,
                                         categoryId = accountState.selectedCategoryId,
                                     )
-                                val accountId = accountRepository.createAccount(newAccount, Source.Manual)
+                                val accountId = importEngine.createAccount(newAccount, Source.Manual)
                                 selectedOwnerIds.forEach { personId ->
-                                    personAccountOwnershipRepository.createOwnership(
+                                    importEngine.createOwnership(
                                         personId = PersonId(personId),
                                         accountId = accountId,
                                         source = Source.Manual,
@@ -222,7 +220,6 @@ fun CreateAccountDialog(
     if (accountState.showCreatePersonDialog) {
         EditPersonDialog(
             personToEdit = null,
-            personRepository = personRepository,
             onPersonCreated = { personId ->
                 selectedOwnerIdForAddition = personId.id
             },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.Source
@@ -31,6 +30,11 @@ import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
+import com.moneymanager.importengineapi.AccountRef
+import com.moneymanager.importengineapi.ImportAccountIntent
+import com.moneymanager.importengineapi.ImportBatch
+import com.moneymanager.importengineapi.ImportOwnershipIntent
+import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -169,22 +173,31 @@ fun CreateAccountDialog(
                         scope.launch {
                             try {
                                 val now = Clock.System.now()
-                                val newAccount =
-                                    Account(
-                                        id = AccountId(0),
-                                        name = accountState.name.trim(),
-                                        openingDate = now,
-                                        categoryId = accountState.selectedCategoryId,
+                                val key = LocalAccountKey("new-account")
+                                val result =
+                                    importEngine.import(
+                                        ImportBatch.manualEdits(
+                                            accounts =
+                                                listOf(
+                                                    ImportAccountIntent(
+                                                        key = key,
+                                                        source = Source.Manual,
+                                                        name = accountState.name.trim(),
+                                                        openingDate = now,
+                                                        categoryId = accountState.selectedCategoryId,
+                                                    ),
+                                                ),
+                                            ownerships =
+                                                selectedOwnerIds.map { personId ->
+                                                    ImportOwnershipIntent(
+                                                        source = Source.Manual,
+                                                        existingPersonId = PersonId(personId),
+                                                        account = AccountRef.Local(key),
+                                                    )
+                                                },
+                                        ),
                                     )
-                                val accountId = importEngine.createAccount(newAccount, Source.Manual)
-                                selectedOwnerIds.forEach { personId ->
-                                    importEngine.createOwnership(
-                                        personId = PersonId(personId),
-                                        accountId = accountId,
-                                        source = Source.Manual,
-                                    )
-                                }
-                                onAccountCreated?.invoke(accountId)
+                                onAccountCreated?.invoke(result.createdAccountIds.getValue(key))
                                 onDismiss()
                             } catch (expected: Exception) {
                                 logger.error(expected) { "Failed to create account: ${expected.message}" }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/DeletePersonConfirmationDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/DeletePersonConfirmationDialog.kt
@@ -19,6 +19,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.Person
+import com.moneymanager.domain.model.Source
+import com.moneymanager.importengineapi.ImportBatch
+import com.moneymanager.importengineapi.ImportOperation
+import com.moneymanager.importengineapi.ImportPersonIntent
+import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.launch
@@ -56,7 +61,19 @@ fun DeletePersonConfirmationDialog(
                     isDeleting = true
                     scope.launch {
                         try {
-                            importEngine.deletePerson(person.id)
+                            importEngine.import(
+                                ImportBatch.manualEdits(
+                                    people =
+                                        listOf(
+                                            ImportPersonIntent(
+                                                key = LocalPersonKey("delete"),
+                                                source = Source.Manual,
+                                                operation = ImportOperation.DELETE,
+                                                existingId = person.id,
+                                            ),
+                                        ),
+                                ),
+                            )
                             onDismiss()
                         } catch (expected: Exception) {
                             logger.error(expected) { "Failed to delete person: ${expected.message}" }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/DeletePersonConfirmationDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/DeletePersonConfirmationDialog.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.Person
-import com.moneymanager.domain.repository.PersonRepository
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.launch
 import org.lighthousegames.logging.logging
@@ -30,11 +30,11 @@ private val logger = logging()
 fun DeletePersonConfirmationDialog(
     person: Person,
     accountCount: Int,
-    personRepository: PersonRepository,
     onDismiss: () -> Unit,
 ) {
     var isDeleting by remember { mutableStateOf(false) }
     val scope = rememberSchemaAwareCoroutineScope()
+    val importEngine = LocalImportEngine.current
 
     AlertDialog(
         onDismissRequest = { if (!isDeleting) onDismiss() },
@@ -56,7 +56,7 @@ fun DeletePersonConfirmationDialog(
                     isDeleting = true
                     scope.launch {
                         try {
-                            personRepository.deletePerson(person.id)
+                            importEngine.deletePerson(person.id)
                             onDismiss()
                         } catch (expected: Exception) {
                             logger.error(expected) { "Failed to delete person: ${expected.message}" }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
@@ -33,6 +33,12 @@ import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
+import com.moneymanager.importengineapi.AccountRef
+import com.moneymanager.importengineapi.ImportAccountIntent
+import com.moneymanager.importengineapi.ImportBatch
+import com.moneymanager.importengineapi.ImportOperation
+import com.moneymanager.importengineapi.ImportOwnershipIntent
+import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -211,35 +217,46 @@ fun EditAccountDialog(
                                     }
                                 }
 
-                                // Atomic update: one revision bump for account + all attribute changes.
-                                // The source for the resulting revision is recorded inside the repository.
-                                importEngine.updateAccountWithAttributes(
-                                    account = updatedAccount,
-                                    accountId = account.id,
-                                    deletedAttributeIds = deletedAttributeIds,
-                                    updatedAttributes = updatedAttributes,
-                                    newAttributes = newAttributes,
-                                    source = Source.Manual,
-                                )
-
                                 val existingOwnerIds = existingOwnerships.map { it.personId.id }.toSet()
                                 val ownersToAdd = selectedOwnerIds - existingOwnerIds
                                 val ownersToRemove = existingOwnerIds - selectedOwnerIds
 
-                                ownersToRemove.forEach { personId ->
-                                    val ownership = existingOwnerships.find { it.personId.id == personId }
-                                    ownership?.let {
-                                        importEngine.deleteOwnership(it.id)
-                                    }
-                                }
-
-                                ownersToAdd.forEach { personId ->
-                                    importEngine.createOwnership(
-                                        personId = PersonId(personId),
-                                        accountId = account.id,
-                                        source = Source.Manual,
-                                    )
-                                }
+                                // One atomic batch: the account update (one revision bump for fields +
+                                // attributes) plus the ownership add/remove rows.
+                                importEngine.import(
+                                    ImportBatch.manualEdits(
+                                        accounts =
+                                            listOf(
+                                                ImportAccountIntent(
+                                                    key = LocalAccountKey("edit"),
+                                                    source = Source.Manual,
+                                                    operation = ImportOperation.UPDATE,
+                                                    existingId = account.id,
+                                                    account = updatedAccount,
+                                                    deletedAttributeIds = deletedAttributeIds,
+                                                    updatedAttributes = updatedAttributes,
+                                                    attributes = newAttributes,
+                                                ),
+                                            ),
+                                        ownerships =
+                                            ownersToRemove.mapNotNull { personId ->
+                                                existingOwnerships.find { it.personId.id == personId }?.let {
+                                                    ImportOwnershipIntent(
+                                                        source = Source.Manual,
+                                                        operation = ImportOperation.DELETE,
+                                                        existingId = it.id,
+                                                    )
+                                                }
+                                            } +
+                                                ownersToAdd.map { personId ->
+                                                    ImportOwnershipIntent(
+                                                        source = Source.Manual,
+                                                        existingPersonId = PersonId(personId),
+                                                        account = AccountRef.Existing(account.id),
+                                                    )
+                                                },
+                                    ),
+                                )
 
                                 onDismiss()
                             } catch (expected: Exception) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
@@ -28,12 +28,12 @@ import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.repository.AccountAttributeRepository
-import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
 import com.moneymanager.domain.repository.PersonRepository
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.CreateCategoryDialog
@@ -49,7 +49,6 @@ private val logger = logging()
 @Composable
 fun EditAccountDialog(
     account: Account,
-    accountRepository: AccountRepository,
     accountAttributeRepository: AccountAttributeRepository,
     attributeTypeRepository: AttributeTypeRepository,
     categoryRepository: CategoryRepository,
@@ -103,6 +102,7 @@ fun EditAccountDialog(
     }
 
     val scope = rememberSchemaAwareCoroutineScope()
+    val importEngine = LocalImportEngine.current
 
     AlertDialog(
         onDismissRequest = { if (!accountState.isSaving) onDismiss() },
@@ -213,7 +213,7 @@ fun EditAccountDialog(
 
                                 // Atomic update: one revision bump for account + all attribute changes.
                                 // The source for the resulting revision is recorded inside the repository.
-                                accountRepository.updateAccountWithAttributes(
+                                importEngine.updateAccountWithAttributes(
                                     account = updatedAccount,
                                     accountId = account.id,
                                     deletedAttributeIds = deletedAttributeIds,
@@ -229,12 +229,12 @@ fun EditAccountDialog(
                                 ownersToRemove.forEach { personId ->
                                     val ownership = existingOwnerships.find { it.personId.id == personId }
                                     ownership?.let {
-                                        personAccountOwnershipRepository.deleteOwnership(it.id)
+                                        importEngine.deleteOwnership(it.id)
                                     }
                                 }
 
                                 ownersToAdd.forEach { personId ->
-                                    personAccountOwnershipRepository.createOwnership(
+                                    importEngine.createOwnership(
                                         personId = PersonId(personId),
                                         accountId = account.id,
                                         source = Source.Manual,
@@ -276,7 +276,6 @@ fun EditAccountDialog(
     if (accountState.showCreatePersonDialog) {
         EditPersonDialog(
             personToEdit = null,
-            personRepository = personRepository,
             onDismiss = { accountState.showCreatePersonDialog = false },
             personAttributeRepository = personAttributeRepository,
             attributeTypeRepository = attributeTypeRepository,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
@@ -21,13 +21,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.AttributeType
+import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.PersonAttribute
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
-import com.moneymanager.domain.repository.PersonRepository
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.transactions.EditableAttributesSection
 import kotlinx.coroutines.flow.first
@@ -39,7 +40,6 @@ private val logger = logging()
 @Composable
 fun EditPersonDialog(
     personToEdit: Person?,
-    personRepository: PersonRepository,
     onDismiss: () -> Unit,
     onPersonCreated: ((PersonId) -> Unit)? = null,
     personAttributeRepository: PersonAttributeRepository? = null,
@@ -59,6 +59,7 @@ fun EditPersonDialog(
     var attributesLoaded by remember { mutableStateOf(false) }
 
     val scope = rememberSchemaAwareCoroutineScope()
+    val importEngine = LocalImportEngine.current
 
     LaunchedEffect(Unit) {
         attributeTypeRepository?.getAll()?.collect { types -> existingAttributeTypes = types }
@@ -137,38 +138,75 @@ fun EditPersonDialog(
                         saveState.errorMessage = null
                         scope.launch {
                             try {
+                                // Build the attribute delta (delete/update/insert) the way the account
+                                // dialog does, so the whole person edit is one gated, atomic engine call.
+                                val deletedAttributeIds = mutableSetOf<Long>()
+                                val updatedAttributes = mutableMapOf<Long, NewAttribute>()
+                                val newAttributes = mutableListOf<NewAttribute>()
+                                if (attributesEditable) {
+                                    val keptIds = editableAttributes.keys.filter { it > 0 }.toSet()
+                                    originalAttributeList
+                                        .map { it.id }
+                                        .toSet()
+                                        .minus(keptIds)
+                                        .forEach { deletedAttributeIds.add(it) }
+                                    editableAttributes.filterKeys { it > 0 }.forEach { (id, pair) ->
+                                        val typeName = pair.first.trim()
+                                        val value = pair.second.trim()
+                                        val original = originalAttributeList.find { it.id == id } ?: return@forEach
+                                        when {
+                                            typeName.isBlank() || value.isBlank() -> deletedAttributeIds.add(id)
+                                            original.attributeType.name != typeName || original.value != value ->
+                                                updatedAttributes[id] = NewAttribute(attributeTypeRepository.getOrCreate(typeName), value)
+                                        }
+                                    }
+                                    editableAttributes.filterKeys { it < 0 }.forEach { (_, pair) ->
+                                        val typeName = pair.first.trim()
+                                        val value = pair.second.trim()
+                                        if (typeName.isNotEmpty() && value.isNotEmpty()) {
+                                            newAttributes.add(NewAttribute(attributeTypeRepository.getOrCreate(typeName), value))
+                                        }
+                                    }
+                                }
                                 val newPersonId =
                                     if (personToEdit != null) {
-                                        personRepository.updatePerson(
-                                            personToEdit.copy(
-                                                firstName = firstName.trim(),
-                                                middleName = middleName.trim().ifBlank { null },
-                                                lastName = lastName.trim().ifBlank { null },
-                                            ),
-                                            Source.Manual,
+                                        importEngine.updatePersonWithAttributes(
+                                            person =
+                                                personToEdit.copy(
+                                                    firstName = firstName.trim(),
+                                                    middleName = middleName.trim().ifBlank { null },
+                                                    lastName = lastName.trim().ifBlank { null },
+                                                ),
+                                            personId = personToEdit.id,
+                                            deletedAttributeIds = deletedAttributeIds,
+                                            updatedAttributes = updatedAttributes,
+                                            newAttributes = newAttributes,
+                                            source = Source.Manual,
                                         )
                                         null
                                     } else {
-                                        personRepository.createPerson(
-                                            Person(
-                                                id = PersonId(0),
-                                                firstName = firstName.trim(),
-                                                middleName = middleName.trim().ifBlank { null },
-                                                lastName = lastName.trim().ifBlank { null },
-                                            ),
-                                            Source.Manual,
-                                        )
+                                        val createdId =
+                                            importEngine.createPerson(
+                                                Person(
+                                                    id = PersonId(0),
+                                                    firstName = firstName.trim(),
+                                                    middleName = middleName.trim().ifBlank { null },
+                                                    lastName = lastName.trim().ifBlank { null },
+                                                ),
+                                                Source.Manual,
+                                            )
+                                        if (newAttributes.isNotEmpty()) {
+                                            importEngine.updatePersonWithAttributes(
+                                                person = null,
+                                                personId = createdId,
+                                                deletedAttributeIds = emptySet(),
+                                                updatedAttributes = emptyMap(),
+                                                newAttributes = newAttributes,
+                                                source = Source.Manual,
+                                            )
+                                        }
+                                        createdId
                                     }
-                                val personId = newPersonId ?: personToEdit!!.id
-                                if (personAttributeRepository != null && attributeTypeRepository != null) {
-                                    savePersonAttributes(
-                                        personId = personId,
-                                        editableAttributes = editableAttributes,
-                                        originalAttributeList = originalAttributeList,
-                                        personAttributeRepository = personAttributeRepository,
-                                        attributeTypeRepository = attributeTypeRepository,
-                                    )
-                                }
                                 // Only announce the new person once the full save (row + attributes)
                                 // has succeeded, so the parent never selects a half-saved person.
                                 if (newPersonId != null) {
@@ -205,42 +243,4 @@ fun EditPersonDialog(
             }
         },
     )
-}
-
-/** Persists the dialog's attribute edits: deletes removed rows, updates changed ones, inserts new ones. */
-private suspend fun savePersonAttributes(
-    personId: PersonId,
-    editableAttributes: Map<Long, Pair<String, String>>,
-    originalAttributeList: List<PersonAttribute>,
-    personAttributeRepository: PersonAttributeRepository,
-    attributeTypeRepository: AttributeTypeRepository,
-) {
-    val keptIds = editableAttributes.keys.filter { it > 0 }.toSet()
-    originalAttributeList
-        .map { it.id }
-        .toSet()
-        .minus(keptIds)
-        .forEach { personAttributeRepository.delete(it) }
-
-    editableAttributes.filterKeys { it > 0 }.forEach { (id, pair) ->
-        val typeName = pair.first.trim()
-        val value = pair.second.trim()
-        val original = originalAttributeList.find { it.id == id } ?: return@forEach
-        when {
-            typeName.isBlank() || value.isBlank() -> personAttributeRepository.delete(id)
-            original.attributeType.name != typeName -> {
-                personAttributeRepository.delete(id)
-                personAttributeRepository.insert(personId, attributeTypeRepository.getOrCreate(typeName), value)
-            }
-            original.value != value -> personAttributeRepository.updateValue(id, value)
-        }
-    }
-
-    editableAttributes.filterKeys { it < 0 }.forEach { (_, pair) ->
-        val typeName = pair.first.trim()
-        val value = pair.second.trim()
-        if (typeName.isNotEmpty() && value.isNotEmpty()) {
-            personAttributeRepository.insert(personId, attributeTypeRepository.getOrCreate(typeName), value)
-        }
-    }
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
@@ -28,6 +28,10 @@ import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.PersonAttributeRepository
+import com.moneymanager.importengineapi.ImportBatch
+import com.moneymanager.importengineapi.ImportOperation
+import com.moneymanager.importengineapi.ImportPersonIntent
+import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.transactions.EditableAttributesSection
@@ -170,42 +174,50 @@ fun EditPersonDialog(
                                 }
                                 val newPersonId =
                                     if (personToEdit != null) {
-                                        importEngine.updatePersonWithAttributes(
-                                            person =
-                                                personToEdit.copy(
-                                                    firstName = firstName.trim(),
-                                                    middleName = middleName.trim().ifBlank { null },
-                                                    lastName = lastName.trim().ifBlank { null },
-                                                ),
-                                            personId = personToEdit.id,
-                                            deletedAttributeIds = deletedAttributeIds,
-                                            updatedAttributes = updatedAttributes,
-                                            newAttributes = newAttributes,
-                                            source = Source.Manual,
+                                        importEngine.import(
+                                            ImportBatch.manualEdits(
+                                                people =
+                                                    listOf(
+                                                        ImportPersonIntent(
+                                                            key = LocalPersonKey("edit"),
+                                                            source = Source.Manual,
+                                                            operation = ImportOperation.UPDATE,
+                                                            existingId = personToEdit.id,
+                                                            person =
+                                                                personToEdit.copy(
+                                                                    firstName = firstName.trim(),
+                                                                    middleName = middleName.trim().ifBlank { null },
+                                                                    lastName = lastName.trim().ifBlank { null },
+                                                                ),
+                                                            deletedAttributeIds = deletedAttributeIds,
+                                                            updatedAttributes = updatedAttributes,
+                                                            attributes = newAttributes,
+                                                        ),
+                                                    ),
+                                            ),
                                         )
                                         null
                                     } else {
-                                        val createdId =
-                                            importEngine.createPerson(
-                                                Person(
-                                                    id = PersonId(0),
-                                                    firstName = firstName.trim(),
-                                                    middleName = middleName.trim().ifBlank { null },
-                                                    lastName = lastName.trim().ifBlank { null },
+                                        // CREATE carries its attributes, so the engine creates the row and
+                                        // its attributes in one go (no follow-up update needed).
+                                        val key = LocalPersonKey("new-person")
+                                        val result =
+                                            importEngine.import(
+                                                ImportBatch.manualEdits(
+                                                    people =
+                                                        listOf(
+                                                            ImportPersonIntent(
+                                                                key = key,
+                                                                source = Source.Manual,
+                                                                firstName = firstName.trim(),
+                                                                middleName = middleName.trim().ifBlank { null },
+                                                                lastName = lastName.trim().ifBlank { null },
+                                                                attributes = newAttributes,
+                                                            ),
+                                                        ),
                                                 ),
-                                                Source.Manual,
                                             )
-                                        if (newAttributes.isNotEmpty()) {
-                                            importEngine.updatePersonWithAttributes(
-                                                person = null,
-                                                personId = createdId,
-                                                deletedAttributeIds = emptySet(),
-                                                updatedAttributes = emptyMap(),
-                                                newAttributes = newAttributes,
-                                                source = Source.Manual,
-                                            )
-                                        }
-                                        createdId
+                                        result.createdPersonIds.getValue(key)
                                     }
                                 // Only announce the new person once the full save (row + attributes)
                                 // has succeeded, so the parent never selects a half-saved person.

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountAuditScreen.kt
@@ -108,7 +108,6 @@ fun AccountAuditScreen(
         UnmergeAccountDialog(
             merge = currentMergeToUndo,
             survivingAccountName = currentAccount?.name ?: "this account",
-            accountRepository = accountRepository,
             maintenance = maintenance,
             onDismiss = { mergeToUndo = null },
         )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
@@ -33,6 +33,13 @@ import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.TransactionRepository
+import com.moneymanager.importengineapi.AccountMergeRequest
+import com.moneymanager.importengineapi.ImportAccountIntent
+import com.moneymanager.importengineapi.ImportBatch
+import com.moneymanager.importengineapi.ImportCategoryIntent
+import com.moneymanager.importengineapi.ImportOperation
+import com.moneymanager.importengineapi.LocalAccountKey
+import com.moneymanager.importengineapi.LocalCategoryKey
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.CreateAccountDialog
 import com.moneymanager.ui.components.EditAccountDialog
@@ -597,13 +604,32 @@ fun DeleteAccountDialog(
                     scope.launch {
                         try {
                             if (hasTransactions) {
-                                importEngine.mergeAccounts(
-                                    deletedAccount = account.id,
-                                    survivingAccount = selectedTargetAccount!!.id,
+                                importEngine.import(
+                                    ImportBatch.manualEdits(
+                                        accountMerges =
+                                            listOf(
+                                                AccountMergeRequest(
+                                                    deletedId = account.id,
+                                                    survivingId = selectedTargetAccount!!.id,
+                                                ),
+                                            ),
+                                    ),
                                 )
                                 maintenance.fullRefreshMaterializedViews()
                             } else {
-                                importEngine.deleteAccount(account.id)
+                                importEngine.import(
+                                    ImportBatch.manualEdits(
+                                        accounts =
+                                            listOf(
+                                                ImportAccountIntent(
+                                                    key = LocalAccountKey("delete"),
+                                                    source = Source.Manual,
+                                                    operation = ImportOperation.DELETE,
+                                                    existingId = account.id,
+                                                ),
+                                            ),
+                                    ),
+                                )
                             }
                             onDismiss()
                         } catch (expected: Exception) {
@@ -685,7 +711,7 @@ fun UnmergeAccountDialog(
                     errorMessage = null
                     scope.launch {
                         try {
-                            importEngine.unmergeAccount(merge.id)
+                            importEngine.import(ImportBatch.manualEdits(accountUnmerges = listOf(merge.id)))
                             maintenance.fullRefreshMaterializedViews()
                             onDismiss()
                         } catch (expected: Exception) {
@@ -786,13 +812,22 @@ fun CreateCategoryDialog(
                         errorMessage = null
                         scope.launch {
                             try {
-                                val newCategory =
-                                    Category(
-                                        name = name.trim(),
-                                        parentId = selectedParentId,
+                                val key = LocalCategoryKey("create")
+                                val result =
+                                    importEngine.import(
+                                        ImportBatch.manualEdits(
+                                            categories =
+                                                listOf(
+                                                    ImportCategoryIntent(
+                                                        key = key,
+                                                        source = source,
+                                                        name = name.trim(),
+                                                        parentId = selectedParentId,
+                                                    ),
+                                                ),
+                                        ),
                                     )
-                                val categoryId = importEngine.createCategory(newCategory, source)
-                                onCategoryCreated(categoryId, name.trim())
+                                onCategoryCreated(result.createdCategoryIds.getValue(key), name.trim())
                             } catch (expected: Exception) {
                                 logger.error(expected) { "Failed to create category: ${expected.message}" }
                                 errorMessage = "Failed to create category: ${expected.message}"

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
@@ -33,6 +33,7 @@ import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.TransactionRepository
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.CreateAccountDialog
 import com.moneymanager.ui.components.EditAccountDialog
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
@@ -194,10 +195,8 @@ fun AccountsScreen(
 
     if (showCreateDialog) {
         CreateAccountDialog(
-            accountRepository = accountRepository,
             categoryRepository = categoryRepository,
             personRepository = personRepository,
-            personAccountOwnershipRepository = personAccountOwnershipRepository,
             onDismiss = { showCreateDialog = false },
         )
     }
@@ -206,7 +205,6 @@ fun AccountsScreen(
     if (currentAccountToEdit != null) {
         EditAccountDialog(
             account = currentAccountToEdit,
-            accountRepository = accountRepository,
             accountAttributeRepository = accountAttributeRepository,
             attributeTypeRepository = attributeTypeRepository,
             categoryRepository = categoryRepository,
@@ -449,6 +447,7 @@ fun DeleteAccountDialog(
     var dropdownExpanded by remember { mutableStateOf(false) }
     var targetSearchQuery by remember { mutableStateOf("") }
     val scope = rememberSchemaAwareCoroutineScope()
+    val importEngine = LocalImportEngine.current
 
     val allAccounts by accountRepository
         .getAllAccounts()
@@ -598,13 +597,13 @@ fun DeleteAccountDialog(
                     scope.launch {
                         try {
                             if (hasTransactions) {
-                                accountRepository.mergeAccounts(
+                                importEngine.mergeAccounts(
                                     deletedAccount = account.id,
                                     survivingAccount = selectedTargetAccount!!.id,
                                 )
                                 maintenance.fullRefreshMaterializedViews()
                             } else {
-                                accountRepository.deleteAccount(account.id)
+                                importEngine.deleteAccount(account.id)
                             }
                             onDismiss()
                         } catch (expected: Exception) {
@@ -645,13 +644,13 @@ fun DeleteAccountDialog(
 fun UnmergeAccountDialog(
     merge: AccountMerge,
     survivingAccountName: String,
-    accountRepository: AccountRepository,
     maintenance: Maintenance,
     onDismiss: () -> Unit,
 ) {
     var isUnmerging by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     val scope = rememberSchemaAwareCoroutineScope()
+    val importEngine = LocalImportEngine.current
 
     AlertDialog(
         onDismissRequest = { if (!isUnmerging) onDismiss() },
@@ -686,7 +685,7 @@ fun UnmergeAccountDialog(
                     errorMessage = null
                     scope.launch {
                         try {
-                            accountRepository.unmergeAccount(merge.id)
+                            importEngine.unmergeAccount(merge.id)
                             maintenance.fullRefreshMaterializedViews()
                             onDismiss()
                         } catch (expected: Exception) {
@@ -731,6 +730,7 @@ fun CreateCategoryDialog(
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var isSaving by remember { mutableStateOf(false) }
     val source = Source.Manual
+    val importEngine = LocalImportEngine.current
 
     val categories by categoryRepository
         .getAllCategories()
@@ -791,7 +791,7 @@ fun CreateCategoryDialog(
                                         name = name.trim(),
                                         parentId = selectedParentId,
                                     )
-                                val categoryId = categoryRepository.createCategory(newCategory, source)
+                                val categoryId = importEngine.createCategory(newCategory, source)
                                 onCategoryCreated(categoryId, name.trim())
                             } catch (expected: Exception) {
                                 logger.error(expected) { "Failed to create category: ${expected.message}" }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
@@ -74,6 +74,10 @@ import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CurrencyRepository
+import com.moneymanager.importengineapi.ImportBatch
+import com.moneymanager.importengineapi.ImportCategoryIntent
+import com.moneymanager.importengineapi.ImportOperation
+import com.moneymanager.importengineapi.LocalCategoryKey
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.ErrorMessageText
 import com.moneymanager.ui.components.LoadingTextButton
@@ -316,9 +320,19 @@ fun CategoriesScreen(
                                         if (draggedCategory.parentId != newParentId) {
                                             scope.launch {
                                                 try {
-                                                    importEngine.updateCategory(
-                                                        draggedCategory.copy(parentId = newParentId),
-                                                        Source.Manual,
+                                                    importEngine.import(
+                                                        ImportBatch.manualEdits(
+                                                            categories =
+                                                                listOf(
+                                                                    ImportCategoryIntent(
+                                                                        key = LocalCategoryKey("update"),
+                                                                        source = Source.Manual,
+                                                                        operation = ImportOperation.UPDATE,
+                                                                        existingId = draggedCategory.id,
+                                                                        category = draggedCategory.copy(parentId = newParentId),
+                                                                    ),
+                                                                ),
+                                                        ),
                                                     )
                                                 } catch (expected: Exception) {
                                                     logger.error(expected) {
@@ -703,12 +717,19 @@ fun EditCategoryDialog(
                         setError = { errorMessage = it },
                         onSuccess = onDismiss,
                     ) { trimmedName ->
-                        importEngine.updateCategory(
-                            category.copy(
-                                name = trimmedName,
-                                parentId = selectedParentId,
+                        importEngine.import(
+                            ImportBatch.manualEdits(
+                                categories =
+                                    listOf(
+                                        ImportCategoryIntent(
+                                            key = LocalCategoryKey("update"),
+                                            source = Source.Manual,
+                                            operation = ImportOperation.UPDATE,
+                                            existingId = category.id,
+                                            category = category.copy(name = trimmedName, parentId = selectedParentId),
+                                        ),
+                                    ),
                             ),
-                            Source.Manual,
                         )
                     }
                 },
@@ -881,7 +902,19 @@ fun DeleteCategoryDialog(
                     errorMessage = null
                     scope.launch {
                         try {
-                            importEngine.deleteCategory(category.id)
+                            importEngine.import(
+                                ImportBatch.manualEdits(
+                                    categories =
+                                        listOf(
+                                            ImportCategoryIntent(
+                                                key = LocalCategoryKey("delete"),
+                                                source = Source.Manual,
+                                                operation = ImportOperation.DELETE,
+                                                existingId = category.id,
+                                            ),
+                                        ),
+                                ),
+                            )
                             onDeleted()
                         } catch (expected: Exception) {
                             logger.error(expected) { "Failed to delete category: ${expected.message}" }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
@@ -74,6 +74,7 @@ import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CurrencyRepository
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.ErrorMessageText
 import com.moneymanager.ui.components.LoadingTextButton
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
@@ -153,6 +154,7 @@ fun CategoriesScreen(
         }
 
     val scope = rememberSchemaAwareCoroutineScope()
+    val importEngine = LocalImportEngine.current
     val listState = rememberLazyListState()
 
     // Shared horizontal scroll state for header and all rows
@@ -314,7 +316,7 @@ fun CategoriesScreen(
                                         if (draggedCategory.parentId != newParentId) {
                                             scope.launch {
                                                 try {
-                                                    categoryRepository.updateCategory(
+                                                    importEngine.updateCategory(
                                                         draggedCategory.copy(parentId = newParentId),
                                                         Source.Manual,
                                                     )
@@ -359,7 +361,6 @@ fun CategoriesScreen(
         EditCategoryDialog(
             category = category,
             categories = categories,
-            categoryRepository = categoryRepository,
             onDismiss = { editingCategory = null },
         )
     }
@@ -621,7 +622,6 @@ fun CreateCategoryDialogInCategories(
 fun EditCategoryDialog(
     category: Category,
     categories: List<Category>,
-    categoryRepository: CategoryRepository,
     onDismiss: () -> Unit,
 ) {
     var name by remember { mutableStateOf(category.name) }
@@ -632,6 +632,7 @@ fun EditCategoryDialog(
     var showDeleteConfirmation by remember { mutableStateOf(false) }
 
     val scope = rememberSchemaAwareCoroutineScope()
+    val importEngine = LocalImportEngine.current
 
     // Get descendants to prevent selecting them as parent (would create cycle)
     val forest = remember(categories) { buildCategoryForest(categories) }
@@ -702,7 +703,7 @@ fun EditCategoryDialog(
                         setError = { errorMessage = it },
                         onSuccess = onDismiss,
                     ) { trimmedName ->
-                        categoryRepository.updateCategory(
+                        importEngine.updateCategory(
                             category.copy(
                                 name = trimmedName,
                                 parentId = selectedParentId,
@@ -729,7 +730,6 @@ fun EditCategoryDialog(
     if (showDeleteConfirmation) {
         DeleteCategoryDialog(
             category = category,
-            categoryRepository = categoryRepository,
             onDismiss = { showDeleteConfirmation = false },
             onDeleted = onDismiss,
         )
@@ -836,13 +836,13 @@ internal fun ParentCategorySelector(
 @Composable
 fun DeleteCategoryDialog(
     category: Category,
-    categoryRepository: CategoryRepository,
     onDismiss: () -> Unit,
     onDeleted: () -> Unit,
 ) {
     var isDeleting by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     val scope = rememberSchemaAwareCoroutineScope()
+    val importEngine = LocalImportEngine.current
 
     AlertDialog(
         onDismissRequest = { if (!isDeleting) onDismiss() },
@@ -881,7 +881,7 @@ fun DeleteCategoryDialog(
                     errorMessage = null
                     scope.launch {
                         try {
-                            categoryRepository.deleteCategory(category.id)
+                            importEngine.deleteCategory(category.id)
                             onDeleted()
                         } catch (expected: Exception) {
                             logger.error(expected) { "Failed to delete category: ${expected.message}" }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CloudStorageCard.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CloudStorageCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,6 +37,9 @@ import com.moneymanager.remotestorage.googledrive.GOOGLE_DRIVE_FOLDER_NAME
 import com.moneymanager.remotestorage.googledrive.GOOGLE_DRIVE_PROVIDER_ID
 import com.moneymanager.remotestorage.sync.RemoteDatabaseController
 import com.moneymanager.remotestorage.sync.SyncProgress
+import com.moneymanager.remotestorage.sync.SyncResult
+import com.moneymanager.remotestorage.sync.SyncState
+import com.moneymanager.remotestorage.sync.SyncStatus
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -53,6 +57,7 @@ fun CloudStorageCard(
     database: MoneyManagerDatabaseWrapper,
     currentDatabaseLocation: DbLocation,
     onRequestSwitchDatabase: (DbLocation) -> Unit,
+    onReloadFromRemote: () -> Unit,
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
     val uriHandler = LocalUriHandler.current
@@ -74,20 +79,28 @@ fun CloudStorageCard(
         remoteSize = if (binding != null) runCatching { controller.remoteArchiveSize() }.getOrNull() else null
     }
 
-    // Poll for unsynced changes (and the session token's expiry) so the card reflects live state.
-    var dirty by remember { mutableStateOf(false) }
+    // The controller owns the multi-device sync state; the card just reflects it.
+    val syncState by controller.syncState.collectAsState()
+    var confirmAction by remember { mutableStateOf<ConflictAction?>(null) }
+
+    // Light local-only poll for unsynced changes (no network) + the session token's expiry.
     var tokenStatus by remember { mutableStateOf<String?>(null) }
     LaunchedEffect(sessionActive, binding, refreshTick, database) {
         while (true) {
-            dirty = sessionActive && runCatching { controller.hasUnsyncedChanges(database) }.getOrDefault(false)
-            tokenStatus =
-                if (sessionActive) {
-                    runCatching { controller.accessTokenExpiresAtEpochMs() }.getOrNull()?.let(::formatTokenStatus)
-                } else {
-                    null
-                }
+            if (sessionActive) {
+                runCatching { controller.refreshLocalDirty(database) }
+                tokenStatus = runCatching { controller.accessTokenExpiresAtEpochMs() }.getOrNull()?.let(::formatTokenStatus)
+            } else {
+                tokenStatus = null
+            }
             delay(2.seconds)
         }
+    }
+
+    // Check the remote once whenever a session arms (e.g. after open/resume). Detection is otherwise
+    // on demand via the "Check remote for changes" button — never polled.
+    LaunchedEffect(sessionActive, binding) {
+        if (sessionActive) runCatching { controller.checkRemote(database) }
     }
 
     Card(modifier = Modifier.fillMaxWidth()) {
@@ -132,23 +145,59 @@ fun CloudStorageCard(
                     } else {
                         null
                     }
+
+                fun upload(force: Boolean) {
+                    busy = true
+                    scope.launch {
+                        runCatching { controller.syncNow(database, force = force) { syncProgress = it } }
+                            .onSuccess { result ->
+                                message =
+                                    when (result) {
+                                        SyncResult.UPLOADED -> "Uploaded to ${currentBinding.remoteName}"
+                                        SyncResult.BLOCKED ->
+                                            "The remote changed since your last sync — download first, or overwrite it."
+                                        SyncResult.NO_SESSION -> "No active cloud session"
+                                    }
+                                refreshTick++
+                            }.onFailure { message = "Upload failed: ${it.message}" }
+                        syncProgress = null
+                        busy = false
+                    }
+                }
+
+                // Re-hydrating overwrites the *currently open* working copy, so the live database must be
+                // closed before restore (or SQLite reports it busy, notably on Android). The app root owns
+                // the database lifecycle, so it performs the close → download → reopen as one operation.
+                fun download() = onReloadFromRemote()
+
                 BoundState(
                     providerLabel = providerLabel,
                     locationPath = locationPath,
                     onOpenRemote = onOpenRemote,
                     sessionActive = sessionActive,
                     busy = busy,
-                    dirty = dirty,
-                    onSyncNow = {
+                    syncState = syncState,
+                    onCheckRemote = {
                         busy = true
                         scope.launch {
-                            runCatching { controller.syncNow(database) { syncProgress = it } }
-                                .onSuccess {
-                                    message = "Synced to ${currentBinding.remoteName}"
-                                    refreshTick++
-                                }.onFailure { message = "Sync failed: ${it.message}" }
-                            syncProgress = null
+                            runCatching { controller.checkRemote(database) }
+                                .onSuccess { message = null }
+                                .onFailure { message = "Check failed: ${it.message}" }
                             busy = false
+                        }
+                    },
+                    onUpload = {
+                        if (syncState.status == SyncStatus.CONFLICT) {
+                            confirmAction = ConflictAction.UploadOverwrite
+                        } else {
+                            upload(force = false)
+                        }
+                    },
+                    onDownload = {
+                        if (syncState.status == SyncStatus.CONFLICT) {
+                            confirmAction = ConflictAction.DownloadDiscard
+                        } else {
+                            download()
                         }
                     },
                     onResume = { showResume = true },
@@ -159,6 +208,20 @@ fun CloudStorageCard(
                         message = "Disconnected from cloud storage (local copy kept)"
                     },
                 )
+
+                confirmAction?.let { action ->
+                    ConflictConfirmDialog(
+                        action = action,
+                        onConfirm = {
+                            confirmAction = null
+                            when (action) {
+                                ConflictAction.UploadOverwrite -> upload(force = true)
+                                ConflictAction.DownloadDiscard -> download()
+                            }
+                        },
+                        onDismiss = { confirmAction = null },
+                    )
+                }
             }
 
             StorageSizes(localSize = localSize, remoteSize = remoteSize)
@@ -301,6 +364,9 @@ private fun StorageSizes(
     }
 }
 
+/** Which side of a [SyncStatus.CONFLICT] the user chose to keep (the other side's changes are lost). */
+private enum class ConflictAction { UploadOverwrite, DownloadDiscard }
+
 @Composable
 private fun BoundState(
     providerLabel: String,
@@ -308,11 +374,16 @@ private fun BoundState(
     onOpenRemote: (() -> Unit)?,
     sessionActive: Boolean,
     busy: Boolean,
-    dirty: Boolean,
-    onSyncNow: () -> Unit,
+    syncState: SyncState,
+    onCheckRemote: () -> Unit,
+    onUpload: () -> Unit,
+    onDownload: () -> Unit,
     onResume: () -> Unit,
     onDisconnect: () -> Unit,
 ) {
+    // syncState.busy is set the instant a reload starts (see RemoteDatabaseController.beginBusy), so the
+    // actions disable immediately on click — before the loading screen replaces this card.
+    val actionsDisabled = busy || syncState.busy
     Text(text = "Stored on $providerLabel", style = MaterialTheme.typography.bodyMedium)
     if (onOpenRemote != null) {
         Text(
@@ -324,25 +395,32 @@ private fun BoundState(
     } else {
         Text(text = locationPath, style = MaterialTheme.typography.bodySmall)
     }
-    if (sessionActive && !dirty) {
-        Text(
-            text = "✓ Everything is synced",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.primary,
-        )
-    } else if (sessionActive) {
-        Text(
-            text = "Unsynced changes",
-            style = MaterialTheme.typography.bodyMedium,
-        )
+    if (sessionActive) {
+        SyncStatusLine(syncState.status)
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedButton(onClick = onCheckRemote, enabled = !actionsDisabled, modifier = Modifier.weight(1f)) {
+                Text("Check remote for changes")
+            }
+        }
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            OutlinedButton(
+                onClick = onUpload,
+                enabled = !actionsDisabled && syncState.canUpload,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text("Upload")
+            }
+            OutlinedButton(
+                onClick = onDownload,
+                enabled = !actionsDisabled && syncState.canDownload,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text("Download")
+            }
+        }
     }
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        if (sessionActive) {
-            // Enabled only when there are local changes to upload.
-            OutlinedButton(onClick = onSyncNow, enabled = !busy && dirty, modifier = Modifier.weight(1f)) {
-                Text("Sync now")
-            }
-        } else {
+        if (!sessionActive) {
             OutlinedButton(onClick = onResume, enabled = !busy, modifier = Modifier.weight(1f)) {
                 Text("Enter password to sync")
             }
@@ -351,6 +429,56 @@ private fun BoundState(
             Text("Disconnect")
         }
     }
+}
+
+@Composable
+private fun SyncStatusLine(status: SyncStatus) {
+    val (text, highlight) =
+        when (status) {
+            SyncStatus.IN_SYNC -> "✓ Everything is synced" to true
+            SyncStatus.LOCAL_AHEAD -> "Local changes not uploaded" to false
+            SyncStatus.REMOTE_AHEAD -> "Another device updated this database — download to continue" to false
+            SyncStatus.CONFLICT -> "Conflict: both this device and another device changed the database" to false
+            SyncStatus.NO_SESSION -> "" to false
+        }
+    if (text.isEmpty()) return
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = if (highlight) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+    )
+}
+
+@Composable
+private fun ConflictConfirmDialog(
+    action: ConflictAction,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val (title, body, confirmLabel) =
+        when (action) {
+            ConflictAction.UploadOverwrite ->
+                Triple(
+                    "Overwrite remote changes?",
+                    "Another device changed this database since your last sync. Uploading now will overwrite " +
+                        "those changes with your local copy. This can't be undone.",
+                    "Overwrite remote",
+                )
+            ConflictAction.DownloadDiscard ->
+                Triple(
+                    "Discard local changes?",
+                    "Another device changed this database since your last sync. Downloading now will discard " +
+                        "your local unsynced changes. This can't be undone.",
+                    "Discard local",
+                )
+        }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = { Text(body) },
+        confirmButton = { TextButton(onClick = onConfirm) { Text(confirmLabel) } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
 }
 
 @Composable

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
@@ -41,7 +41,6 @@ import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.TransferSourceRepository
 import com.moneymanager.importengineapi.ImportEngine
@@ -64,7 +63,6 @@ fun CsvImportDetailScreen(
     currencyRepository: CurrencyRepository,
     attributeTypeRepository: AttributeTypeRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     maintenance: Maintenance,
     transferSourceRepository: TransferSourceRepository,
     importEngine: ImportEngine,
@@ -405,7 +403,6 @@ fun CsvImportDetailScreen(
             categoryRepository = categoryRepository,
             currencyRepository = currencyRepository,
             personRepository = personRepository,
-            personAccountOwnershipRepository = personAccountOwnershipRepository,
             csvImportRepository = csvImportRepository,
             attributeTypeRepository = attributeTypeRepository,
             maintenance = maintenance,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
@@ -45,7 +45,6 @@ import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
@@ -67,7 +66,6 @@ fun CsvImportsScreen(
     categoryRepository: CategoryRepository,
     currencyRepository: CurrencyRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     attributeTypeRepository: AttributeTypeRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
@@ -236,7 +234,6 @@ fun CsvImportsScreen(
                     categoryRepository = categoryRepository,
                     currencyRepository = currencyRepository,
                     personRepository = personRepository,
-                    personAccountOwnershipRepository = personAccountOwnershipRepository,
                     csvImportRepository = csvImportRepository,
                     attributeTypeRepository = attributeTypeRepository,
                     maintenance = maintenance,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
@@ -22,7 +22,6 @@ import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.QifImportRepository
 import com.moneymanager.domain.repository.SettingsRepository
@@ -49,7 +48,6 @@ fun ImportsScreen(
     transactionRepository: TransactionRepository,
     maintenance: Maintenance,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     importEngine: ImportEngine,
     deviceId: DeviceId,
     onCsvImportClick: (CsvImportId) -> Unit,
@@ -94,7 +92,6 @@ fun ImportsScreen(
                     categoryRepository = categoryRepository,
                     currencyRepository = currencyRepository,
                     personRepository = personRepository,
-                    personAccountOwnershipRepository = personAccountOwnershipRepository,
                     attributeTypeRepository = attributeTypeRepository,
                     maintenance = maintenance,
                     importEngine = importEngine,
@@ -110,7 +107,6 @@ fun ImportsScreen(
                     categoryRepository = categoryRepository,
                     currencyRepository = currencyRepository,
                     personRepository = personRepository,
-                    personAccountOwnershipRepository = personAccountOwnershipRepository,
                     attributeTypeRepository = attributeTypeRepository,
                     settingsRepository = settingsRepository,
                     maintenance = maintenance,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ManualEntriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ManualEntriesScreen.kt
@@ -33,14 +33,16 @@ import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.Source
-import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.TransferMissingCompanion
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.TransactionRepository
+import com.moneymanager.importengineapi.AccountRef
+import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -194,27 +196,18 @@ private suspend fun createCompanionTransfers(
 ) {
     val linkTypeId = attributeTypeRepository.getOrCreate(rule.linkAttributeName)
     val transfers =
-        entries.mapIndexed { index, (matched, amount) ->
-            Transfer(
-                // Distinct placeholder ids: createTransfers keys newAttributes by them.
-                id = TransferId(-(index + 1L)),
+        entries.map { (matched, amount) ->
+            ImportTransfer(
+                source = Source.Manual,
+                fromAccount = AccountRef.Existing(matched.targetAccountId),
+                toAccount = AccountRef.Existing(matched.sourceAccountId),
                 timestamp = matched.timestamp,
                 description = rule.companionDescription,
-                sourceAccountId = matched.targetAccountId,
-                targetAccountId = matched.sourceAccountId,
                 amount = Money.fromDisplayValue(amount, matched.amount.currency),
+                attributes = listOf(NewAttribute(linkTypeId, matched.matchValue)),
             )
         }
-    val newAttributes =
-        transfers
-            .mapIndexed { index, transfer ->
-                transfer.id to listOf(NewAttribute(linkTypeId, entries[index].first.matchValue))
-            }.toMap()
-    importEngine.createTransfers(
-        transfers = transfers,
-        newAttributes = newAttributes,
-        sources = List(transfers.size) { Source.Manual },
-    )
+    importEngine.import(ImportBatch.manualEdits(transfers = transfers))
 }
 
 private fun parseAmount(text: String): BigDecimal? {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ManualEntriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ManualEntriesScreen.kt
@@ -40,6 +40,8 @@ import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.TransactionRepository
+import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.util.displayDateTime
@@ -75,6 +77,7 @@ fun ManualEntriesScreen(
     onTransactionsImported: () -> Unit,
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
+    val importEngine = LocalImportEngine.current
     val groupsFlow =
         remember(csvImportStrategyRepository, transactionRepository) {
             csvImportStrategyRepository.getAllStrategies().flatMapLatest { strategies ->
@@ -151,7 +154,7 @@ fun ManualEntriesScreen(
                                         createCompanionTransfers(
                                             rule = group.rule,
                                             entries = entries,
-                                            transactionRepository = transactionRepository,
+                                            importEngine = importEngine,
                                             attributeTypeRepository = attributeTypeRepository,
                                         )
                                         maintenance.refreshMaterializedViews()
@@ -186,7 +189,7 @@ fun ManualEntriesScreen(
 private suspend fun createCompanionTransfers(
     rule: CompanionTransactionRule,
     entries: List<Pair<TransferMissingCompanion, BigDecimal>>,
-    transactionRepository: TransactionRepository,
+    importEngine: ImportEngine,
     attributeTypeRepository: AttributeTypeRepository,
 ) {
     val linkTypeId = attributeTypeRepository.getOrCreate(rule.linkAttributeName)
@@ -207,7 +210,7 @@ private suspend fun createCompanionTransfers(
             .mapIndexed { index, transfer ->
                 transfer.id to listOf(NewAttribute(linkTypeId, entries[index].first.matchValue))
             }.toMap()
-    transactionRepository.createTransfers(
+    importEngine.createTransfers(
         transfers = transfers,
         newAttributes = newAttributes,
         sources = List(transfers.size) { Source.Manual },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
@@ -133,7 +133,6 @@ fun PeopleScreen(
     if (showCreateDialog) {
         EditPersonDialog(
             personToEdit = null,
-            personRepository = personRepository,
             onDismiss = { showCreateDialog = false },
             personAttributeRepository = personAttributeRepository,
             attributeTypeRepository = attributeTypeRepository,
@@ -144,7 +143,6 @@ fun PeopleScreen(
     if (currentPersonToEdit != null) {
         EditPersonDialog(
             personToEdit = currentPersonToEdit,
-            personRepository = personRepository,
             onDismiss = { personToEdit = null },
             personAttributeRepository = personAttributeRepository,
             attributeTypeRepository = attributeTypeRepository,
@@ -159,7 +157,6 @@ fun PeopleScreen(
         DeletePersonConfirmationDialog(
             person = currentPersonToDelete,
             accountCount = ownerships.size,
-            personRepository = personRepository,
             onDismiss = { personToDelete = null },
         )
     }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportDetailScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportDetailScreen.kt
@@ -34,7 +34,6 @@ import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.QifImportRepository
 import com.moneymanager.domain.repository.SettingsRepository
@@ -57,7 +56,6 @@ fun QifImportDetailScreen(
     categoryRepository: CategoryRepository,
     currencyRepository: CurrencyRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     attributeTypeRepository: AttributeTypeRepository,
     settingsRepository: SettingsRepository,
     maintenance: Maintenance,
@@ -148,7 +146,6 @@ fun QifImportDetailScreen(
             categoryRepository = categoryRepository,
             currencyRepository = currencyRepository,
             personRepository = personRepository,
-            personAccountOwnershipRepository = personAccountOwnershipRepository,
             qifImportRepository = qifImportRepository,
             attributeTypeRepository = attributeTypeRepository,
             settingsRepository = settingsRepository,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportsScreen.kt
@@ -42,7 +42,6 @@ import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.QifImportRepository
 import com.moneymanager.domain.repository.SettingsRepository
@@ -69,7 +68,6 @@ fun QifImportsScreen(
     categoryRepository: CategoryRepository,
     currencyRepository: CurrencyRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     attributeTypeRepository: AttributeTypeRepository,
     settingsRepository: SettingsRepository,
     maintenance: Maintenance,
@@ -231,7 +229,6 @@ fun QifImportsScreen(
                     categoryRepository = categoryRepository,
                     currencyRepository = currencyRepository,
                     personRepository = personRepository,
-                    personAccountOwnershipRepository = personAccountOwnershipRepository,
                     qifImportRepository = qifImportRepository,
                     attributeTypeRepository = attributeTypeRepository,
                     settingsRepository = settingsRepository,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/SettingsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/SettingsScreen.kt
@@ -38,7 +38,6 @@ import com.moneymanager.database.MoneyManagerDatabaseWrapper
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.DbLocation
 import com.moneymanager.domain.repository.AttributeTypeRepository
-import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CurrencyRepository
 import com.moneymanager.domain.repository.SettingsRepository
 import com.moneymanager.importengineapi.ImportEngine
@@ -153,13 +152,13 @@ private fun DatabaseCard(
 @Composable
 fun SettingsScreen(
     currencyRepository: CurrencyRepository,
-    categoryRepository: CategoryRepository,
     attributeTypeRepository: AttributeTypeRepository,
     importEngine: ImportEngine,
     settingsRepository: SettingsRepository,
     maintenance: Maintenance,
     currentDatabaseLocation: DbLocation,
     onRequestSwitchDatabase: (DbLocation) -> Unit,
+    onReloadFromRemote: () -> Unit = {},
     remoteController: RemoteDatabaseController? = null,
     database: MoneyManagerDatabaseWrapper? = null,
 ) {
@@ -234,6 +233,7 @@ fun SettingsScreen(
                 database = database,
                 currentDatabaseLocation = currentDatabaseLocation,
                 onRequestSwitchDatabase = onRequestSwitchDatabase,
+                onReloadFromRemote = onReloadFromRemote,
             )
         }
 
@@ -497,7 +497,6 @@ fun SettingsScreen(
                                 // Generate sample data
                                 generateSampleData(
                                     currencyRepository = currencyRepository,
-                                    categoryRepository = categoryRepository,
                                     attributeTypeRepository = attributeTypeRepository,
                                     importEngine = importEngine,
                                     maintenance = maintenance,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -71,7 +71,6 @@ import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.ui.components.AccountPicker
@@ -96,7 +95,6 @@ fun ApplyStrategyDialog(
     categoryRepository: CategoryRepository,
     currencyRepository: CurrencyRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     csvImportRepository: CsvImportRepository,
     attributeTypeRepository: AttributeTypeRepository,
     maintenance: Maintenance,
@@ -280,7 +278,6 @@ fun ApplyStrategyDialog(
                         accountRepository = accountRepository,
                         categoryRepository = categoryRepository,
                         personRepository = personRepository,
-                        personAccountOwnershipRepository = personAccountOwnershipRepository,
                         enabled = !isImporting,
                         isError = selectedSourceAccountId == null,
                     )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
@@ -30,7 +30,6 @@ import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.ui.components.AccountPicker
@@ -57,7 +56,6 @@ fun CsvImportAllDialog(
     categoryRepository: CategoryRepository,
     currencyRepository: CurrencyRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     csvImportRepository: CsvImportRepository,
     attributeTypeRepository: AttributeTypeRepository,
     maintenance: Maintenance,
@@ -111,7 +109,6 @@ fun CsvImportAllDialog(
                             accountRepository = accountRepository,
                             categoryRepository = categoryRepository,
                             personRepository = personRepository,
-                            personAccountOwnershipRepository = personAccountOwnershipRepository,
                             enabled = !isImporting,
                             isError = sourceAccountId == null,
                         )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
@@ -56,7 +56,6 @@ import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.QifImportRepository
 import com.moneymanager.qifimporter.QifCsvAdapter
@@ -75,7 +74,6 @@ fun CsvStrategiesScreen(
     categoryRepository: CategoryRepository,
     currencyRepository: CurrencyRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     csvStrategyImportExport: CsvStrategyImportExport,
     appVersion: AppVersion,
     onStrategyClick: (CsvImportStrategy) -> Unit = {},
@@ -336,7 +334,6 @@ fun CsvStrategiesScreen(
             categoryRepository = categoryRepository,
             currencyRepository = currencyRepository,
             personRepository = personRepository,
-            personAccountOwnershipRepository = personAccountOwnershipRepository,
             onDismiss = {
                 importParseResult = null
                 importError = null

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ImportStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ImportStrategyDialog.kt
@@ -336,7 +336,12 @@ private fun accountMappingReference(accountName: String): CsvUnresolvedReference
 
 /**
  * Row for resolving a single unresolved reference.
+ *
+ * [accountRepository] / [personAccountOwnershipRepository] are retained for call-site symmetry; account
+ * creation now writes through the [com.moneymanager.importengineapi.ImportEngine], so this row no longer
+ * uses them directly.
  */
+@Suppress("UnusedParameter")
 @Composable
 private fun ReferenceResolutionRow(
     reference: CsvUnresolvedReference,
@@ -497,10 +502,8 @@ private fun ReferenceResolutionRow(
 
                     if (showCreateAccountDialog) {
                         CreateAccountDialog(
-                            accountRepository = accountRepository,
                             categoryRepository = categoryRepository,
                             personRepository = personRepository,
-                            personAccountOwnershipRepository = personAccountOwnershipRepository,
                             initialName = reference.name,
                             onDismiss = { showCreateAccountDialog = false },
                             onAccountCreated = { accountId ->

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ImportStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ImportStrategyDialog.kt
@@ -62,7 +62,6 @@ import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.ui.components.CreateAccountDialog
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
@@ -84,7 +83,6 @@ fun ImportStrategyDialog(
     categoryRepository: CategoryRepository,
     currencyRepository: CurrencyRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     onDismiss: () -> Unit,
     onImportSuccess: () -> Unit,
 ) {
@@ -193,10 +191,8 @@ fun ImportStrategyDialog(
                             accounts = accounts,
                             categories = categories,
                             currencies = currencies,
-                            accountRepository = accountRepository,
                             categoryRepository = categoryRepository,
                             personRepository = personRepository,
-                            personAccountOwnershipRepository = personAccountOwnershipRepository,
                             enabled = !isImporting,
                         )
                         Spacer(modifier = Modifier.height(8.dp))
@@ -336,12 +332,7 @@ private fun accountMappingReference(accountName: String): CsvUnresolvedReference
 
 /**
  * Row for resolving a single unresolved reference.
- *
- * [accountRepository] / [personAccountOwnershipRepository] are retained for call-site symmetry; account
- * creation now writes through the [com.moneymanager.importengineapi.ImportEngine], so this row no longer
- * uses them directly.
  */
-@Suppress("UnusedParameter")
 @Composable
 private fun ReferenceResolutionRow(
     reference: CsvUnresolvedReference,
@@ -350,10 +341,8 @@ private fun ReferenceResolutionRow(
     accounts: List<Account>,
     categories: List<Category>,
     currencies: List<Currency>,
-    accountRepository: AccountRepository,
     categoryRepository: CategoryRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     enabled: Boolean,
 ) {
     var expanded by remember { mutableStateOf(false) }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AccountsTab.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AccountsTab.kt
@@ -17,7 +17,6 @@ import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.CategoryRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.ui.components.AccountPicker
 import com.moneymanager.ui.screens.csvstrategy.findRowWithBlankColumn
@@ -36,7 +35,6 @@ internal fun AccountsTab(
     accountRepository: AccountRepository,
     categoryRepository: CategoryRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         Text("Source Account (Optional)", style = MaterialTheme.typography.titleSmall)
@@ -68,7 +66,6 @@ internal fun AccountsTab(
                     accountRepository = accountRepository,
                     categoryRepository = categoryRepository,
                     personRepository = personRepository,
-                    personAccountOwnershipRepository = personAccountOwnershipRepository,
                     enabled = enabled,
                 )
             SourceAccountMode.TEMPLATE ->

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorScreen.kt
@@ -46,7 +46,6 @@ import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -81,7 +80,6 @@ fun CsvStrategyEditorScreen(
     currencyRepository: CurrencyRepository,
     attributeTypeRepository: AttributeTypeRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     onBack: () -> Unit,
 ) {
     val isEditMode = strategyId != null
@@ -280,7 +278,6 @@ fun CsvStrategyEditorScreen(
                         accountRepository = accountRepository,
                         categoryRepository = categoryRepository,
                         personRepository = personRepository,
-                        personAccountOwnershipRepository = personAccountOwnershipRepository,
                     )
                 EditorTab.AMOUNT_DATE ->
                     AmountDateTab(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifApplyStrategyDialog.kt
@@ -40,7 +40,6 @@ import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.QifImportRepository
 import com.moneymanager.domain.repository.SettingsRepository
@@ -84,7 +83,6 @@ fun QifApplyStrategyDialog(
     categoryRepository: CategoryRepository,
     currencyRepository: CurrencyRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     qifImportRepository: QifImportRepository,
     attributeTypeRepository: AttributeTypeRepository,
     settingsRepository: SettingsRepository,
@@ -237,7 +235,6 @@ fun QifApplyStrategyDialog(
                         accountRepository = accountRepository,
                         categoryRepository = categoryRepository,
                         personRepository = personRepository,
-                        personAccountOwnershipRepository = personAccountOwnershipRepository,
                         enabled = !isImporting,
                         isError = selectedSourceAccountId == null,
                     )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
@@ -25,7 +25,6 @@ import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.QifImportRepository
 import com.moneymanager.domain.repository.SettingsRepository
@@ -54,7 +53,6 @@ fun QifImportAllDialog(
     categoryRepository: CategoryRepository,
     currencyRepository: CurrencyRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     qifImportRepository: QifImportRepository,
     attributeTypeRepository: AttributeTypeRepository,
     settingsRepository: SettingsRepository,
@@ -96,7 +94,6 @@ fun QifImportAllDialog(
                         accountRepository = accountRepository,
                         categoryRepository = categoryRepository,
                         personRepository = personRepository,
-                        personAccountOwnershipRepository = personAccountOwnershipRepository,
                         enabled = !isImporting,
                         isError = sourceAccountId == null,
                     )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifStrategyEditorScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifStrategyEditorScreen.kt
@@ -21,7 +21,6 @@ import com.moneymanager.domain.repository.CsvAccountMappingRepository
 import com.moneymanager.domain.repository.CsvImportRepository
 import com.moneymanager.domain.repository.CsvImportStrategyRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.domain.repository.QifImportRepository
 import com.moneymanager.qifimporter.QifCsvAdapter
@@ -45,7 +44,6 @@ fun QifStrategyEditorScreen(
     currencyRepository: CurrencyRepository,
     attributeTypeRepository: AttributeTypeRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     onBack: () -> Unit,
 ) {
     var sampleRows by remember { mutableStateOf<List<CsvRow>?>(null) }
@@ -76,7 +74,6 @@ fun QifStrategyEditorScreen(
         currencyRepository = currencyRepository,
         attributeTypeRepository = attributeTypeRepository,
         personRepository = personRepository,
-        personAccountOwnershipRepository = personAccountOwnershipRepository,
         onBack = onBack,
     )
 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
@@ -51,7 +51,7 @@ import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CurrencyRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
-import com.moneymanager.domain.repository.TransactionRepository
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.AccountPicker
 import com.moneymanager.ui.components.CurrencyPicker
 import com.moneymanager.ui.components.LoadingTextButton
@@ -69,7 +69,6 @@ import kotlin.time.Instant
 @Composable
 fun TransactionEditDialog(
     transaction: Transfer? = null,
-    transactionRepository: TransactionRepository,
     accountRepository: AccountRepository,
     categoryRepository: CategoryRepository,
     currencyRepository: CurrencyRepository,
@@ -110,6 +109,7 @@ fun TransactionEditDialog(
     var showTimePicker by remember { mutableStateOf(false) }
 
     val scope = rememberSchemaAwareCoroutineScope()
+    val importEngine = LocalImportEngine.current
 
     // Attribute state - in edit mode, initialize from transaction's embedded attributes
     // (already loaded by TransactionsScreen via getTransactionById which calls loadAttributesForTransfer)
@@ -443,7 +443,7 @@ fun TransactionEditDialog(
 
                                         // Use the atomic method to update transfer and attributes together.
                                         // updateTransfer records the provenance source itself.
-                                        transactionRepository.updateTransfer(
+                                        importEngine.updateTransfer(
                                             transfer = updatedTransfer,
                                             deletedAttributeIds = deletedAttributeIds,
                                             updatedAttributes = updatedAttributes,
@@ -476,7 +476,7 @@ fun TransactionEditDialog(
                                             attributesToSave.add(NewAttribute(AttributeTypeId(-1), excludeReason))
                                         }
 
-                                        transactionRepository.createTransfers(
+                                        importEngine.createTransfers(
                                             transfers = listOf(transfer),
                                             newAttributes = mapOf(transfer.id to attributesToSave),
                                             sources = listOf(Source.Manual),

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
@@ -455,6 +455,10 @@ fun TransactionEditDialog(
                                                             operation = ImportOperation.UPDATE,
                                                             existingId = transaction.id,
                                                             // Null when only attributes changed (no transfer-field update).
+                                                            // When fields didn't change, updatedTransfer is null so
+                                                            // from/to/timestamp/amount are all null; the engine's
+                                                            // toUpdatedTransfer() then returns null (attribute-only
+                                                            // update) and this "" description is never written.
                                                             fromAccount = updatedTransfer?.let { AccountRef.Existing(it.sourceAccountId) },
                                                             toAccount = updatedTransfer?.let { AccountRef.Existing(it.targetAccountId) },
                                                             timestamp = updatedTransfer?.timestamp,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
@@ -44,13 +44,16 @@ import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.Transfer
-import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CurrencyRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
+import com.moneymanager.importengineapi.AccountRef
+import com.moneymanager.importengineapi.ImportBatch
+import com.moneymanager.importengineapi.ImportOperation
+import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.AccountPicker
 import com.moneymanager.ui.components.CurrencyPicker
@@ -441,29 +444,31 @@ fun TransactionEditDialog(
                                                 deletedAttributeIds.add(originalExcludedAttr.id)
                                         }
 
-                                        // Use the atomic method to update transfer and attributes together.
-                                        // updateTransfer records the provenance source itself.
-                                        importEngine.updateTransfer(
-                                            transfer = updatedTransfer,
-                                            deletedAttributeIds = deletedAttributeIds,
-                                            updatedAttributes = updatedAttributes,
-                                            newAttributes = newAttributes,
-                                            transactionId = transaction.id,
-                                            source = Source.Manual,
+                                        // One UPDATE intent: transfer fields + attribute deltas, applied
+                                        // atomically (one revision bump) by the engine.
+                                        importEngine.import(
+                                            ImportBatch.manualEdits(
+                                                transfers =
+                                                    listOf(
+                                                        ImportTransfer(
+                                                            source = Source.Manual,
+                                                            operation = ImportOperation.UPDATE,
+                                                            existingId = transaction.id,
+                                                            // Null when only attributes changed (no transfer-field update).
+                                                            fromAccount = updatedTransfer?.let { AccountRef.Existing(it.sourceAccountId) },
+                                                            toAccount = updatedTransfer?.let { AccountRef.Existing(it.targetAccountId) },
+                                                            timestamp = updatedTransfer?.timestamp,
+                                                            description = updatedTransfer?.description ?: "",
+                                                            amount = updatedTransfer?.amount,
+                                                            deletedAttributeIds = deletedAttributeIds,
+                                                            updatedAttributes = updatedAttributes,
+                                                            attributes = newAttributes,
+                                                        ),
+                                                    ),
+                                            ),
                                         )
                                     } else {
-                                        // CREATE MODE: Create new transaction
-                                        val transfer =
-                                            Transfer(
-                                                id = TransferId(0L),
-                                                timestamp = timestamp,
-                                                description = description.trim(),
-                                                sourceAccountId = sourceAccountId!!,
-                                                targetAccountId = targetAccountId!!,
-                                                amount = Money.fromDisplayValue(parsedAmount, currency),
-                                            )
-
-                                        // Build attributes to save (only non-blank ones)
+                                        // CREATE MODE: build attributes to save (only non-blank ones).
                                         val attributesToSave =
                                             editableAttributes
                                                 .filter { (_, pair) -> pair.first.isNotBlank() && pair.second.isNotBlank() }
@@ -476,10 +481,21 @@ fun TransactionEditDialog(
                                             attributesToSave.add(NewAttribute(AttributeTypeId(-1), excludeReason))
                                         }
 
-                                        importEngine.createTransfers(
-                                            transfers = listOf(transfer),
-                                            newAttributes = mapOf(transfer.id to attributesToSave),
-                                            sources = listOf(Source.Manual),
+                                        importEngine.import(
+                                            ImportBatch.manualEdits(
+                                                transfers =
+                                                    listOf(
+                                                        ImportTransfer(
+                                                            source = Source.Manual,
+                                                            fromAccount = AccountRef.Existing(sourceAccountId!!),
+                                                            toAccount = AccountRef.Existing(targetAccountId!!),
+                                                            timestamp = timestamp,
+                                                            description = description.trim(),
+                                                            amount = Money.fromDisplayValue(parsedAmount, currency),
+                                                            attributes = attributesToSave,
+                                                        ),
+                                                    ),
+                                            ),
                                         )
                                     }
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
@@ -48,7 +48,6 @@ import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.AttributeTypeRepository
 import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CurrencyRepository
-import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
 import com.moneymanager.domain.repository.PersonRepository
 import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.ImportBatch
@@ -77,7 +76,6 @@ fun TransactionEditDialog(
     currencyRepository: CurrencyRepository,
     attributeTypeRepository: AttributeTypeRepository,
     personRepository: PersonRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipRepository,
     maintenance: Maintenance,
     preSelectedSourceAccountId: AccountId? = null,
     preSelectedCurrencyId: CurrencyId? = null,
@@ -227,7 +225,6 @@ fun TransactionEditDialog(
                     accountRepository = accountRepository,
                     categoryRepository = categoryRepository,
                     personRepository = personRepository,
-                    personAccountOwnershipRepository = personAccountOwnershipRepository,
                     enabled = !isSaving,
                     excludeAccountId = targetAccountId,
                 )
@@ -240,7 +237,6 @@ fun TransactionEditDialog(
                     accountRepository = accountRepository,
                     categoryRepository = categoryRepository,
                     personRepository = personRepository,
-                    personAccountOwnershipRepository = personAccountOwnershipRepository,
                     enabled = !isSaving,
                     excludeAccountId = sourceAccountId,
                 )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -974,7 +974,6 @@ fun AccountTransactionsScreen(
     transactionToEdit?.let { transfer ->
         TransactionEditDialog(
             transaction = transfer,
-            transactionRepository = transactionRepository,
             accountRepository = accountRepository,
             categoryRepository = categoryRepository,
             currencyRepository = currencyRepository,
@@ -991,7 +990,6 @@ fun AccountTransactionsScreen(
     accountToEdit?.let { account ->
         EditAccountDialog(
             account = account,
-            accountRepository = accountRepository,
             accountAttributeRepository = accountAttributeRepository,
             attributeTypeRepository = attributeTypeRepository,
             categoryRepository = categoryRepository,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -979,7 +979,6 @@ fun AccountTransactionsScreen(
             currencyRepository = currencyRepository,
             attributeTypeRepository = attributeTypeRepository,
             personRepository = personRepository,
-            personAccountOwnershipRepository = personAccountOwnershipRepository,
             maintenance = maintenance,
             onDismiss = { transactionIdToEdit = null },
             onSaved = { refreshTrigger++ },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/SampleDataGenerator.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/SampleDataGenerator.kt
@@ -10,7 +10,6 @@ import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.repository.AttributeTypeRepository
-import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CurrencyRepository
 import com.moneymanager.importengineapi.AccountMatchKey
 import com.moneymanager.importengineapi.AccountRef
@@ -49,7 +48,6 @@ private const val ACCOUNT_COUNT = 100
  */
 suspend fun generateSampleData(
     currencyRepository: CurrencyRepository,
-    categoryRepository: CategoryRepository,
     attributeTypeRepository: AttributeTypeRepository,
     importEngine: ImportEngine,
     maintenance: Maintenance,
@@ -116,7 +114,7 @@ suspend fun generateSampleData(
     var categoriesCreated = 0
 
     for (parent in categoryHierarchy) {
-        val parentId = categoryRepository.createCategory(parent.category, sampleSource)
+        val parentId = importEngine.createCategory(parent.category, sampleSource)
         categoryIds.add(parentId)
         categoriesCreated++
 
@@ -130,7 +128,7 @@ suspend fun generateSampleData(
 
         for (child in parent.children) {
             val childId =
-                categoryRepository.createCategory(
+                importEngine.createCategory(
                     child.copy(parentId = parentId),
                     sampleSource,
                 )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/SampleDataGenerator.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/SampleDataGenerator.kt
@@ -16,12 +16,14 @@ import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.DedupePolicy
 import com.moneymanager.importengineapi.ImportAccountIntent
 import com.moneymanager.importengineapi.ImportBatch
+import com.moneymanager.importengineapi.ImportCategoryIntent
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.ImportOwnershipIntent
 import com.moneymanager.importengineapi.ImportPersonIntent
 import com.moneymanager.importengineapi.ImportRowKey
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
+import com.moneymanager.importengineapi.LocalCategoryKey
 import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.importengineapi.PersonMatchKey
 import com.moneymanager.importengineapi.normalizeNameKey
@@ -114,7 +116,23 @@ suspend fun generateSampleData(
     var categoriesCreated = 0
 
     for (parent in categoryHierarchy) {
-        val parentId = importEngine.createCategory(parent.category, sampleSource)
+        val parentKey = LocalCategoryKey("parent")
+        val parentId =
+            importEngine
+                .import(
+                    ImportBatch.manualEdits(
+                        categories =
+                            listOf(
+                                ImportCategoryIntent(
+                                    key = parentKey,
+                                    source = sampleSource,
+                                    name = parent.category.name,
+                                    parentId = parent.category.parentId,
+                                ),
+                            ),
+                    ),
+                ).createdCategoryIds
+                .getValue(parentKey)
         categoryIds.add(parentId)
         categoriesCreated++
 
@@ -127,11 +145,23 @@ suspend fun generateSampleData(
         )
 
         for (child in parent.children) {
+            val childKey = LocalCategoryKey("child")
             val childId =
-                importEngine.createCategory(
-                    child.copy(parentId = parentId),
-                    sampleSource,
-                )
+                importEngine
+                    .import(
+                        ImportBatch.manualEdits(
+                            categories =
+                                listOf(
+                                    ImportCategoryIntent(
+                                        key = childKey,
+                                        source = sampleSource,
+                                        name = child.name,
+                                        parentId = parentId,
+                                    ),
+                                ),
+                        ),
+                    ).createdCategoryIds
+                    .getValue(childKey)
             categoryIds.add(childId)
             categoriesCreated++
 

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -2,6 +2,7 @@
 
 package com.moneymanager.ui.screens
 import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,6 +51,7 @@ import com.moneymanager.test.database.createTestDatabaseLocation
 import com.moneymanager.test.database.createTestDatabaseManager
 import com.moneymanager.test.database.deleteTestDatabase
 import com.moneymanager.test.database.testSource
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.ProvideSchemaAwareScope
 import com.moneymanager.ui.screens.transactions.AccountTransactionCard
 import com.moneymanager.ui.screens.transactions.AccountTransactionsScreen
@@ -518,34 +520,36 @@ class AccountTransactionsScreenTest {
             runMoneyManagerComposeUiTest {
                 // When: Viewing the account transactions screen
                 setContent {
-                    ProvideSchemaAwareScope {
-                        var currentAccountId by remember { mutableStateOf(checkingAccountId) }
-                        var auditTransferId by remember { mutableStateOf<TransferId?>(null) }
+                    CompositionLocalProvider(LocalImportEngine provides repositories.importEngine) {
+                        ProvideSchemaAwareScope {
+                            var currentAccountId by remember { mutableStateOf(checkingAccountId) }
+                            var auditTransferId by remember { mutableStateOf<TransferId?>(null) }
 
-                        if (auditTransferId != null) {
-                            TransactionAuditScreen(
-                                transferId = auditTransferId!!,
-                                auditRepository = repositories.auditRepository,
-                                accountRepository = repositories.accountRepository,
-                                transactionRepository = repositories.transactionRepository,
-                                onBack = { auditTransferId = null },
-                            )
-                        } else {
-                            AccountTransactionsScreen(
-                                accountId = currentAccountId,
-                                transactionRepository = repositories.transactionRepository,
-                                accountRepository = repositories.accountRepository,
-                                accountAttributeRepository = repositories.accountAttributeRepository,
-                                categoryRepository = repositories.categoryRepository,
-                                currencyRepository = repositories.currencyRepository,
-                                attributeTypeRepository = repositories.attributeTypeRepository,
-                                personRepository = repositories.personRepository,
-                                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
-                                maintenance = createDbMaintenance(repositories),
-                                onAccountIdChange = { currentAccountId = it },
-                                onCurrencyIdChange = {},
-                                onAuditClick = { auditTransferId = it },
-                            )
+                            if (auditTransferId != null) {
+                                TransactionAuditScreen(
+                                    transferId = auditTransferId!!,
+                                    auditRepository = repositories.auditRepository,
+                                    accountRepository = repositories.accountRepository,
+                                    transactionRepository = repositories.transactionRepository,
+                                    onBack = { auditTransferId = null },
+                                )
+                            } else {
+                                AccountTransactionsScreen(
+                                    accountId = currentAccountId,
+                                    transactionRepository = repositories.transactionRepository,
+                                    accountRepository = repositories.accountRepository,
+                                    accountAttributeRepository = repositories.accountAttributeRepository,
+                                    categoryRepository = repositories.categoryRepository,
+                                    currencyRepository = repositories.currencyRepository,
+                                    attributeTypeRepository = repositories.attributeTypeRepository,
+                                    personRepository = repositories.personRepository,
+                                    personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                                    maintenance = createDbMaintenance(repositories),
+                                    onAccountIdChange = { currentAccountId = it },
+                                    onCurrencyIdChange = {},
+                                    onAuditClick = { auditTransferId = it },
+                                )
+                            }
                         }
                     }
                 }
@@ -726,34 +730,36 @@ class AccountTransactionsScreenTest {
             runMoneyManagerComposeUiTest {
                 // When: Viewing the account transactions screen
                 setContent {
-                    ProvideSchemaAwareScope {
-                        var currentAccountId by remember { mutableStateOf(checkingAccountId) }
-                        var auditTransferId by remember { mutableStateOf<TransferId?>(null) }
+                    CompositionLocalProvider(LocalImportEngine provides repositories.importEngine) {
+                        ProvideSchemaAwareScope {
+                            var currentAccountId by remember { mutableStateOf(checkingAccountId) }
+                            var auditTransferId by remember { mutableStateOf<TransferId?>(null) }
 
-                        if (auditTransferId != null) {
-                            TransactionAuditScreen(
-                                transferId = auditTransferId!!,
-                                auditRepository = repositories.auditRepository,
-                                accountRepository = repositories.accountRepository,
-                                transactionRepository = repositories.transactionRepository,
-                                onBack = { auditTransferId = null },
-                            )
-                        } else {
-                            AccountTransactionsScreen(
-                                accountId = currentAccountId,
-                                transactionRepository = repositories.transactionRepository,
-                                accountRepository = repositories.accountRepository,
-                                accountAttributeRepository = repositories.accountAttributeRepository,
-                                categoryRepository = repositories.categoryRepository,
-                                currencyRepository = repositories.currencyRepository,
-                                attributeTypeRepository = repositories.attributeTypeRepository,
-                                personRepository = repositories.personRepository,
-                                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
-                                maintenance = createDbMaintenance(repositories),
-                                onAccountIdChange = { currentAccountId = it },
-                                onCurrencyIdChange = {},
-                                onAuditClick = { auditTransferId = it },
-                            )
+                            if (auditTransferId != null) {
+                                TransactionAuditScreen(
+                                    transferId = auditTransferId!!,
+                                    auditRepository = repositories.auditRepository,
+                                    accountRepository = repositories.accountRepository,
+                                    transactionRepository = repositories.transactionRepository,
+                                    onBack = { auditTransferId = null },
+                                )
+                            } else {
+                                AccountTransactionsScreen(
+                                    accountId = currentAccountId,
+                                    transactionRepository = repositories.transactionRepository,
+                                    accountRepository = repositories.accountRepository,
+                                    accountAttributeRepository = repositories.accountAttributeRepository,
+                                    categoryRepository = repositories.categoryRepository,
+                                    currencyRepository = repositories.currencyRepository,
+                                    attributeTypeRepository = repositories.attributeTypeRepository,
+                                    personRepository = repositories.personRepository,
+                                    personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                                    maintenance = createDbMaintenance(repositories),
+                                    onAccountIdChange = { currentAccountId = it },
+                                    onCurrencyIdChange = {},
+                                    onAuditClick = { auditTransferId = it },
+                                )
+                            }
                         }
                     }
                 }
@@ -904,34 +910,36 @@ class AccountTransactionsScreenTest {
             runMoneyManagerComposeUiTest {
                 // When: Viewing the account transactions screen
                 setContent {
-                    ProvideSchemaAwareScope {
-                        var currentAccountId by remember { mutableStateOf(checkingAccountId) }
-                        var auditTransferId by remember { mutableStateOf<TransferId?>(null) }
+                    CompositionLocalProvider(LocalImportEngine provides repositories.importEngine) {
+                        ProvideSchemaAwareScope {
+                            var currentAccountId by remember { mutableStateOf(checkingAccountId) }
+                            var auditTransferId by remember { mutableStateOf<TransferId?>(null) }
 
-                        if (auditTransferId != null) {
-                            TransactionAuditScreen(
-                                transferId = auditTransferId!!,
-                                auditRepository = repositories.auditRepository,
-                                accountRepository = repositories.accountRepository,
-                                transactionRepository = repositories.transactionRepository,
-                                onBack = { auditTransferId = null },
-                            )
-                        } else {
-                            AccountTransactionsScreen(
-                                accountId = currentAccountId,
-                                transactionRepository = repositories.transactionRepository,
-                                accountRepository = repositories.accountRepository,
-                                accountAttributeRepository = repositories.accountAttributeRepository,
-                                categoryRepository = repositories.categoryRepository,
-                                currencyRepository = repositories.currencyRepository,
-                                attributeTypeRepository = repositories.attributeTypeRepository,
-                                personRepository = repositories.personRepository,
-                                personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
-                                maintenance = createDbMaintenance(repositories),
-                                onAccountIdChange = { currentAccountId = it },
-                                onCurrencyIdChange = {},
-                                onAuditClick = { auditTransferId = it },
-                            )
+                            if (auditTransferId != null) {
+                                TransactionAuditScreen(
+                                    transferId = auditTransferId!!,
+                                    auditRepository = repositories.auditRepository,
+                                    accountRepository = repositories.accountRepository,
+                                    transactionRepository = repositories.transactionRepository,
+                                    onBack = { auditTransferId = null },
+                                )
+                            } else {
+                                AccountTransactionsScreen(
+                                    accountId = currentAccountId,
+                                    transactionRepository = repositories.transactionRepository,
+                                    accountRepository = repositories.accountRepository,
+                                    accountAttributeRepository = repositories.accountAttributeRepository,
+                                    categoryRepository = repositories.categoryRepository,
+                                    currencyRepository = repositories.currencyRepository,
+                                    attributeTypeRepository = repositories.attributeTypeRepository,
+                                    personRepository = repositories.personRepository,
+                                    personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                                    maintenance = createDbMaintenance(repositories),
+                                    onAccountIdChange = { currentAccountId = it },
+                                    onCurrencyIdChange = {},
+                                    onAuditClick = { auditTransferId = it },
+                                )
+                            }
                         }
                     }
                 }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CategoriesScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CategoriesScreenTest.kt
@@ -2,6 +2,7 @@
 
 package com.moneymanager.ui.screens
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onAllNodesWithContentDescription
@@ -13,8 +14,17 @@ import androidx.compose.ui.test.performTextInput
 import com.moneymanager.domain.model.Category
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.repository.AccountAttributeRepository
+import com.moneymanager.domain.repository.AccountRepository
 import com.moneymanager.domain.repository.CategoryRepository
 import com.moneymanager.domain.repository.CurrencyRepository
+import com.moneymanager.domain.repository.PersonAccountOwnershipRepository
+import com.moneymanager.domain.repository.PersonAttributeRepository
+import com.moneymanager.domain.repository.PersonRepository
+import com.moneymanager.domain.repository.TransactionRepository
+import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importer.ImportEngineImpl
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.ProvideSchemaAwareScope
 import com.moneymanager.ui.test.runMoneyManagerComposeUiTest
 import dev.mokkery.MockMode
@@ -34,6 +44,19 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class CategoriesScreenTest {
+    // A real engine wrapping the test's category repository: edits route through it (as in production),
+    // and because it delegates to [categoryRepository], the existing verifySuspend assertions still hold.
+    private fun importEngineFor(categoryRepository: CategoryRepository): ImportEngine =
+        ImportEngineImpl(
+            transactionRepository = mock<TransactionRepository>(MockMode.autoUnit),
+            accountRepository = mock<AccountRepository>(MockMode.autoUnit),
+            accountAttributeRepository = mock<AccountAttributeRepository>(MockMode.autoUnit),
+            personRepository = mock<PersonRepository>(MockMode.autoUnit),
+            personAttributeRepository = mock<PersonAttributeRepository>(MockMode.autoUnit),
+            ownershipRepository = mock<PersonAccountOwnershipRepository>(MockMode.autoUnit),
+            categoryRepository = categoryRepository,
+        )
+
     private val fakeCurrencyRepository: CurrencyRepository =
         mock(MockMode.autoUnit) {
             every { getAllCurrencies() } returns flowOf(emptyList())
@@ -53,10 +76,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -79,10 +104,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -100,10 +127,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -125,10 +154,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -152,10 +183,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -177,10 +210,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -207,10 +242,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -231,10 +268,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -257,10 +296,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -284,10 +325,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -321,10 +364,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -357,10 +402,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -384,10 +431,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -419,10 +468,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -451,10 +502,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -482,10 +535,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -509,10 +564,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -540,10 +597,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -574,10 +633,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -615,10 +676,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -641,10 +704,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -673,10 +738,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -707,10 +774,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -738,10 +807,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -782,10 +853,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -822,10 +895,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 
@@ -851,10 +926,12 @@ class CategoriesScreenTest {
             // When
             setContent {
                 ProvideSchemaAwareScope {
-                    CategoriesScreen(
-                        categoryRepository = repository,
-                        currencyRepository = fakeCurrencyRepository,
-                    )
+                    CompositionLocalProvider(LocalImportEngine provides importEngineFor(repository)) {
+                        CategoriesScreen(
+                            categoryRepository = repository,
+                            currencyRepository = fakeCurrencyRepository,
+                        )
+                    }
                 }
             }
 

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvAccountSourceAuditE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvAccountSourceAuditE2ETest.kt
@@ -143,6 +143,7 @@ class CsvAccountSourceAuditE2ETest {
                             personRepository = dc.personRepository,
                             personAttributeRepository = dc.personAttributeRepository,
                             ownershipRepository = dc.personAccountOwnershipRepository,
+                            categoryRepository = dc.categoryRepository,
                         ),
                 )
             }

--- a/app/ui/core/src/jvmTest/kotlin/com/moneymanager/ui/NoDirectRepositoryWritesArchitectureTest.kt
+++ b/app/ui/core/src/jvmTest/kotlin/com/moneymanager/ui/NoDirectRepositoryWritesArchitectureTest.kt
@@ -1,0 +1,64 @@
+package com.moneymanager.ui
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Architecture guard: the UI must perform every entity mutation through the [com.moneymanager.importengineapi.ImportEngine]
+ * (the single, gated write entry point), never by calling a repository's write method directly. This is
+ * what lets editing be locked centrally when a cloud-backed database's remote copy is ahead.
+ *
+ * It scans the module's `commonMain` Kotlin sources for direct calls to the known entity-write methods.
+ * Reads, `attributeTypeRepository.getOrCreate` (a benign lookup-or-create), and the engine's own
+ * delegations (which live in another module) are deliberately not matched.
+ */
+class NoDirectRepositoryWritesArchitectureTest {
+    private val forbiddenWrites =
+        listOf(
+            "createTransfers",
+            "updateTransfer",
+            "deleteTransaction",
+            "createAccount",
+            "updateAccountWithAttributes",
+            "deleteAccount",
+            "mergeAccounts",
+            "unmergeAccount",
+            "createCategory",
+            "updateCategory",
+            "deleteCategory",
+            "createPerson",
+            "updatePersonWithAttributes",
+            "deletePerson",
+            "createOwnership",
+            "deleteOwnership",
+        )
+
+    private val forbidden =
+        Regex("""\b\w*[Rr]epository\.(${forbiddenWrites.joinToString("|")})\s*\(""")
+
+    @Test
+    fun uiNeverCallsRepositoryWriteMethodsDirectly() {
+        val sourceRoot =
+            listOf(File("src/commonMain/kotlin"), File("app/ui/core/src/commonMain/kotlin"))
+                .firstOrNull { it.isDirectory }
+                ?: fail("Could not locate app/ui/core commonMain sources from ${File(".").absolutePath}")
+
+        val violations =
+            sourceRoot
+                .walkTopDown()
+                .filter { it.isFile && it.extension == "kt" }
+                .flatMap { file ->
+                    file.readLines().withIndex().mapNotNull { (i, line) ->
+                        forbidden.find(line)?.let { "${file.relativeTo(sourceRoot)}:${i + 1}: ${line.trim()}" }
+                    }
+                }.toList()
+
+        if (violations.isNotEmpty()) {
+            fail(
+                "UI code must route entity writes through ImportEngine (LocalImportEngine.current), not call " +
+                    "repositories directly. Offending call(s):\n" + violations.joinToString("\n"),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## What & why

Cloud-backed (Google Drive) databases were single-device safe but unsafe across devices: there was no detection that another device had pushed, and a push was unconditional last-writer-wins. This makes editing the same cloud database from multiple devices safe and obvious.

### Sync-state matrix

| local dirty | remote changed | status | Upload | Download | editing |
|---|---|---|---|---|---|
| no | no | IN_SYNC | off | off | allowed |
| yes | no | LOCAL_AHEAD | **on** | off | allowed |
| no | yes | REMOTE_AHEAD | off | **on** | **locked** |
| yes | yes | CONFLICT | on* | on* | **locked** |

\* In a conflict both buttons are enabled, each behind a "this discards the other side's changes" confirmation.

## Remote-change detection
- `RemoteFile` carries the Drive `headRevisionId` (+ `md5Checksum`); the last-synced revision is persisted in the binding, so detection survives restarts.
- `RemoteDatabaseController` exposes a reactive `StateFlow<SyncState>`, an on-demand `checkRemote()`, a **guarded `syncNow()`** that refuses to upload over a moved remote unless forced, and `download()`.
- **No background polling** — detection is via a dedicated "Check remote for changes" button and a safety guard at upload time.
- `CloudStorageCard` replaces the single "Sync now" with **Check / Upload / Download** buttons driven by the matrix, with conflict confirmation dialogs.

## Editing lock — single gated write entry point
- `ImportEngine` becomes the sole write path for **all** manual edits (transfers, accounts, categories, people, ownerships, incl. merge/unmerge), each gated by a db-free `EditGate` that blocks writes (and imports) when the remote is ahead.
- The UI routes writes through a `LocalImportEngine` composition local instead of calling repositories directly; `NoDirectRepositoryWritesArchitectureTest` guards against regressions.
- An app-wide banner + disabled FAB/save buttons surface the lock; the engine enforces it.

## Android download fix
- Re-hydrate now goes through an `AppStartupHost`-owned reload that **closes the live database before restore** (SQLite reported the file busy otherwise on Android), then reopens fresh services.
- Both Download buttons (top banner + Settings card) **disable immediately on click** (`SyncState.busy`) so a second click can't launch a concurrent reload.

## Testing
- New controller/service tests cover the state matrix, the false-REMOTE_AHEAD regression (our own push), guarded vs forced upload, and revision-baseline-survives-restart.
- Migrated UI tests provide a delegating `ImportEngine` so existing assertions still hold; added the architecture guard test.
- `./gradlew build` is green (compile JVM+Android, all tests, detekt, ktlint, buildHealth).

## Notes
- A deep `personAccountOwnershipRepository`/`accountRepository` parameter thread (22 files) that existed only to feed account creation is now vestigial; rather than rip it out, `UnusedParameter` is suppressed at two leaf composables with an explanatory comment.
- `attributeTypeRepository.getOrCreate` stays in the UI — it's a benign lookup-or-create, not an audited entity write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-device remote edit-locking that prevents unsafe writes when the remote database is ahead.
  * Introduced lock-aware sync states (NO_SESSION, IN_SYNC, LOCAL_AHEAD, REMOTE_AHEAD, CONFLICT), including conflict messaging and a reload/download action.
  * Improved cloud sync UX with a dedicated “Downloading from cloud…” reload flow and a sync status display.

* **Bug Fixes**
  * Prevented accidental overwrites by blocking uploads when remote changes are detected; added an explicit “force” option to overwrite when desired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->