### PR TITLE
Route all DB writes through the ImportEngine (sole writer)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,11 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 | `gradle/build-logic/` | Convention plugins (kotlin, android, compose, metro, mappie) |
 | `utils/bigdecimal/` | Arbitrary-precision decimal arithmetic (JVM/Android) |
 | `utils/currency/` | Locale-aware currency formatting |
-| `app/model/core/` | Domain models and repository interfaces |
+| `app/model/core/` | Domain models and `*ReadRepository`/`*WriteRepository` interfaces |
 | `app/db/core/` | SQLDelight database, repository implementations, mappers |
+| `app/importengineapi/` | `ImportEngine` interface + `ImportBatch`/`ImportResult` model + `ImportEngine.*` write helpers (DB-free) |
+| `app/importer/` | `ImportEngineImpl` — the **sole** DB writer (consumes write repositories) |
+| `app/csvimporter/`, `app/qifimporter/`, `app/apiimporter/` | Parse/download sources and build an `ImportBatch` (DB-free, enforced) |
 | `app/di/core/` | Metro DI configuration |
 | `app/ui/core/` | Compose UI (JVM/Android only) |
 | `app/main/jvm/` | JVM Desktop entry point |
@@ -72,6 +75,39 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 **Important**: Store booleans as INTEGER (0/1). Don't use `AS Boolean` in .sq files.
 
 **Mappie** generates type-safe mappers from database entities to domain models. Annotate mapper interfaces with `@Mapper`.
+
+## Database Writes (the ImportEngine is the sole writer)
+
+**Every database mutation goes through the `ImportEngine`.** The UI, importers, services, and DI
+bootstrap never call a `*WriteRepository` directly. A caller builds an `ImportBatch` declaratively
+(transfers + account/person/category/currency intents, CSV/API strategy + mapping + CSV/QIF staging +
+API-session mutations, attribute-type names to resolve, settings) and calls `importEngine.import(batch)`,
+reading generated ids back from `ImportResult`. Convenience `ImportEngine.*` extensions
+(`ImportEngineActions.kt`, `ImportEngineConfigActions.kt` in `app/importengineapi`) wrap the common
+one-item cases — `createCurrency`, `deleteCsvStrategy`, `createCsvImport`, `getOrCreateAttributeType`,
+`setDefaultCurrency`, `insertApiRequest`, …
+
+**Why:** one write seam means one `EditGate`, so writes can be blocked centrally when a cloud-backed
+database is locked, and provenance/audit recording lives in a single place.
+
+**Read vs write interfaces:** repositories come in `*ReadRepository` + `*WriteRepository` pairs (write
+extends read). **Only `ImportEngineImpl` (`app/importer`) is injected with write repositories.** The UI
+gets a fully read-only `AppServices` (every field a `*ReadRepository`) plus the prebuilt `ImportEngine`;
+the engine is constructed in di/core via `DatabaseComponent.createImportEngine(editGate)`. In Compose,
+reach it through `LocalImportEngine.current`.
+
+**Enforced in Gradle:** `moneymanager.kotlin-multiplatform-convention` registers a
+`verifyNoWriteRepositoryUsage` check (wired into `check`) that fails if a module's main sources
+reference any `*WriteRepository`. Exempt: `:app:model:core` (interfaces), `:app:db:core` (impls),
+`:app:di:core` (wiring), `:app:importer` (the engine), `:test:app:db` (fixtures).
+
+**The one exception:** `DeviceWriteRepository` is injected directly in `DeviceIdModule` (di/core).
+`DeviceId` is a synchronous singleton that every write-repo impl — and therefore the engine — depends
+on, so routing it through the suspend engine would be a DI cycle.
+
+**How to apply:** to add a write (new field, entity, or config), extend `ImportBatch`/`ImportResult`
+and `ImportEngineImpl`, add a helper if useful, and call it — never inject a `*WriteRepository` outside
+the engine.
 
 ## Dependency Injection
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,11 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 | `utils/bigdecimal/` | Arbitrary-precision decimal arithmetic (JVM/Android) |
 | `utils/currency/` | Locale-aware currency formatting |
 | `utils/archive/` | Compress + password-encrypt the DB archive (`ArchiveCodec`); shared by remote backends |
-| `app/model/core/` | Domain models and repository interfaces |
+| `app/model/core/` | Domain models and `*ReadRepository`/`*WriteRepository` interfaces |
 | `app/db/core/` | SQLDelight database, repository implementations, mappers |
+| `app/importengineapi/` | `ImportEngine` interface + `ImportBatch`/`ImportResult` model + `ImportEngine.*` write helpers (DB-free) |
+| `app/importer/` | `ImportEngineImpl` — the **sole** DB writer (consumes write repositories) |
+| `app/csvimporter/`, `app/qifimporter/`, `app/apiimporter/` | Parse/download sources and build an `ImportBatch` (DB-free, enforced) |
 | `app/remotestorage/core/` | Generic `RemoteStorageProvider` interface + factory (DB-free, backend-agnostic) |
 | `app/remotestorage/googledrive/` | Google Drive backend — Drive REST v3 over Ktor (JVM + Android) |
 | `app/remotestorage/sync/` | Hydrate/push orchestration (`RemoteDatabaseSyncService`/`RemoteDatabaseController`) |
@@ -82,6 +85,39 @@ so existing local databases are expected to be deleted/recreated rather than mig
 **Important**: Store booleans as INTEGER (0/1). Don't use `AS Boolean` in .sq files.
 
 **Mappie** generates type-safe mappers from database entities to domain models. Annotate mapper interfaces with `@Mapper`.
+
+## Database Writes (the ImportEngine is the sole writer)
+
+**Every database mutation goes through the `ImportEngine`.** The UI, importers, services, and DI
+bootstrap never call a `*WriteRepository` directly. A caller builds an `ImportBatch` declaratively
+(transfers + account/person/category/currency intents, CSV/API strategy + mapping + CSV/QIF staging +
+API-session mutations, attribute-type names to resolve, settings) and calls `importEngine.import(batch)`,
+reading generated ids back from `ImportResult`. Convenience `ImportEngine.*` extensions
+(`ImportEngineActions.kt`, `ImportEngineConfigActions.kt` in `app/importengineapi`) wrap the common
+one-item cases — `createCurrency`, `deleteCsvStrategy`, `createCsvImport`, `getOrCreateAttributeType`,
+`setDefaultCurrency`, `insertApiRequest`, …
+
+**Why:** one write seam means one `EditGate`, so writes can be blocked centrally when a cloud-backed
+database is locked, and provenance/audit recording lives in a single place.
+
+**Read vs write interfaces:** repositories come in `*ReadRepository` + `*WriteRepository` pairs (write
+extends read). **Only `ImportEngineImpl` (`app/importer`) is injected with write repositories.** The UI
+gets a fully read-only `AppServices` (every field a `*ReadRepository`) plus the prebuilt `ImportEngine`;
+the engine is constructed in di/core via `DatabaseComponent.createImportEngine(editGate)`. In Compose,
+reach it through `LocalImportEngine.current`.
+
+**Enforced in Gradle:** `moneymanager.kotlin-multiplatform-convention` registers a
+`verifyNoWriteRepositoryUsage` check (wired into `check`) that fails if a module's main sources
+reference any `*WriteRepository`. Exempt: `:app:model:core` (interfaces), `:app:db:core` (impls),
+`:app:di:core` (wiring), `:app:importer` (the engine), `:test:app:db` (fixtures).
+
+**The one exception:** `DeviceWriteRepository` is injected directly in `DeviceIdModule` (di/core).
+`DeviceId` is a synchronous singleton that every write-repo impl — and therefore the engine — depends
+on, so routing it through the suspend engine would be a DI cycle.
+
+**How to apply:** to add a write (new field, entity, or config), extend `ImportBatch`/`ImportResult`
+and `ImportEngineImpl`, add a helper if useful, and call it — never inject a `*WriteRepository` outside
+the engine.
 
 ## Remote Storage (Cloud-backed databases)
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ A personal finance money manager built with **Kotlin Multiplatform** and **Compo
 | `utils/rest/` | REST/HTTP utilities |
 | `utils/compose/*` | Reusable Compose components (file picker, scrollbar) |
 | `utils/archive/` | Compress + password-encrypt the database archive (shared by remote backends) |
-| `app/model/core/` | Domain models and repository interfaces |
+| `app/model/core/` | Domain models and `*ReadRepository`/`*WriteRepository` interfaces |
 | `app/db/core/` | SQLDelight database, repository implementations, mappers |
-| `app/importengineapi/` | DB-free import API — `ImportBatch`, dedup policies, source/key types |
+| `app/importengineapi/` | DB-free import/write API — `ImportBatch`/`ImportResult`, `ImportEngine.*` helpers, dedup policies, source/key types |
 | `app/csvimporter/`, `app/qifimporter/`, `app/apiimporter/` | Per-format importers that build an `ImportBatch` (DB-free) |
 | `app/importer/` | Central import engine — applies an `ImportBatch`, deduplicates; the sole DB writer |
 | `app/remotestorage/core/` | Generic remote-storage provider interface (DB-free, backend-agnostic) |
@@ -109,6 +109,11 @@ A personal finance money manager built with **Kotlin Multiplatform** and **Compo
 
 ## Development Notes
 
+* **Single write seam** — every database mutation goes through the `ImportEngine`: callers build an
+  `ImportBatch` and call `importEngine.import(batch)`; they never use a `*WriteRepository` directly.
+  Repositories are split into read/write pairs, only `app/importer` is injected with the write side, and
+  the UI gets a read-only view plus the engine. A Gradle `verifyNoWriteRepositoryUsage` check enforces
+  it. (The lone exception is device-id bootstrap.) See [`CLAUDE.md`](CLAUDE.md) for details.
 * **Database design**, **CI/CD** and the **data model** are designed and reviewed closely.
 * The **UI** and **unit tests** are partly AI-generated and will be reviewed/refactored over time.
 * See [`CLAUDE.md`](CLAUDE.md) for detailed contributor/AI-assistant guidance.

--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
@@ -37,8 +37,7 @@ import com.moneymanager.domain.model.csv.ImportStatus
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.ApiResponseTransactionInsert
-import com.moneymanager.domain.repository.ApiSessionWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.ApiSessionReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.importengineapi.AccountMatchKey
 import com.moneymanager.importengineapi.AccountRef
@@ -57,6 +56,8 @@ import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.importengineapi.PersonMatchKey
+import com.moneymanager.importengineapi.getOrCreateAttributeType
+import com.moneymanager.importengineapi.insertApiResponseTransactions
 import com.moneymanager.importengineapi.normalizeNameKey
 import com.moneymanager.importengineapi.personalCounterpartyKey
 import com.moneymanager.rest.ApiClient
