### PR TITLE
Fix horizontal scroll wheel on Linux in wide tables

### DIFF
--- a/app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
+++ b/app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
@@ -1,0 +1,6 @@
+package com.moneymanager.ui.navigation
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.ui.Modifier
+
+actual fun Modifier.linuxHorizontalScrollWheel(scrollState: ScrollState): Modifier = this // No-op on Android - no mouse wheel

--- a/app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
+++ b/app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
@@ -3,4 +3,6 @@ package com.moneymanager.ui.navigation
 import androidx.compose.foundation.ScrollState
 import androidx.compose.ui.Modifier
 
-actual fun Modifier.linuxHorizontalScrollWheel(scrollState: ScrollState): Modifier = this // No-op on Android - no mouse wheel
+// No-op on Android - no mouse wheel; scrollState is required by the common expect signature.
+@Suppress("UnusedParameter")
+actual fun Modifier.linuxHorizontalScrollWheel(scrollState: ScrollState): Modifier = this

--- a/app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
+++ b/app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
@@ -3,6 +3,4 @@ package com.moneymanager.ui.navigation
 import androidx.compose.foundation.ScrollState
 import androidx.compose.ui.Modifier
 
-// No-op on Android - no mouse wheel; scrollState is part of the expect signature.
-@Suppress("UnusedParameter")
-actual fun Modifier.linuxHorizontalScrollWheel(scrollState: ScrollState): Modifier = this
+actual fun Modifier.linuxHorizontalScrollWheel(scrollState: ScrollState): Modifier = this // No-op on Android - no mouse wheel

--- a/app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
+++ b/app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
@@ -3,4 +3,6 @@ package com.moneymanager.ui.navigation
 import androidx.compose.foundation.ScrollState
 import androidx.compose.ui.Modifier
 
-actual fun Modifier.linuxHorizontalScrollWheel(scrollState: ScrollState): Modifier = this // No-op on Android - no mouse wheel
+// No-op on Android - no mouse wheel; scrollState is part of the expect signature.
+@Suppress("UnusedParameter")
+actual fun Modifier.linuxHorizontalScrollWheel(scrollState: ScrollState): Modifier = this

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTable.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/csv/CsvPreviewTable.kt
@@ -44,6 +44,7 @@ import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.model.csv.ImportStatus
+import com.moneymanager.ui.navigation.linuxHorizontalScrollWheel
 
 private val TRANSFER_COLUMN_WIDTH = 120.dp
 private val ROW_INDEX_COLUMN_WIDTH = 60.dp
@@ -122,7 +123,7 @@ fun CsvPreviewTable(
             }
         }
 