@@ -194,7 +195,7 @@ data class ApiTransactionsDownloadProgress(
 suspend fun downloadApiSessionAccounts(
     token: String,
     apiClient: ApiClient,
-    apiSessionRepository: ApiSessionWriteRepository,
+    apiSessionRepository: ApiSessionReadRepository,
     sessionId: ApiSessionId,
     strategy: ApiImportStrategy,
     sca: ScaParams? = null,
@@ -265,7 +266,7 @@ private suspend fun fetchAncestorContexts(
 suspend fun downloadApiSessionTransactions(
     token: String,
     apiClient: ApiClient,
-    apiSessionRepository: ApiSessionWriteRepository,
+    apiSessionRepository: ApiSessionReadRepository,
     sessionId: ApiSessionId,
     strategy: ApiImportStrategy,
     accountsSessionId: ApiSessionId? = null,
@@ -390,7 +391,7 @@ suspend fun downloadApiSessionTransactions(
 suspend fun downloadApiSessionAccountIdentifiers(
     token: String,
     apiClient: ApiClient,
-    apiSessionRepository: ApiSessionWriteRepository,
+    apiSessionRepository: ApiSessionReadRepository,
     sessionId: ApiSessionId,
     strategy: ApiImportStrategy,
     accountsSessionId: ApiSessionId? = null,
@@ -446,7 +447,7 @@ suspend fun downloadApiSessionAccountIdentifiers(
 suspend fun downloadApiSessionPeople(
     token: String,
     apiClient: ApiClient,
-    apiSessionRepository: ApiSessionWriteRepository,
+    apiSessionRepository: ApiSessionReadRepository,
     sessionId: ApiSessionId,
     strategy: ApiImportStrategy,
     sca: ScaParams? = null,
@@ -480,10 +481,9 @@ private fun validatePeopleOwnershipConfig(config: ApiPersonImportConfig) {
  * profile (via [ApiPersonImportConfig.accountOwnerAncestorExpr]).
  */
 suspend fun importApiSessionPeople(
-    apiSessionRepository: ApiSessionWriteRepository,
+    apiSessionRepository: ApiSessionReadRepository,
     accountRepository: AccountReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
     importEngine: ImportEngine,
     sessionId: ApiSessionId,
     strategy: ApiImportStrategy,
@@ -491,7 +491,7 @@ suspend fun importApiSessionPeople(
 ): ApiPeopleImportResult {
     val config = strategy.peopleDownload ?: return ApiPeopleImportResult(personCount = 0, ownershipCount = 0)
     validatePeopleOwnershipConfig(config)
-    val externalIdAttributeTypeId = strategy.personExternalIdAttribute?.let { attributeTypeRepository.getOrCreate(it) }
+    val externalIdAttributeTypeId = strategy.personExternalIdAttribute?.let { importEngine.getOrCreateAttributeType(it) }
     val requestsById = apiSessionRepository.getRequestsBySession(sessionId).associateBy { it.id }
     val peopleResponses =
         apiSessionRepository.getResponsesBySession(sessionId).filter { response ->
@@ -557,7 +557,7 @@ suspend fun importApiSessionPeople(
 
 /** Builds a map of profile external id → the [AccountId]s fetched under that profile. */
 private suspend fun buildProfileAccountMap(
-    apiSessionRepository: ApiSessionWriteRepository,
+    apiSessionRepository: ApiSessionReadRepository,
     accountRepository: AccountReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
     accountsSessionId: ApiSessionId?,
@@ -586,7 +586,7 @@ private suspend fun buildProfileAccountMap(
 
 /** Returns every [AccountId] imported under [accountsSessionId] (used for [ApiPersonImportConfig.ownsAllAccounts]). */
 private suspend fun loadSessionAccountIds(
-    apiSessionRepository: ApiSessionWriteRepository,
+    apiSessionRepository: ApiSessionReadRepository,
     accountRepository: AccountReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
     accountsSessionId: ApiSessionId?,
@@ -629,9 +629,8 @@ private fun JsonObject.toPersonOwner(
 }
 
 suspend fun importApiSessionTransactions(
-    apiSessionRepository: ApiSessionWriteRepository,
+    apiSessionRepository: ApiSessionReadRepository,
     currencyRepository: CurrencyReadRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
     sessionId: ApiSessionId,
     accountsSessionId: ApiSessionId? = null,
     strategy: ApiImportStrategy,
@@ -643,7 +642,6 @@ suspend fun importApiSessionTransactions(
         setupImportSession(
             apiSessionRepository = apiSessionRepository,
             currencyRepository = currencyRepository,
-            attributeTypeRepository = attributeTypeRepository,
             sessionId = sessionId,
             accountsSessionId = accountsSessionId,
             strategy = strategy,
@@ -762,14 +760,13 @@ private data class ImportSetup(
     val counts: ImportCounts,
     val progressMutex: Mutex,
     val onProgress: (ApiSessionImportProgress) -> Unit,
-    val apiSessionRepository: ApiSessionWriteRepository,
+    val apiSessionRepository: ApiSessionReadRepository,
     val importEngine: ImportEngine,
 )
 
 private suspend fun setupImportSession(
-    apiSessionRepository: ApiSessionWriteRepository,
+    apiSessionRepository: ApiSessionReadRepository,
     currencyRepository: CurrencyReadRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
     sessionId: ApiSessionId,
     accountsSessionId: ApiSessionId?,
     strategy: ApiImportStrategy,
@@ -823,7 +820,7 @@ private suspend fun setupImportSession(
     val transactionResponses = responses.filter { requestsById[it.requestId]?.resolveAccountExternalId(strategy) != null }
 
     val currencyCache = CurrencyCache(currencyRepository)
-    val attributeTypeCache = AttributeTypeCache(attributeTypeRepository)
+    val attributeTypeCache = AttributeTypeCache(importEngine)
     val customTxFields = strategy.transactionMappings.customFields
     val uniqueIdTxFields = strategy.transactionMappings.uniqueIdentifierFields
     val counterpartyIdField = strategy.transactionMappings.counterpartyIdField
@@ -1010,7 +1007,7 @@ private suspend fun resolveOwnAccountKey(
 }
 
 suspend fun discoverApiCounterpartiesToCreate(
-    apiSessionRepository: ApiSessionWriteRepository,
+    apiSessionRepository: ApiSessionReadRepository,
     accountRepository: AccountReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
     sessionId: ApiSessionId,
@@ -1568,8 +1565,8 @@ private suspend fun prepareTransactionTransfers(setup: ImportSetup): PreparedTra
 
 /**
  * Assembles the single [ImportBatch] from the prepared transfers + the resolver's account/people/ownership
- * intents and runs the engine exactly once. The engine performs every entity/transfer/ownership write; the
- * only DB write here is the API bookkeeping ([ApiSessionWriteRepository.insertResponseTransactions]).
+ * intents and runs the engine exactly once. The engine performs every write, including the API
+ * bookkeeping (the response-transaction records, via an [ImportBatch] session mutation).
  */
 private suspend fun runImportEngine(
     setup: ImportSetup,
@@ -1664,7 +1661,7 @@ private suspend fun runImportEngine(
             )
     }
 
-    setup.apiSessionRepository.insertResponseTransactions(
+    setup.importEngine.insertApiResponseTransactions(
         responseRecords
             .sortedWith(compareBy<ResponseTransactionImportRecord> { it.pageIndex }.thenBy { it.itemIndex })
             .map { it.toInsert() },
@@ -2891,10 +2888,11 @@ private fun JsonObject.resolveJsonElementPath(dotPath: String): JsonElement? {
 }
 
 private class AttributeTypeCache(
-    private val repo: AttributeTypeWriteRepository,
+    private val importEngine: ImportEngine,
 ) {
     private val mutex = Mutex()
     private val cache = mutableMapOf<String, AttributeTypeId>()
 
-    suspend fun getOrCreate(name: String): AttributeTypeId = mutex.withLock { cache.getOrPut(name) { repo.getOrCreate(name) } }
+    suspend fun getOrCreate(name: String): AttributeTypeId =
+        mutex.withLock { cache.getOrPut(name) { importEngine.getOrCreateAttributeType(name) } }
 }

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -21,11 +21,11 @@ import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
 import com.moneymanager.domain.model.csvstrategy.HardCodedAccountMapping
 import com.moneymanager.domain.model.csvstrategy.TransferField
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportReadRepository
 import com.moneymanager.importengineapi.AccountRef
+import com.moneymanager.importengineapi.CsvImportMutation
 import com.moneymanager.importengineapi.DedupePolicy
 import com.moneymanager.importengineapi.ExistingUniqueKeyExtractor
 import com.moneymanager.importengineapi.ImportBatch
@@ -33,6 +33,12 @@ import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.ImportFee
 import com.moneymanager.importengineapi.ImportRowKey
 import com.moneymanager.importengineapi.ImportTransfer
+import com.moneymanager.importengineapi.applyCsvImportMutations
+import com.moneymanager.importengineapi.createAccount
+import com.moneymanager.importengineapi.createAccounts
+import com.moneymanager.importengineapi.createCsvMapping
+import com.moneymanager.importengineapi.createCsvMappings
+import com.moneymanager.importengineapi.getOrCreateAttributeTypes
 import kotlinx.coroutines.flow.first
 import org.lighthousegames.logging.logging
 import kotlin.time.Clock
@@ -62,10 +68,9 @@ suspend fun bulkApplyCsv(
     sourceAccountOverride: AccountId?,
     strategies: List<CsvImportStrategy>,
     currencies: List<Currency>,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
-    csvImportRepository: CsvImportWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
+    csvImportRepository: CsvImportReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     onProgress: (done: Int, total: Int) -> Unit,
@@ -116,8 +121,6 @@ suspend fun bulkApplyCsv(
                     currencies = currencies,
                     csvAccountMappingRepository = csvAccountMappingRepository,
                     accountRepository = accountRepository,
-                    csvImportRepository = csvImportRepository,
-                    attributeTypeRepository = attributeTypeRepository,
                     maintenance = maintenance,
                     importEngine = importEngine,
                     refreshViews = false,
@@ -185,20 +188,20 @@ fun buildCsvMapper(
  * one bad mapping doesn't block the rest. [kind] just labels log messages ("selected"/"auto-captured").
  */
 private suspend fun persistMappingsWithFallback(
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
+    importEngine: ImportEngine,
     mappings: List<CsvAccountMapping>,
     kind: String,
 ) {
     if (mappings.isEmpty()) return
     try {
-        csvAccountMappingRepository.createMappings(mappings)
+        importEngine.createCsvMappings(mappings)
         logger.info { "Saved ${mappings.size} $kind account mappings" }
     } catch (expected: Exception) {
         // Batch is atomic, nothing was committed — retry per mapping so one bad mapping doesn't block the rest
         logger.warn(expected) { "Bulk $kind mapping save failed, falling back to per-mapping save" }
         for (mapping in mappings) {
             try {
-                csvAccountMappingRepository.createMapping(
+                importEngine.createCsvMapping(
                     strategyId = mapping.strategyId,
                     columnName = mapping.columnName,
                     valuePattern = mapping.valuePattern,
@@ -216,7 +219,7 @@ private suspend fun persistMappingsWithFallback(
  * created. Failures are skipped — transfers referencing a missing account fail later.
  */
 private suspend fun createNewAccounts(
-    accountRepository: AccountWriteRepository,
+    importEngine: ImportEngine,
     accountsToCreate: List<NewAccount>,
     csvImportId: CsvImportId,
     firstRowByAccountName: Map<String, Long>,
@@ -233,21 +236,21 @@ private suspend fun createNewAccounts(
             )
         }
     // CSV provenance pointing each account at the first row that referenced it (its creation row);
-    // row-less when unknown. Recorded atomically by the repository.
+    // row-less when unknown.
     val sourceFor: (Account) -> Source = { account ->
         Source.Csv(csvImportId, firstRowByAccountName[account.name])
     }
     try {
-        // Bulk-create all accounts in a single database transaction
-        val createdIds = accountRepository.createAccountsBatch(newAccounts, sourceFor)
-        newAccounts.zip(createdIds).forEach { (account, _) -> createdAccountNames.add(account.name) }
+        // Bulk-create all accounts in a single engine batch
+        importEngine.createAccounts(newAccounts, sourceFor)
+        newAccounts.forEach { account -> createdAccountNames.add(account.name) }
         logger.info { "Created ${accountsToCreate.size} new accounts" }
     } catch (expected: Exception) {
-        // Batch is atomic, nothing was committed — fall back to per-account creation to skip only failing accounts
+        // Bulk create failed — fall back to per-account creation to skip only failing accounts
         logger.warn(expected) { "Bulk account creation failed, falling back to per-account creation" }
         for (account in newAccounts) {
             try {
-                accountRepository.createAccount(account, sourceFor(account))
+                importEngine.createAccount(account, sourceFor(account))
                 createdAccountNames.add(account.name)
                 logger.info { "Created new account: ${account.name}" }
             } catch (expectedAccountError: Exception) {
@@ -349,10 +352,8 @@ suspend fun runCsvImport(
     selectedNewAccountNames: Map<String, String>,
     selectedSourceAccountId: AccountId?,
     currencies: List<Currency>,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
-    csvImportRepository: CsvImportWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     refreshViews: Boolean = true,
@@ -371,14 +372,14 @@ suspend fun runCsvImport(
             strategyId = strategy.id,
             accountSelections = selectedExistingAccounts,
         )
-    persistMappingsWithFallback(csvAccountMappingRepository, selectedMappingsToPersist, "selected")
+    persistMappingsWithFallback(importEngine, selectedMappingsToPersist, "selected")
 
     // Create new accounts first (skip failures - transfers using them will fail later).
     // Record CSV provenance pointing each account at the first row that referenced it.
     val firstRowByAccountName = buildFirstRowByAccountName(basePrep, selectedNewAccountNames)
     val createdAccountNames =
         createNewAccounts(
-            accountRepository = accountRepository,
+            importEngine = importEngine,
             accountsToCreate = accountsToCreate,
             csvImportId = csvImport.id,
             firstRowByAccountName = firstRowByAccountName,
@@ -394,7 +395,7 @@ suspend fun runCsvImport(
                 selectedNewAccountNames = selectedNewAccountNames,
                 strategyId = strategy.id,
             )
-        persistMappingsWithFallback(csvAccountMappingRepository, mappingsToCapture, "auto-captured")
+        persistMappingsWithFallback(importEngine, mappingsToCapture, "auto-captured")
     }
 
     // Re-map with new account IDs
@@ -432,18 +433,14 @@ suspend fun runCsvImport(
     logger.info { "Prepared $validCount valid transfers, $errorCount error rows" }
 
     // Mark mapping errors as ERROR status in database and save error messages
-    for (errorRow in finalPrep.errorRows) {
-        csvImportRepository.updateRowStatus(
-            csvImport.id,
-            errorRow.rowIndex,
-            ImportStatus.ERROR.name,
-        )
-        csvImportRepository.saveError(
-            csvImport.id,
-            errorRow.rowIndex,
-            errorRow.errorMessage,
-        )
-    }
+    importEngine.applyCsvImportMutations(
+        finalPrep.errorRows.flatMap { errorRow ->
+            listOf(
+                CsvImportMutation.UpdateRowStatus(csvImport.id, errorRow.rowIndex, ImportStatus.ERROR.name),
+                CsvImportMutation.SaveError(csvImport.id, errorRow.rowIndex, errorRow.errorMessage),
+            )
+        },
+    )
 
     // Pre-resolve attribute types
     val allAttributeTypeNames =
@@ -451,10 +448,7 @@ suspend fun runCsvImport(
             .flatMap { it.attributes }
             .map { it.first }
             .toSet()
-    val attributeTypeIdByName =
-        allAttributeTypeNames.associateWith { name ->
-            attributeTypeRepository.getOrCreate(name)
-        }
+    val attributeTypeIdByName = importEngine.getOrCreateAttributeTypes(allAttributeTypeNames.toList())
 
     logger.info { "Starting to import $validCount transfers" }
 
@@ -480,7 +474,7 @@ suspend fun runCsvImport(
         if (finalPrep.validTransfers.any { it.feeAmount != null }) {
             val feeAccountName = "${strategy.name} Fees"
             accountsByName[feeAccountName]?.id
-                ?: accountRepository.createAccount(
+                ?: importEngine.createAccount(
                     Account(
                         id = AccountId(0),
                         name = feeAccountName,
@@ -562,29 +556,19 @@ suspend fun runCsvImport(
             ImportStatus.ERROR -> Unit
         }
     }
+    val statusMutations = mutableListOf<CsvImportMutation>()
     if (importedStatuses.isNotEmpty()) {
-        csvImportRepository.updateRowStatusesBatch(
-            csvImport.id,
-            ImportStatus.IMPORTED.name,
-            importedStatuses,
-        )
-        csvImportRepository.clearErrors(csvImport.id, importedStatuses.keys.toList())
+        statusMutations += CsvImportMutation.UpdateRowStatuses(csvImport.id, ImportStatus.IMPORTED.name, importedStatuses)
+        statusMutations += CsvImportMutation.ClearErrors(csvImport.id, importedStatuses.keys.toList())
     }
     if (duplicateStatuses.isNotEmpty()) {
-        csvImportRepository.updateRowStatusesBatch(
-            csvImport.id,
-            ImportStatus.DUPLICATE.name,
-            duplicateStatuses,
-        )
+        statusMutations += CsvImportMutation.UpdateRowStatuses(csvImport.id, ImportStatus.DUPLICATE.name, duplicateStatuses)
     }
     if (updatedStatuses.isNotEmpty()) {
-        csvImportRepository.updateRowStatusesBatch(
-            csvImport.id,
-            ImportStatus.UPDATED.name,
-            updatedStatuses,
-        )
-        csvImportRepository.clearErrors(csvImport.id, updatedStatuses.keys.toList())
+        statusMutations += CsvImportMutation.UpdateRowStatuses(csvImport.id, ImportStatus.UPDATED.name, updatedStatuses)
+        statusMutations += CsvImportMutation.ClearErrors(csvImport.id, updatedStatuses.keys.toList())
     }
+    importEngine.applyCsvImportMutations(statusMutations)
     val successCount = importResult.transfersImported + importResult.updated
     val duplicateCount = importResult.duplicates
 
@@ -600,11 +584,15 @@ suspend fun runCsvImport(
 
     if ((successCount + duplicateCount) > 0) {
         runCatching {
-            csvImportRepository.recordImportApplication(
-                id = csvImport.id,
-                strategyId = strategy.id,
-                strategyName = strategy.name,
-                appliedAt = Clock.System.now(),
+            importEngine.applyCsvImportMutations(
+                listOf(
+                    CsvImportMutation.RecordApplication(
+                        id = csvImport.id,
+                        strategyId = strategy.id,
+                        strategyName = strategy.name,
+                        appliedAt = Clock.System.now(),
+                    ),
+                ),
             )
         }.onFailure { error ->
             logger.warn {

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -563,6 +563,8 @@ suspend fun runCsvImport(
     }
     if (duplicateStatuses.isNotEmpty()) {
         statusMutations += CsvImportMutation.UpdateRowStatuses(csvImport.id, ImportStatus.DUPLICATE.name, duplicateStatuses)
+        // A row retried from ERROR can resolve as DUPLICATE; clear its stale error like imported/updated do.
+        statusMutations += CsvImportMutation.ClearErrors(csvImport.id, duplicateStatuses.keys.toList())
     }
     if (updatedStatuses.isNotEmpty()) {
         statusMutations += CsvImportMutation.UpdateRowStatuses(csvImport.id, ImportStatus.UPDATED.name, updatedStatuses)
@@ -603,11 +605,11 @@ suspend fun runCsvImport(
 
     logger.info { "Import completed successfully" }
 
-    // The engine import is atomic: on success there are no per-row failures
-    // (any failure throws to the caller), so the import is complete.
+    // The engine import is atomic: any engine failure throws to the caller. The only per-row failures
+    // are mapping errors detected before the import, so surface those to the dialog.
     return CsvImportResult(
         successCount = successCount,
-        failedRows = emptyList(),
+        failedRows = finalPrep.errorRows.map { CsvImportResult.FailedRow(it.rowIndex, it.errorMessage) },
         duplicateCount = duplicateCount,
     )
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/Application.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/Application.kt
@@ -20,7 +20,7 @@ import com.moneymanager.domain.repository.PersonAccountOwnershipWriteRepository
 import com.moneymanager.domain.repository.PersonAttributeWriteRepository
 import com.moneymanager.domain.repository.PersonWriteRepository
 import com.moneymanager.domain.repository.QifImportWriteRepository
-import com.moneymanager.domain.repository.RelationshipTypeReadRepository
+import com.moneymanager.domain.repository.RelationshipTypeWriteRepository
 import com.moneymanager.domain.repository.SettingsWriteRepository
 import com.moneymanager.domain.repository.TransactionWriteRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
@@ -59,7 +59,7 @@ data class Transactions(
     val transactionRepository: TransactionWriteRepository,
     val transferSourceRepository: TransferSourceReadRepository,
     val attributeTypeRepository: AttributeTypeWriteRepository,
-    val relationshipTypeRepository: RelationshipTypeReadRepository,
+    val relationshipTypeRepository: RelationshipTypeWriteRepository,
     val transferRelationshipRepository: TransferRelationshipReadRepository,
 )
 

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
@@ -51,6 +51,7 @@ import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportCategoryIntent
 import com.moneymanager.importengineapi.ImportCurrencyIntent
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.ImportResult
 import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.importengineapi.LocalCategoryKey
 import com.moneymanager.importengineapi.LocalCurrencyKey
@@ -334,14 +335,15 @@ class CsvStrategyExportService(
         }
 
         // Create the requested new entities through the engine (the sole writer); they are then read
-        // back below via the re-fetched lookup maps.
-        importEngine.import(
-            ImportBatch(
-                accountsToCreate = accountIntents.values.toList(),
-                categories = categoryIntents.values.toList(),
-                currencies = currencyIntents.values.toList(),
-            ),
-        )
+        // back below via the re-fetched lookup maps, keyed by the engine-returned ids.
+        val importResult =
+            importEngine.import(
+                ImportBatch(
+                    accountsToCreate = accountIntents.values.toList(),
+                    categories = categoryIntents.values.toList(),
+                    currencies = currencyIntents.values.toList(),
+                ),
+            )
 
         // Build lookup maps including both existing and newly created entities
         val accounts = accountRepository.getAllAccounts().first()
@@ -380,7 +382,17 @@ class CsvStrategyExportService(
                         }
                     }
                 }
-                is Resolution.CreateNew -> Unit
+                is Resolution.CreateNew ->
+                    aliasCreatedEntity(
+                        ref,
+                        importResult,
+                        accounts,
+                        categories,
+                        currencies,
+                        accountsByName,
+                        categoriesByName,
+                        currenciesByCode,
+                    )
             }
         }
 
@@ -401,6 +413,36 @@ class CsvStrategyExportService(
             createdAt = now,
             updatedAt = now,
         )
+    }
+
+    // A new entity is created under its (possibly renamed) resolution name, but the export's field
+    // mappings still reference it by the original ref.name. Alias ref.name to the just-created entity
+    // (looked up by the engine-returned id) so toDomain resolves it instead of failing/UNCATEGORIZED.
+    @Suppress("LongParameterList")
+    private fun aliasCreatedEntity(
+        ref: UnresolvedReference,
+        importResult: ImportResult,
+        accounts: List<Account>,
+        categories: List<Category>,
+        currencies: List<Currency>,
+        accountsByName: MutableMap<String, Account>,
+        categoriesByName: MutableMap<String, Category>,
+        currenciesByCode: MutableMap<String, Currency>,
+    ) {
+        when (ref.type) {
+            ReferenceType.ACCOUNT -> {
+                val id = importResult.createdAccountIds[LocalAccountKey(ref.name)] ?: return
+                accounts.find { it.id == id }?.let { accountsByName[ref.name] = it }
+            }
+            ReferenceType.CATEGORY -> {
+                val id = importResult.createdCategoryIds[LocalCategoryKey(ref.name)] ?: return
+                categories.find { it.id == id }?.let { categoriesByName[ref.name] = it }
+            }
+            ReferenceType.CURRENCY -> {
+                val id = importResult.createdCurrencyIds[LocalCurrencyKey(ref.name)] ?: return
+                currencies.find { it.id == id }?.let { currenciesByCode[ref.name] = it }
+            }
+        }
     }
 
     private fun FieldMapping.toExport(

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
@@ -333,20 +333,15 @@ class CsvStrategyExportService(
             }
         }
 
-        val importResult =
-            importEngine.import(
-                ImportBatch(
-                    accountsToCreate = accountIntents.values.toList(),
-                    categories = categoryIntents.values.toList(),
-                    currencies = currencyIntents.values.toList(),
-                ),
-            )
-        val createdAccounts =
-            accountIntents.mapValues { (_, intent) -> requireNotNull(importResult.createdAccountIds[intent.key]) }
-        val createdCategories =
-            categoryIntents.mapValues { (_, intent) -> requireNotNull(importResult.createdCategoryIds[intent.key]) }
-        val createdCurrencies =
-            currencyIntents.mapValues { (_, intent) -> requireNotNull(importResult.createdCurrencyIds[intent.key]) }
+        // Create the requested new entities through the engine (the sole writer); they are then read
+        // back below via the re-fetched lookup maps.
+        importEngine.import(
+            ImportBatch(
+                accountsToCreate = accountIntents.values.toList(),
+                categories = categoryIntents.values.toList(),
+                currencies = currencyIntents.values.toList(),
+            ),
+        )
 
         // Build lookup maps including both existing and newly created entities
         val accounts = accountRepository.getAllAccounts().first()

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
@@ -42,9 +42,18 @@ import com.moneymanager.domain.model.csvstrategy.export.HardCodedTimezoneExport
 import com.moneymanager.domain.model.csvstrategy.export.RegexAccountExport
 import com.moneymanager.domain.model.csvstrategy.export.TemplateAccountExport
 import com.moneymanager.domain.model.csvstrategy.export.TimezoneLookupExport
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.CategoryWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.CategoryReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
+import com.moneymanager.importengineapi.AccountMatchKey
+import com.moneymanager.importengineapi.ImportAccountIntent
+import com.moneymanager.importengineapi.ImportBatch
+import com.moneymanager.importengineapi.ImportCategoryIntent
+import com.moneymanager.importengineapi.ImportCurrencyIntent
+import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.LocalAccountKey
+import com.moneymanager.importengineapi.LocalCategoryKey
+import com.moneymanager.importengineapi.LocalCurrencyKey
 import kotlinx.coroutines.flow.first
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
@@ -127,9 +136,10 @@ private data class StrategyReferenceData(
  * Service for converting between domain models and portable export format.
  */
 class CsvStrategyExportService(
-    private val accountRepository: AccountWriteRepository,
-    private val currencyRepository: CurrencyWriteRepository,
-    private val categoryRepository: CategoryWriteRepository,
+    private val accountRepository: AccountReadRepository,
+    private val currencyRepository: CurrencyReadRepository,
+    private val categoryRepository: CategoryReadRepository,
+    private val importEngine: ImportEngine,
 ) {
     // Entities created while importing a strategy are a manual user action on this device.
     private val source = Source.Manual
@@ -291,41 +301,52 @@ class CsvStrategyExportService(
         export: CsvStrategyExport,
         resolutions: Map<UnresolvedReference, Resolution>,
     ): CsvImportStrategy {
-        // First, create any new entities that were requested
-        val createdAccounts = mutableMapOf<String, AccountId>()
-        val createdCategories = mutableMapOf<String, Long>()
-        val createdCurrencies = mutableMapOf<String, CurrencyId>()
+        // First, create any new entities that were requested — in one engine batch (the sole writer).
+        val accountIntents = mutableMapOf<String, ImportAccountIntent>()
+        val categoryIntents = mutableMapOf<String, ImportCategoryIntent>()
+        val currencyIntents = mutableMapOf<String, ImportCurrencyIntent>()
 
         for ((ref, resolution) in resolutions) {
             if (resolution is Resolution.CreateNew) {
                 when (ref.type) {
-                    ReferenceType.ACCOUNT -> {
-                        val account =
-                            Account(
-                                id = AccountId(0),
+                    ReferenceType.ACCOUNT ->
+                        accountIntents[ref.name] =
+                            ImportAccountIntent(
+                                key = LocalAccountKey(ref.name),
+                                source = source,
+                                match = AccountMatchKey.AlwaysCreate,
                                 name = resolution.name,
                                 openingDate = Instant.fromEpochMilliseconds(System.currentTimeMillis()),
                             )
-                        val id = accountRepository.createAccount(account, source)
-                        createdAccounts[ref.name] = id
-                    }
-                    ReferenceType.CATEGORY -> {
-                        val category = Category(name = resolution.name)
-                        val id = categoryRepository.createCategory(category, source)
-                        createdCategories[ref.name] = id
-                    }
-                    ReferenceType.CURRENCY -> {
-                        val id =
-                            currencyRepository.upsertCurrencyByCode(
+                    ReferenceType.CATEGORY ->
+                        categoryIntents[ref.name] =
+                            ImportCategoryIntent(key = LocalCategoryKey(ref.name), source = source, name = resolution.name)
+                    ReferenceType.CURRENCY ->
+                        currencyIntents[ref.name] =
+                            ImportCurrencyIntent(
+                                key = LocalCurrencyKey(ref.name),
+                                source = source,
                                 code = resolution.name,
                                 name = resolution.name,
-                                source = source,
                             )
-                        createdCurrencies[ref.name] = id
-                    }
                 }
             }
         }
+
+        val importResult =
+            importEngine.import(
+                ImportBatch(
+                    accountsToCreate = accountIntents.values.toList(),
+                    categories = categoryIntents.values.toList(),
+                    currencies = currencyIntents.values.toList(),
+                ),
+            )
+        val createdAccounts =
+            accountIntents.mapValues { (_, intent) -> requireNotNull(importResult.createdAccountIds[intent.key]) }
+        val createdCategories =
+            categoryIntents.mapValues { (_, intent) -> requireNotNull(importResult.createdCategoryIds[intent.key]) }
+        val createdCurrencies =
+            currencyIntents.mapValues { (_, intent) -> requireNotNull(importResult.createdCurrencyIds[intent.key]) }
 
         // Build lookup maps including both existing and newly created entities
         val accounts = accountRepository.getAllAccounts().first()

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -48,6 +48,16 @@ class ImportEngineDbTest : DbTest() {
             personAttributeRepository = repositories.personAttributeRepository,
             ownershipRepository = repositories.personAccountOwnershipRepository,
             categoryRepository = repositories.categoryRepository,
+            currencyRepository = repositories.currencyRepository,
+            attributeTypeRepository = repositories.attributeTypeRepository,
+            relationshipTypeRepository = repositories.relationshipTypeRepository,
+            csvImportStrategyRepository = repositories.csvImportStrategyRepository,
+            apiImportStrategyRepository = repositories.apiImportStrategyRepository,
+            csvAccountMappingRepository = repositories.csvAccountMappingRepository,
+            csvImportRepository = repositories.csvImportRepository,
+            qifImportRepository = repositories.qifImportRepository,
+            apiSessionRepository = repositories.apiSessionRepository,
+            settingsRepository = repositories.settingsRepository,
         )
 
     private suspend fun gbp(): Currency =

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/qif/SantanderQifE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/qif/SantanderQifE2ETest.kt
@@ -109,7 +109,6 @@ class SantanderQifE2ETest : DbTest() {
             csvAccountMappingRepository = repositories.csvAccountMappingRepository,
             accountRepository = repositories.accountRepository,
             qifImportRepository = repositories.qifImportRepository,
-            attributeTypeRepository = repositories.attributeTypeRepository,
             maintenance = maintenance,
             importEngine = repositories.importEngine,
             onProgress = { _, _ -> },

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/service/CsvStrategyExportRoundTripTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/service/CsvStrategyExportRoundTripTest.kt
@@ -30,6 +30,7 @@ class CsvStrategyExportRoundTripTest : DbTest() {
                     accountRepository = repositories.accountRepository,
                     currencyRepository = repositories.currencyRepository,
                     categoryRepository = repositories.categoryRepository,
+                    importEngine = repositories.importEngine,
                 )
             val appVersion = AppVersion("1.0.0-test")
 

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/DeviceIdModule.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/DeviceIdModule.kt
@@ -11,6 +11,13 @@ import dev.zacsweers.metro.SingleIn
 /**
  * Module that provides DeviceId as a singleton.
  * The DeviceId is computed once from the DeviceWriteRepository when first accessed.
+ *
+ * NOTE: This is the one deliberate exception to the "only the ImportEngine injects a *WriteRepository"
+ * rule. [DeviceId] is a synchronous singleton that every write-repository impl (and therefore the
+ * ImportEngine itself) depends on, so it must be resolved at graph-construction time — before, and as a
+ * dependency of, the engine. Routing it through the (suspend) engine would create a dependency cycle
+ * (engine -> write repos -> DeviceId -> engine), so [DeviceWriteRepository] is injected here directly.
+ * The arch check that forbids write-repo injection outside the engine whitelists this module.
  */
 @ContributesTo(DatabaseScope::class)
 interface DeviceIdModule {

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/ImportEngineFactory.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/ImportEngineFactory.kt
@@ -1,0 +1,33 @@
+package com.moneymanager.di.database
+
+import com.moneymanager.importengineapi.EditGate
+import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importer.ImportEngineImpl
+
+/**
+ * Builds an [ImportEngine] bound to [editGate] from the database component's write repositories. This
+ * lives in di/core (which legitimately holds the write repositories) so the UI layer never has to —
+ * the UI receives only the constructed [ImportEngine] plus read repositories. The session passes its
+ * own [editGate] (e.g. a cloud-sync lock) here rather than relying on the always-writable DI binding.
+ */
+fun DatabaseComponent.createImportEngine(editGate: EditGate): ImportEngine =
+    ImportEngineImpl(
+        transactionRepository = transactionRepository,
+        accountRepository = accountRepository,
+        accountAttributeRepository = accountAttributeRepository,
+        personRepository = personRepository,
+        personAttributeRepository = personAttributeRepository,
+        ownershipRepository = personAccountOwnershipRepository,
+        categoryRepository = categoryRepository,
+        currencyRepository = currencyRepository,
+        attributeTypeRepository = attributeTypeRepository,
+        relationshipTypeRepository = relationshipTypeRepository,
+        csvImportStrategyRepository = csvImportStrategyRepository,
+        apiImportStrategyRepository = apiImportStrategyRepository,
+        csvAccountMappingRepository = csvAccountMappingRepository,
+        csvImportRepository = csvImportRepository,
+        qifImportRepository = qifImportRepository,
+        apiSessionRepository = apiSessionRepository,
+        settingsRepository = settingsRepository,
+        editGate = editGate,
+    )

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/RepositoryModule.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/RepositoryModule.kt
@@ -323,10 +323,11 @@ interface RepositoryModule {
     @Provides
     @SingleIn(DatabaseScope::class)
     fun provideCsvStrategyExportService(
-        accountRepository: AccountWriteRepository,
-        currencyRepository: CurrencyWriteRepository,
-        categoryRepository: CategoryWriteRepository,
-    ): CsvStrategyExportService = CsvStrategyExportService(accountRepository, currencyRepository, categoryRepository)
+        accountRepository: AccountReadRepository,
+        currencyRepository: CurrencyReadRepository,
+        categoryRepository: CategoryReadRepository,
+        importEngine: ImportEngine,
+    ): CsvStrategyExportService = CsvStrategyExportService(accountRepository, currencyRepository, categoryRepository, importEngine)
 
     @Provides
     @SingleIn(DatabaseScope::class)
@@ -388,6 +389,16 @@ interface RepositoryModule {
         personAttributeRepository: PersonAttributeWriteRepository,
         ownershipRepository: PersonAccountOwnershipWriteRepository,
         categoryRepository: CategoryWriteRepository,
+        currencyRepository: CurrencyWriteRepository,
+        attributeTypeRepository: AttributeTypeWriteRepository,
+        relationshipTypeRepository: RelationshipTypeWriteRepository,
+        csvImportStrategyRepository: CsvImportStrategyWriteRepository,
+        apiImportStrategyRepository: ApiImportStrategyWriteRepository,
+        csvAccountMappingRepository: CsvAccountMappingWriteRepository,
+        csvImportRepository: CsvImportWriteRepository,
+        qifImportRepository: QifImportWriteRepository,
+        apiSessionRepository: ApiSessionWriteRepository,
+        settingsRepository: SettingsWriteRepository,
     ): ImportEngine =
         ImportEngineImpl(
             transactionRepository = transactionRepository,
@@ -397,5 +408,15 @@ interface RepositoryModule {
             personAttributeRepository = personAttributeRepository,
             ownershipRepository = ownershipRepository,
             categoryRepository = categoryRepository,
+            currencyRepository = currencyRepository,
+            attributeTypeRepository = attributeTypeRepository,
+            relationshipTypeRepository = relationshipTypeRepository,
+            csvImportStrategyRepository = csvImportStrategyRepository,
+            apiImportStrategyRepository = apiImportStrategyRepository,
+            csvAccountMappingRepository = csvAccountMappingRepository,
+            csvImportRepository = csvImportRepository,
+            qifImportRepository = qifImportRepository,
+            apiSessionRepository = apiSessionRepository,
+            settingsRepository = settingsRepository,
         )
 }

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ApiSessionMutation.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ApiSessionMutation.kt
@@ -1,0 +1,94 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.importengineapi
+
+import com.moneymanager.domain.model.ApiRequestId
+import com.moneymanager.domain.model.ApiResponseId
+import com.moneymanager.domain.model.ApiResponseTransactionState
+import com.moneymanager.domain.model.ApiSessionId
+import com.moneymanager.domain.model.ApiSessionType
+import com.moneymanager.domain.model.DeviceId
+import com.moneymanager.domain.model.JsonPath
+import com.moneymanager.domain.model.MonzoCredentialId
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
+import com.moneymanager.domain.repository.ApiResponseTransactionInsert
+import kotlin.time.Instant
+
+/**
+ * Writes on the API session/credential/request/response tables. The engine applies these so the API
+ * traffic recorder, connect flow and import service never hold an `ApiSessionWriteRepository`. Create
+ * variants carry a [String] `key` whose generated id is read back from the matching map on
+ * [ImportResult].
+ */
+sealed interface ApiSessionMutation {
+    data class CreateCredential(
+        val key: String,
+        val token: String,
+        val createdAt: Instant,
+        val type: ApiSessionType = ApiSessionType.MONZO,
+        val strategyId: ApiImportStrategyId? = null,
+        val privateKey: String? = null,
+        val publicKey: String? = null,
+    ) : ApiSessionMutation
+
+    data class UpdateCredentialStrategy(
+        val credentialId: MonzoCredentialId,
+        val strategyId: ApiImportStrategyId?,
+    ) : ApiSessionMutation
+
+    data class UpdateCredentialKeys(
+        val credentialId: MonzoCredentialId,
+        val privateKey: String?,
+        val publicKey: String?,
+    ) : ApiSessionMutation
+
+    data class CreateSession(
+        val key: String,
+        val token: String,
+        val deviceId: DeviceId,
+        val createdAt: Instant,
+        val expiresAt: Instant?,
+        val type: ApiSessionType = ApiSessionType.MONZO,
+        val credentialId: MonzoCredentialId? = null,
+    ) : ApiSessionMutation
+
+    data class InsertRequest(
+        val key: String,
+        val sessionId: ApiSessionId,
+        val method: String,
+        val url: String,
+        val headers: Map<String, String>,
+    ) : ApiSessionMutation
+
+    data class InsertResponse(
+        val key: String,
+        val requestId: ApiRequestId,
+        val sessionId: ApiSessionId,
+        val json: String,
+    ) : ApiSessionMutation
+
+    data class DeleteSession(
+        val id: ApiSessionId,
+    ) : ApiSessionMutation
+
+    data class InsertResponseTransaction(
+        val key: String,
+        val responseId: ApiResponseId,
+        val jsonPath: JsonPath,
+        val state: ApiResponseTransactionState,
+        val transactionId: TransferId?,
+        val errorMessage: String?,
+    ) : ApiSessionMutation
+
+    data class InsertResponseTransactions(
+        val transactions: List<ApiResponseTransactionInsert>,
+    ) : ApiSessionMutation
+
+    data class MarkSessionImported(
+        val id: ApiSessionId,
+        val revisionId: Long,
+        val importedAt: Instant,
+        val importDurationMillis: Long? = null,
+    ) : ApiSessionMutation
+}

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ApiSessionMutation.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ApiSessionMutation.kt
@@ -48,7 +48,6 @@ sealed interface ApiSessionMutation {
         val token: String,
         val deviceId: DeviceId,
         val createdAt: Instant,
-        val expiresAt: Instant?,
         val type: ApiSessionType = ApiSessionType.MONZO,
         val credentialId: MonzoCredentialId? = null,
     ) : ApiSessionMutation

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
@@ -8,6 +8,8 @@ import com.moneymanager.domain.model.ApiRequestId
 import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.Auditable
 import com.moneymanager.domain.model.Category
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.MergeId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.NewAttribute
@@ -215,6 +217,29 @@ data class ImportCategoryIntent(
 ) : Auditable,
     WriteIntent
 
+/** Builder-chosen placeholder identity for a currency created in this batch, before DB ids exist. */
+@JvmInline
+value class LocalCurrencyKey(
+    val value: String,
+)
+
+/**
+ * A currency to create/update/delete. CREATE upserts by [code] (existing code is updated to [name]);
+ * the resulting id is read back from [ImportResult.createdCurrencyIds] via [key]. [existingId]/[currency]
+ * target the row for UPDATE; [existingId] for DELETE.
+ */
+data class ImportCurrencyIntent(
+    val key: LocalCurrencyKey,
+    override val source: Source,
+    val code: String? = null,
+    val name: String? = null,
+    override val operation: ImportOperation = ImportOperation.CREATE,
+    val existingId: CurrencyId? = null,
+    /** UPDATE: the new currency row, passed straight to the repository. */
+    val currency: Currency? = null,
+) : Auditable,
+    WriteIntent
+
 /** A request to merge [deletedId] into [survivingId] (reassign its transfers, then delete it). */
 data class AccountMergeRequest(
     val deletedId: AccountId,
@@ -323,8 +348,24 @@ data class ImportBatch(
     val peopleToCreate: List<ImportPersonIntent> = emptyList(),
     val ownerships: List<ImportOwnershipIntent> = emptyList(),
     val categories: List<ImportCategoryIntent> = emptyList(),
+    val currencies: List<ImportCurrencyIntent> = emptyList(),
+    val csvStrategyMutations: List<CsvStrategyMutation> = emptyList(),
+    val apiStrategyMutations: List<ApiStrategyMutation> = emptyList(),
+    val csvMappingMutations: List<CsvMappingMutation> = emptyList(),
+    val csvImportMutations: List<CsvImportMutation> = emptyList(),
+    val qifImportMutations: List<QifImportMutation> = emptyList(),
+    val apiSessionMutations: List<ApiSessionMutation> = emptyList(),
+    val settings: ImportSettings? = null,
     val accountMerges: List<AccountMergeRequest> = emptyList(),
     val accountUnmerges: List<MergeId> = emptyList(),
+    /**
+     * Attribute-type names to resolve (get-or-create) before anything else; the resulting ids are
+     * returned in [ImportResult.attributeTypeIds]. Lets producers build [NewAttribute]s by id without
+     * holding an `AttributeTypeWriteRepository` — they issue a resolve-only batch first.
+     */
+    val attributeTypeNames: List<String> = emptyList(),
+    /** Relationship-type names to resolve (get-or-create); ids returned in [ImportResult.relationshipTypeIds]. */
+    val relationshipTypeNames: List<String> = emptyList(),
     /** Required when [dedupePolicy] is [DedupePolicy.UniqueIdentifier] or [DedupePolicy.ApiMultiKey]. */
     val uniqueKeyExtractor: ExistingUniqueKeyExtractor? = null,
     /** Required when [dedupePolicy] is [DedupePolicy.ApiMultiKey]. */
@@ -342,6 +383,7 @@ data class ImportBatch(
             people: List<ImportPersonIntent> = emptyList(),
             ownerships: List<ImportOwnershipIntent> = emptyList(),
             categories: List<ImportCategoryIntent> = emptyList(),
+            currencies: List<ImportCurrencyIntent> = emptyList(),
             accountMerges: List<AccountMergeRequest> = emptyList(),
             accountUnmerges: List<MergeId> = emptyList(),
         ): ImportBatch =
@@ -352,6 +394,7 @@ data class ImportBatch(
                 peopleToCreate = people,
                 ownerships = ownerships,
                 categories = categories,
+                currencies = currencies,
                 accountMerges = accountMerges,
                 accountUnmerges = accountUnmerges,
             )

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportConfigIntents.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportConfigIntents.kt
@@ -1,0 +1,196 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.importengineapi
+
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
+import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
+import com.moneymanager.domain.model.csv.CsvImportId
+import com.moneymanager.domain.model.csvstrategy.CsvAccountMapping
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.model.qif.QifImportId
+import com.moneymanager.domain.model.qif.QifImportRecord
+import kotlin.time.Instant
+
+/*
+ * Intents for the import-configuration and staging tables (strategies, account mappings, CSV/QIF
+ * staging rows, settings, device). The engine applies these so callers never hold the corresponding
+ * write repository. Create variants carry a String `key` whose generated id is read back from the
+ * matching map on ImportResult.
+ */
+
+/** A write on the CSV import-strategy table. */
+sealed interface CsvStrategyMutation {
+    data class Create(
+        val key: String,
+        val strategy: CsvImportStrategy,
+        val source: Source,
+    ) : CsvStrategyMutation
+
+    data class Update(
+        val strategy: CsvImportStrategy,
+        val source: Source,
+    ) : CsvStrategyMutation
+
+    data class Delete(
+        val id: CsvImportStrategyId,
+    ) : CsvStrategyMutation
+}
+
+/** A write on the API import-strategy table. */
+sealed interface ApiStrategyMutation {
+    data class Create(
+        val key: String,
+        val strategy: ApiImportStrategy,
+        val source: Source,
+    ) : ApiStrategyMutation
+
+    data class Update(
+        val strategy: ApiImportStrategy,
+        val source: Source,
+    ) : ApiStrategyMutation
+
+    data class Delete(
+        val id: ApiImportStrategyId,
+    ) : ApiStrategyMutation
+}
+
+/** A write on the CSV account-mapping table. */
+sealed interface CsvMappingMutation {
+    data class Create(
+        val key: String,
+        val strategyId: CsvImportStrategyId,
+        val columnName: String,
+        val valuePattern: Regex,
+        val accountId: AccountId,
+    ) : CsvMappingMutation
+
+    data class CreateBatch(
+        val mappings: List<CsvAccountMapping>,
+    ) : CsvMappingMutation
+
+    data class Update(
+        val mapping: CsvAccountMapping,
+    ) : CsvMappingMutation
+
+    data class Delete(
+        val id: Long,
+    ) : CsvMappingMutation
+
+    data class DeleteForStrategy(
+        val strategyId: CsvImportStrategyId,
+    ) : CsvMappingMutation
+}
+
+/** A write on the CSV staging tables (the stored file + per-row status write-back). */
+sealed interface CsvImportMutation {
+    data class Create(
+        val key: String,
+        val fileName: String,
+        val headers: List<String>,
+        val rows: List<List<String>>,
+        val fileChecksum: String,
+        val fileLastModified: Instant,
+    ) : CsvImportMutation
+
+    data class Delete(
+        val id: CsvImportId,
+    ) : CsvImportMutation
+
+    data class UpdateRowTransferId(
+        val id: CsvImportId,
+        val rowIndex: Long,
+        val transferId: TransferId,
+    ) : CsvImportMutation
+
+    data class UpdateRowTransferIds(
+        val id: CsvImportId,
+        val rowTransferMap: Map<Long, TransferId>,
+    ) : CsvImportMutation
+
+    data class UpdateRowStatus(
+        val id: CsvImportId,
+        val rowIndex: Long,
+        val status: String,
+        val transferId: TransferId? = null,
+    ) : CsvImportMutation
+
+    data class UpdateRowStatuses(
+        val id: CsvImportId,
+        val status: String,
+        val rowTransferMap: Map<Long, TransferId?>,
+    ) : CsvImportMutation
+
+    data class SaveError(
+        val id: CsvImportId,
+        val rowIndex: Long,
+        val errorMessage: String,
+    ) : CsvImportMutation
+
+    data class ClearError(
+        val id: CsvImportId,
+        val rowIndex: Long,
+    ) : CsvImportMutation
+
+    data class ClearErrors(
+        val id: CsvImportId,
+        val rowIndexes: Collection<Long>,
+    ) : CsvImportMutation
+
+    data class RecordApplication(
+        val id: CsvImportId,
+        val strategyId: CsvImportStrategyId,
+        val strategyName: String,
+        val appliedAt: Instant,
+    ) : CsvImportMutation
+}
+
+/** A write on the QIF staging tables (the stored file + per-record status write-back). */
+sealed interface QifImportMutation {
+    data class Create(
+        val key: String,
+        val fileName: String,
+        val records: List<QifImportRecord>,
+        val accountType: String,
+        val fileChecksum: String,
+        val fileLastModified: Instant,
+    ) : QifImportMutation
+
+    data class Delete(
+        val id: QifImportId,
+    ) : QifImportMutation
+
+    data class UpdateRecordStatuses(
+        val id: QifImportId,
+        val status: String,
+        val recordTransferMap: Map<Long, TransferId?>,
+    ) : QifImportMutation
+
+    data class SaveError(
+        val id: QifImportId,
+        val recordIndex: Long,
+        val errorMessage: String,
+    ) : QifImportMutation
+
+    data class ClearErrors(
+        val id: QifImportId,
+        val recordIndexes: Collection<Long>,
+    ) : QifImportMutation
+
+    data class RecordApplication(
+        val id: QifImportId,
+        val strategyId: CsvImportStrategyId,
+        val strategyName: String,
+        val appliedAt: Instant,
+    ) : QifImportMutation
+}
+
+/** Settings writes; non-null fields are applied. */
+data class ImportSettings(
+    val defaultCurrencyId: CurrencyId? = null,
+    val lastQifAccountId: AccountId? = null,
+)

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineActions.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineActions.kt
@@ -3,9 +3,7 @@ package com.moneymanager.importengineapi
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AttributeTypeId
-import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
-import com.moneymanager.domain.model.RelationshipTypeId
 import com.moneymanager.domain.model.Source
 
 /*
@@ -29,27 +27,6 @@ suspend fun ImportEngine.createCurrency(
             ),
         )
     return requireNotNull(result.createdCurrencyIds[key]) { "Currency $code was not created" }
-}
-
-/** Updates an existing currency row. */
-suspend fun ImportEngine.updateCurrency(
-    currency: Currency,
-    source: Source = Source.Manual,
-) {
-    import(
-        ImportBatch(
-            currencies =
-                listOf(
-                    ImportCurrencyIntent(
-                        key = LocalCurrencyKey(currency.code),
-                        source = source,
-                        operation = ImportOperation.UPDATE,
-                        existingId = currency.id,
-                        currency = currency,
-                    ),
-                ),
-        ),
-    )
 }
 
 /** Deletes a currency by id. */
@@ -81,12 +58,6 @@ suspend fun ImportEngine.getOrCreateAttributeType(name: String): AttributeTypeId
 /** Resolves (get-or-create) several attribute-type ids by name in one batch. */
 suspend fun ImportEngine.getOrCreateAttributeTypes(names: List<String>): Map<String, AttributeTypeId> =
     if (names.isEmpty()) emptyMap() else import(ImportBatch(attributeTypeNames = names)).attributeTypeIds
-
-/** Resolves (get-or-create) a single relationship-type id by name. */
-suspend fun ImportEngine.getOrCreateRelationshipType(name: String): RelationshipTypeId =
-    requireNotNull(import(ImportBatch(relationshipTypeNames = listOf(name))).relationshipTypeIds[name]) {
-        "Relationship type $name was not resolved"
-    }
 
 /**
  * Creates [accounts] (always new, no matching), returning their ids in input order. [sourceFor] gives

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineActions.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineActions.kt
@@ -1,0 +1,119 @@
+package com.moneymanager.importengineapi
+
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AttributeTypeId
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.RelationshipTypeId
+import com.moneymanager.domain.model.Source
+
+/*
+ * Convenience ImportEngine extensions for single, non-transfer writes. Each builds a one-item
+ * ImportBatch and calls ImportEngine.import, so callers mutate the database without holding a
+ * write repository — the engine remains the sole writer. Use these instead of injecting the
+ * corresponding *WriteRepository.
+ */
+
+/** Upserts a currency by [code] and returns its id (the engine's `upsertCurrencyByCode`). */
+suspend fun ImportEngine.createCurrency(
+    code: String,
+    name: String,
+    source: Source = Source.Manual,
+): CurrencyId {
+    val key = LocalCurrencyKey(code)
+    val result =
+        import(
+            ImportBatch(
+                currencies = listOf(ImportCurrencyIntent(key = key, source = source, code = code, name = name)),
+            ),
+        )
+    return requireNotNull(result.createdCurrencyIds[key]) { "Currency $code was not created" }
+}
+
+/** Updates an existing currency row. */
+suspend fun ImportEngine.updateCurrency(
+    currency: Currency,
+    source: Source = Source.Manual,
+) {
+    import(
+        ImportBatch(
+            currencies =
+                listOf(
+                    ImportCurrencyIntent(
+                        key = LocalCurrencyKey(currency.code),
+                        source = source,
+                        operation = ImportOperation.UPDATE,
+                        existingId = currency.id,
+                        currency = currency,
+                    ),
+                ),
+        ),
+    )
+}
+
+/** Deletes a currency by id. */
+suspend fun ImportEngine.deleteCurrency(
+    id: CurrencyId,
+    source: Source = Source.Manual,
+) {
+    import(
+        ImportBatch(
+            currencies =
+                listOf(
+                    ImportCurrencyIntent(
+                        key = LocalCurrencyKey(id.toString()),
+                        source = source,
+                        operation = ImportOperation.DELETE,
+                        existingId = id,
+                    ),
+                ),
+        ),
+    )
+}
+
+/** Resolves (get-or-create) a single attribute-type id by name. */
+suspend fun ImportEngine.getOrCreateAttributeType(name: String): AttributeTypeId =
+    requireNotNull(import(ImportBatch(attributeTypeNames = listOf(name))).attributeTypeIds[name]) {
+        "Attribute type $name was not resolved"
+    }
+
+/** Resolves (get-or-create) several attribute-type ids by name in one batch. */
+suspend fun ImportEngine.getOrCreateAttributeTypes(names: List<String>): Map<String, AttributeTypeId> =
+    if (names.isEmpty()) emptyMap() else import(ImportBatch(attributeTypeNames = names)).attributeTypeIds
+
+/** Resolves (get-or-create) a single relationship-type id by name. */
+suspend fun ImportEngine.getOrCreateRelationshipType(name: String): RelationshipTypeId =
+    requireNotNull(import(ImportBatch(relationshipTypeNames = listOf(name))).relationshipTypeIds[name]) {
+        "Relationship type $name was not resolved"
+    }
+
+/**
+ * Creates [accounts] (always new, no matching), returning their ids in input order. [sourceFor] gives
+ * each account's provenance. Mirrors `AccountWriteRepository.createAccountsBatch` but via the engine.
+ */
+suspend fun ImportEngine.createAccounts(
+    accounts: List<Account>,
+    sourceFor: (Account) -> Source,
+): List<AccountId> {
+    if (accounts.isEmpty()) return emptyList()
+    val intents =
+        accounts.mapIndexed { index, account ->
+            ImportAccountIntent(
+                key = LocalAccountKey("create-$index"),
+                source = sourceFor(account),
+                match = AccountMatchKey.AlwaysCreate,
+                name = account.name,
+                openingDate = account.openingDate,
+                categoryId = account.categoryId,
+            )
+        }
+    val result = import(ImportBatch(accountsToCreate = intents))
+    return intents.map { requireNotNull(result.createdAccountIds[it.key]) { "Account ${it.name} was not created" } }
+}
+
+/** Creates a single new account (always new, no matching) and returns its id. */
+suspend fun ImportEngine.createAccount(
+    account: Account,
+    source: Source,
+): AccountId = createAccounts(listOf(account)) { source }.single()

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
@@ -190,8 +190,9 @@ suspend fun ImportEngine.createApiCredential(
     privateKey: String? = null,
     publicKey: String? = null,
 ): MonzoCredentialId {
-    // The read-back key is echoed through ImportResult, so use an opaque label rather than the secret token.
-    val key = "create_api_credential"
+    // The read-back key is echoed through ImportResult, so derive it from the (non-secret) createdAt
+    // timestamp rather than the secret token. A helper creates exactly one credential per batch.
+    val key = createdAt.toString()
     return requireNotNull(
         import(
             ImportBatch(
@@ -217,8 +218,9 @@ suspend fun ImportEngine.createApiSession(
     type: ApiSessionType = ApiSessionType.MONZO,
     credentialId: MonzoCredentialId? = null,
 ): ApiSessionId {
-    // The read-back key is echoed through ImportResult, so use an opaque label rather than the secret token.
-    val key = "create_api_session"
+    // The read-back key is echoed through ImportResult, so derive it from the (non-secret) createdAt
+    // timestamp rather than the secret token. A helper creates exactly one session per batch.
+    val key = createdAt.toString()
     return requireNotNull(
         import(
             ImportBatch(

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
@@ -1,0 +1,295 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.importengineapi
+
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.ApiRequestId
+import com.moneymanager.domain.model.ApiResponseId
+import com.moneymanager.domain.model.ApiResponseTransactionState
+import com.moneymanager.domain.model.ApiSessionId
+import com.moneymanager.domain.model.ApiSessionType
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.DeviceId
+import com.moneymanager.domain.model.JsonPath
+import com.moneymanager.domain.model.MonzoCredentialId
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
+import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
+import com.moneymanager.domain.model.csv.CsvImportId
+import com.moneymanager.domain.model.csvstrategy.CsvAccountMapping
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.model.qif.QifImportId
+import com.moneymanager.domain.model.qif.QifImportRecord
+import com.moneymanager.domain.repository.ApiResponseTransactionInsert
+import kotlin.time.Instant
+
+/**
+ * Convenience [ImportEngine] extensions mirroring the config/staging/session/settings/device write
+ * repositories, each building a one-item [ImportBatch]. Callers use these instead of injecting the
+ * corresponding `*WriteRepository`, keeping the engine the sole writer. A constant key is used for
+ * single-item batches that need their generated id read back.
+ */
+private const val KEY = "it"
+
+// region CSV strategies
+
+suspend fun ImportEngine.createCsvStrategy(
+    strategy: CsvImportStrategy,
+    source: Source = Source.Manual,
+): CsvImportStrategyId =
+    requireNotNull(
+        import(ImportBatch(csvStrategyMutations = listOf(CsvStrategyMutation.Create(KEY, strategy, source))))
+            .createdCsvStrategyIds[KEY],
+    )
+
+suspend fun ImportEngine.updateCsvStrategy(
+    strategy: CsvImportStrategy,
+    source: Source = Source.Manual,
+) {
+    import(ImportBatch(csvStrategyMutations = listOf(CsvStrategyMutation.Update(strategy, source))))
+}
+
+suspend fun ImportEngine.deleteCsvStrategy(id: CsvImportStrategyId) {
+    import(ImportBatch(csvStrategyMutations = listOf(CsvStrategyMutation.Delete(id))))
+}
+
+// endregion
+
+// region API strategies
+
+suspend fun ImportEngine.createApiStrategy(
+    strategy: ApiImportStrategy,
+    source: Source = Source.Manual,
+): ApiImportStrategyId =
+    requireNotNull(
+        import(ImportBatch(apiStrategyMutations = listOf(ApiStrategyMutation.Create(KEY, strategy, source))))
+            .createdApiStrategyIds[KEY],
+    )
+
+suspend fun ImportEngine.updateApiStrategy(
+    strategy: ApiImportStrategy,
+    source: Source = Source.Manual,
+) {
+    import(ImportBatch(apiStrategyMutations = listOf(ApiStrategyMutation.Update(strategy, source))))
+}
+
+suspend fun ImportEngine.deleteApiStrategy(id: ApiImportStrategyId) {
+    import(ImportBatch(apiStrategyMutations = listOf(ApiStrategyMutation.Delete(id))))
+}
+
+// endregion
+
+// region CSV account mappings
+
+suspend fun ImportEngine.createCsvMapping(
+    strategyId: CsvImportStrategyId,
+    columnName: String,
+    valuePattern: Regex,
+    accountId: AccountId,
+): Long =
+    requireNotNull(
+        import(
+            ImportBatch(
+                csvMappingMutations = listOf(CsvMappingMutation.Create(KEY, strategyId, columnName, valuePattern, accountId)),
+            ),
+        ).createdCsvMappingIds[KEY],
+    )
+
+suspend fun ImportEngine.createCsvMappings(mappings: List<CsvAccountMapping>) {
+    import(ImportBatch(csvMappingMutations = listOf(CsvMappingMutation.CreateBatch(mappings))))
+}
+
+suspend fun ImportEngine.updateCsvMapping(mapping: CsvAccountMapping) {
+    import(ImportBatch(csvMappingMutations = listOf(CsvMappingMutation.Update(mapping))))
+}
+
+suspend fun ImportEngine.deleteCsvMapping(id: Long) {
+    import(ImportBatch(csvMappingMutations = listOf(CsvMappingMutation.Delete(id))))
+}
+
+suspend fun ImportEngine.deleteCsvMappingsForStrategy(strategyId: CsvImportStrategyId) {
+    import(ImportBatch(csvMappingMutations = listOf(CsvMappingMutation.DeleteForStrategy(strategyId))))
+}
+
+// endregion
+
+// region CSV staging
+
+suspend fun ImportEngine.createCsvImport(
+    fileName: String,
+    headers: List<String>,
+    rows: List<List<String>>,
+    fileChecksum: String,
+    fileLastModified: Instant,
+): CsvImportId =
+    requireNotNull(
+        import(
+            ImportBatch(
+                csvImportMutations = listOf(CsvImportMutation.Create(KEY, fileName, headers, rows, fileChecksum, fileLastModified)),
+            ),
+        ).createdCsvImportIds[KEY],
+    )
+
+suspend fun ImportEngine.deleteCsvImport(id: CsvImportId) {
+    import(ImportBatch(csvImportMutations = listOf(CsvImportMutation.Delete(id))))
+}
+
+/** Applies several CSV staging write-backs (status/error/application) in one batch. */
+suspend fun ImportEngine.applyCsvImportMutations(mutations: List<CsvImportMutation>) {
+    if (mutations.isNotEmpty()) import(ImportBatch(csvImportMutations = mutations))
+}
+
+// endregion
+
+// region QIF staging
+
+suspend fun ImportEngine.createQifImport(
+    fileName: String,
+    records: List<QifImportRecord>,
+    accountType: String,
+    fileChecksum: String,
+    fileLastModified: Instant,
+): QifImportId =
+    requireNotNull(
+        import(
+            ImportBatch(
+                qifImportMutations =
+                    listOf(QifImportMutation.Create(KEY, fileName, records, accountType, fileChecksum, fileLastModified)),
+            ),
+        ).createdQifImportIds[KEY],
+    )
+
+suspend fun ImportEngine.deleteQifImport(id: QifImportId) {
+    import(ImportBatch(qifImportMutations = listOf(QifImportMutation.Delete(id))))
+}
+
+/** Applies several QIF staging write-backs (status/error/application) in one batch. */
+suspend fun ImportEngine.applyQifImportMutations(mutations: List<QifImportMutation>) {
+    if (mutations.isNotEmpty()) import(ImportBatch(qifImportMutations = mutations))
+}
+
+// endregion
+
+// region Settings
+
+suspend fun ImportEngine.setDefaultCurrency(id: CurrencyId) {
+    import(ImportBatch(settings = ImportSettings(defaultCurrencyId = id)))
+}
+
+suspend fun ImportEngine.setLastQifAccount(id: AccountId) {
+    import(ImportBatch(settings = ImportSettings(lastQifAccountId = id)))
+}
+
+// endregion
+
+// region API sessions
+
+suspend fun ImportEngine.createApiCredential(
+    token: String,
+    createdAt: Instant,
+    type: ApiSessionType = ApiSessionType.MONZO,
+    strategyId: ApiImportStrategyId? = null,
+    privateKey: String? = null,
+    publicKey: String? = null,
+): MonzoCredentialId =
+    requireNotNull(
+        import(
+            ImportBatch(
+                apiSessionMutations =
+                    listOf(ApiSessionMutation.CreateCredential(KEY, token, createdAt, type, strategyId, privateKey, publicKey)),
+            ),
+        ).apiCredentialIds[KEY],
+    )
+
+suspend fun ImportEngine.updateApiCredentialStrategy(
+    credentialId: MonzoCredentialId,
+    strategyId: ApiImportStrategyId?,
+) {
+    import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.UpdateCredentialStrategy(credentialId, strategyId))))
+}
+
+suspend fun ImportEngine.updateApiCredentialKeys(
+    credentialId: MonzoCredentialId,
+    privateKey: String?,
+    publicKey: String?,
+) {
+    import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.UpdateCredentialKeys(credentialId, privateKey, publicKey))))
+}
+
+suspend fun ImportEngine.createApiSession(
+    token: String,
+    deviceId: DeviceId,
+    createdAt: Instant,
+    expiresAt: Instant?,
+    type: ApiSessionType = ApiSessionType.MONZO,
+    credentialId: MonzoCredentialId? = null,
+): ApiSessionId =
+    requireNotNull(
+        import(
+            ImportBatch(
+                apiSessionMutations =
+                    listOf(ApiSessionMutation.CreateSession(KEY, token, deviceId, createdAt, expiresAt, type, credentialId)),
+            ),
+        ).apiSessionIds[KEY],
+    )
+
+suspend fun ImportEngine.insertApiRequest(
+    sessionId: ApiSessionId,
+    method: String,
+    url: String,
+    headers: Map<String, String>,
+): ApiRequestId =
+    requireNotNull(
+        import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.InsertRequest(KEY, sessionId, method, url, headers))))
+            .apiRequestIds[KEY],
+    )
+
+suspend fun ImportEngine.insertApiResponse(
+    requestId: ApiRequestId,
+    sessionId: ApiSessionId,
+    json: String,
+): ApiResponseId =
+    requireNotNull(
+        import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.InsertResponse(KEY, requestId, sessionId, json))))
+            .apiResponseIds[KEY],
+    )
+
+suspend fun ImportEngine.deleteApiSession(id: ApiSessionId) {
+    import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.DeleteSession(id))))
+}
+
+suspend fun ImportEngine.insertApiResponseTransaction(
+    responseId: ApiResponseId,
+    jsonPath: JsonPath,
+    state: ApiResponseTransactionState,
+    transactionId: TransferId?,
+    errorMessage: String?,
+) {
+    import(
+        ImportBatch(
+            apiSessionMutations =
+                listOf(ApiSessionMutation.InsertResponseTransaction(KEY, responseId, jsonPath, state, transactionId, errorMessage)),
+        ),
+    )
+}
+
+suspend fun ImportEngine.insertApiResponseTransactions(transactions: List<ApiResponseTransactionInsert>) {
+    import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.InsertResponseTransactions(transactions))))
+}
+
+suspend fun ImportEngine.markApiSessionImported(
+    id: ApiSessionId,
+    revisionId: Long,
+    importedAt: Instant,
+    importDurationMillis: Long? = null,
+) {
+    import(
+        ImportBatch(
+            apiSessionMutations = listOf(ApiSessionMutation.MarkSessionImported(id, revisionId, importedAt, importDurationMillis)),
+        ),
+    )
+}
+
+// endregion

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
@@ -189,15 +189,18 @@ suspend fun ImportEngine.createApiCredential(
     strategyId: ApiImportStrategyId? = null,
     privateKey: String? = null,
     publicKey: String? = null,
-): MonzoCredentialId =
-    requireNotNull(
+): MonzoCredentialId {
+    // The read-back key is echoed through ImportResult, so use an opaque label rather than the secret token.
+    val key = "create_api_credential"
+    return requireNotNull(
         import(
             ImportBatch(
                 apiSessionMutations =
-                    listOf(ApiSessionMutation.CreateCredential(token, token, createdAt, type, strategyId, privateKey, publicKey)),
+                    listOf(ApiSessionMutation.CreateCredential(key, token, createdAt, type, strategyId, privateKey, publicKey)),
             ),
-        ).apiCredentialIds[token],
+        ).apiCredentialIds[key],
     )
+}
 
 suspend fun ImportEngine.updateApiCredentialKeys(
     credentialId: MonzoCredentialId,
@@ -213,15 +216,18 @@ suspend fun ImportEngine.createApiSession(
     createdAt: Instant,
     type: ApiSessionType = ApiSessionType.MONZO,
     credentialId: MonzoCredentialId? = null,
-): ApiSessionId =
-    requireNotNull(
+): ApiSessionId {
+    // The read-back key is echoed through ImportResult, so use an opaque label rather than the secret token.
+    val key = "create_api_session"
+    return requireNotNull(
         import(
             ImportBatch(
                 apiSessionMutations =
-                    listOf(ApiSessionMutation.CreateSession(token, token, deviceId, createdAt, type, credentialId)),
+                    listOf(ApiSessionMutation.CreateSession(key, token, deviceId, createdAt, type, credentialId)),
             ),
-        ).apiSessionIds[token],
+        ).apiSessionIds[key],
     )
+}
 
 suspend fun ImportEngine.insertApiRequest(
     sessionId: ApiSessionId,

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
@@ -5,15 +5,12 @@ package com.moneymanager.importengineapi
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.ApiRequestId
 import com.moneymanager.domain.model.ApiResponseId
-import com.moneymanager.domain.model.ApiResponseTransactionState
 import com.moneymanager.domain.model.ApiSessionId
 import com.moneymanager.domain.model.ApiSessionType
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.DeviceId
-import com.moneymanager.domain.model.JsonPath
 import com.moneymanager.domain.model.MonzoCredentialId
 import com.moneymanager.domain.model.Source
-import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
 import com.moneymanager.domain.model.csv.CsvImportId
@@ -25,24 +22,25 @@ import com.moneymanager.domain.model.qif.QifImportRecord
 import com.moneymanager.domain.repository.ApiResponseTransactionInsert
 import kotlin.time.Instant
 
-/**
- * Convenience [ImportEngine] extensions mirroring the config/staging/session/settings/device write
- * repositories, each building a one-item [ImportBatch]. Callers use these instead of injecting the
- * corresponding `*WriteRepository`, keeping the engine the sole writer. A constant key is used for
- * single-item batches that need their generated id read back.
+/*
+ * Convenience ImportEngine extensions mirroring the config/staging/session/settings write repositories,
+ * each building a one-item ImportBatch. Callers use these instead of injecting the corresponding write
+ * repository, keeping the engine the sole writer. Each create reads its generated id back from the
+ * result map under a per-call read-back key derived from the input.
  */
-private const val KEY = "it"
 
 // region CSV strategies
 
 suspend fun ImportEngine.createCsvStrategy(
     strategy: CsvImportStrategy,
     source: Source = Source.Manual,
-): CsvImportStrategyId =
-    requireNotNull(
-        import(ImportBatch(csvStrategyMutations = listOf(CsvStrategyMutation.Create(KEY, strategy, source))))
-            .createdCsvStrategyIds[KEY],
+): CsvImportStrategyId {
+    val key = strategy.name
+    return requireNotNull(
+        import(ImportBatch(csvStrategyMutations = listOf(CsvStrategyMutation.Create(key, strategy, source))))
+            .createdCsvStrategyIds[key],
     )
+}
 
 suspend fun ImportEngine.updateCsvStrategy(
     strategy: CsvImportStrategy,
@@ -62,11 +60,13 @@ suspend fun ImportEngine.deleteCsvStrategy(id: CsvImportStrategyId) {
 suspend fun ImportEngine.createApiStrategy(
     strategy: ApiImportStrategy,
     source: Source = Source.Manual,
-): ApiImportStrategyId =
-    requireNotNull(
-        import(ImportBatch(apiStrategyMutations = listOf(ApiStrategyMutation.Create(KEY, strategy, source))))
-            .createdApiStrategyIds[KEY],
+): ApiImportStrategyId {
+    val key = strategy.name
+    return requireNotNull(
+        import(ImportBatch(apiStrategyMutations = listOf(ApiStrategyMutation.Create(key, strategy, source))))
+            .createdApiStrategyIds[key],
     )
+}
 
 suspend fun ImportEngine.updateApiStrategy(
     strategy: ApiImportStrategy,
@@ -88,14 +88,16 @@ suspend fun ImportEngine.createCsvMapping(
     columnName: String,
     valuePattern: Regex,
     accountId: AccountId,
-): Long =
-    requireNotNull(
+): Long {
+    val key = columnName
+    return requireNotNull(
         import(
             ImportBatch(
-                csvMappingMutations = listOf(CsvMappingMutation.Create(KEY, strategyId, columnName, valuePattern, accountId)),
+                csvMappingMutations = listOf(CsvMappingMutation.Create(key, strategyId, columnName, valuePattern, accountId)),
             ),
-        ).createdCsvMappingIds[KEY],
+        ).createdCsvMappingIds[key],
     )
+}
 
 suspend fun ImportEngine.createCsvMappings(mappings: List<CsvAccountMapping>) {
     import(ImportBatch(csvMappingMutations = listOf(CsvMappingMutation.CreateBatch(mappings))))
@@ -109,10 +111,6 @@ suspend fun ImportEngine.deleteCsvMapping(id: Long) {
     import(ImportBatch(csvMappingMutations = listOf(CsvMappingMutation.Delete(id))))
 }
 
-suspend fun ImportEngine.deleteCsvMappingsForStrategy(strategyId: CsvImportStrategyId) {
-    import(ImportBatch(csvMappingMutations = listOf(CsvMappingMutation.DeleteForStrategy(strategyId))))
-}
-
 // endregion
 
 // region CSV staging
@@ -123,14 +121,16 @@ suspend fun ImportEngine.createCsvImport(
     rows: List<List<String>>,
     fileChecksum: String,
     fileLastModified: Instant,
-): CsvImportId =
-    requireNotNull(
+): CsvImportId {
+    val key = fileName
+    return requireNotNull(
         import(
             ImportBatch(
-                csvImportMutations = listOf(CsvImportMutation.Create(KEY, fileName, headers, rows, fileChecksum, fileLastModified)),
+                csvImportMutations = listOf(CsvImportMutation.Create(key, fileName, headers, rows, fileChecksum, fileLastModified)),
             ),
-        ).createdCsvImportIds[KEY],
+        ).createdCsvImportIds[key],
     )
+}
 
 suspend fun ImportEngine.deleteCsvImport(id: CsvImportId) {
     import(ImportBatch(csvImportMutations = listOf(CsvImportMutation.Delete(id))))
@@ -151,15 +151,17 @@ suspend fun ImportEngine.createQifImport(
     accountType: String,
     fileChecksum: String,
     fileLastModified: Instant,
-): QifImportId =
-    requireNotNull(
+): QifImportId {
+    val key = fileName
+    return requireNotNull(
         import(
             ImportBatch(
                 qifImportMutations =
-                    listOf(QifImportMutation.Create(KEY, fileName, records, accountType, fileChecksum, fileLastModified)),
+                    listOf(QifImportMutation.Create(key, fileName, records, accountType, fileChecksum, fileLastModified)),
             ),
-        ).createdQifImportIds[KEY],
+        ).createdQifImportIds[key],
     )
+}
 
 suspend fun ImportEngine.deleteQifImport(id: QifImportId) {
     import(ImportBatch(qifImportMutations = listOf(QifImportMutation.Delete(id))))
@@ -193,21 +195,16 @@ suspend fun ImportEngine.createApiCredential(
     strategyId: ApiImportStrategyId? = null,
     privateKey: String? = null,
     publicKey: String? = null,
-): MonzoCredentialId =
-    requireNotNull(
+): MonzoCredentialId {
+    val key = token
+    return requireNotNull(
         import(
             ImportBatch(
                 apiSessionMutations =
-                    listOf(ApiSessionMutation.CreateCredential(KEY, token, createdAt, type, strategyId, privateKey, publicKey)),
+                    listOf(ApiSessionMutation.CreateCredential(key, token, createdAt, type, strategyId, privateKey, publicKey)),
             ),
-        ).apiCredentialIds[KEY],
+        ).apiCredentialIds[key],
     )
-
-suspend fun ImportEngine.updateApiCredentialStrategy(
-    credentialId: MonzoCredentialId,
-    strategyId: ApiImportStrategyId?,
-) {
-    import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.UpdateCredentialStrategy(credentialId, strategyId))))
 }
 
 suspend fun ImportEngine.updateApiCredentialKeys(
@@ -222,56 +219,42 @@ suspend fun ImportEngine.createApiSession(
     token: String,
     deviceId: DeviceId,
     createdAt: Instant,
-    expiresAt: Instant?,
     type: ApiSessionType = ApiSessionType.MONZO,
     credentialId: MonzoCredentialId? = null,
-): ApiSessionId =
-    requireNotNull(
+): ApiSessionId {
+    val key = token
+    return requireNotNull(
         import(
             ImportBatch(
                 apiSessionMutations =
-                    listOf(ApiSessionMutation.CreateSession(KEY, token, deviceId, createdAt, expiresAt, type, credentialId)),
+                    listOf(ApiSessionMutation.CreateSession(key, token, deviceId, createdAt, expiresAt = null, type, credentialId)),
             ),
-        ).apiSessionIds[KEY],
+        ).apiSessionIds[key],
     )
+}
 
 suspend fun ImportEngine.insertApiRequest(
     sessionId: ApiSessionId,
     method: String,
     url: String,
     headers: Map<String, String>,
-): ApiRequestId =
-    requireNotNull(
-        import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.InsertRequest(KEY, sessionId, method, url, headers))))
-            .apiRequestIds[KEY],
+): ApiRequestId {
+    val key = url
+    return requireNotNull(
+        import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.InsertRequest(key, sessionId, method, url, headers))))
+            .apiRequestIds[key],
     )
+}
 
 suspend fun ImportEngine.insertApiResponse(
     requestId: ApiRequestId,
     sessionId: ApiSessionId,
     json: String,
-): ApiResponseId =
-    requireNotNull(
-        import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.InsertResponse(KEY, requestId, sessionId, json))))
-            .apiResponseIds[KEY],
-    )
-
-suspend fun ImportEngine.deleteApiSession(id: ApiSessionId) {
-    import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.DeleteSession(id))))
-}
-
-suspend fun ImportEngine.insertApiResponseTransaction(
-    responseId: ApiResponseId,
-    jsonPath: JsonPath,
-    state: ApiResponseTransactionState,
-    transactionId: TransferId?,
-    errorMessage: String?,
-) {
-    import(
-        ImportBatch(
-            apiSessionMutations =
-                listOf(ApiSessionMutation.InsertResponseTransaction(KEY, responseId, jsonPath, state, transactionId, errorMessage)),
-        ),
+): ApiResponseId {
+    val key = requestId.toString()
+    return requireNotNull(
+        import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.InsertResponse(key, requestId, sessionId, json))))
+            .apiResponseIds[key],
     )
 }
 

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
@@ -88,16 +88,14 @@ suspend fun ImportEngine.createCsvMapping(
     columnName: String,
     valuePattern: Regex,
     accountId: AccountId,
-): Long {
-    val key = columnName
-    return requireNotNull(
+): Long =
+    requireNotNull(
         import(
             ImportBatch(
-                csvMappingMutations = listOf(CsvMappingMutation.Create(key, strategyId, columnName, valuePattern, accountId)),
+                csvMappingMutations = listOf(CsvMappingMutation.Create(columnName, strategyId, columnName, valuePattern, accountId)),
             ),
-        ).createdCsvMappingIds[key],
+        ).createdCsvMappingIds[columnName],
     )
-}
 
 suspend fun ImportEngine.createCsvMappings(mappings: List<CsvAccountMapping>) {
     import(ImportBatch(csvMappingMutations = listOf(CsvMappingMutation.CreateBatch(mappings))))
@@ -121,16 +119,14 @@ suspend fun ImportEngine.createCsvImport(
     rows: List<List<String>>,
     fileChecksum: String,
     fileLastModified: Instant,
-): CsvImportId {
-    val key = fileName
-    return requireNotNull(
+): CsvImportId =
+    requireNotNull(
         import(
             ImportBatch(
-                csvImportMutations = listOf(CsvImportMutation.Create(key, fileName, headers, rows, fileChecksum, fileLastModified)),
+                csvImportMutations = listOf(CsvImportMutation.Create(fileName, fileName, headers, rows, fileChecksum, fileLastModified)),
             ),
-        ).createdCsvImportIds[key],
+        ).createdCsvImportIds[fileName],
     )
-}
 
 suspend fun ImportEngine.deleteCsvImport(id: CsvImportId) {
     import(ImportBatch(csvImportMutations = listOf(CsvImportMutation.Delete(id))))
@@ -151,17 +147,15 @@ suspend fun ImportEngine.createQifImport(
     accountType: String,
     fileChecksum: String,
     fileLastModified: Instant,
-): QifImportId {
-    val key = fileName
-    return requireNotNull(
+): QifImportId =
+    requireNotNull(
         import(
             ImportBatch(
                 qifImportMutations =
-                    listOf(QifImportMutation.Create(key, fileName, records, accountType, fileChecksum, fileLastModified)),
+                    listOf(QifImportMutation.Create(fileName, fileName, records, accountType, fileChecksum, fileLastModified)),
             ),
-        ).createdQifImportIds[key],
+        ).createdQifImportIds[fileName],
     )
-}
 
 suspend fun ImportEngine.deleteQifImport(id: QifImportId) {
     import(ImportBatch(qifImportMutations = listOf(QifImportMutation.Delete(id))))
@@ -195,17 +189,15 @@ suspend fun ImportEngine.createApiCredential(
     strategyId: ApiImportStrategyId? = null,
     privateKey: String? = null,
     publicKey: String? = null,
-): MonzoCredentialId {
-    val key = token
-    return requireNotNull(
+): MonzoCredentialId =
+    requireNotNull(
         import(
             ImportBatch(
                 apiSessionMutations =
-                    listOf(ApiSessionMutation.CreateCredential(key, token, createdAt, type, strategyId, privateKey, publicKey)),
+                    listOf(ApiSessionMutation.CreateCredential(token, token, createdAt, type, strategyId, privateKey, publicKey)),
             ),
-        ).apiCredentialIds[key],
+        ).apiCredentialIds[token],
     )
-}
 
 suspend fun ImportEngine.updateApiCredentialKeys(
     credentialId: MonzoCredentialId,
@@ -221,30 +213,26 @@ suspend fun ImportEngine.createApiSession(
     createdAt: Instant,
     type: ApiSessionType = ApiSessionType.MONZO,
     credentialId: MonzoCredentialId? = null,
-): ApiSessionId {
-    val key = token
-    return requireNotNull(
+): ApiSessionId =
+    requireNotNull(
         import(
             ImportBatch(
                 apiSessionMutations =
-                    listOf(ApiSessionMutation.CreateSession(key, token, deviceId, createdAt, expiresAt = null, type, credentialId)),
+                    listOf(ApiSessionMutation.CreateSession(token, token, deviceId, createdAt, type, credentialId)),
             ),
-        ).apiSessionIds[key],
+        ).apiSessionIds[token],
     )
-}
 
 suspend fun ImportEngine.insertApiRequest(
     sessionId: ApiSessionId,
     method: String,
     url: String,
     headers: Map<String, String>,
-): ApiRequestId {
-    val key = url
-    return requireNotNull(
-        import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.InsertRequest(key, sessionId, method, url, headers))))
-            .apiRequestIds[key],
+): ApiRequestId =
+    requireNotNull(
+        import(ImportBatch(apiSessionMutations = listOf(ApiSessionMutation.InsertRequest(url, sessionId, method, url, headers))))
+            .apiRequestIds[url],
     )
-}
 
 suspend fun ImportEngine.insertApiResponse(
     requestId: ApiRequestId,

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportResult.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportResult.kt
@@ -1,9 +1,21 @@
 package com.moneymanager.importengineapi
 
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.ApiRequestId
+import com.moneymanager.domain.model.ApiResponseId
+import com.moneymanager.domain.model.ApiResponseTransactionId
+import com.moneymanager.domain.model.ApiSessionId
+import com.moneymanager.domain.model.AttributeTypeId
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.MonzoCredentialId
 import com.moneymanager.domain.model.PersonId
+import com.moneymanager.domain.model.RelationshipTypeId
 import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
+import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.csv.ImportStatus
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.model.qif.QifImportId
 
 /**
  * Per-row outcome of dedupe + write, for status write-back by the caller.
@@ -44,6 +56,22 @@ data class ImportResult(
     val createdAccountIds: Map<LocalAccountKey, AccountId> = emptyMap(),
     val createdCategoryIds: Map<LocalCategoryKey, Long> = emptyMap(),
     val createdPersonIds: Map<LocalPersonKey, PersonId> = emptyMap(),
+    val createdCurrencyIds: Map<LocalCurrencyKey, CurrencyId> = emptyMap(),
+    /** Resolved (get-or-create) attribute-type ids for each name in [ImportBatch.attributeTypeNames]. */
+    val attributeTypeIds: Map<String, AttributeTypeId> = emptyMap(),
+    /** Resolved (get-or-create) relationship-type ids for each name in [ImportBatch.relationshipTypeNames]. */
+    val relationshipTypeIds: Map<String, RelationshipTypeId> = emptyMap(),
+    // Generated ids for config/staging/session Create mutations, keyed by the mutation's `key`.
+    val createdCsvStrategyIds: Map<String, CsvImportStrategyId> = emptyMap(),
+    val createdApiStrategyIds: Map<String, ApiImportStrategyId> = emptyMap(),
+    val createdCsvMappingIds: Map<String, Long> = emptyMap(),
+    val createdCsvImportIds: Map<String, CsvImportId> = emptyMap(),
+    val createdQifImportIds: Map<String, QifImportId> = emptyMap(),
+    val apiCredentialIds: Map<String, MonzoCredentialId> = emptyMap(),
+    val apiSessionIds: Map<String, ApiSessionId> = emptyMap(),
+    val apiRequestIds: Map<String, ApiRequestId> = emptyMap(),
+    val apiResponseIds: Map<String, ApiResponseId> = emptyMap(),
+    val apiResponseTransactionIds: Map<String, ApiResponseTransactionId> = emptyMap(),
 )
 
 /**

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -1105,7 +1105,7 @@ class ImportEngineImpl(
                     )
                 is ApiSessionMutation.CreateSession ->
                     apiSessionIds[m.key] =
-                        apiSessionRepository.createSession(m.token, m.deviceId, m.createdAt, m.expiresAt, m.type, m.credentialId)
+                        apiSessionRepository.createSession(m.token, m.deviceId, m.createdAt, expiresAt = null, m.type, m.credentialId)
                 is ApiSessionMutation.InsertRequest ->
                     apiRequestIds[m.key] = apiSessionRepository.insertRequest(m.sessionId, m.method, m.url, m.headers)
                 is ApiSessionMutation.InsertResponse ->

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -1001,11 +1001,23 @@ class ImportEngineImpl(
         val apiResponseTransactionIds: Map<String, ApiResponseTransactionId>,
     )
 
+    // Fail fast rather than silently overwrite a generated id when two create mutations share a read-back
+    // key in one batch — a duplicate key would otherwise drop the earlier id from the ImportResult map.
+    private fun <K, V> MutableMap<K, V>.putUnique(
+        key: K,
+        value: V,
+        label: String,
+    ) {
+        require(key !in this) { "Duplicate $label read-back key in ImportBatch: $key" }
+        this[key] = value
+    }
+
     private suspend fun applyConfigMutations(batch: ImportBatch): ConfigOutcome {
         val csvStrategyIds = mutableMapOf<String, CsvImportStrategyId>()
         for (m in batch.csvStrategyMutations) {
             when (m) {
-                is CsvStrategyMutation.Create -> csvStrategyIds[m.key] = csvImportStrategyRepository.createStrategy(m.strategy, m.source)
+                is CsvStrategyMutation.Create ->
+                    csvStrategyIds.putUnique(m.key, csvImportStrategyRepository.createStrategy(m.strategy, m.source), "CsvStrategy")
                 is CsvStrategyMutation.Update -> csvImportStrategyRepository.updateStrategy(m.strategy, m.source)
                 is CsvStrategyMutation.Delete -> csvImportStrategyRepository.deleteStrategy(m.id)
             }
@@ -1014,7 +1026,8 @@ class ImportEngineImpl(
         val apiStrategyIds = mutableMapOf<String, ApiImportStrategyId>()
         for (m in batch.apiStrategyMutations) {
             when (m) {
-                is ApiStrategyMutation.Create -> apiStrategyIds[m.key] = apiImportStrategyRepository.createStrategy(m.strategy, m.source)
+                is ApiStrategyMutation.Create ->
+                    apiStrategyIds.putUnique(m.key, apiImportStrategyRepository.createStrategy(m.strategy, m.source), "ApiStrategy")
                 is ApiStrategyMutation.Update -> apiImportStrategyRepository.updateStrategy(m.strategy, m.source)
                 is ApiStrategyMutation.Delete -> apiImportStrategyRepository.deleteStrategy(m.id)
             }
@@ -1024,8 +1037,11 @@ class ImportEngineImpl(
         for (m in batch.csvMappingMutations) {
             when (m) {
                 is CsvMappingMutation.Create ->
-                    csvMappingIds[m.key] =
-                        csvAccountMappingRepository.createMapping(m.strategyId, m.columnName, m.valuePattern, m.accountId)
+                    csvMappingIds.putUnique(
+                        m.key,
+                        csvAccountMappingRepository.createMapping(m.strategyId, m.columnName, m.valuePattern, m.accountId),
+                        "CsvMapping",
+                    )
                 is CsvMappingMutation.CreateBatch -> csvAccountMappingRepository.createMappings(m.mappings)
                 is CsvMappingMutation.Update -> csvAccountMappingRepository.updateMapping(m.mapping)
                 is CsvMappingMutation.Delete -> csvAccountMappingRepository.deleteMapping(m.id)
@@ -1037,8 +1053,11 @@ class ImportEngineImpl(
         for (m in batch.csvImportMutations) {
             when (m) {
                 is CsvImportMutation.Create ->
-                    csvImportIds[m.key] =
-                        csvImportRepository.createImport(m.fileName, m.headers, m.rows, m.fileChecksum, m.fileLastModified)
+                    csvImportIds.putUnique(
+                        m.key,
+                        csvImportRepository.createImport(m.fileName, m.headers, m.rows, m.fileChecksum, m.fileLastModified),
+                        "CsvImport",
+                    )
                 is CsvImportMutation.Delete -> csvImportRepository.deleteImport(m.id)
                 is CsvImportMutation.UpdateRowTransferId -> csvImportRepository.updateRowTransferId(m.id, m.rowIndex, m.transferId)
                 is CsvImportMutation.UpdateRowTransferIds -> csvImportRepository.updateRowTransferIdsBatch(m.id, m.rowTransferMap)
@@ -1061,8 +1080,11 @@ class ImportEngineImpl(
         for (m in batch.qifImportMutations) {
             when (m) {
                 is QifImportMutation.Create ->
-                    qifImportIds[m.key] =
-                        qifImportRepository.createImport(m.fileName, m.records, m.accountType, m.fileChecksum, m.fileLastModified)
+                    qifImportIds.putUnique(
+                        m.key,
+                        qifImportRepository.createImport(m.fileName, m.records, m.accountType, m.fileChecksum, m.fileLastModified),
+                        "QifImport",
+                    )
                 is QifImportMutation.Delete -> qifImportRepository.deleteImport(m.id)
                 is QifImportMutation.UpdateRecordStatuses ->
                     qifImportRepository.updateRecordStatusesBatch(
@@ -1090,8 +1112,11 @@ class ImportEngineImpl(
         for (m in batch.apiSessionMutations) {
             when (m) {
                 is ApiSessionMutation.CreateCredential ->
-                    apiCredentialIds[m.key] =
-                        apiSessionRepository.createCredential(m.token, m.createdAt, m.type, m.strategyId, m.privateKey, m.publicKey)
+                    apiCredentialIds.putUnique(
+                        m.key,
+                        apiSessionRepository.createCredential(m.token, m.createdAt, m.type, m.strategyId, m.privateKey, m.publicKey),
+                        "ApiCredential",
+                    )
                 is ApiSessionMutation.UpdateCredentialStrategy ->
                     apiSessionRepository.updateCredentialStrategy(
                         m.credentialId,
@@ -1104,16 +1129,30 @@ class ImportEngineImpl(
                         m.publicKey,
                     )
                 is ApiSessionMutation.CreateSession ->
-                    apiSessionIds[m.key] =
-                        apiSessionRepository.createSession(m.token, m.deviceId, m.createdAt, expiresAt = null, m.type, m.credentialId)
+                    apiSessionIds.putUnique(
+                        m.key,
+                        apiSessionRepository.createSession(m.token, m.deviceId, m.createdAt, expiresAt = null, m.type, m.credentialId),
+                        "ApiSession",
+                    )
                 is ApiSessionMutation.InsertRequest ->
-                    apiRequestIds[m.key] = apiSessionRepository.insertRequest(m.sessionId, m.method, m.url, m.headers)
+                    apiRequestIds.putUnique(
+                        m.key,
+                        apiSessionRepository.insertRequest(m.sessionId, m.method, m.url, m.headers),
+                        "ApiRequest",
+                    )
                 is ApiSessionMutation.InsertResponse ->
-                    apiResponseIds[m.key] = apiSessionRepository.insertResponse(m.requestId, m.sessionId, m.json)
+                    apiResponseIds.putUnique(
+                        m.key,
+                        apiSessionRepository.insertResponse(m.requestId, m.sessionId, m.json),
+                        "ApiResponse",
+                    )
                 is ApiSessionMutation.DeleteSession -> apiSessionRepository.deleteSession(m.id)
                 is ApiSessionMutation.InsertResponseTransaction ->
-                    apiResponseTransactionIds[m.key] =
-                        apiSessionRepository.insertResponseTransaction(m.responseId, m.jsonPath, m.state, m.transactionId, m.errorMessage)
+                    apiResponseTransactionIds.putUnique(
+                        m.key,
+                        apiSessionRepository.insertResponseTransaction(m.responseId, m.jsonPath, m.state, m.transactionId, m.errorMessage),
+                        "ApiResponseTransaction",
+                    )
                 is ApiSessionMutation.InsertResponseTransactions -> apiSessionRepository.insertResponseTransactions(m.transactions)
                 is ApiSessionMutation.MarkSessionImported ->
                     apiSessionRepository.markSessionImported(m.id, m.revisionId, m.importedAt, m.importDurationMillis)

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -4,8 +4,14 @@ package com.moneymanager.importer
 
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.ApiRequestId
+import com.moneymanager.domain.model.ApiResponseId
+import com.moneymanager.domain.model.ApiResponseTransactionId
+import com.moneymanager.domain.model.ApiSessionId
 import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.Category
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.MonzoCredentialId
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.NewRelationship
 import com.moneymanager.domain.model.Person
@@ -14,17 +20,36 @@ import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.WellKnownIds
+import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
+import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.csv.ImportStatus
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.model.qif.QifImportId
 import com.moneymanager.domain.repository.AccountAttributeWriteRepository
 import com.moneymanager.domain.repository.AccountWriteRepository
+import com.moneymanager.domain.repository.ApiImportStrategyWriteRepository
+import com.moneymanager.domain.repository.ApiSessionWriteRepository
+import com.moneymanager.domain.repository.AttributeTypeWriteRepository
 import com.moneymanager.domain.repository.CategoryWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
+import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
+import com.moneymanager.domain.repository.CsvImportWriteRepository
+import com.moneymanager.domain.repository.CurrencyWriteRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipWriteRepository
 import com.moneymanager.domain.repository.PersonAttributeWriteRepository
 import com.moneymanager.domain.repository.PersonWriteRepository
+import com.moneymanager.domain.repository.QifImportWriteRepository
+import com.moneymanager.domain.repository.RelationshipTypeWriteRepository
+import com.moneymanager.domain.repository.SettingsWriteRepository
 import com.moneymanager.domain.repository.TransactionWriteRepository
 import com.moneymanager.domain.repository.TransferUpdate
 import com.moneymanager.importengineapi.AccountMatchKey
 import com.moneymanager.importengineapi.AccountRef
+import com.moneymanager.importengineapi.ApiSessionMutation
+import com.moneymanager.importengineapi.ApiStrategyMutation
+import com.moneymanager.importengineapi.CsvImportMutation
+import com.moneymanager.importengineapi.CsvMappingMutation
+import com.moneymanager.importengineapi.CsvStrategyMutation
 import com.moneymanager.importengineapi.DedupePolicy
 import com.moneymanager.importengineapi.EditGate
 import com.moneymanager.importengineapi.ImportAccountIntent
@@ -38,8 +63,10 @@ import com.moneymanager.importengineapi.ImportRowKey
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.importengineapi.LocalCategoryKey
+import com.moneymanager.importengineapi.LocalCurrencyKey
 import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.importengineapi.PersonMatchKey
+import com.moneymanager.importengineapi.QifImportMutation
 import com.moneymanager.importengineapi.RowOutcome
 import com.moneymanager.importengineapi.WriteIntent
 import com.moneymanager.importengineapi.bankKeyFromExternalId
@@ -65,6 +92,16 @@ class ImportEngineImpl(
     private val personAttributeRepository: PersonAttributeWriteRepository,
     private val ownershipRepository: PersonAccountOwnershipWriteRepository,
     private val categoryRepository: CategoryWriteRepository,
+    private val currencyRepository: CurrencyWriteRepository,
+    private val attributeTypeRepository: AttributeTypeWriteRepository,
+    private val relationshipTypeRepository: RelationshipTypeWriteRepository,
+    private val csvImportStrategyRepository: CsvImportStrategyWriteRepository,
+    private val apiImportStrategyRepository: ApiImportStrategyWriteRepository,
+    private val csvAccountMappingRepository: CsvAccountMappingWriteRepository,
+    private val csvImportRepository: CsvImportWriteRepository,
+    private val qifImportRepository: QifImportWriteRepository,
+    private val apiSessionRepository: ApiSessionWriteRepository,
+    private val settingsRepository: SettingsWriteRepository,
     private val editGate: EditGate = EditGate.AlwaysWritable,
 ) : ImportEngine {
     override suspend fun import(
@@ -75,7 +112,23 @@ class ImportEngineImpl(
         editGate.ensureWritable()
         validate(batch)
 
+        // ----- Lookup-table resolution (first: ids feed attributes/relationships built by callers) -----
+        val attributeTypeIds = batch.attributeTypeNames.associateWith { attributeTypeRepository.getOrCreate(it) }
+        val relationshipTypeIds = batch.relationshipTypeNames.associateWith { relationshipTypeRepository.getOrCreate(it) }
+
+        // ----- Config / staging / session / settings / device mutations -----
+        val config = applyConfigMutations(batch)
+
         // ----- CREATE phase (first, so batch-local keys resolve for dependents) -----
+        val createdCurrencyIds = mutableMapOf<LocalCurrencyKey, CurrencyId>()
+        for (intent in batch.currencies.creates()) {
+            createdCurrencyIds[intent.key] =
+                currencyRepository.upsertCurrencyByCode(
+                    requireNotNull(intent.code),
+                    requireNotNull(intent.name),
+                    intent.source,
+                )
+        }
         val createdCategoryIds = mutableMapOf<LocalCategoryKey, Long>()
         for (intent in batch.categories.creates()) {
             createdCategoryIds[intent.key] =
@@ -125,6 +178,9 @@ class ImportEngineImpl(
         for (intent in batch.categories.updates()) {
             categoryRepository.updateCategory(requireNotNull(intent.category), intent.source)
         }
+        for (intent in batch.currencies.updates()) {
+            currencyRepository.updateCurrency(requireNotNull(intent.currency), intent.source)
+        }
         for (intent in batch.peopleToCreate.updates()) {
             personRepository.updatePersonWithAttributes(
                 person = intent.person,
@@ -145,6 +201,7 @@ class ImportEngineImpl(
         batch.transfers.deletes().forEach { transactionRepository.deleteTransaction(requireNotNull(it.existingId).id) }
         batch.accountsToCreate.deletes().forEach { accountRepository.deleteAccount(requireNotNull(it.existingId)) }
         batch.categories.deletes().forEach { categoryRepository.deleteCategory(requireNotNull(it.existingId)) }
+        batch.currencies.deletes().forEach { currencyRepository.deleteCurrency(requireNotNull(it.existingId)) }
         batch.peopleToCreate.deletes().forEach { personRepository.deletePerson(requireNotNull(it.existingId)) }
 
         return ImportResult(
@@ -161,6 +218,19 @@ class ImportEngineImpl(
             createdAccountIds = accountResolution.keyToId,
             createdCategoryIds = createdCategoryIds,
             createdPersonIds = personResolution.keyToId,
+            createdCurrencyIds = createdCurrencyIds,
+            attributeTypeIds = attributeTypeIds,
+            relationshipTypeIds = relationshipTypeIds,
+            createdCsvStrategyIds = config.csvStrategyIds,
+            createdApiStrategyIds = config.apiStrategyIds,
+            createdCsvMappingIds = config.csvMappingIds,
+            createdCsvImportIds = config.csvImportIds,
+            createdQifImportIds = config.qifImportIds,
+            apiCredentialIds = config.apiCredentialIds,
+            apiSessionIds = config.apiSessionIds,
+            apiRequestIds = config.apiRequestIds,
+            apiResponseIds = config.apiResponseIds,
+            apiResponseTransactionIds = config.apiResponseTransactionIds,
         )
     }
 
@@ -198,6 +268,14 @@ class ImportEngineImpl(
                 ImportOperation.UPDATE ->
                     require(it.existingId != null && it.category != null) { "UPDATE category requires existingId and category" }
                 ImportOperation.DELETE -> require(it.existingId != null) { "DELETE category requires existingId" }
+            }
+        }
+        batch.currencies.forEach {
+            when (it.operation) {
+                ImportOperation.CREATE -> require(it.code != null && it.name != null) { "CREATE currency requires code/name" }
+                ImportOperation.UPDATE ->
+                    require(it.currency != null) { "UPDATE currency requires currency" }
+                ImportOperation.DELETE -> require(it.existingId != null) { "DELETE currency requires existingId" }
             }
         }
         batch.peopleToCreate.forEach {
@@ -907,4 +985,159 @@ class ImportEngineImpl(
             if (!middleName.isNullOrBlank()) append(" ").append(middleName)
             if (!lastName.isNullOrBlank()) append(" ").append(lastName)
         }
+
+    // region Config / staging / session / settings / device mutations
+
+    private class ConfigOutcome(
+        val csvStrategyIds: Map<String, CsvImportStrategyId>,
+        val apiStrategyIds: Map<String, ApiImportStrategyId>,
+        val csvMappingIds: Map<String, Long>,
+        val csvImportIds: Map<String, CsvImportId>,
+        val qifImportIds: Map<String, QifImportId>,
+        val apiCredentialIds: Map<String, MonzoCredentialId>,
+        val apiSessionIds: Map<String, ApiSessionId>,
+        val apiRequestIds: Map<String, ApiRequestId>,
+        val apiResponseIds: Map<String, ApiResponseId>,
+        val apiResponseTransactionIds: Map<String, ApiResponseTransactionId>,
+    )
+
+    private suspend fun applyConfigMutations(batch: ImportBatch): ConfigOutcome {
+        val csvStrategyIds = mutableMapOf<String, CsvImportStrategyId>()
+        for (m in batch.csvStrategyMutations) {
+            when (m) {
+                is CsvStrategyMutation.Create -> csvStrategyIds[m.key] = csvImportStrategyRepository.createStrategy(m.strategy, m.source)
+                is CsvStrategyMutation.Update -> csvImportStrategyRepository.updateStrategy(m.strategy, m.source)
+                is CsvStrategyMutation.Delete -> csvImportStrategyRepository.deleteStrategy(m.id)
+            }
+        }
+
+        val apiStrategyIds = mutableMapOf<String, ApiImportStrategyId>()
+        for (m in batch.apiStrategyMutations) {
+            when (m) {
+                is ApiStrategyMutation.Create -> apiStrategyIds[m.key] = apiImportStrategyRepository.createStrategy(m.strategy, m.source)
+                is ApiStrategyMutation.Update -> apiImportStrategyRepository.updateStrategy(m.strategy, m.source)
+                is ApiStrategyMutation.Delete -> apiImportStrategyRepository.deleteStrategy(m.id)
+            }
+        }
+
+        val csvMappingIds = mutableMapOf<String, Long>()
+        for (m in batch.csvMappingMutations) {
+            when (m) {
+                is CsvMappingMutation.Create ->
+                    csvMappingIds[m.key] =
+                        csvAccountMappingRepository.createMapping(m.strategyId, m.columnName, m.valuePattern, m.accountId)
+                is CsvMappingMutation.CreateBatch -> csvAccountMappingRepository.createMappings(m.mappings)
+                is CsvMappingMutation.Update -> csvAccountMappingRepository.updateMapping(m.mapping)
+                is CsvMappingMutation.Delete -> csvAccountMappingRepository.deleteMapping(m.id)
+                is CsvMappingMutation.DeleteForStrategy -> csvAccountMappingRepository.deleteMappingsForStrategy(m.strategyId)
+            }
+        }
+
+        val csvImportIds = mutableMapOf<String, CsvImportId>()
+        for (m in batch.csvImportMutations) {
+            when (m) {
+                is CsvImportMutation.Create ->
+                    csvImportIds[m.key] =
+                        csvImportRepository.createImport(m.fileName, m.headers, m.rows, m.fileChecksum, m.fileLastModified)
+                is CsvImportMutation.Delete -> csvImportRepository.deleteImport(m.id)
+                is CsvImportMutation.UpdateRowTransferId -> csvImportRepository.updateRowTransferId(m.id, m.rowIndex, m.transferId)
+                is CsvImportMutation.UpdateRowTransferIds -> csvImportRepository.updateRowTransferIdsBatch(m.id, m.rowTransferMap)
+                is CsvImportMutation.UpdateRowStatus -> csvImportRepository.updateRowStatus(m.id, m.rowIndex, m.status, m.transferId)
+                is CsvImportMutation.UpdateRowStatuses -> csvImportRepository.updateRowStatusesBatch(m.id, m.status, m.rowTransferMap)
+                is CsvImportMutation.SaveError -> csvImportRepository.saveError(m.id, m.rowIndex, m.errorMessage)
+                is CsvImportMutation.ClearError -> csvImportRepository.clearError(m.id, m.rowIndex)
+                is CsvImportMutation.ClearErrors -> csvImportRepository.clearErrors(m.id, m.rowIndexes)
+                is CsvImportMutation.RecordApplication ->
+                    csvImportRepository.recordImportApplication(
+                        m.id,
+                        m.strategyId,
+                        m.strategyName,
+                        m.appliedAt,
+                    )
+            }
+        }
+
+        val qifImportIds = mutableMapOf<String, QifImportId>()
+        for (m in batch.qifImportMutations) {
+            when (m) {
+                is QifImportMutation.Create ->
+                    qifImportIds[m.key] =
+                        qifImportRepository.createImport(m.fileName, m.records, m.accountType, m.fileChecksum, m.fileLastModified)
+                is QifImportMutation.Delete -> qifImportRepository.deleteImport(m.id)
+                is QifImportMutation.UpdateRecordStatuses ->
+                    qifImportRepository.updateRecordStatusesBatch(
+                        m.id,
+                        m.status,
+                        m.recordTransferMap,
+                    )
+                is QifImportMutation.SaveError -> qifImportRepository.saveError(m.id, m.recordIndex, m.errorMessage)
+                is QifImportMutation.ClearErrors -> qifImportRepository.clearErrors(m.id, m.recordIndexes)
+                is QifImportMutation.RecordApplication ->
+                    qifImportRepository.recordImportApplication(
+                        m.id,
+                        m.strategyId,
+                        m.strategyName,
+                        m.appliedAt,
+                    )
+            }
+        }
+
+        val apiCredentialIds = mutableMapOf<String, MonzoCredentialId>()
+        val apiSessionIds = mutableMapOf<String, ApiSessionId>()
+        val apiRequestIds = mutableMapOf<String, ApiRequestId>()
+        val apiResponseIds = mutableMapOf<String, ApiResponseId>()
+        val apiResponseTransactionIds = mutableMapOf<String, ApiResponseTransactionId>()
+        for (m in batch.apiSessionMutations) {
+            when (m) {
+                is ApiSessionMutation.CreateCredential ->
+                    apiCredentialIds[m.key] =
+                        apiSessionRepository.createCredential(m.token, m.createdAt, m.type, m.strategyId, m.privateKey, m.publicKey)
+                is ApiSessionMutation.UpdateCredentialStrategy ->
+                    apiSessionRepository.updateCredentialStrategy(
+                        m.credentialId,
+                        m.strategyId,
+                    )
+                is ApiSessionMutation.UpdateCredentialKeys ->
+                    apiSessionRepository.updateCredentialKeys(
+                        m.credentialId,
+                        m.privateKey,
+                        m.publicKey,
+                    )
+                is ApiSessionMutation.CreateSession ->
+                    apiSessionIds[m.key] =
+                        apiSessionRepository.createSession(m.token, m.deviceId, m.createdAt, m.expiresAt, m.type, m.credentialId)
+                is ApiSessionMutation.InsertRequest ->
+                    apiRequestIds[m.key] = apiSessionRepository.insertRequest(m.sessionId, m.method, m.url, m.headers)
+                is ApiSessionMutation.InsertResponse ->
+                    apiResponseIds[m.key] = apiSessionRepository.insertResponse(m.requestId, m.sessionId, m.json)
+                is ApiSessionMutation.DeleteSession -> apiSessionRepository.deleteSession(m.id)
+                is ApiSessionMutation.InsertResponseTransaction ->
+                    apiResponseTransactionIds[m.key] =
+                        apiSessionRepository.insertResponseTransaction(m.responseId, m.jsonPath, m.state, m.transactionId, m.errorMessage)
+                is ApiSessionMutation.InsertResponseTransactions -> apiSessionRepository.insertResponseTransactions(m.transactions)
+                is ApiSessionMutation.MarkSessionImported ->
+                    apiSessionRepository.markSessionImported(m.id, m.revisionId, m.importedAt, m.importDurationMillis)
+            }
+        }
+
+        batch.settings?.let { s ->
+            s.defaultCurrencyId?.let { settingsRepository.setDefaultCurrencyId(it) }
+            s.lastQifAccountId?.let { settingsRepository.setLastQifAccountId(it) }
+        }
+
+        return ConfigOutcome(
+            csvStrategyIds = csvStrategyIds,
+            apiStrategyIds = apiStrategyIds,
+            csvMappingIds = csvMappingIds,
+            csvImportIds = csvImportIds,
+            qifImportIds = qifImportIds,
+            apiCredentialIds = apiCredentialIds,
+            apiSessionIds = apiSessionIds,
+            apiRequestIds = apiRequestIds,
+            apiResponseIds = apiResponseIds,
+            apiResponseTransactionIds = apiResponseTransactionIds,
+        )
+    }
+
+    // endregion
 }

--- a/app/main/android/src/main/kotlin/com/moneymanager/android/MainActivity.kt
+++ b/app/main/android/src/main/kotlin/com/moneymanager/android/MainActivity.kt
@@ -11,6 +11,7 @@ import com.moneymanager.database.MoneyManagerDatabaseWrapper
 import com.moneymanager.di.AppComponent
 import com.moneymanager.di.AppComponentParams
 import com.moneymanager.di.database.DatabaseComponent
+import com.moneymanager.di.database.createImportEngine
 import com.moneymanager.di.database.toApplication
 import com.moneymanager.di.initializeVersionReader
 import com.moneymanager.importengineapi.EditingLockedException
@@ -111,11 +112,14 @@ class MainActivity : ComponentActivity() {
                 appVersion = component.appVersion,
                 localSettings = component.localSettings,
                 createAppServices = { database ->
-                    DatabaseComponent.create(database).toApplication().toAppServices(
-                        editGate = {
-                            if (controller.syncState.value.editingLocked) throw EditingLockedException()
-                        },
-                    )
+                    val component = DatabaseComponent.create(database)
+                    val importEngine =
+                        component.createImportEngine(
+                            editGate = {
+                                if (controller.syncState.value.editingLocked) throw EditingLockedException()
+                            },
+                        )
+                    component.toApplication().toAppServices(importEngine)
                 },
                 onInfoLog = { message -> Log.i(TAG, message) },
                 onErrorLog = { message, error -> Log.e(TAG, message, error) },

--- a/app/main/jvm/src/main/kotlin/com/moneymanager/Main.kt
+++ b/app/main/jvm/src/main/kotlin/com/moneymanager/Main.kt
@@ -15,6 +15,7 @@ import com.moneymanager.database.MoneyManagerDatabaseWrapper
 import com.moneymanager.di.AppComponent
 import com.moneymanager.di.AppComponentParams
 import com.moneymanager.di.database.DatabaseComponent
+import com.moneymanager.di.database.createImportEngine
 import com.moneymanager.di.database.toApplication
 import com.moneymanager.importengineapi.EditingLockedException
 import com.moneymanager.remotestorage.sync.SyncResult
@@ -144,11 +145,14 @@ private fun MainWindow(onExit: () -> Unit) {
                 appVersion = appVersion,
                 localSettings = localSettings,
                 createAppServices = { database ->
-                    DatabaseComponent.create(database).toApplication().toAppServices(
-                        editGate = {
-                            if (remoteController.syncState.value.editingLocked) throw EditingLockedException()
-                        },
-                    )
+                    val component = DatabaseComponent.create(database)
+                    val importEngine =
+                        component.createImportEngine(
+                            editGate = {
+                                if (remoteController.syncState.value.editingLocked) throw EditingLockedException()
+                            },
+                        )
+                    component.toApplication().toAppServices(importEngine)
                 },
                 onInfoLog = { message -> logger.info { message } },
                 onErrorLog = { message, error -> logger.error(error) { message } },

--- a/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifImportApplier.kt
+++ b/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifImportApplier.kt
@@ -25,10 +25,9 @@ import com.moneymanager.domain.model.csvstrategy.FieldMappingId
 import com.moneymanager.domain.model.csvstrategy.HardCodedCurrencyMapping
 import com.moneymanager.domain.model.csvstrategy.TransferField
 import com.moneymanager.domain.model.qif.QifImport
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.QifImportWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.QifImportReadRepository
 import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.DedupePolicy
 import com.moneymanager.importengineapi.ImportBatch
@@ -39,6 +38,11 @@ import com.moneymanager.importengineapi.ImportRowKey
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.importengineapi.PersonMatchKey
+import com.moneymanager.importengineapi.QifImportMutation
+import com.moneymanager.importengineapi.applyQifImportMutations
+import com.moneymanager.importengineapi.createAccounts
+import com.moneymanager.importengineapi.createCsvMappings
+import com.moneymanager.importengineapi.getOrCreateAttributeTypes
 import com.moneymanager.importengineapi.normalizeNameKey
 import kotlinx.coroutines.flow.first
 import org.lighthousegames.logging.logging
@@ -122,10 +126,9 @@ suspend fun bulkApplyQif(
     sourceAccountId: AccountId,
     strategies: List<CsvImportStrategy>,
     currencies: List<Currency>,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
-    qifImportRepository: QifImportWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
+    qifImportRepository: QifImportReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     onProgress: (done: Int, total: Int) -> Unit,
@@ -171,8 +174,6 @@ suspend fun bulkApplyQif(
                     currencies = currencies,
                     csvAccountMappingRepository = csvAccountMappingRepository,
                     accountRepository = accountRepository,
-                    qifImportRepository = qifImportRepository,
-                    attributeTypeRepository = attributeTypeRepository,
                     maintenance = maintenance,
                     importEngine = importEngine,
                     refreshViews = false,
@@ -238,12 +239,14 @@ fun buildMapper(
 
 /** Records that this strategy was applied to the import (so the import shows as imported). */
 suspend fun recordApplication(
-    qifImportRepository: QifImportWriteRepository,
+    importEngine: ImportEngine,
     qifImport: QifImport,
     strategy: CsvImportStrategy,
 ) {
     runCatching {
-        qifImportRepository.recordImportApplication(qifImport.id, strategy.id, strategy.name, Clock.System.now())
+        importEngine.applyQifImportMutations(
+            listOf(QifImportMutation.RecordApplication(qifImport.id, strategy.id, strategy.name, Clock.System.now())),
+        )
     }.onFailure { logger.warn { "Could not record QIF import application: ${it.message}" } }
 }
 
@@ -257,10 +260,8 @@ suspend fun runImport(
     selectedNewAccountNames: Map<String, String>,
     selectedSourceAccountId: AccountId?,
     currencies: List<Currency>,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
-    qifImportRepository: QifImportWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     refreshViews: Boolean = true,
@@ -268,7 +269,7 @@ suspend fun runImport(
     // Persist any "map to existing account" selections so future imports reuse them.
     val selectedMappingsToPersist = buildPendingAccountMappings(basePrep, strategy.id, selectedExistingAccounts)
     if (selectedMappingsToPersist.isNotEmpty()) {
-        runCatching { csvAccountMappingRepository.createMappings(selectedMappingsToPersist) }
+        runCatching { importEngine.createCsvMappings(selectedMappingsToPersist) }
             .onFailure { logger.warn(it) { "Failed to persist account mappings" } }
     }
 
@@ -285,7 +286,7 @@ suspend fun runImport(
         // record that referenced each account.
         val firstRecordByAccountName = buildFirstRowByAccountName(basePrep, selectedNewAccountNames)
         runCatching {
-            accountRepository.createAccountsBatch(newAccounts) { account ->
+            importEngine.createAccounts(newAccounts) { account ->
                 Source.Qif(qifImport.id, firstRecordByAccountName[account.name])
             }
         }.onFailure { logger.warn(it) { "Failed to bulk-create accounts" } }
@@ -299,10 +300,14 @@ suspend fun runImport(
     val finalPrep = mapper.prepareImport(rows)
 
     // Surface mapping errors on their records.
-    finalPrep.errorRows.forEach { errorRow ->
-        qifImportRepository.updateRecordStatusesBatch(qifImport.id, ImportStatus.ERROR.name, mapOf(errorRow.rowIndex to null))
-        qifImportRepository.saveError(qifImport.id, errorRow.rowIndex, errorRow.errorMessage)
-    }
+    importEngine.applyQifImportMutations(
+        finalPrep.errorRows.flatMap { errorRow ->
+            listOf(
+                QifImportMutation.UpdateRecordStatuses(qifImport.id, ImportStatus.ERROR.name, mapOf(errorRow.rowIndex to null)),
+                QifImportMutation.SaveError(qifImport.id, errorRow.rowIndex, errorRow.errorMessage),
+            )
+        },
+    )
 
     if (finalPrep.validTransfers.isEmpty()) {
         return QifImportResult(successCount = 0, failedCount = finalPrep.errorRows.size)
@@ -310,11 +315,13 @@ suspend fun runImport(
 
     // Pre-resolve attribute types.
     val attributeTypeIdByName =
-        finalPrep.validTransfers
-            .flatMap { it.attributes }
-            .map { it.first }
-            .toSet()
-            .associateWith { attributeTypeRepository.getOrCreate(it) }
+        importEngine.getOrCreateAttributeTypes(
+            finalPrep.validTransfers
+                .flatMap { it.attributes }
+                .map { it.first }
+                .toSet()
+                .toList(),
+        )
 
     fun attributesFor(attributes: List<Pair<String, String>>): List<NewAttribute> =
         attributes.mapNotNull { (typeName, value) ->
@@ -410,20 +417,22 @@ suspend fun runImport(
                 else -> duplicateRecords[recordIndex] = outcomes.firstOrNull()?.transferId
             }
         }
+    val statusMutations = mutableListOf<QifImportMutation>()
     if (importedRecords.isNotEmpty()) {
-        qifImportRepository.updateRecordStatusesBatch(qifImport.id, ImportStatus.IMPORTED.name, importedRecords)
-        qifImportRepository.clearErrors(qifImport.id, importedRecords.keys.toList())
+        statusMutations += QifImportMutation.UpdateRecordStatuses(qifImport.id, ImportStatus.IMPORTED.name, importedRecords)
+        statusMutations += QifImportMutation.ClearErrors(qifImport.id, importedRecords.keys.toList())
     }
     if (updatedRecords.isNotEmpty()) {
-        qifImportRepository.updateRecordStatusesBatch(qifImport.id, ImportStatus.UPDATED.name, updatedRecords)
-        qifImportRepository.clearErrors(qifImport.id, updatedRecords.keys.toList())
+        statusMutations += QifImportMutation.UpdateRecordStatuses(qifImport.id, ImportStatus.UPDATED.name, updatedRecords)
+        statusMutations += QifImportMutation.ClearErrors(qifImport.id, updatedRecords.keys.toList())
     }
     if (duplicateRecords.isNotEmpty()) {
-        qifImportRepository.updateRecordStatusesBatch(qifImport.id, ImportStatus.DUPLICATE.name, duplicateRecords)
+        statusMutations += QifImportMutation.UpdateRecordStatuses(qifImport.id, ImportStatus.DUPLICATE.name, duplicateRecords)
     }
+    importEngine.applyQifImportMutations(statusMutations)
 
     if (importedRecords.isNotEmpty() || updatedRecords.isNotEmpty() || duplicateRecords.isNotEmpty()) {
-        recordApplication(qifImportRepository, qifImport, strategy)
+        recordApplication(importEngine, qifImport, strategy)
     }
 
     if (refreshViews) {

--- a/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifImportApplier.kt
+++ b/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifImportApplier.kt
@@ -428,6 +428,8 @@ suspend fun runImport(
     }
     if (duplicateRecords.isNotEmpty()) {
         statusMutations += QifImportMutation.UpdateRecordStatuses(qifImport.id, ImportStatus.DUPLICATE.name, duplicateRecords)
+        // A record retried from ERROR can resolve as DUPLICATE; clear its stale error like imported/updated do.
+        statusMutations += QifImportMutation.ClearErrors(qifImport.id, duplicateRecords.keys.toList())
     }
     importEngine.applyQifImportMutations(statusMutations)
 

--- a/app/ui/core/build.gradle.kts
+++ b/app/ui/core/build.gradle.kts
@@ -15,7 +15,6 @@ kotlin {
                 api(projects.app.csvimporter)
                 api(projects.app.db.core)
                 api(projects.app.importengineapi)
-                api(projects.app.importer)
                 api(projects.app.model.core)
                 api(projects.app.qifimporter)
                 api(projects.app.remotestorage.core)
@@ -105,7 +104,6 @@ kotlin {
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.http)
                 implementation(projects.app.apiimporter)
-                implementation(projects.app.importer)
                 implementation(projects.utils.rest)
 
                 runtimeOnly(libs.kotlinx.coroutines.swing)
@@ -120,6 +118,7 @@ kotlin {
                 implementation(libs.compose.ui.test.desktop)
                 implementation(libs.mokkery.core)
                 implementation(projects.app.di.core)
+                implementation(projects.app.importer)
             }
         }
         getByName("androidDeviceTest") {
@@ -133,6 +132,7 @@ kotlin {
                 implementation(libs.ktor.client.mock)
                 implementation(libs.mokkery.core)
                 implementation(projects.app.di.core)
+                implementation(projects.app.importer)
                 implementation(projects.test.app.db)
             }
             kotlin.srcDir("src/commonTest/kotlin")
@@ -146,6 +146,7 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.mokkery.core)
                 implementation(projects.app.di.core)
+                implementation(projects.app.importer)
                 implementation(projects.test.app.db)
             }
         }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppServices.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppServices.kt
@@ -6,28 +6,32 @@ import com.moneymanager.domain.CsvStrategyImportExport
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.DeviceId
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.ApiImportStrategyWriteRepository
-import com.moneymanager.domain.repository.ApiSessionWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.ApiImportStrategyReadRepository
+import com.moneymanager.domain.repository.ApiSessionReadRepository
+import com.moneymanager.domain.repository.AttributeTypeReadRepository
 import com.moneymanager.domain.repository.AuditReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CsvImportWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.DeviceReadRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipReadRepository
 import com.moneymanager.domain.repository.PersonAttributeReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
-import com.moneymanager.domain.repository.QifImportWriteRepository
-import com.moneymanager.domain.repository.SettingsWriteRepository
+import com.moneymanager.domain.repository.QifImportReadRepository
+import com.moneymanager.domain.repository.SettingsReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.domain.repository.TransferSourceReadRepository
-import com.moneymanager.importengineapi.EditGate
 import com.moneymanager.importengineapi.ImportEngine
-import com.moneymanager.importer.ImportEngineImpl
 
+/**
+ * The UI's view of the database. Every repository here is a **read** interface — the UI never mutates
+ * the database through a repository. All writes go through [TransactionsDomain.importEngine] (the single
+ * write seam, which carries the session's edit gate). The engine is built in di/core
+ * ([com.moneymanager.di.database.createImportEngine]) so the write repositories never reach this layer.
+ */
 data class AppServices(
     val accounts: AccountsDomain,
     val imports: ImportsDomain,
@@ -39,28 +43,28 @@ data class AppServices(
 )
 
 data class AccountsDomain(
-    val accountRepository: AccountWriteRepository,
+    val accountRepository: AccountReadRepository,
     val accountAttributeRepository: AccountAttributeReadRepository,
     val categoryRepository: CategoryReadRepository,
-    val currencyRepository: CurrencyWriteRepository,
+    val currencyRepository: CurrencyReadRepository,
 )
 
 data class ImportsDomain(
-    val apiImportStrategyRepository: ApiImportStrategyWriteRepository,
-    val apiSessionRepository: ApiSessionWriteRepository,
-    val csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    val csvImportRepository: CsvImportWriteRepository,
-    val csvImportStrategyRepository: CsvImportStrategyWriteRepository,
+    val apiImportStrategyRepository: ApiImportStrategyReadRepository,
+    val apiSessionRepository: ApiSessionReadRepository,
+    val csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    val csvImportRepository: CsvImportReadRepository,
+    val csvImportStrategyRepository: CsvImportStrategyReadRepository,
     val csvStrategyExportService: CsvStrategyExportService,
     val csvStrategyImportExport: CsvStrategyImportExport,
-    val qifImportRepository: QifImportWriteRepository,
+    val qifImportRepository: QifImportReadRepository,
     val maintenance: Maintenance,
 )
 
 data class TransactionsDomain(
     val transactionRepository: TransactionReadRepository,
     val transferSourceRepository: TransferSourceReadRepository,
-    val attributeTypeRepository: AttributeTypeWriteRepository,
+    val attributeTypeRepository: AttributeTypeReadRepository,
     val importEngine: ImportEngine,
 )
 
@@ -71,7 +75,7 @@ data class PeopleDomain(
 )
 
 data class SettingsDomain(
-    val settingsRepository: SettingsWriteRepository,
+    val settingsRepository: SettingsReadRepository,
     val deviceRepository: DeviceReadRepository,
 )
 
@@ -79,7 +83,11 @@ data class AuditDomain(
     val auditRepository: AuditReadRepository,
 )
 
-fun Application.toAppServices(editGate: EditGate = EditGate.AlwaysWritable) =
+/**
+ * Narrows the db-layer [Application] (whose repositories are write interfaces) to the UI's read-only
+ * [AppServices], plugging in the already-constructed [importEngine] as the single write seam.
+ */
+fun Application.toAppServices(importEngine: ImportEngine) =
     AppServices(
         accounts =
             AccountsDomain(
@@ -105,17 +113,7 @@ fun Application.toAppServices(editGate: EditGate = EditGate.AlwaysWritable) =
                 transactionRepository = transactions.transactionRepository,
                 transferSourceRepository = transactions.transferSourceRepository,
                 attributeTypeRepository = transactions.attributeTypeRepository,
-                importEngine =
-                    ImportEngineImpl(
-                        transactionRepository = transactions.transactionRepository,
-                        accountRepository = accounts.accountRepository,
-                        accountAttributeRepository = accounts.accountAttributeRepository,
-                        personRepository = people.personRepository,
-                        personAttributeRepository = people.personAttributeRepository,
-                        ownershipRepository = people.personAccountOwnershipRepository,
-                        categoryRepository = accounts.categoryRepository,
-                        editGate = editGate,
-                    ),
+                importEngine = importEngine,
             ),
         people =
             PeopleDomain(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -379,7 +379,6 @@ fun MoneyManagerApp(
                                         }
                                         SettingsScreen(
                                             currencyRepository = services.accounts.currencyRepository,
-                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
                                             importEngine = services.transactions.importEngine,
                                             settingsRepository = services.settings.settingsRepository,
                                             maintenance = services.imports.maintenance,
@@ -453,7 +452,6 @@ fun MoneyManagerApp(
                                             settingsRepository = services.settings.settingsRepository,
                                             apiSessionRepository = services.imports.apiSessionRepository,
                                             apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
-                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
                                             accountAttributeRepository = services.accounts.accountAttributeRepository,
                                             accountRepository = services.accounts.accountRepository,
                                             currencyRepository = services.accounts.currencyRepository,
@@ -528,7 +526,6 @@ fun MoneyManagerApp(
                                             accountRepository = services.accounts.accountRepository,
                                             categoryRepository = services.accounts.categoryRepository,
                                             currencyRepository = services.accounts.currencyRepository,
-                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
                                             personRepository = services.people.personRepository,
                                             maintenance = services.imports.maintenance,
                                             transferSourceRepository = services.transactions.transferSourceRepository,
@@ -555,7 +552,6 @@ fun MoneyManagerApp(
                                             categoryRepository = services.accounts.categoryRepository,
                                             currencyRepository = services.accounts.currencyRepository,
                                             personRepository = services.people.personRepository,
-                                            attributeTypeRepository = services.transactions.attributeTypeRepository,
                                             settingsRepository = services.settings.settingsRepository,
                                             maintenance = services.imports.maintenance,
                                             importEngine = services.transactions.importEngine,
@@ -755,7 +751,6 @@ fun MoneyManagerApp(
                                             currentlyViewedCurrencyId = null
                                         }
                                         ApiConnectScreen(
-                                            apiSessionRepository = services.imports.apiSessionRepository,
                                             apiImportStrategyRepository = services.imports.apiImportStrategyRepository,
                                             onCredentialSaved = {
                                                 navigationHistory.navigateBack()
@@ -792,7 +787,6 @@ fun MoneyManagerApp(
                 if (defaultCurrencyLoaded && defaultCurrencyId == null) {
                     DefaultCurrencyInitDialog(
                         currencyRepository = services.accounts.currencyRepository,
-                        settingsRepository = services.settings.settingsRepository,
                     )
                 }
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -379,7 +379,6 @@ fun MoneyManagerApp(
                                         }
                                         SettingsScreen(
                                             currencyRepository = services.accounts.currencyRepository,
-                                            importEngine = services.transactions.importEngine,
                                             settingsRepository = services.settings.settingsRepository,
                                             maintenance = services.imports.maintenance,
                                             currentDatabaseLocation = databaseLocation,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/AccountPicker.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/AccountPicker.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.moneymanager.domain.model.AccountId
-import com.moneymanager.domain.repository.AccountWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
@@ -46,7 +46,7 @@ fun AccountPicker(
     selectedAccountId: AccountId?,
     onAccountSelected: (AccountId) -> Unit,
     label: String,
-    accountRepository: AccountWriteRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
     personRepository: PersonReadRepository,
     enabled: Boolean = true,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.Modifier
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.Source
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AttributeTypeReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
 import com.moneymanager.domain.repository.PersonAttributeReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
@@ -54,7 +54,7 @@ fun CreateAccountDialog(
     categoryRepository: CategoryReadRepository,
     personRepository: PersonReadRepository,
     personAttributeRepository: PersonAttributeReadRepository? = null,
-    attributeTypeRepository: AttributeTypeWriteRepository? = null,
+    attributeTypeRepository: AttributeTypeReadRepository? = null,
     onDismiss: () -> Unit,
     onAccountCreated: ((AccountId) -> Unit)? = null,
     initialName: String = "",

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateCurrencyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CreateCurrencyDialog.kt
@@ -18,8 +18,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.CurrencyId
-import com.moneymanager.domain.model.Source
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.importengineapi.createCurrency
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.launch
 import org.lighthousegames.logging.logging
@@ -29,16 +29,15 @@ private val logger = logging()
 /**
  * A dialog for creating a new currency.
  *
- * @param currencyRepository Repository to create currencies
  * @param onCurrencyCreated Callback invoked when a currency is created, with the new currency ID
  * @param onDismiss Callback invoked when the dialog is dismissed
  */
 @Composable
 fun CreateCurrencyDialog(
-    currencyRepository: CurrencyWriteRepository,
     onCurrencyCreated: (CurrencyId) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val importEngine = LocalImportEngine.current
     var code by remember { mutableStateOf("") }
     var name by remember { mutableStateOf("") }
     val saveState = rememberDialogSaveState()
@@ -89,7 +88,7 @@ fun CreateCurrencyDialog(
                             saveState.errorMessage = null
                             scope.launch {
                                 try {
-                                    val currencyId = currencyRepository.upsertCurrencyByCode(code.trim(), name.trim(), Source.Manual)
+                                    val currencyId = importEngine.createCurrency(code.trim(), name.trim())
                                     onCurrencyCreated(currencyId)
                                 } catch (expected: Exception) {
                                     logger.error(expected) { "Failed to create currency: ${expected.message}" }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CurrencyPicker.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/CurrencyPicker.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.moneymanager.domain.model.CurrencyId
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 
 /**
@@ -31,7 +31,7 @@ import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
  * @param selectedCurrencyId The currently selected currency ID, or null if none selected
  * @param onCurrencySelected Callback invoked when a currency is selected
  * @param label The label text displayed on the dropdown
- * @param currencyRepository Repository to fetch currencies and create new ones
+ * @param currencyRepository Repository to fetch currencies
  * @param modifier Optional modifier for the component
  * @param enabled Whether the picker is enabled
  * @param placeholder Placeholder text shown when dropdown is expanded
@@ -42,7 +42,7 @@ fun CurrencyPicker(
     selectedCurrencyId: CurrencyId?,
     onCurrencySelected: (CurrencyId) -> Unit,
     label: String,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     placeholder: String = "Type to search...",
@@ -125,7 +125,6 @@ fun CurrencyPicker(
 
     if (showCreateCurrencyDialog) {
         CreateCurrencyDialog(
-            currencyRepository = currencyRepository,
             onCurrencyCreated = { currencyId ->
                 onCurrencySelected(currencyId)
                 showCreateCurrencyDialog = false

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/DefaultCurrencyInitDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/DefaultCurrencyInitDialog.kt
@@ -16,17 +16,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.currency.Currency
 import com.moneymanager.domain.model.CurrencyId
-import com.moneymanager.domain.repository.CurrencyWriteRepository
-import com.moneymanager.domain.repository.SettingsWriteRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
+import com.moneymanager.importengineapi.setDefaultCurrency
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
 @Composable
-fun DefaultCurrencyInitDialog(
-    currencyRepository: CurrencyWriteRepository,
-    settingsRepository: SettingsWriteRepository,
-) {
+fun DefaultCurrencyInitDialog(currencyRepository: CurrencyReadRepository) {
+    val importEngine = LocalImportEngine.current
     val scope = rememberSchemaAwareCoroutineScope()
     var selectedCurrencyId by remember { mutableStateOf<CurrencyId?>(null) }
     var initialized by remember { mutableStateOf(false) }
@@ -66,7 +65,7 @@ fun DefaultCurrencyInitDialog(
                 onClick = {
                     selectedCurrencyId?.let { id ->
                         scope.launch {
-                            settingsRepository.setDefaultCurrencyId(id)
+                            importEngine.setDefaultCurrency(id)
                         }
                     }
                 },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
@@ -28,7 +28,7 @@ import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AttributeTypeReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipReadRepository
 import com.moneymanager.domain.repository.PersonAttributeReadRepository
@@ -39,6 +39,7 @@ import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportOperation
 import com.moneymanager.importengineapi.ImportOwnershipIntent
 import com.moneymanager.importengineapi.LocalAccountKey
+import com.moneymanager.importengineapi.getOrCreateAttributeType
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -56,7 +57,7 @@ private val logger = logging()
 fun EditAccountDialog(
     account: Account,
     accountAttributeRepository: AccountAttributeReadRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    attributeTypeRepository: AttributeTypeReadRepository,
     categoryRepository: CategoryReadRepository,
     personRepository: PersonReadRepository,
     personAttributeRepository: PersonAttributeReadRepository? = null,
@@ -202,7 +203,7 @@ fun EditAccountDialog(
                                         val typeChanged = original.attributeType.name != typeName
                                         val valueChanged = original.value != value
                                         if (typeChanged || valueChanged) {
-                                            val typeId = attributeTypeRepository.getOrCreate(typeName.trim())
+                                            val typeId = importEngine.getOrCreateAttributeType(typeName.trim())
                                             updatedAttributes[id] = NewAttribute(typeId, value.trim())
                                         }
                                     }
@@ -212,7 +213,7 @@ fun EditAccountDialog(
                                 editableAttributes.filter { (id, _) -> id < 0 }.forEach { (_, pair) ->
                                     val (typeName, value) = pair
                                     if (typeName.isNotBlank() && value.isNotBlank()) {
-                                        val typeId = attributeTypeRepository.getOrCreate(typeName.trim())
+                                        val typeId = importEngine.getOrCreateAttributeType(typeName.trim())
                                         newAttributes.add(NewAttribute(typeId, value.trim()))
                                     }
                                 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
@@ -26,12 +26,13 @@ import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.PersonAttribute
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.Source
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AttributeTypeReadRepository
 import com.moneymanager.domain.repository.PersonAttributeReadRepository
 import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportOperation
 import com.moneymanager.importengineapi.ImportPersonIntent
 import com.moneymanager.importengineapi.LocalPersonKey
+import com.moneymanager.importengineapi.getOrCreateAttributeType
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.transactions.EditableAttributesSection
@@ -47,7 +48,7 @@ fun EditPersonDialog(
     onDismiss: () -> Unit,
     onPersonCreated: ((PersonId) -> Unit)? = null,
     personAttributeRepository: PersonAttributeReadRepository? = null,
-    attributeTypeRepository: AttributeTypeWriteRepository? = null,
+    attributeTypeRepository: AttributeTypeReadRepository? = null,
 ) {
     var firstName by remember { mutableStateOf(personToEdit?.firstName.orEmpty()) }
     var middleName by remember { mutableStateOf(personToEdit?.middleName.orEmpty()) }
@@ -161,14 +162,14 @@ fun EditPersonDialog(
                                         when {
                                             typeName.isBlank() || value.isBlank() -> deletedAttributeIds.add(id)
                                             original.attributeType.name != typeName || original.value != value ->
-                                                updatedAttributes[id] = NewAttribute(attributeTypeRepository.getOrCreate(typeName), value)
+                                                updatedAttributes[id] = NewAttribute(importEngine.getOrCreateAttributeType(typeName), value)
                                         }
                                     }
                                     editableAttributes.filterKeys { it < 0 }.forEach { (_, pair) ->
                                         val typeName = pair.first.trim()
                                         val value = pair.second.trim()
                                         if (typeName.isNotEmpty() && value.isNotEmpty()) {
-                                            newAttributes.add(NewAttribute(attributeTypeRepository.getOrCreate(typeName), value))
+                                            newAttributes.add(NewAttribute(importEngine.getOrCreateAttributeType(typeName), value))
                                         }
                                     }
                                 }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountAuditScreen.kt
@@ -35,7 +35,7 @@ import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.SourceRecord
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.qif.QifImportId
-import com.moneymanager.domain.repository.AccountWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.AuditReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
 import com.moneymanager.ui.audit.AuditDiffCard
@@ -57,7 +57,7 @@ import kotlinx.datetime.toLocalDateTime
 fun AccountAuditScreen(
     accountId: AccountId,
     auditRepository: AuditReadRepository,
-    accountRepository: AccountWriteRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
     maintenance: Maintenance,
     onApiSourceClick: (ApiSessionId, ApiRequestId, String) -> Unit = { _, _, _ -> },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
@@ -27,8 +27,8 @@ import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.AttributeTypeReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
@@ -53,9 +53,9 @@ private val logger = logging()
 
 @Composable
 fun AccountsScreen(
-    accountRepository: AccountWriteRepository,
+    accountRepository: AccountReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    attributeTypeRepository: AttributeTypeReadRepository,
     categoryRepository: CategoryReadRepository,
     transactionRepository: TransactionReadRepository,
     personRepository: PersonReadRepository,
@@ -305,7 +305,7 @@ fun AccountCard(
     account: Account,
     category: Category?,
     balances: List<AccountBalance>,
-    accountRepository: AccountWriteRepository,
+    accountRepository: AccountReadRepository,
     personRepository: PersonReadRepository,
     personAccountOwnershipRepository: PersonAccountOwnershipReadRepository,
     maintenance: Maintenance,
@@ -442,7 +442,7 @@ fun AccountCard(
 @Composable
 fun DeleteAccountDialog(
     account: Account,
-    accountRepository: AccountWriteRepository,
+    accountRepository: AccountReadRepository,
     maintenance: Maintenance,
     onDismiss: () -> Unit,
 ) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiConnectScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiConnectScreen.kt
@@ -34,8 +34,9 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
-import com.moneymanager.domain.repository.ApiImportStrategyWriteRepository
-import com.moneymanager.domain.repository.ApiSessionWriteRepository
+import com.moneymanager.domain.repository.ApiImportStrategyReadRepository
+import com.moneymanager.importengineapi.createApiCredential
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.launch
@@ -49,10 +50,10 @@ import kotlin.time.Clock
  */
 @Composable
 fun ApiConnectScreen(
-    apiSessionRepository: ApiSessionWriteRepository,
-    apiImportStrategyRepository: ApiImportStrategyWriteRepository,
+    apiImportStrategyRepository: ApiImportStrategyReadRepository,
     onCredentialSaved: () -> Unit = {},
 ) {
+    val importEngine = LocalImportEngine.current
     val scope = rememberSchemaAwareCoroutineScope()
     val uriHandler = LocalUriHandler.current
 
@@ -209,7 +210,7 @@ fun ApiConnectScreen(
                         errorMessage = null
                         scope.launch {
                             try {
-                                apiSessionRepository.createCredential(
+                                importEngine.createApiCredential(
                                     token = trimmedToken,
                                     createdAt = Clock.System.now(),
                                     strategyId = strategyId,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -378,7 +378,6 @@ fun ApiSessionsScreen(
                                                 token = credential.token,
                                                 deviceId = deviceId,
                                                 createdAt = Clock.System.now(),
-                                                expiresAt = null,
                                                 credentialId = credential.id,
                                             )
                                         refresh()

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -79,13 +79,15 @@ import com.moneymanager.domain.model.MonzoCredential
 import com.moneymanager.domain.model.MonzoCredentialId
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.ApiImportStrategyWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.ApiImportStrategyReadRepository
 import com.moneymanager.domain.repository.ApiSessionImportRevision
-import com.moneymanager.domain.repository.ApiSessionWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.ApiSessionReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.createApiSession
+import com.moneymanager.importengineapi.markApiSessionImported
+import com.moneymanager.importengineapi.updateApiCredentialKeys
 import com.moneymanager.rest.ApiSessionTrafficRecorder
 import com.moneymanager.rest.ScaParams
 import com.moneymanager.rest.createApiClient
@@ -115,12 +117,11 @@ import kotlin.time.Instant
 
 @Composable
 fun ApiSessionsScreen(
-    apiSessionRepository: ApiSessionWriteRepository,
-    apiImportStrategyRepository: ApiImportStrategyWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    apiSessionRepository: ApiSessionReadRepository,
+    apiImportStrategyRepository: ApiImportStrategyReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
-    accountRepository: AccountWriteRepository,
-    currencyRepository: CurrencyWriteRepository,
+    accountRepository: AccountReadRepository,
+    currencyRepository: CurrencyReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     deviceId: DeviceId,
@@ -251,7 +252,6 @@ fun ApiSessionsScreen(
                 importApiSessionTransactions(
                     apiSessionRepository = apiSessionRepository,
                     currencyRepository = currencyRepository,
-                    attributeTypeRepository = attributeTypeRepository,
                     sessionId = session.id,
                     strategy = strategy,
                     importEngine = importEngine,
@@ -271,7 +271,6 @@ fun ApiSessionsScreen(
                         apiSessionRepository = apiSessionRepository,
                         accountRepository = accountRepository,
                         accountAttributeRepository = accountAttributeRepository,
-                        attributeTypeRepository = attributeTypeRepository,
                         importEngine = importEngine,
                         sessionId = session.id,
                         strategy = strategy,
@@ -285,7 +284,7 @@ fun ApiSessionsScreen(
                     personCount = transactionsResult.personCount + (peopleResult?.personCount ?: 0),
                 )
             val importDurationMillis = System.currentTimeMillis() - importStartedAt
-            apiSessionRepository.markSessionImported(
+            importEngine.markApiSessionImported(
                 id = session.id,
                 revisionId = strategy.revisionId,
                 importedAt = Clock.System.now(),
@@ -349,7 +348,7 @@ fun ApiSessionsScreen(
                                 onGenerateSigningKey = {
                                     scope.launch {
                                         val keyPair = withContext(Dispatchers.Default) { generateScaKeyPair() }
-                                        apiSessionRepository.updateCredentialKeys(
+                                        importEngine.updateApiCredentialKeys(
                                             credentialId = credential.id,
                                             privateKey = keyPair.privateKeyPem,
                                             publicKey = keyPair.publicKeyPem,
@@ -375,7 +374,7 @@ fun ApiSessionsScreen(
                                     scope.launch {
                                         val strategy = resolveStrategy(credential) ?: return@launch
                                         val newSessionId =
-                                            apiSessionRepository.createSession(
+                                            importEngine.createApiSession(
                                                 token = credential.token,
                                                 deviceId = deviceId,
                                                 createdAt = Clock.System.now(),
@@ -394,7 +393,7 @@ fun ApiSessionsScreen(
                                                     trafficRecorder =
                                                         ApiSessionTrafficRecorder(
                                                             sessionId = newSessionId,
-                                                            apiSessionRepository = apiSessionRepository,
+                                                            importEngine = importEngine,
                                                         ),
                                                     engine = null,
                                                 )
@@ -920,7 +919,7 @@ private fun SessionStatusBadge(isActive: Boolean) {
 
 @Composable
 fun ApiSessionTrafficScreen(
-    apiSessionRepository: ApiSessionWriteRepository,
+    apiSessionRepository: ApiSessionReadRepository,
     sessionId: ApiSessionId,
     highlightRequestId: ApiRequestId? = null,
     highlightJsonPath: String? = null,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -84,13 +84,13 @@ import com.moneymanager.domain.repository.ApiImportStrategyReadRepository
 import com.moneymanager.domain.repository.ApiSessionImportRevision
 import com.moneymanager.domain.repository.ApiSessionReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
-import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.createApiSession
 import com.moneymanager.importengineapi.markApiSessionImported
 import com.moneymanager.importengineapi.updateApiCredentialKeys
 import com.moneymanager.rest.ApiSessionTrafficRecorder
 import com.moneymanager.rest.ScaParams
 import com.moneymanager.rest.createApiClient
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.api.sca.generateScaKeyPair
 import com.moneymanager.ui.api.sca.signScaChallenge
 import com.moneymanager.ui.background.LocalBackgroundTaskManager
@@ -123,13 +123,13 @@ fun ApiSessionsScreen(
     accountRepository: AccountReadRepository,
     currencyRepository: CurrencyReadRepository,
     maintenance: Maintenance,
-    importEngine: ImportEngine,
     deviceId: DeviceId,
     onMonzoConnectClick: () -> Unit = {},
     onApiStrategiesClick: () -> Unit = {},
     onSessionClick: (ApiSession) -> Unit = {},
     onTransactionsImported: () -> Unit = {},
 ) {
+    val importEngine = LocalImportEngine.current
     val scope = rememberSchemaAwareCoroutineScope()
     val backgroundTasks = LocalBackgroundTaskManager.current
     val clipboard = LocalClipboard.current

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
@@ -73,7 +73,7 @@ import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportCategoryIntent
 import com.moneymanager.importengineapi.ImportOperation
@@ -101,7 +101,7 @@ private val HIERARCHY_COLUMN_WIDTH = 250.dp
 @Composable
 fun CategoriesScreen(
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     onAuditClick: (Category) -> Unit = {},
 ) {
     val categories by categoryRepository

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
@@ -34,16 +34,16 @@ import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.csv.CsvRow
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CsvImportWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.domain.repository.TransferSourceReadRepository
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.deleteCsvImport
 import com.moneymanager.ui.components.csv.CsvPreviewTable
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -55,13 +55,12 @@ import kotlinx.coroutines.launch
 fun CsvImportDetailScreen(
     importId: CsvImportId,
     scrollToRowIndex: Long? = null,
-    csvImportRepository: CsvImportWriteRepository,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
+    csvImportRepository: CsvImportReadRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
     maintenance: Maintenance,
     transferSourceRepository: TransferSourceReadRepository,
@@ -371,7 +370,7 @@ fun CsvImportDetailScreen(
                     onClick = {
                         isDeleting = true
                         scope.launch {
-                            csvImportRepository.deleteImport(importId)
+                            importEngine.deleteCsvImport(importId)
                             showDeleteDialog = false
                             onDeleted()
                         }
@@ -403,8 +402,6 @@ fun CsvImportDetailScreen(
             categoryRepository = categoryRepository,
             currencyRepository = currencyRepository,
             personRepository = personRepository,
-            csvImportRepository = csvImportRepository,
-            attributeTypeRepository = attributeTypeRepository,
             maintenance = maintenance,
             importEngine = importEngine,
             onDismiss = { showApplyStrategyDialog = false },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
@@ -38,15 +38,15 @@ import com.moneymanager.csv.CsvParser
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csv.CsvImportId
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CsvImportWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.createCsvImport
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.csv.CsvImportAllDialog
@@ -59,14 +59,13 @@ import kotlin.time.Clock
 @Suppress("LongParameterList", "DuplicatedCode")
 @Composable
 fun CsvImportsScreen(
-    csvImportRepository: CsvImportWriteRepository,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
+    csvImportRepository: CsvImportReadRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     onImportClick: (CsvImportId) -> Unit,
@@ -105,7 +104,7 @@ fun CsvImportsScreen(
                                     result.content,
                                     CsvParseOptions(delimiter = delimiter),
                                 )
-                            csvImportRepository.createImport(
+                            importEngine.createCsvImport(
                                 fileName = result.fileName,
                                 headers = parseResult.headers,
                                 rows = parseResult.rows,
@@ -235,7 +234,6 @@ fun CsvImportsScreen(
                     currencyRepository = currencyRepository,
                     personRepository = personRepository,
                     csvImportRepository = csvImportRepository,
-                    attributeTypeRepository = attributeTypeRepository,
                     maintenance = maintenance,
                     importEngine = importEngine,
                     onDismiss = { showImportAll = false },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CurrenciesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CurrenciesScreen.kt
@@ -13,7 +13,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.compose.scrollbar.VerticalScrollbarForLazyList
 import com.moneymanager.domain.model.Currency
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
+import com.moneymanager.importengineapi.deleteCurrency
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.CreateCurrencyDialog
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -24,7 +26,7 @@ private val logger = logging()
 
 @Composable
 fun CurrenciesScreen(
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     onAuditClick: (Currency) -> Unit = {},
 ) {
     val currencies by currencyRepository
@@ -66,7 +68,6 @@ fun CurrenciesScreen(
                         items(currencies) { currency ->
                             CurrencyCard(
                                 currency = currency,
-                                currencyRepository = currencyRepository,
                                 onAuditClick = { onAuditClick(currency) },
                             )
                         }
@@ -91,7 +92,6 @@ fun CurrenciesScreen(
 
         if (showCreateDialog) {
             CreateCurrencyDialog(
-                currencyRepository = currencyRepository,
                 onCurrencyCreated = { showCreateDialog = false },
                 onDismiss = { showCreateDialog = false },
             )
@@ -102,7 +102,6 @@ fun CurrenciesScreen(
 @Composable
 fun CurrencyCard(
     currency: Currency,
-    currencyRepository: CurrencyWriteRepository,
     onAuditClick: () -> Unit = {},
 ) {
     var showDeleteDialog by remember { mutableStateOf(false) }
@@ -152,7 +151,6 @@ fun CurrencyCard(
     if (showDeleteDialog) {
         DeleteCurrencyDialog(
             currency = currency,
-            currencyRepository = currencyRepository,
             onDismiss = { showDeleteDialog = false },
         )
     }
@@ -161,9 +159,9 @@ fun CurrencyCard(
 @Composable
 fun DeleteCurrencyDialog(
     currency: Currency,
-    currencyRepository: CurrencyWriteRepository,
     onDismiss: () -> Unit,
 ) {
+    val importEngine = LocalImportEngine.current
     var isDeleting by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     val scope = rememberSchemaAwareCoroutineScope()
@@ -207,7 +205,7 @@ fun DeleteCurrencyDialog(
                     errorMessage = null
                     scope.launch {
                         try {
-                            currencyRepository.deleteCurrency(currency.id)
+                            importEngine.deleteCurrency(currency.id)
                             onDismiss()
                         } catch (expected: Exception) {
                             logger.error(expected) { "Failed to delete currency: ${expected.message}" }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CurrencyAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CurrencyAuditScreen.kt
@@ -11,7 +11,7 @@ import com.moneymanager.domain.model.CurrencyAuditEntry
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.SourceRecord
 import com.moneymanager.domain.repository.AuditReadRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.ui.audit.AuditDiffCard
 import com.moneymanager.ui.audit.AuditScreen
 import com.moneymanager.ui.audit.AuditScreenData
@@ -26,7 +26,7 @@ import kotlin.time.Instant
 fun CurrencyAuditScreen(
     currencyId: CurrencyId,
     auditRepository: AuditReadRepository,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     onBack: () -> Unit,
 ) {
     AuditScreen(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
@@ -13,18 +13,17 @@ import com.moneymanager.domain.model.DeviceId
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.qif.QifImportId
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.ApiImportStrategyWriteRepository
-import com.moneymanager.domain.repository.ApiSessionWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.ApiImportStrategyReadRepository
+import com.moneymanager.domain.repository.ApiSessionReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CsvImportWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
-import com.moneymanager.domain.repository.QifImportWriteRepository
-import com.moneymanager.domain.repository.SettingsWriteRepository
+import com.moneymanager.domain.repository.QifImportReadRepository
+import com.moneymanager.domain.repository.SettingsReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.ui.navigation.ImportTab
@@ -33,18 +32,17 @@ import com.moneymanager.ui.navigation.ImportTab
 fun ImportsScreen(
     selectedTab: ImportTab,
     onTabSelected: (ImportTab) -> Unit,
-    csvImportRepository: CsvImportWriteRepository,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    qifImportRepository: QifImportWriteRepository,
+    csvImportRepository: CsvImportReadRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    qifImportRepository: QifImportReadRepository,
     categoryRepository: CategoryReadRepository,
-    settingsRepository: SettingsWriteRepository,
-    apiSessionRepository: ApiSessionWriteRepository,
-    apiImportStrategyRepository: ApiImportStrategyWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    settingsRepository: SettingsReadRepository,
+    apiSessionRepository: ApiSessionReadRepository,
+    apiImportStrategyRepository: ApiImportStrategyReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
-    accountRepository: AccountWriteRepository,
-    currencyRepository: CurrencyWriteRepository,
+    accountRepository: AccountReadRepository,
+    currencyRepository: CurrencyReadRepository,
     transactionRepository: TransactionReadRepository,
     maintenance: Maintenance,
     personRepository: PersonReadRepository,
@@ -92,7 +90,6 @@ fun ImportsScreen(
                     categoryRepository = categoryRepository,
                     currencyRepository = currencyRepository,
                     personRepository = personRepository,
-                    attributeTypeRepository = attributeTypeRepository,
                     maintenance = maintenance,
                     importEngine = importEngine,
                     onImportClick = onCsvImportClick,
@@ -107,7 +104,6 @@ fun ImportsScreen(
                     categoryRepository = categoryRepository,
                     currencyRepository = currencyRepository,
                     personRepository = personRepository,
-                    attributeTypeRepository = attributeTypeRepository,
                     settingsRepository = settingsRepository,
                     maintenance = maintenance,
                     importEngine = importEngine,
@@ -118,7 +114,6 @@ fun ImportsScreen(
                 ApiSessionsScreen(
                     apiSessionRepository = apiSessionRepository,
                     apiImportStrategyRepository = apiImportStrategyRepository,
-                    attributeTypeRepository = attributeTypeRepository,
                     accountAttributeRepository = accountAttributeRepository,
                     accountRepository = accountRepository,
                     currencyRepository = currencyRepository,
@@ -134,7 +129,6 @@ fun ImportsScreen(
                 ManualEntriesScreen(
                     csvImportStrategyRepository = csvImportStrategyRepository,
                     transactionRepository = transactionRepository,
-                    attributeTypeRepository = attributeTypeRepository,
                     maintenance = maintenance,
                     onTransactionsImported = onTransactionsImported,
                 )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
@@ -118,7 +118,6 @@ fun ImportsScreen(
                     accountRepository = accountRepository,
                     currencyRepository = currencyRepository,
                     maintenance = maintenance,
-                    importEngine = importEngine,
                     deviceId = deviceId,
                     onMonzoConnectClick = onAddCredentialClick,
                     onApiStrategiesClick = onApiStrategiesClick,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ManualEntriesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ManualEntriesScreen.kt
@@ -36,13 +36,13 @@ import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.TransferMissingCompanion
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.ImportTransfer
+import com.moneymanager.importengineapi.getOrCreateAttributeType
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -72,9 +72,8 @@ private data class PendingCompanionGroup(
 @OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 fun ManualEntriesScreen(
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
     transactionRepository: TransactionReadRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
     maintenance: Maintenance,
     onTransactionsImported: () -> Unit,
 ) {
@@ -157,7 +156,6 @@ fun ManualEntriesScreen(
                                             rule = group.rule,
                                             entries = entries,
                                             importEngine = importEngine,
-                                            attributeTypeRepository = attributeTypeRepository,
                                         )
                                         maintenance.refreshMaterializedViews()
                                         entries.forEach { (matched, _) -> amounts.remove(matched.transferId) }
@@ -192,9 +190,8 @@ private suspend fun createCompanionTransfers(
     rule: CompanionTransactionRule,
     entries: List<Pair<TransferMissingCompanion, BigDecimal>>,
     importEngine: ImportEngine,
-    attributeTypeRepository: AttributeTypeWriteRepository,
 ) {
-    val linkTypeId = attributeTypeRepository.getOrCreate(rule.linkAttributeName)
+    val linkTypeId = importEngine.getOrCreateAttributeType(rule.linkAttributeName)
     val transfers =
         entries.map { (matched, amount) ->
             ImportTransfer(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
@@ -40,7 +40,7 @@ import com.moneymanager.compose.scrollbar.VerticalScrollbarForLazyList
 import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.PersonAccountOwnership
 import com.moneymanager.domain.model.PersonId
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AttributeTypeReadRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipReadRepository
 import com.moneymanager.domain.repository.PersonAttributeReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
@@ -53,7 +53,7 @@ fun PeopleScreen(
     personRepository: PersonReadRepository,
     personAttributeRepository: PersonAttributeReadRepository,
     personAccountOwnershipRepository: PersonAccountOwnershipReadRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    attributeTypeRepository: AttributeTypeReadRepository,
     scrollToPersonId: PersonId? = null,
     onAuditClick: (Person) -> Unit = {},
 ) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportDetailScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportDetailScreen.kt
@@ -28,16 +28,16 @@ import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.ImportStatus
 import com.moneymanager.domain.model.qif.QifImportId
 import com.moneymanager.domain.model.qif.QifImportRecord
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
-import com.moneymanager.domain.repository.QifImportWriteRepository
-import com.moneymanager.domain.repository.SettingsWriteRepository
+import com.moneymanager.domain.repository.QifImportReadRepository
+import com.moneymanager.domain.repository.SettingsReadRepository
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.deleteQifImport
 import com.moneymanager.ui.components.qif.QifRecordList
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -49,15 +49,14 @@ import kotlinx.coroutines.launch
 fun QifImportDetailScreen(
     importId: QifImportId,
     scrollToRecordIndex: Long? = null,
-    qifImportRepository: QifImportWriteRepository,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
+    qifImportRepository: QifImportReadRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
-    settingsRepository: SettingsWriteRepository,
+    settingsRepository: SettingsReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     onBack: () -> Unit,
@@ -146,8 +145,6 @@ fun QifImportDetailScreen(
             categoryRepository = categoryRepository,
             currencyRepository = currencyRepository,
             personRepository = personRepository,
-            qifImportRepository = qifImportRepository,
-            attributeTypeRepository = attributeTypeRepository,
             settingsRepository = settingsRepository,
             maintenance = maintenance,
             importEngine = importEngine,
@@ -168,7 +165,7 @@ fun QifImportDetailScreen(
                 TextButton(onClick = {
                     showDeleteDialog = false
                     scope.launch {
-                        qifImportRepository.deleteImport(importId)
+                        importEngine.deleteQifImport(importId)
                         onDeleted()
                     }
                 }) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportsScreen.kt
@@ -36,16 +36,16 @@ import com.moneymanager.compose.filepicker.rememberMultipleFilePicker
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.qif.QifImport
 import com.moneymanager.domain.model.qif.QifImportId
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
-import com.moneymanager.domain.repository.QifImportWriteRepository
-import com.moneymanager.domain.repository.SettingsWriteRepository
+import com.moneymanager.domain.repository.QifImportReadRepository
+import com.moneymanager.domain.repository.SettingsReadRepository
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.createQifImport
 import com.moneymanager.qif.QifParser
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -61,15 +61,14 @@ import kotlin.time.Clock
 // Mirrors CsvImportsScreen (QIF reuses the CSV import engine); overlap is intentional.
 @Suppress("LongParameterList", "DuplicatedCode")
 fun QifImportsScreen(
-    qifImportRepository: QifImportWriteRepository,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
+    qifImportRepository: QifImportReadRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
-    settingsRepository: SettingsWriteRepository,
+    settingsRepository: SettingsReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     onImportClick: (QifImportId) -> Unit,
@@ -104,7 +103,7 @@ fun QifImportsScreen(
                                 continue
                             }
                             val parseResult = QifParser().parse(result.content)
-                            qifImportRepository.createImport(
+                            importEngine.createQifImport(
                                 fileName = result.fileName,
                                 records = parseResult.toImportRecords(),
                                 accountType = parseResult.dominantAccountType(),
@@ -230,7 +229,6 @@ fun QifImportsScreen(
                     currencyRepository = currencyRepository,
                     personRepository = personRepository,
                     qifImportRepository = qifImportRepository,
-                    attributeTypeRepository = attributeTypeRepository,
                     settingsRepository = settingsRepository,
                     maintenance = maintenance,
                     importEngine = importEngine,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/SettingsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/SettingsScreen.kt
@@ -39,10 +39,10 @@ import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.DbLocation
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.SettingsReadRepository
-import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.setDefaultCurrency
 import com.moneymanager.remotestorage.sync.RemoteDatabaseController
 import com.moneymanager.ui.DatabasePickerMode
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.CurrencyPicker
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -152,7 +152,6 @@ private fun DatabaseCard(
 @Composable
 fun SettingsScreen(
     currencyRepository: CurrencyReadRepository,
-    importEngine: ImportEngine,
     settingsRepository: SettingsReadRepository,
     maintenance: Maintenance,
     currentDatabaseLocation: DbLocation,
@@ -161,6 +160,7 @@ fun SettingsScreen(
     remoteController: RemoteDatabaseController? = null,
     database: MoneyManagerDatabaseWrapper? = null,
 ) {
+    val importEngine = LocalImportEngine.current
     var showWarningDialog by remember { mutableStateOf(false) }
     var isGenerating by remember { mutableStateOf(false) }
     var showProgressDialog by remember { mutableStateOf(false) }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/SettingsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/SettingsScreen.kt
@@ -37,10 +37,10 @@ import androidx.compose.ui.unit.sp
 import com.moneymanager.database.MoneyManagerDatabaseWrapper
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.DbLocation
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
-import com.moneymanager.domain.repository.SettingsWriteRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
+import com.moneymanager.domain.repository.SettingsReadRepository
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.setDefaultCurrency
 import com.moneymanager.remotestorage.sync.RemoteDatabaseController
 import com.moneymanager.ui.DatabasePickerMode
 import com.moneymanager.ui.components.CurrencyPicker
@@ -151,10 +151,9 @@ private fun DatabaseCard(
 
 @Composable
 fun SettingsScreen(
-    currencyRepository: CurrencyWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     importEngine: ImportEngine,
-    settingsRepository: SettingsWriteRepository,
+    settingsRepository: SettingsReadRepository,
     maintenance: Maintenance,
     currentDatabaseLocation: DbLocation,
     onRequestSwitchDatabase: (DbLocation) -> Unit,
@@ -210,7 +209,7 @@ fun SettingsScreen(
                     selectedCurrencyId = defaultCurrencyId,
                     onCurrencySelected = { currencyId ->
                         scope.launch {
-                            settingsRepository.setDefaultCurrencyId(currencyId)
+                            importEngine.setDefaultCurrency(currencyId)
                         }
                     },
                     label = "Default Currency",
@@ -497,7 +496,6 @@ fun SettingsScreen(
                                 // Generate sample data
                                 generateSampleData(
                                     currencyRepository = currencyRepository,
-                                    attributeTypeRepository = attributeTypeRepository,
                                     importEngine = importEngine,
                                     maintenance = maintenance,
                                     progressFlow = progressFlow,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiImportStrategyAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiImportStrategyAuditScreen.kt
@@ -12,7 +12,7 @@ import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
 import com.moneymanager.domain.model.apistrategy.ApiStrategyConfig
 import com.moneymanager.domain.model.apistrategy.PaginationMode
-import com.moneymanager.domain.repository.ApiImportStrategyWriteRepository
+import com.moneymanager.domain.repository.ApiImportStrategyReadRepository
 import com.moneymanager.domain.repository.AuditReadRepository
 import com.moneymanager.ui.audit.AuditDiffCard
 import com.moneymanager.ui.audit.AuditScreen
@@ -31,7 +31,7 @@ import kotlin.time.Instant
 fun ApiImportStrategyAuditScreen(
     strategyId: ApiImportStrategyId,
     auditRepository: AuditReadRepository,
-    apiImportStrategyRepository: ApiImportStrategyWriteRepository,
+    apiImportStrategyRepository: ApiImportStrategyReadRepository,
     onBack: () -> Unit,
 ) {
     AuditScreen(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategiesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategiesScreen.kt
@@ -37,18 +37,21 @@ import androidx.compose.ui.unit.dp
 import com.moneymanager.compose.scrollbar.VerticalScrollbarForLazyList
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
-import com.moneymanager.domain.repository.ApiImportStrategyWriteRepository
+import com.moneymanager.domain.repository.ApiImportStrategyReadRepository
+import com.moneymanager.importengineapi.deleteApiStrategy
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import kotlinx.coroutines.launch
 
 @Composable
 fun ApiStrategiesScreen(
-    apiImportStrategyRepository: ApiImportStrategyWriteRepository,
+    apiImportStrategyRepository: ApiImportStrategyReadRepository,
     onBack: () -> Unit = {},
     onCreateStrategy: () -> Unit = {},
     onEditStrategy: (ApiImportStrategyId) -> Unit = {},
     onAuditHistoryClick: ((ApiImportStrategy) -> Unit)? = null,
 ) {
+    val importEngine = LocalImportEngine.current
     val strategies by apiImportStrategyRepository
         .getAllStrategies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
@@ -121,7 +124,7 @@ fun ApiStrategiesScreen(
                 TextButton(
                     onClick = {
                         scope.launch {
-                            apiImportStrategyRepository.deleteStrategy(strategy.id)
+                            importEngine.deleteApiStrategy(strategy.id)
                         }
                         strategyPendingDelete = null
                     },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ApiStrategyEditorScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ApiStrategyEditorScreen.kt
@@ -31,11 +31,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
-import com.moneymanager.domain.repository.ApiImportStrategyWriteRepository
-import com.moneymanager.domain.repository.ApiSessionWriteRepository
+import com.moneymanager.domain.repository.ApiImportStrategyReadRepository
+import com.moneymanager.domain.repository.ApiSessionReadRepository
+import com.moneymanager.importengineapi.createApiStrategy
+import com.moneymanager.importengineapi.updateApiStrategy
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.apistrategy.JsonPathEntry
@@ -55,11 +57,12 @@ import kotlin.uuid.Uuid
 @Composable
 fun ApiStrategyEditorScreen(
     strategyId: ApiImportStrategyId?,
-    apiImportStrategyRepository: ApiImportStrategyWriteRepository,
-    apiSessionRepository: ApiSessionWriteRepository,
+    apiImportStrategyRepository: ApiImportStrategyReadRepository,
+    apiSessionRepository: ApiSessionReadRepository,
     onBack: () -> Unit,
 ) {
     val isEditMode = strategyId != null
+    val importEngine = LocalImportEngine.current
     val scope = rememberSchemaAwareCoroutineScope()
 
     val strategyFlow =
@@ -159,9 +162,9 @@ fun ApiStrategyEditorScreen(
                         updatedAt = now,
                     )
                 if (isEditMode) {
-                    apiImportStrategyRepository.updateStrategy(strategy, Source.Manual)
+                    importEngine.updateApiStrategy(strategy)
                 } else {
-                    apiImportStrategyRepository.createStrategy(strategy, Source.Manual)
+                    importEngine.createApiStrategy(strategy)
                 }
                 onBack()
             } catch (expected: Exception) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -64,13 +64,11 @@ import com.moneymanager.domain.model.csvstrategy.CsvAccountMapping
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.HardCodedAccountMapping
 import com.moneymanager.domain.model.csvstrategy.TransferField
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CsvImportWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.ui.components.AccountPicker
@@ -90,14 +88,12 @@ private val logger = logging()
 fun ApplyStrategyDialog(
     csvImport: CsvImport,
     rows: List<CsvRow>,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
-    csvImportRepository: CsvImportWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     onDismiss: () -> Unit,
@@ -363,8 +359,6 @@ fun ApplyStrategyDialog(
                                     currencies = currencies,
                                     csvAccountMappingRepository = csvAccountMappingRepository,
                                     accountRepository = accountRepository,
-                                    csvImportRepository = csvImportRepository,
-                                    attributeTypeRepository = attributeTypeRepository,
                                     maintenance = maintenance,
                                     importEngine = importEngine,
                                 )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
@@ -23,13 +23,12 @@ import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CsvImportWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.ui.components.AccountPicker
@@ -50,14 +49,13 @@ import kotlinx.coroutines.launch
 @Suppress("LongParameterList", "LongMethod", "DuplicatedCode")
 fun CsvImportAllDialog(
     unimported: List<CsvImport>,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
-    csvImportRepository: CsvImportWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    csvImportRepository: CsvImportReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     onDismiss: () -> Unit,
@@ -149,7 +147,6 @@ fun CsvImportAllDialog(
                                         csvAccountMappingRepository = csvAccountMappingRepository,
                                         accountRepository = accountRepository,
                                         csvImportRepository = csvImportRepository,
-                                        attributeTypeRepository = attributeTypeRepository,
                                         maintenance = maintenance,
                                         importEngine = importEngine,
                                         onProgress = { done, total -> progress = done to total },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvImportStrategyAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvImportStrategyAuditScreen.kt
@@ -15,7 +15,7 @@ import com.moneymanager.domain.model.csvstrategy.FieldMapping
 import com.moneymanager.domain.model.csvstrategy.RowPreprocessingRule
 import com.moneymanager.domain.model.csvstrategy.TransferField
 import com.moneymanager.domain.repository.AuditReadRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.ui.audit.AuditDiffCard
 import com.moneymanager.ui.audit.AuditScreen
 import com.moneymanager.ui.audit.AuditScreenData
@@ -33,7 +33,7 @@ import kotlin.time.Instant
 fun CsvImportStrategyAuditScreen(
     strategyId: CsvImportStrategyId,
     auditRepository: AuditReadRepository,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
     onBack: () -> Unit,
 ) {
     AuditScreen(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
@@ -50,14 +50,14 @@ import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
 import com.moneymanager.domain.model.qif.QifImportId
-import com.moneymanager.domain.repository.AccountWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CsvImportWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
-import com.moneymanager.domain.repository.QifImportWriteRepository
+import com.moneymanager.domain.repository.QifImportReadRepository
 import com.moneymanager.qifimporter.QifCsvAdapter
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import kotlinx.coroutines.flow.first
@@ -66,13 +66,13 @@ import nl.jacobras.humanreadable.HumanReadable
 
 @Composable
 fun CsvStrategiesScreen(
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvImportRepository: CsvImportWriteRepository,
-    qifImportRepository: QifImportWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    csvImportRepository: CsvImportReadRepository,
+    qifImportRepository: QifImportReadRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
     csvStrategyImportExport: CsvStrategyImportExport,
     appVersion: AppVersion,
@@ -253,7 +253,6 @@ fun CsvStrategiesScreen(
                         items(strategies) { strategy ->
                             CsvStrategyCard(
                                 strategy = strategy,
-                                csvImportStrategyRepository = csvImportStrategyRepository,
                                 onEditClick = {
                                     onStrategyClick(strategy)
                                     strategyToEdit = strategy
@@ -328,7 +327,6 @@ fun CsvStrategiesScreen(
         ImportStrategyDialog(
             parseResult = currentParseResult,
             csvImportStrategyRepository = csvImportStrategyRepository,
-            csvAccountMappingRepository = csvAccountMappingRepository,
             csvStrategyImportExport = csvStrategyImportExport,
             accountRepository = accountRepository,
             categoryRepository = categoryRepository,
@@ -349,7 +347,6 @@ fun CsvStrategiesScreen(
 @Composable
 fun CsvStrategyCard(
     strategy: CsvImportStrategy,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
     onEditClick: () -> Unit,
     onExportClick: () -> Unit,
     onAuditClick: () -> Unit = {},
@@ -430,7 +427,6 @@ fun CsvStrategyCard(
     if (showDeleteDialog) {
         DeleteCsvStrategyDialog(
             strategy = strategy,
-            csvImportStrategyRepository = csvImportStrategyRepository,
             onDismiss = { showDeleteDialog = false },
         )
     }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ImportStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ImportStrategyDialog.kt
@@ -53,16 +53,19 @@ import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.Category
 import com.moneymanager.domain.model.Currency
-import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.csvstrategy.CsvAccountMapping
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
 import com.moneymanager.domain.model.csvstrategy.export.CsvAccountMappingExport
-import com.moneymanager.domain.repository.AccountWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
+import com.moneymanager.importengineapi.createCsvMapping
+import com.moneymanager.importengineapi.createCsvStrategy
+import com.moneymanager.importengineapi.deleteCsvStrategy
+import com.moneymanager.importengineapi.updateCsvMapping
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.CreateAccountDialog
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -76,16 +79,16 @@ import kotlinx.coroutines.launch
 @Composable
 fun ImportStrategyDialog(
     parseResult: CsvImportParseResult,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
     csvStrategyImportExport: CsvStrategyImportExport,
-    accountRepository: AccountWriteRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
     onDismiss: () -> Unit,
     onImportSuccess: () -> Unit,
 ) {
+    val importEngine = LocalImportEngine.current
     val accounts by accountRepository
         .getAllAccounts()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
@@ -234,10 +237,10 @@ fun ImportStrategyDialog(
                                     accounts = accountRepository.getAllAccounts().first(),
                                 )
 
-                            val persistedStrategyId = csvImportStrategyRepository.createStrategy(strategy, Source.Manual)
+                            val persistedStrategyId = importEngine.createCsvStrategy(strategy)
                             createdStrategyId = persistedStrategyId
                             resolvedAccountMappings.forEach { mapping ->
-                                csvAccountMappingRepository.createMapping(
+                                importEngine.createCsvMapping(
                                     strategyId = persistedStrategyId,
                                     columnName = mapping.columnName,
                                     valuePattern = mapping.valuePattern,
@@ -249,7 +252,7 @@ fun ImportStrategyDialog(
                         } catch (expected: Exception) {
                             createdStrategyId?.let { strategyId ->
                                 runCatching {
-                                    csvImportStrategyRepository.deleteStrategy(strategyId)
+                                    importEngine.deleteCsvStrategy(strategyId)
                                 }
                             }
                             errorMessage = "Failed to import: ${expected.message}"
@@ -800,9 +803,9 @@ internal fun AccountMappingEditorDialog(
     existingMapping: CsvAccountMapping?,
     strategyId: CsvImportStrategyId,
     accounts: List<Account>,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
     onDismiss: () -> Unit,
 ) {
+    val importEngine = LocalImportEngine.current
     val isEditMode = existingMapping != null
     var columnName by remember { mutableStateOf(existingMapping?.columnName.orEmpty()) }
     var patternText by remember { mutableStateOf(existingMapping?.valuePattern?.pattern.orEmpty()) }
@@ -874,7 +877,7 @@ internal fun AccountMappingEditorDialog(
                             try {
                                 val pattern = Regex(patternText, RegexOption.IGNORE_CASE)
                                 if (existingMapping != null) {
-                                    csvAccountMappingRepository.updateMapping(
+                                    importEngine.updateCsvMapping(
                                         existingMapping.copy(
                                             columnName = columnName,
                                             valuePattern = pattern,
@@ -882,7 +885,7 @@ internal fun AccountMappingEditorDialog(
                                         ),
                                     )
                                 } else {
-                                    csvAccountMappingRepository.createMapping(
+                                    importEngine.createCsvMapping(
                                         strategyId = strategyId,
                                         columnName = columnName,
                                         valuePattern = pattern,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/StrategyDialogs.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/StrategyDialogs.kt
@@ -35,9 +35,10 @@ import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.qif.QifImport
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CsvImportWriteRepository
-import com.moneymanager.domain.repository.QifImportWriteRepository
+import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.domain.repository.QifImportReadRepository
+import com.moneymanager.importengineapi.deleteCsvStrategy
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.launch
@@ -49,9 +50,9 @@ import nl.jacobras.humanreadable.HumanReadable
 @Composable
 fun DeleteCsvStrategyDialog(
     strategy: CsvImportStrategy,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
     onDismiss: () -> Unit,
 ) {
+    val importEngine = LocalImportEngine.current
     var isDeleting by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     val scope = rememberSchemaAwareCoroutineScope()
@@ -85,7 +86,7 @@ fun DeleteCsvStrategyDialog(
                     errorMessage = null
                     scope.launch {
                         try {
-                            csvImportStrategyRepository.deleteStrategy(strategy.id)
+                            importEngine.deleteCsvStrategy(strategy.id)
                             onDismiss()
                         } catch (expected: Exception) {
                             errorMessage = "Failed to delete: ${expected.message}"
@@ -180,7 +181,7 @@ fun ExportAccountMappingsDialog(
  */
 @Composable
 fun SelectCsvImportDialog(
-    csvImportRepository: CsvImportWriteRepository,
+    csvImportRepository: CsvImportReadRepository,
     onCsvSelected: (CsvImport) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -274,7 +275,7 @@ fun SelectCsvImportDialog(
  */
 @Composable
 fun SelectQifImportDialog(
-    qifImportRepository: QifImportWriteRepository,
+    qifImportRepository: QifImportReadRepository,
     onQifSelected: (QifImport) -> Unit,
     onDismiss: () -> Unit,
 ) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AccountsTab.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AccountsTab.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvRow
-import com.moneymanager.domain.repository.AccountWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.ui.components.AccountPicker
@@ -32,7 +32,7 @@ internal fun AccountsTab(
     rows: List<CsvRow>,
     firstRow: CsvRow?,
     enabled: Boolean,
-    accountRepository: AccountWriteRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
     personRepository: PersonReadRepository,
 ) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AmountDateTab.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AmountDateTab.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvRow
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.ui.components.CurrencyPicker
 import com.moneymanager.ui.screens.csvstrategy.getSampleValue
 
@@ -30,7 +30,7 @@ internal fun AmountDateTab(
     csvColumns: List<CsvColumn>,
     firstRow: CsvRow?,
     enabled: Boolean,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         Text("Amount Column", style = MaterialTheme.typography.titleSmall)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorScreen.kt
@@ -303,7 +303,13 @@ fun CsvStrategyEditorScreen(
                         accounts = accounts,
                         onEditAccountMapping = { editingAccountMapping = it },
                         onDeleteAccountMapping = { mapping ->
-                            scope.launch { importEngine.deleteCsvMapping(mapping.id) }
+                            scope.launch {
+                                try {
+                                    importEngine.deleteCsvMapping(mapping.id)
+                                } catch (expected: Exception) {
+                                    state.errorMessage = "Failed to delete account mapping: ${expected.message}"
+                                }
+                            }
                         },
                         onAddAccountMapping = { showAddAccountMappingDialog = true },
                     )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorScreen.kt
@@ -32,21 +32,24 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.model.csvstrategy.CsvAccountMapping
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.AttributeTypeReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CsvImportWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
+import com.moneymanager.importengineapi.createCsvStrategy
+import com.moneymanager.importengineapi.deleteCsvMapping
+import com.moneymanager.importengineapi.updateCsvStrategy
+import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.csvstrategy.AccountMappingEditorDialog
@@ -68,21 +71,22 @@ import kotlin.uuid.Uuid
 fun CsvStrategyEditorScreen(
     csvImportId: CsvImportId?,
     strategyId: CsvImportStrategyId?,
-    csvImportRepository: CsvImportWriteRepository,
+    csvImportRepository: CsvImportReadRepository,
     // When set, the editor uses these fixed columns and sample rows instead of loading them from a
     // CSV import. QIF reuses this editor by supplying its fixed columns (see QifCsvAdapter).
     columnsOverride: List<CsvColumn>? = null,
     sampleRowsOverride: List<CsvRow>? = null,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    currencyRepository: CurrencyReadRepository,
+    attributeTypeRepository: AttributeTypeReadRepository,
     personRepository: PersonReadRepository,
     onBack: () -> Unit,
 ) {
     val isEditMode = strategyId != null
+    val importEngine = LocalImportEngine.current
     val scope = rememberSchemaAwareCoroutineScope()
 
     // Repository flows are collected via the schema-aware helper so database schema errors are
@@ -222,9 +226,9 @@ fun CsvStrategyEditorScreen(
                         updatedAt = now,
                     )
                 if (isEditMode) {
-                    csvImportStrategyRepository.updateStrategy(strategy, Source.Manual)
+                    importEngine.updateCsvStrategy(strategy)
                 } else {
-                    csvImportStrategyRepository.createStrategy(strategy, Source.Manual)
+                    importEngine.createCsvStrategy(strategy)
                 }
                 onBack()
             } catch (expected: Exception) {
@@ -299,7 +303,7 @@ fun CsvStrategyEditorScreen(
                         accounts = accounts,
                         onEditAccountMapping = { editingAccountMapping = it },
                         onDeleteAccountMapping = { mapping ->
-                            scope.launch { csvAccountMappingRepository.deleteMapping(mapping.id) }
+                            scope.launch { importEngine.deleteCsvMapping(mapping.id) }
                         },
                         onAddAccountMapping = { showAddAccountMappingDialog = true },
                     )
@@ -328,7 +332,6 @@ fun CsvStrategyEditorScreen(
             existingMapping = mapping,
             strategyId = currentStrategyId,
             accounts = accounts,
-            csvAccountMappingRepository = csvAccountMappingRepository,
             onDismiss = { editingAccountMapping = null },
         )
     }
@@ -338,7 +341,6 @@ fun CsvStrategyEditorScreen(
             existingMapping = null,
             strategyId = strategyId,
             accounts = accounts,
-            csvAccountMappingRepository = csvAccountMappingRepository,
             onDismiss = { showAddAccountMappingDialog = false },
         )
     }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifApplyStrategyDialog.kt
@@ -34,16 +34,15 @@ import com.moneymanager.domain.model.csvstrategy.HardCodedAccountMapping
 import com.moneymanager.domain.model.csvstrategy.TransferField
 import com.moneymanager.domain.model.qif.QifImport
 import com.moneymanager.domain.model.qif.QifImportRecord
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
-import com.moneymanager.domain.repository.QifImportWriteRepository
-import com.moneymanager.domain.repository.SettingsWriteRepository
+import com.moneymanager.domain.repository.SettingsReadRepository
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.setLastQifAccount
 import com.moneymanager.qifimporter.QifCsvAdapter
 import com.moneymanager.qifimporter.QifImportResult
 import com.moneymanager.qifimporter.buildMapper
@@ -77,15 +76,13 @@ private val logger = logging()
 fun QifApplyStrategyDialog(
     qifImport: QifImport,
     records: List<QifImportRecord>,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
-    qifImportRepository: QifImportWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
-    settingsRepository: SettingsWriteRepository,
+    settingsRepository: SettingsReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     onDismiss: () -> Unit,
@@ -311,13 +308,11 @@ fun QifApplyStrategyDialog(
                                     currencies = currencies,
                                     csvAccountMappingRepository = csvAccountMappingRepository,
                                     accountRepository = accountRepository,
-                                    qifImportRepository = qifImportRepository,
-                                    attributeTypeRepository = attributeTypeRepository,
                                     maintenance = maintenance,
                                     importEngine = importEngine,
                                 )
                             // Remember the source account so the next QIF import pre-selects it.
-                            selectedSourceAccountId?.let { settingsRepository.setLastQifAccountId(it) }
+                            selectedSourceAccountId?.let { importEngine.setLastQifAccount(it) }
                             onImportComplete(result)
                         } catch (expected: Exception) {
                             logger.error(expected) { "QIF import failed: ${expected.message}" }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifApplyStrategyDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifApplyStrategyDialog.kt
@@ -57,6 +57,7 @@ import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.csv.ImportPreviewSection
 import com.moneymanager.ui.screens.csv.NewAccountResolutionSection
 import com.moneymanager.ui.screens.csv.StrategySelector
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.lighthousegames.logging.logging
@@ -311,8 +312,17 @@ fun QifApplyStrategyDialog(
                                     maintenance = maintenance,
                                     importEngine = importEngine,
                                 )
-                            // Remember the source account so the next QIF import pre-selects it.
-                            selectedSourceAccountId?.let { importEngine.setLastQifAccount(it) }
+                            // Best-effort: the import already persisted, so a failure to remember the
+                            // source account must not make a completed import look failed.
+                            try {
+                                selectedSourceAccountId?.let { importEngine.setLastQifAccount(it) }
+                            } catch (cancellation: CancellationException) {
+                                throw cancellation
+                            } catch (expected: Exception) {
+                                logger.error(expected) {
+                                    "QIF import completed, but failed to remember last QIF account: ${expected.message}"
+                                }
+                            }
                             onImportComplete(result)
                         } catch (expected: Exception) {
                             logger.error(expected) { "QIF import failed: ${expected.message}" }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
@@ -19,16 +19,16 @@ import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.qif.QifImport
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
-import com.moneymanager.domain.repository.QifImportWriteRepository
-import com.moneymanager.domain.repository.SettingsWriteRepository
+import com.moneymanager.domain.repository.QifImportReadRepository
+import com.moneymanager.domain.repository.SettingsReadRepository
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.setLastQifAccount
 import com.moneymanager.qifimporter.bulkApplyQif
 import com.moneymanager.ui.components.AccountPicker
 import com.moneymanager.ui.components.LoadingTextButton
@@ -47,15 +47,14 @@ import kotlinx.coroutines.launch
 @Suppress("LongParameterList", "LongMethod", "DuplicatedCode")
 fun QifImportAllDialog(
     unimported: List<QifImport>,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
-    qifImportRepository: QifImportWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
-    settingsRepository: SettingsWriteRepository,
+    qifImportRepository: QifImportReadRepository,
+    settingsRepository: SettingsReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     onDismiss: () -> Unit,
@@ -123,12 +122,11 @@ fun QifImportAllDialog(
                                         csvAccountMappingRepository = csvAccountMappingRepository,
                                         accountRepository = accountRepository,
                                         qifImportRepository = qifImportRepository,
-                                        attributeTypeRepository = attributeTypeRepository,
                                         maintenance = maintenance,
                                         importEngine = importEngine,
                                         onProgress = { done, total -> progress = done to total },
                                     )
-                                settingsRepository.setLastQifAccountId(source)
+                                importEngine.setLastQifAccount(source)
                                 summary = result.toSummary()
                             } finally {
                                 isImporting = false

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifStrategyEditorScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifStrategyEditorScreen.kt
@@ -14,15 +14,15 @@ import androidx.compose.ui.Modifier
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
 import com.moneymanager.domain.model.qif.QifImportId
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.AttributeTypeReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
-import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
-import com.moneymanager.domain.repository.CsvImportWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingReadRepository
+import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
-import com.moneymanager.domain.repository.QifImportWriteRepository
+import com.moneymanager.domain.repository.QifImportReadRepository
 import com.moneymanager.qifimporter.QifCsvAdapter
 import com.moneymanager.ui.screens.csvstrategy.editor.CsvStrategyEditorScreen
 
@@ -35,14 +35,14 @@ import com.moneymanager.ui.screens.csvstrategy.editor.CsvStrategyEditorScreen
 fun QifStrategyEditorScreen(
     qifImportId: QifImportId,
     strategyId: CsvImportStrategyId?,
-    qifImportRepository: QifImportWriteRepository,
-    csvImportRepository: CsvImportWriteRepository,
-    csvImportStrategyRepository: CsvImportStrategyWriteRepository,
-    csvAccountMappingRepository: CsvAccountMappingWriteRepository,
-    accountRepository: AccountWriteRepository,
+    qifImportRepository: QifImportReadRepository,
+    csvImportRepository: CsvImportReadRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    csvAccountMappingRepository: CsvAccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    currencyRepository: CurrencyReadRepository,
+    attributeTypeRepository: AttributeTypeReadRepository,
     personRepository: PersonReadRepository,
     onBack: () -> Unit,
 ) {

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionAuditScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionAuditScreen.kt
@@ -33,7 +33,7 @@ import com.moneymanager.domain.model.SourceRecord
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.qif.QifImportId
-import com.moneymanager.domain.repository.AccountWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.AuditReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.ui.audit.AttributeChange
@@ -59,7 +59,7 @@ private val LABEL_WIDTH = 80.dp
 fun TransactionAuditScreen(
     transferId: TransferId,
     auditRepository: AuditReadRepository,
-    accountRepository: AccountWriteRepository,
+    accountRepository: AccountReadRepository,
     transactionRepository: TransactionReadRepository,
     currentDeviceId: DeviceId? = null,
     onCsvSourceClick: (CsvImportId, Long) -> Unit = { _, _ -> },

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
@@ -44,15 +44,16 @@ import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.Transfer
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.AttributeTypeReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportOperation
 import com.moneymanager.importengineapi.ImportTransfer
+import com.moneymanager.importengineapi.getOrCreateAttributeType
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.AccountPicker
 import com.moneymanager.ui.components.CurrencyPicker
@@ -71,10 +72,10 @@ import kotlin.time.Instant
 @Composable
 fun TransactionEditDialog(
     transaction: Transfer? = null,
-    accountRepository: AccountWriteRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    currencyRepository: CurrencyReadRepository,
+    attributeTypeRepository: AttributeTypeReadRepository,
     personRepository: PersonReadRepository,
     maintenance: Maintenance,
     preSelectedSourceAccountId: AccountId? = null,
@@ -413,7 +414,7 @@ fun TransactionEditDialog(
                                                 val typeChanged = original.attributeType.name != typeName
                                                 val valueChanged = original.value != value
                                                 if (typeChanged || valueChanged) {
-                                                    val typeId = attributeTypeRepository.getOrCreate(typeName)
+                                                    val typeId = importEngine.getOrCreateAttributeType(typeName)
                                                     updatedAttributes[id] = NewAttribute(typeId, value)
                                                 }
                                             }
@@ -424,7 +425,7 @@ fun TransactionEditDialog(
                                         editableAttributes.filter { (id, _) -> id < 0 }.forEach { (_, pair) ->
                                             val (typeName, value) = pair
                                             if (typeName.isNotBlank() && value.isNotBlank()) {
-                                                val typeId = attributeTypeRepository.getOrCreate(typeName)
+                                                val typeId = importEngine.getOrCreateAttributeType(typeName)
                                                 newAttributes.add(NewAttribute(typeId, value))
                                             }
                                         }
@@ -473,7 +474,7 @@ fun TransactionEditDialog(
                                             editableAttributes
                                                 .filter { (_, pair) -> pair.first.isNotBlank() && pair.second.isNotBlank() }
                                                 .map { (_, pair) ->
-                                                    val typeId = attributeTypeRepository.getOrCreate(pair.first.trim())
+                                                    val typeId = importEngine.getOrCreateAttributeType(pair.first.trim())
                                                     NewAttribute(typeId, pair.second.trim())
                                                 }.toMutableList()
 

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -51,10 +51,10 @@ import com.moneymanager.domain.model.TransactionId
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
-import com.moneymanager.domain.repository.AccountWriteRepository
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.AttributeTypeReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
@@ -108,11 +108,11 @@ private fun verticalMatrixScrollTarget(
 fun AccountTransactionsScreen(
     accountId: AccountId,
     transactionRepository: TransactionReadRepository,
-    accountRepository: AccountWriteRepository,
+    accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
-    currencyRepository: CurrencyWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    attributeTypeRepository: AttributeTypeReadRepository,
     personRepository: PersonReadRepository,
     personAccountOwnershipRepository: PersonAccountOwnershipReadRepository,
     maintenance: Maintenance,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/SampleDataGenerator.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/util/SampleDataGenerator.kt
@@ -4,13 +4,11 @@ package com.moneymanager.ui.util
 
 import com.moneymanager.bigdecimal.BigDecimal
 import com.moneymanager.domain.Maintenance
-import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.Category
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.Source
-import com.moneymanager.domain.repository.AttributeTypeWriteRepository
-import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.importengineapi.AccountMatchKey
 import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.DedupePolicy
@@ -26,6 +24,7 @@ import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.importengineapi.LocalCategoryKey
 import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.importengineapi.PersonMatchKey
+import com.moneymanager.importengineapi.getOrCreateAttributeTypes
 import com.moneymanager.importengineapi.normalizeNameKey
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -44,13 +43,11 @@ private const val ACCOUNT_COUNT = 100
 /**
  * Generates sample data through the central [ImportEngine] — the sole DB writer for entities and
  * transfers — so accounts, people, ownerships and transactions are created exactly the way a real
- * import creates them (with `Source.SampleGenerator` provenance). Categories and attribute types have
- * no engine creation path, so (mirroring how real importers behave) they are created directly up front
- * and then referenced by id from the batch.
+ * import creates them (with `Source.SampleGenerator` provenance). Attribute types are resolved
+ * (get-or-create) through the engine up front and then referenced by id from the batch.
  */
 suspend fun generateSampleData(
-    currencyRepository: CurrencyWriteRepository,
-    attributeTypeRepository: AttributeTypeWriteRepository,
+    currencyRepository: CurrencyReadRepository,
     importEngine: ImportEngine,
     maintenance: Maintenance,
     progressFlow: MutableStateFlow<GenerationProgress>,
@@ -258,10 +255,8 @@ suspend fun generateSampleData(
             "Check Number",
         )
 
-    val attributeTypeIds = mutableListOf<AttributeTypeId>()
-    for (typeName in attributeTypeNames) {
-        attributeTypeIds.add(attributeTypeRepository.getOrCreate(typeName))
-    }
+    val attributeTypeIdsByName = importEngine.getOrCreateAttributeTypes(attributeTypeNames)
+    val attributeTypeIds = attributeTypeNames.map { attributeTypeIdsByName.getValue(it) }
 
     // Step 7: Determine transaction counts per account (variable distribution)
     val transactionCounts =

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoBalanceFixtureE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoBalanceFixtureE2ETest.kt
@@ -112,7 +112,6 @@ class MonzoBalanceFixtureE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
@@ -548,7 +548,7 @@ class MonzoImportE2ETest : DbTest() {
                     trafficRecorder =
                         ApiSessionTrafficRecorder(
                             sessionId = sessionId,
-                            apiSessionRepository = repositories.apiSessionRepository,
+                            importEngine = repositories.importEngine,
                         ),
                     engine = mockEngine,
                 )
@@ -578,7 +578,6 @@ class MonzoImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,
@@ -732,7 +731,7 @@ class MonzoImportE2ETest : DbTest() {
                     trafficRecorder =
                         ApiSessionTrafficRecorder(
                             sessionId = sessionId,
-                            apiSessionRepository = repositories.apiSessionRepository,
+                            importEngine = repositories.importEngine,
                         ),
                     engine = mockEngine,
                 )
@@ -761,7 +760,6 @@ class MonzoImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,
@@ -817,7 +815,7 @@ class MonzoImportE2ETest : DbTest() {
                 }
             val apiClient =
                 createApiClient(
-                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.apiSessionRepository),
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.importEngine),
                     engine = mockEngine,
                 )
             val strategy =
@@ -853,7 +851,6 @@ class MonzoImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,
@@ -903,7 +900,7 @@ class MonzoImportE2ETest : DbTest() {
                 }
             val apiClient =
                 createApiClient(
-                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.apiSessionRepository),
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.importEngine),
                     engine = mockEngine,
                 )
             val strategy =
@@ -931,7 +928,6 @@ class MonzoImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,
@@ -987,7 +983,7 @@ class MonzoImportE2ETest : DbTest() {
                 }
             val apiClient =
                 createApiClient(
-                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.apiSessionRepository),
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.importEngine),
                     engine = mockEngine,
                 )
             val strategy =
@@ -1022,7 +1018,6 @@ class MonzoImportE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,
@@ -1078,7 +1073,7 @@ class MonzoImportE2ETest : DbTest() {
                 }
             val apiClient =
                 createApiClient(
-                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.apiSessionRepository),
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.importEngine),
                     engine = mockEngine,
                 )
             val strategy =
@@ -1114,7 +1109,6 @@ class MonzoImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,
@@ -1225,7 +1219,7 @@ class MonzoImportE2ETest : DbTest() {
                 }
             val apiClient =
                 createApiClient(
-                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.apiSessionRepository),
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.importEngine),
                     engine = mockEngine,
                 )
             val strategy =
@@ -1261,7 +1255,6 @@ class MonzoImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,
@@ -1319,7 +1312,7 @@ class MonzoImportE2ETest : DbTest() {
                 }
             val apiClient =
                 createApiClient(
-                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.apiSessionRepository),
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.importEngine),
                     engine = mockEngine,
                 )
 
@@ -1351,7 +1344,6 @@ class MonzoImportE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,
@@ -1406,7 +1398,7 @@ class MonzoImportE2ETest : DbTest() {
                 }
             val apiClient =
                 createApiClient(
-                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.apiSessionRepository),
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.importEngine),
                     engine = mockEngine,
                 )
 
@@ -1428,7 +1420,6 @@ class MonzoImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,
@@ -1490,7 +1481,7 @@ class MonzoImportE2ETest : DbTest() {
                     }
                 val apiClient =
                     createApiClient(
-                        trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.apiSessionRepository),
+                        trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.importEngine),
                         engine = mockEngine,
                     )
 
@@ -1511,7 +1502,6 @@ class MonzoImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,
@@ -1601,7 +1591,7 @@ class MonzoImportE2ETest : DbTest() {
                 }
             val apiClient =
                 createApiClient(
-                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.apiSessionRepository),
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.importEngine),
                     engine = mockEngine,
                 )
             // Configure the strategy to use local_amount / local_currency fields
@@ -1639,7 +1629,6 @@ class MonzoImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,
@@ -1696,7 +1685,7 @@ class MonzoImportE2ETest : DbTest() {
                 }
             val apiClient =
                 createApiClient(
-                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.apiSessionRepository),
+                    trafficRecorder = ApiSessionTrafficRecorder(sessionId, repositories.importEngine),
                     engine = mockEngine,
                 )
             // Use the seeded Monzo strategy unchanged: it already maps the fee via atm_fees_detailed.fee_amount.
@@ -1725,7 +1714,6 @@ class MonzoImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CategoriesScreenTest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CategoriesScreenTest.kt
@@ -16,11 +16,20 @@ import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.repository.AccountAttributeWriteRepository
 import com.moneymanager.domain.repository.AccountWriteRepository
+import com.moneymanager.domain.repository.ApiImportStrategyWriteRepository
+import com.moneymanager.domain.repository.ApiSessionWriteRepository
+import com.moneymanager.domain.repository.AttributeTypeWriteRepository
 import com.moneymanager.domain.repository.CategoryWriteRepository
+import com.moneymanager.domain.repository.CsvAccountMappingWriteRepository
+import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
+import com.moneymanager.domain.repository.CsvImportWriteRepository
 import com.moneymanager.domain.repository.CurrencyWriteRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipWriteRepository
 import com.moneymanager.domain.repository.PersonAttributeWriteRepository
 import com.moneymanager.domain.repository.PersonWriteRepository
+import com.moneymanager.domain.repository.QifImportWriteRepository
+import com.moneymanager.domain.repository.RelationshipTypeWriteRepository
+import com.moneymanager.domain.repository.SettingsWriteRepository
 import com.moneymanager.domain.repository.TransactionWriteRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importer.ImportEngineImpl
@@ -55,6 +64,16 @@ class CategoriesScreenTest {
             personAttributeRepository = mock<PersonAttributeWriteRepository>(MockMode.autoUnit),
             ownershipRepository = mock<PersonAccountOwnershipWriteRepository>(MockMode.autoUnit),
             categoryRepository = categoryRepository,
+            currencyRepository = mock<CurrencyWriteRepository>(MockMode.autoUnit),
+            attributeTypeRepository = mock<AttributeTypeWriteRepository>(MockMode.autoUnit),
+            relationshipTypeRepository = mock<RelationshipTypeWriteRepository>(MockMode.autoUnit),
+            csvImportStrategyRepository = mock<CsvImportStrategyWriteRepository>(MockMode.autoUnit),
+            apiImportStrategyRepository = mock<ApiImportStrategyWriteRepository>(MockMode.autoUnit),
+            csvAccountMappingRepository = mock<CsvAccountMappingWriteRepository>(MockMode.autoUnit),
+            csvImportRepository = mock<CsvImportWriteRepository>(MockMode.autoUnit),
+            qifImportRepository = mock<QifImportWriteRepository>(MockMode.autoUnit),
+            apiSessionRepository = mock<ApiSessionWriteRepository>(MockMode.autoUnit),
+            settingsRepository = mock<SettingsWriteRepository>(MockMode.autoUnit),
         )
 
     private val fakeCurrencyRepository: CurrencyWriteRepository =

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvAccountSourceAuditE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvAccountSourceAuditE2ETest.kt
@@ -132,8 +132,6 @@ class CsvAccountSourceAuditE2ETest {
                     currencies = currencies,
                     csvAccountMappingRepository = dc.csvAccountMappingRepository,
                     accountRepository = dc.accountRepository,
-                    csvImportRepository = dc.csvImportRepository,
-                    attributeTypeRepository = dc.attributeTypeRepository,
                     maintenance = DbMaintenance(dc.maintenanceService),
                     importEngine =
                         ImportEngineImpl(
@@ -144,6 +142,16 @@ class CsvAccountSourceAuditE2ETest {
                             personAttributeRepository = dc.personAttributeRepository,
                             ownershipRepository = dc.personAccountOwnershipRepository,
                             categoryRepository = dc.categoryRepository,
+                            currencyRepository = dc.currencyRepository,
+                            attributeTypeRepository = dc.attributeTypeRepository,
+                            relationshipTypeRepository = dc.relationshipTypeRepository,
+                            csvImportStrategyRepository = dc.csvImportStrategyRepository,
+                            apiImportStrategyRepository = dc.apiImportStrategyRepository,
+                            csvAccountMappingRepository = dc.csvAccountMappingRepository,
+                            csvImportRepository = dc.csvImportRepository,
+                            qifImportRepository = dc.qifImportRepository,
+                            apiSessionRepository = dc.apiSessionRepository,
+                            settingsRepository = dc.settingsRepository,
                         ),
                 )
             }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/MonzoImportAuditE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/MonzoImportAuditE2ETest.kt
@@ -170,7 +170,7 @@ class MonzoImportAuditE2ETest {
 
                 val apiClient =
                     createApiClient(
-                        trafficRecorder = ApiSessionTrafficRecorder(sessionId, dc.apiSessionRepository),
+                        trafficRecorder = ApiSessionTrafficRecorder(sessionId, dc.importEngine),
                         engine = mockEngine,
                     )
                 val strategy =
@@ -196,7 +196,6 @@ class MonzoImportAuditE2ETest {
                 importApiSessionTransactions(
                     apiSessionRepository = dc.apiSessionRepository,
                     currencyRepository = dc.currencyRepository,
-                    attributeTypeRepository = dc.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = dc.importEngine,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
@@ -251,7 +251,7 @@ class StarlingImportE2ETest : DbTest() {
             val apiClient =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = sessionId, importEngine = repositories.importEngine),
                     engine = mockEngine(feedRequestUrls = feedRequestUrls),
                 )
 
@@ -274,7 +274,6 @@ class StarlingImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,
@@ -323,7 +322,7 @@ class StarlingImportE2ETest : DbTest() {
             val apiClient =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = sessionId, importEngine = repositories.importEngine),
                     engine = mockEngine(),
                 )
 
@@ -344,7 +343,6 @@ class StarlingImportE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,
@@ -422,7 +420,7 @@ class StarlingImportE2ETest : DbTest() {
             val apiClient =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = sessionId, importEngine = repositories.importEngine),
                     engine = mockEngine(feedJson = FEED_SAME_BANK_JSON),
                 )
 
@@ -443,7 +441,6 @@ class StarlingImportE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,
@@ -502,7 +499,7 @@ class StarlingImportE2ETest : DbTest() {
             val apiClient =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = sessionId, importEngine = repositories.importEngine),
                     engine = mockEngine(),
                 )
 
@@ -523,7 +520,6 @@ class StarlingImportE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,
@@ -572,7 +568,7 @@ class StarlingImportE2ETest : DbTest() {
             val apiClient =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = sessionId, importEngine = repositories.importEngine),
                     engine = mockEngine(identifiersJson = IDENTIFIERS_JSON),
                 )
 
@@ -600,7 +596,6 @@ class StarlingImportE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,
@@ -665,7 +660,7 @@ class StarlingImportE2ETest : DbTest() {
             val apiClient =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = sessionId, importEngine = repositories.importEngine),
                     engine = mockEngine(identifiersJson = IDENTIFIERS_JSON),
                 )
 
@@ -693,7 +688,6 @@ class StarlingImportE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,
@@ -722,7 +716,7 @@ class StarlingImportE2ETest : DbTest() {
             val apiClient =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = sessionId, importEngine = repositories.importEngine),
                     engine = mockEngine(identifiersJson = IDENTIFIERS_JSON),
                 )
 
@@ -750,7 +744,6 @@ class StarlingImportE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,
@@ -784,7 +777,7 @@ class StarlingImportE2ETest : DbTest() {
             val apiClient =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = sessionId, importEngine = repositories.importEngine),
                     engine = mockEngine(),
                 )
 
@@ -816,7 +809,6 @@ class StarlingImportE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,
@@ -826,7 +818,6 @@ class StarlingImportE2ETest : DbTest() {
                 accountRepository = repositories.accountRepository,
                 accountAttributeRepository = repositories.accountAttributeRepository,
                 importEngine = repositories.importEngine,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 accountsSessionId = sessionId,
@@ -861,7 +852,7 @@ class StarlingImportE2ETest : DbTest() {
             val apiClient =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = sessionId, importEngine = repositories.importEngine),
                     engine = mockEngine(),
                 )
             downloadApiSessionAccounts(
@@ -885,7 +876,6 @@ class StarlingImportE2ETest : DbTest() {
                 accountRepository = repositories.accountRepository,
                 accountAttributeRepository = repositories.accountAttributeRepository,
                 importEngine = repositories.importEngine,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 accountsSessionId = sessionId,
@@ -896,7 +886,6 @@ class StarlingImportE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = sessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,
@@ -930,7 +919,7 @@ class StarlingImportE2ETest : DbTest() {
             fun clientFor(session: ApiSessionId) =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = session, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = session, importEngine = repositories.importEngine),
                     engine = mockEngine(feedJson = FEED_HOLDER_COUNTERPARTY_JSON),
                 )
 
@@ -948,7 +937,6 @@ class StarlingImportE2ETest : DbTest() {
                 accountRepository = repositories.accountRepository,
                 accountAttributeRepository = repositories.accountAttributeRepository,
                 importEngine = repositories.importEngine,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = peopleSessionId,
                 strategy = strategy,
             )
@@ -973,7 +961,6 @@ class StarlingImportE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = txSessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,
@@ -1010,7 +997,7 @@ class StarlingImportE2ETest : DbTest() {
             val apiClient =
                 createApiClient(
                     trafficRecorder =
-                        ApiSessionTrafficRecorder(sessionId = sessionId, apiSessionRepository = repositories.apiSessionRepository),
+                        ApiSessionTrafficRecorder(sessionId = sessionId, importEngine = repositories.importEngine),
                     engine = mockEngine(feedJson = FEED_WITH_DECLINED_JSON),
                 )
 
@@ -1032,7 +1019,6 @@ class StarlingImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/test/MoneyManagerTestApp.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/test/MoneyManagerTestApp.kt
@@ -94,7 +94,7 @@ internal object MoneyManagerTestApp {
                 MoneyManagerApp(
                     appVersion = appVersion,
                     databaseLocation = state.location,
-                    services = dc.toApplication().toAppServices(),
+                    services = dc.toApplication().toAppServices(dc.importEngine),
                     onRequestSwitchDatabase = {},
                 )
             }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
@@ -116,7 +116,7 @@ class WiseImportE2ETest : DbTest() {
                     trafficRecorder =
                         ApiSessionTrafficRecorder(
                             sessionId = sessionId,
-                            apiSessionRepository = repositories.apiSessionRepository,
+                            importEngine = repositories.importEngine,
                         ),
                     engine = mockEngine,
                 )
@@ -145,7 +145,6 @@ class WiseImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,
@@ -206,7 +205,7 @@ class WiseImportE2ETest : DbTest() {
                     trafficRecorder =
                         ApiSessionTrafficRecorder(
                             sessionId = sessionId,
-                            apiSessionRepository = repositories.apiSessionRepository,
+                            importEngine = repositories.importEngine,
                         ),
                     engine = mockEngine,
                 )
@@ -228,7 +227,6 @@ class WiseImportE2ETest : DbTest() {
                 importApiSessionTransactions(
                     apiSessionRepository = repositories.apiSessionRepository,
                     currencyRepository = repositories.currencyRepository,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = sessionId,
                     strategy = strategy,
                     importEngine = repositories.importEngine,
@@ -270,7 +268,7 @@ class WiseImportE2ETest : DbTest() {
                     trafficRecorder =
                         ApiSessionTrafficRecorder(
                             sessionId = sessionId,
-                            apiSessionRepository = repositories.apiSessionRepository,
+                            importEngine = repositories.importEngine,
                         ),
                     engine = engine(),
                 )
@@ -288,7 +286,6 @@ class WiseImportE2ETest : DbTest() {
             importApiSessionTransactions(
                 apiSessionRepository = repositories.apiSessionRepository,
                 currencyRepository = repositories.currencyRepository,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = accountsSessionId,
                 strategy = strategy,
                 importEngine = repositories.importEngine,
@@ -313,7 +310,6 @@ class WiseImportE2ETest : DbTest() {
                     accountRepository = repositories.accountRepository,
                     accountAttributeRepository = repositories.accountAttributeRepository,
                     importEngine = repositories.importEngine,
-                    attributeTypeRepository = repositories.attributeTypeRepository,
                     sessionId = peopleSessionId,
                     strategy = strategy,
                     accountsSessionId = accountsSessionId,
@@ -361,7 +357,7 @@ class WiseImportE2ETest : DbTest() {
                     trafficRecorder =
                         ApiSessionTrafficRecorder(
                             sessionId = peopleSessionId,
-                            apiSessionRepository = repositories.apiSessionRepository,
+                            importEngine = repositories.importEngine,
                         ),
                     engine =
                         MockEngine { _ ->
@@ -374,7 +370,6 @@ class WiseImportE2ETest : DbTest() {
                 accountRepository = repositories.accountRepository,
                 accountAttributeRepository = repositories.accountAttributeRepository,
                 importEngine = repositories.importEngine,
-                attributeTypeRepository = repositories.attributeTypeRepository,
                 sessionId = peopleSessionId,
                 strategy = strategy,
             )

--- a/gradle/build-logic/src/main/kotlin/VerifyNoWriteRepositoryUsageTask.kt
+++ b/gradle/build-logic/src/main/kotlin/VerifyNoWriteRepositoryUsageTask.kt
@@ -1,9 +1,11 @@
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
@@ -15,7 +17,9 @@ import org.gradle.api.tasks.TaskAction
  * compile-time narrowing in `Application`/`AppServices` is the primary guard; this catches regressions
  * a contributor might introduce by re-injecting a write repository.
  *
- * [allowedFileNames] lists file names exempt from the check (e.g. a documented bootstrap exception).
+ * [allowedFilePaths] lists module-relative file paths exempt from the check (e.g. a documented
+ * bootstrap exception). Paths are matched precisely so a same-named file elsewhere can't bypass the
+ * guard.
  */
 abstract class VerifyNoWriteRepositoryUsageTask : DefaultTask() {
     @get:InputFiles
@@ -23,27 +27,35 @@ abstract class VerifyNoWriteRepositoryUsageTask : DefaultTask() {
     abstract val sources: ConfigurableFileCollection
 
     @get:Input
-    abstract val allowedFileNames: SetProperty<String>
+    abstract val allowedFilePaths: SetProperty<String>
 
     @get:Input
     abstract val projectPath: Property<String>
 
+    @get:Internal
+    abstract val projectDirectory: DirectoryProperty
+
     @TaskAction
     fun verify() {
-        val allowed = allowedFileNames.get()
+        val allowed = allowedFilePaths.get()
         val regex = Regex("""\b[A-Za-z]+WriteRepository\b""")
         val offenders = sortedSetOf<String>()
+        val projectDir = projectDirectory.get().asFile.toPath().toAbsolutePath().normalize()
+
+        fun relativePathOf(file: java.io.File): String =
+            projectDir.relativize(file.toPath().toAbsolutePath().normalize()).toString().replace('\\', '/')
 
         sources.files
-            .filter { it.isFile && it.name.endsWith(".kt") && it.name !in allowed }
+            .filter { it.isFile && it.name.endsWith(".kt") && relativePathOf(it) !in allowed }
             .forEach { file ->
+                val relativePath = relativePathOf(file)
                 file.readLines().forEachIndexed { index, line ->
                     val trimmed = line.trimStart()
                     // Skip comment lines: KDoc/block (`*`, `/*`) and line comments (`//`) may name a
                     // write repository in prose without being a real usage.
                     val isComment = trimmed.startsWith("*") || trimmed.startsWith("//") || trimmed.startsWith("/*")
                     if (!isComment && regex.containsMatchIn(line)) {
-                        offenders.add("${file.name}:${index + 1}  ${line.trim()}")
+                        offenders.add("$relativePath:${index + 1}  ${line.trim()}")
                     }
                 }
             }

--- a/gradle/build-logic/src/main/kotlin/VerifyNoWriteRepositoryUsageTask.kt
+++ b/gradle/build-logic/src/main/kotlin/VerifyNoWriteRepositoryUsageTask.kt
@@ -1,0 +1,59 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Fails the build if any inspected Kotlin source references a `*WriteRepository` type. This backstops
+ * the read/write split: only the ImportEngine may take write repositories, so the producer/UI modules
+ * (which this task is applied to) must talk to the engine, never a write repository directly. The
+ * compile-time narrowing in `Application`/`AppServices` is the primary guard; this catches regressions
+ * a contributor might introduce by re-injecting a write repository.
+ *
+ * [allowedFileNames] lists file names exempt from the check (e.g. a documented bootstrap exception).
+ */
+abstract class VerifyNoWriteRepositoryUsageTask : DefaultTask() {
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sources: ConfigurableFileCollection
+
+    @get:Input
+    abstract val allowedFileNames: SetProperty<String>
+
+    @get:Input
+    abstract val projectPath: Property<String>
+
+    @TaskAction
+    fun verify() {
+        val allowed = allowedFileNames.get()
+        val regex = Regex("""\b[A-Za-z]+WriteRepository\b""")
+        val offenders = sortedSetOf<String>()
+
+        sources.files
+            .filter { it.isFile && it.name.endsWith(".kt") && it.name !in allowed }
+            .forEach { file ->
+                file.readLines().forEachIndexed { index, line ->
+                    val trimmed = line.trimStart()
+                    // Skip comment lines: KDoc/block (`*`, `/*`) and line comments (`//`) may name a
+                    // write repository in prose without being a real usage.
+                    val isComment = trimmed.startsWith("*") || trimmed.startsWith("//") || trimmed.startsWith("/*")
+                    if (!isComment && regex.containsMatchIn(line)) {
+                        offenders.add("${file.name}:${index + 1}  ${line.trim()}")
+                    }
+                }
+            }
+
+        require(offenders.isEmpty()) {
+            buildString {
+                appendLine("${projectPath.get()} must not reference any *WriteRepository — route writes through the ImportEngine.")
+                appendLine("Offending references:")
+                offenders.forEach { appendLine("  $it") }
+            }
+        }
+    }
+}

--- a/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-multiplatform-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-multiplatform-convention.gradle.kts
@@ -39,7 +39,7 @@ if (project.path !in writeRepositoryExemptModules) {
             group = "verification"
             description = "Fails if this module references a *WriteRepository (writes must go through the ImportEngine)."
             projectPath.set(project.path)
-            allowedFileNames.set(emptySet<String>())
+            allowedFileNames.set(emptySet())
             // Scan only main source sets — test code may legitimately seed fixtures via write repositories.
             listOf("commonMain", "jvmMain", "androidMain").forEach { sourceSet ->
                 sources.from(fileTree("src/$sourceSet") { include("**/*.kt") })

--- a/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-multiplatform-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-multiplatform-convention.gradle.kts
@@ -32,14 +32,19 @@ configure<KotlinMultiplatformExtension> {
  * documented device-bootstrap exception), and the engine itself (the sole writer).
  */
 val writeRepositoryExemptModules =
-    setOf(":app:model:core", ":app:db:core", ":app:di:core", ":app:importer", ":test:app:db")
+    setOf(":app:model:core", ":app:db:core", ":app:di:core", ":test:app:db")
+// The importer module is scanned, but its sole writer — ImportEngineImpl — is allowed by exact path so a
+// new importer file can't quietly re-inject a write repository.
+val allowedWriteRepositoryPathsByModule =
+    mapOf(":app:importer" to setOf("src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt"))
 if (project.path !in writeRepositoryExemptModules) {
     val verifyNoWriteRepositoryUsage =
         tasks.register<VerifyNoWriteRepositoryUsageTask>("verifyNoWriteRepositoryUsage") {
             group = "verification"
             description = "Fails if this module references a *WriteRepository (writes must go through the ImportEngine)."
             projectPath.set(project.path)
-            allowedFileNames.set(emptySet())
+            projectDirectory.set(layout.projectDirectory)
+            allowedFilePaths.set(allowedWriteRepositoryPathsByModule[project.path].orEmpty())
             // Scan only main source sets — test code may legitimately seed fixtures via write repositories.
             listOf("commonMain", "jvmMain", "androidMain").forEach { sourceSet ->
                 sources.from(fileTree("src/$sourceSet") { include("**/*.kt") })

--- a/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-multiplatform-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-multiplatform-convention.gradle.kts
@@ -24,3 +24,28 @@ configure<KotlinMultiplatformExtension> {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
 }
+
+/**
+ * Enforces the read/write repository split: only the ImportEngine may use a `*WriteRepository`, so every
+ * other module must route writes through the engine. Exempted are the infrastructure modules that
+ * legitimately define the interfaces (model), implement them (db), inject them (di — including the one
+ * documented device-bootstrap exception), and the engine itself (the sole writer).
+ */
+val writeRepositoryExemptModules =
+    setOf(":app:model:core", ":app:db:core", ":app:di:core", ":app:importer", ":test:app:db")
+if (project.path !in writeRepositoryExemptModules) {
+    val verifyNoWriteRepositoryUsage =
+        tasks.register<VerifyNoWriteRepositoryUsageTask>("verifyNoWriteRepositoryUsage") {
+            group = "verification"
+            description = "Fails if this module references a *WriteRepository (writes must go through the ImportEngine)."
+            projectPath.set(project.path)
+            allowedFileNames.set(emptySet<String>())
+            // Scan only main source sets — test code may legitimately seed fixtures via write repositories.
+            listOf("commonMain", "jvmMain", "androidMain").forEach { sourceSet ->
+                sources.from(fileTree("src/$sourceSet") { include("**/*.kt") })
+            }
+        }
+    tasks.matching { it.name == "check" }.configureEach {
+        dependsOn(verifyNoWriteRepositoryUsage)
+    }
+}

--- a/utils/rest/build.gradle.kts
+++ b/utils/rest/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(libs.ktor.client.core)
+                api(projects.app.importengineapi)
                 api(projects.app.model.core)
 
                 implementation(libs.ktor.client.cio)
@@ -31,10 +32,11 @@ kotlin {
 
         jvmMain {
             dependencies {
-                api(projects.app.model.core)
+                api(projects.app.importengineapi)
 
                 implementation(libs.ktor.http)
                 implementation(libs.ktor.utils)
+                implementation(projects.app.model.core)
             }
         }
 

--- a/utils/rest/src/commonMain/kotlin/com/moneymanager/rest/ApiSessionTrafficRecorder.kt
+++ b/utils/rest/src/commonMain/kotlin/com/moneymanager/rest/ApiSessionTrafficRecorder.kt
@@ -2,19 +2,26 @@ package com.moneymanager.rest
 
 import com.moneymanager.domain.model.ApiRequestId
 import com.moneymanager.domain.model.ApiSessionId
-import com.moneymanager.domain.repository.ApiSessionWriteRepository
+import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.insertApiRequest
+import com.moneymanager.importengineapi.insertApiResponse
 
+/**
+ * Records API request/response traffic through the [ImportEngine] (the single DB writer) rather than a
+ * write repository, so even this mid-HTTP bookkeeping passes the engine's edit gate. Each call issues a
+ * one-item import batch and reads the generated id back.
+ */
 class ApiSessionTrafficRecorder(
     private val sessionId: ApiSessionId,
-    private val apiSessionRepository: ApiSessionWriteRepository,
+    private val importEngine: ImportEngine,
 ) : ApiTrafficRecorder {
     override suspend fun recordRequest(
         method: String,
         url: String,
         headers: Map<String, String>,
     ): Long =
-        apiSessionRepository
-            .insertRequest(
+        importEngine
+            .insertApiRequest(
                 sessionId = sessionId,
                 method = method,
                 url = url,
@@ -25,8 +32,8 @@ class ApiSessionTrafficRecorder(
         requestId: Long,
         body: String,
     ): Long =
-        apiSessionRepository
-            .insertResponse(
+        importEngine
+            .insertApiResponse(
                 requestId = ApiRequestId(requestId),
                 sessionId = sessionId,
                 json = body,


### PR DESCRIPTION
## What & why

Builds on #571 (read/write repository split). Makes the **`ImportEngine` the single database writer for the entire app**, not just imported entities — so there is one write seam (and one edit gate for cloud-sync safety). Every other module now routes mutations through `engine.import(ImportBatch)` and reads generated ids back from `ImportResult`.

## Changes

- **`ImportBatch`/`ImportResult`** gain intent families for the remaining write repositories: `ImportCurrencyIntent`, `attributeTypeNames`/`relationshipTypeNames` resolve-lists (engine does the get-or-create, returns ids), and sealed mutation types for CSV/API strategies, CSV account mappings, CSV/QIF staging (+ row-status writeback), API sessions, and settings. Ergonomic `ImportEngine.*` extension helpers (`ImportEngineActions.kt`, `ImportEngineConfigActions.kt`) keep call sites terse.
- **All callers migrated**: UI screens/dialogs (via `LocalImportEngine`), `SampleDataGenerator`, `CsvStrategyExportService`, `CsvImportApplier`/`QifImportApplier`, `ApiSessionImportService`, and `ApiSessionTrafficRecorder` (utils/rest now depends on `importengineapi`; mid-HTTP request/response recording goes through the engine).
- **Engine construction moved to di/core** (`DatabaseComponent.createImportEngine(editGate)`). **`AppServices` is now fully read-only** — every field a `*ReadRepository` + the prebuilt `importEngine` — so `ui/core` references no write repository. Screen parameter chains were narrowed read-only.
- **Enforcement**: `moneymanager.kotlin-multiplatform-convention` registers `verifyNoWriteRepositoryUsage` (wired into `check`), failing on any `*WriteRepository` reference in main sources. Exempt: `:app:model:core` (interfaces), `:app:db:core` (impls), `:app:di:core` (wiring), `:app:importer` (the engine), `:test:app:db` (fixtures).

## One documented exception

`DeviceWriteRepository.getOrCreateDevice` stays injected in `DeviceIdModule`. `DeviceId` is a synchronous singleton that every write-repo impl (and thus the engine) depends on, so routing it through the suspend engine would create a DI cycle. Documented in code and whitelisted by the arch check.

## Verification

`./gradlew build` is green — compile (main + test, all modules), detekt, ktlint, buildHealth, and the new arch check all pass. All tests pass except the pre-existing load-flaky `SchemaAwareCoroutineScopeE2ETest` (Compose-desktop timeout under full-build load; passes in isolation). The pre-existing `NoDirectRepositoryWritesArchitectureTest` passes, corroborating the invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified the underlying import pathway for CSV, QIF, and API imports to apply configuration, staging, and related records in a consistent way.
  * Improved handling for created/updated identifiers (e.g., currencies and attribute/relationship types) during import runs.
  * Updated the API traffic recorder and UI write flows to use the same centralized import mechanism.
* **Documentation**
  * Expanded project and development documentation to clarify the single “write seam” for imports.
* **Tests / Chores**
  * Updated import-related wiring in tests and added build-time verification to prevent unintended write usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->