-    Column(modifier = modifier) {
+    Column(modifier = modifier.linuxHorizontalScrollWheel(horizontalScrollState)) {
         // Header row
         Row(
             modifier =

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.kt
@@ -1,0 +1,20 @@
+package com.moneymanager.ui.navigation
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.ui.Modifier
+
+/**
+ * Makes the horizontal scroll wheel (or the wheel-tilt left/right gesture) scroll [scrollState]
+ * while the pointer is over the modified element.
+ *
+ * This only exists to work around Linux/X11. There, this particular mouse delivers a horizontal
+ * wheel notch as a raw AWT button 4/5 press (not a [java.awt.event.MouseWheelEvent]), so Compose —
+ * which only tracks buttons 1-3 — drops it entirely and the bound [scrollState] never moves.
+ * Vertical scrolling is unaffected because it arrives as a normal `MouseWheelEvent`. The JVM
+ * implementation bridges those raw button presses into a horizontal scroll (see
+ * LinuxHorizontalScrollWheel.jvm.kt).
+ *
+ * On Windows/macOS the horizontal wheel already reaches Compose, so the JVM implementation is a
+ * no-op there. On Android there is no mouse wheel, so this is a no-op too.
+ */
+expect fun Modifier.linuxHorizontalScrollWheel(scrollState: ScrollState): Modifier

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
@@ -83,6 +83,7 @@ import com.moneymanager.ui.components.ErrorMessageText
 import com.moneymanager.ui.components.LoadingTextButton
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import com.moneymanager.ui.navigation.linuxHorizontalScrollWheel
 import com.moneymanager.ui.util.CategoryNode
 import com.moneymanager.ui.util.buildCategoryForest
 import com.moneymanager.ui.util.flattenCategoryForest
@@ -402,7 +403,7 @@ private fun CurrencyHeaderRow(
 
         // Scrollable currency headers
         Row(
-            modifier = Modifier.horizontalScroll(scrollState),
+            modifier = Modifier.linuxHorizontalScrollWheel(scrollState).horizontalScroll(scrollState),
         ) {
             currencies.forEach { currency ->
                 Text(
@@ -589,7 +590,7 @@ fun CategoryTreeItem(
         // Right column: scrollable balance matrix (aligned with header)
         if (currenciesWithBalances.isNotEmpty()) {
             Row(
-                modifier = Modifier.horizontalScroll(balancesScrollState),
+                modifier = Modifier.linuxHorizontalScrollWheel(balancesScrollState).horizontalScroll(balancesScrollState),
             ) {
                 currenciesWithBalances.forEach { currency ->
                     val balance = balancesByCurrency[currency.id]

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -77,6 +77,7 @@ import com.moneymanager.ui.components.AccountPicker
 import com.moneymanager.ui.components.LoadingTextButton
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import com.moneymanager.ui.navigation.linuxHorizontalScrollWheel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.lighthousegames.logging.logging
@@ -816,6 +817,7 @@ private fun TransferPreviewTable(transfers: List<Transfer>) {
         modifier =
             Modifier
                 .fillMaxWidth()
+                .linuxHorizontalScrollWheel(scrollState)
                 .horizontalScroll(scrollState),
     ) {
         Column {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -61,6 +61,7 @@ import com.moneymanager.domain.repository.TransactionRepository
 import com.moneymanager.ui.components.EditAccountDialog
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import com.moneymanager.ui.navigation.linuxHorizontalScrollWheel
 import com.moneymanager.ui.util.formatAmount
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -434,6 +435,7 @@ fun AccountTransactionsScreen(
                                 modifier =
                                     Modifier
                                         .weight(1f)
+                                        .linuxHorizontalScrollWheel(horizontalScrollState)
                                         .horizontalScroll(horizontalScrollState),
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
@@ -536,6 +538,7 @@ fun AccountTransactionsScreen(
                                     modifier =
                                         Modifier
                                             .weight(1f)
+                                            .linuxHorizontalScrollWheel(horizontalScrollState)
                                             .verticalScroll(verticalScrollState)
                                             .horizontalScroll(horizontalScrollState),
                                     verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.jvm.kt
+++ b/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.jvm.kt
@@ -1,0 +1,71 @@
+@file:OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+
+package com.moneymanager.ui.navigation
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
+import java.awt.AWTEvent
+import java.awt.Toolkit
+import java.awt.event.AWTEventListener
+import java.awt.event.MouseEvent
+import kotlinx.coroutines.launch
+
+private val isLinux: Boolean =
+    System.getProperty("os.name").orEmpty().contains("linux", ignoreCase = true)
+
+// On Linux/X11 a horizontal wheel notch arrives as a raw AWT button press rather than a
+// MouseWheelEvent: button 4 for one direction, button 5 for the other. Compose only tracks buttons
+// 1-3, so it never delivers these through its pointer pipeline and a bound horizontalScroll never
+// moves. We listen for 4/5 at the AWT level instead and scroll the hovered region ourselves.
+// (Vertical scrolling is untouched: it arrives as a normal MouseWheelEvent that Compose handles.)
+// Side buttons are 6/7 here, handled separately in MouseButtonNavigation.jvm.kt.
+private const val AWT_BUTTON_SCROLL_LEFT = 4
+private const val AWT_BUTTON_SCROLL_RIGHT = 5
+
+// Pixels scrolled per wheel notch. Roughly a column's worth in the wide tables this is used on.
+private const val SCROLL_STEP_PX = 120f
+
+actual fun Modifier.linuxHorizontalScrollWheel(scrollState: ScrollState): Modifier =
+    if (!isLinux) {
+        // Windows/macOS deliver the horizontal wheel to Compose already; nothing to bridge.
+        this
+    } else {
+        composed {
+            var hovered by remember { mutableStateOf(false) }
+            val scope = rememberCoroutineScope()
+
+            DisposableEffect(scrollState) {
+                val toolkit = Toolkit.getDefaultToolkit()
+                val listener =
+                    AWTEventListener { event ->
+                        if (event is MouseEvent && event.id == MouseEvent.MOUSE_PRESSED && hovered) {
+                            val delta =
+                                when (event.button) {
+                                    AWT_BUTTON_SCROLL_LEFT -> -SCROLL_STEP_PX
+                                    AWT_BUTTON_SCROLL_RIGHT -> SCROLL_STEP_PX
+                                    else -> return@AWTEventListener
+                                }
+                            scope.launch { scrollState.scrollBy(delta) }
+                        }
+                    }
+                toolkit.addAWTEventListener(listener, AWTEvent.MOUSE_EVENT_MASK)
+                onDispose { toolkit.removeAWTEventListener(listener) }
+            }
+
+            // Track hover so only the region under the cursor reacts to the wheel. Keep this outside
+            // the horizontalScroll modifier so the hover bounds are the fixed viewport, not the wide
+            // scrolled content.
+            onPointerEvent(PointerEventType.Enter) { hovered = true }
+                .onPointerEvent(PointerEventType.Exit) { hovered = false }
+        }
+    }

--- a/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.jvm.kt
+++ b/app/ui/core/src/jvmMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.jvm.kt
@@ -14,11 +14,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
+import kotlinx.coroutines.launch
 import java.awt.AWTEvent
 import java.awt.Toolkit
 import java.awt.event.AWTEventListener
 import java.awt.event.MouseEvent
-import kotlinx.coroutines.launch
 
 private val isLinux: Boolean =
     System.getProperty("os.name").orEmpty().contains("linux", ignoreCase = true)

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -78,10 +78,16 @@ exclude:
       - app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/SourceTypeConversions.kt
   # Android no-op actual for the Linux-only horizontal-scroll-wheel modifier: the scrollState
   # parameter is required by the expect signature but unused on Android (no mouse wheel).
+  - name: unused
+    paths:
+      - app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
   - name: UnusedSymbol
     paths:
       - app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
   - name: UnusedDeclaration
+    paths:
+      - app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
+  - name: UnusedSymbolLocal
     paths:
       - app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
   # Metro DI module + platform factories contributed via @ContributesTo/@Provides and expect-actual:

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -76,6 +76,14 @@ exclude:
       - app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/IdConversions.kt
       - app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/InstantConversions.kt
       - app/db/core/src/commonMain/kotlin/com/moneymanager/database/mapper/SourceTypeConversions.kt
+  # Android no-op actual for the Linux-only horizontal-scroll-wheel modifier: the scrollState
+  # parameter is required by the expect signature but unused on Android (no mouse wheel).
+  - name: UnusedSymbol
+    paths:
+      - app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
+  - name: UnusedDeclaration
+    paths:
+      - app/ui/core/src/androidMain/kotlin/com/moneymanager/ui/navigation/LinuxHorizontalScrollWheel.android.kt
   # Metro DI module + platform factories contributed via @ContributesTo/@Provides and expect-actual:
   # Qodana sees no direct usage (mirrors DatabaseManagerModule / CreateDatabaseManager.jvm.kt).
   - name: unused


### PR DESCRIPTION
## Problem

On Linux the horizontal scroll wheel (or wheel-tilt) did nothing in the app's wide horizontally-scrollable tables.

X11 delivers a horizontal wheel notch as a **raw AWT button 4/5 press** rather than a `MouseWheelEvent`. Compose only tracks buttons 1–3, so it drops these events entirely and any bound `horizontalScroll` never moves. Vertical scrolling is unaffected because it arrives as a normal `MouseWheelEvent` that Compose handles. This is the same class of X11 button-remapping problem as the existing back/forward side-button workaround (which sees buttons 6/7 on this platform).

Diagnosed empirically — the horizontal wheel produced only `MOUSE_PRESSED button=4` / `button=5` events with no wheel event.

## Fix

Add `Modifier.linuxHorizontalScrollWheel(scrollState)` (expect/actual, mirroring `mouseButtonNavigation`):

- **JVM (Linux only):** a global `Toolkit.addAWTEventListener` bridges raw button 4 (left) / 5 (right) presses into a `scrollState.scrollBy(...)`, gated on pointer hover so only the region under the cursor reacts. Placed outside the `horizontalScroll` modifier so the hover bounds are the fixed viewport, not the wide scrolled content.
- **JVM (Windows/macOS):** no-op — the horizontal wheel already reaches Compose there.
- **Android:** no-op — no mouse wheel.

Wired into every wide horizontally-scrollable surface: CSV import preview, the transactions account/balance matrix, the categories balance matrix, and the apply-strategy transfer preview.

## Testing

Manually verified on Linux/X11 (JDK 25): the horizontal wheel now scrolls the CSV import preview and the matrices, in the correct direction, only while hovering the relevant region. Vertical scrolling and the back/forward side buttons are unchanged. `lintFormat`, `detekt`, and JVM + Android compilation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* **Linux mouse wheel horizontal scrolling** is now supported across horizontally scrollable views (transactions, category and currency sections, and CSV preview/transfer tables).

## Bug Fixes
* **Horizontal wheel input on Linux** is now correctly translated into horizontal scrolling, improving navigation in wide tables that previously only scrolled vertically or required manual drag.

## Chores
* Updated static analysis configuration for an Android no-op implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->