### PR TITLE
First-run database chooser; fix cloud name clashes and default-currency sync

### DIFF
--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/MoneyManagerDatabaseWrapper.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/MoneyManagerDatabaseWrapper.kt
@@ -15,10 +15,17 @@ class MoneyManagerDatabaseWrapper(
     fun close() = driver.close()
 
     /**
-     * A monotonically-increasing token reflecting how much logical data has changed: the total number
-     * of rows across the append-only `*_audit` tables. Every entity create/update/delete appends an
-     * audit row, while derived materialized-view rebuilds do not, so this is a stable "has the data
-     * changed since last sync?" signal that ignores our own view maintenance.
+     * A token reflecting how much logical, syncable state has changed since it was last captured. It
+     * folds together two things:
+     *  - the total number of rows across the append-only `*_audit` tables (every entity
+     *    create/update/delete appends one), and
+     *  - the values of the singleton `settings` row (default currency, last QIF account), which is
+     *    excluded from the audit trail but is still part of the synced database and must register as a
+     *    change — otherwise e.g. setting the default currency would never be detected as unsynced.
+     *
+     * Derived materialized-view rebuilds append no audit rows and don't touch settings, so this stays a
+     * stable "has the data changed since last sync?" signal that ignores our own view maintenance. Only
+     * equality of two tokens is meaningful (it is a hash, not a counter).
      */
     fun dataChangeToken(): Long {
         val auditTables = mutableListOf<String>()
@@ -33,17 +40,41 @@ class MoneyManagerDatabaseWrapper(
             },
             0,
         )
-        return auditTables.sumOf { table ->
-            executeQuery(
-                null,
-                "SELECT COUNT(*) FROM $table",
-                { cursor ->
-                    cursor.next()
-                    QueryResult.Value(cursor.getLong(0)!!)
-                },
-                0,
-            ).value
-        }
+        val auditRowCount =
+            auditTables.sumOf { table ->
+                executeQuery(
+                    null,
+                    "SELECT COUNT(*) FROM $table",
+                    { cursor ->
+                        cursor.next()
+                        QueryResult.Value(cursor.getLong(0)!!)
+                    },
+                    0,
+                ).value
+            }
+        return foldSettingsInto(auditRowCount)
+    }
+
+    /**
+     * Mixes the non-audited `settings` row (id = 1) into [base] with a rolling hash, so a change to any
+     * tracked setting (default currency, last QIF account) yields a different token even though the
+     * settings table appends no audit rows. A missing row leaves [base] unchanged.
+     */
+    private fun foldSettingsInto(base: Long): Long {
+        var token = base
+        executeQuery(
+            null,
+            "SELECT COALESCE(default_currency_id, 0), COALESCE(last_qif_account_id, 0) FROM settings WHERE id = 1",
+            { cursor ->
+                if (cursor.next().value) {
+                    token = token * SETTINGS_HASH_PRIME + cursor.getLong(0)!!
+                    token = token * SETTINGS_HASH_PRIME + cursor.getLong(1)!!
+                }
+                QueryResult.Unit
+            },
+            0,
+        )
+        return token
     }
 
     /**
@@ -235,5 +266,10 @@ class MoneyManagerDatabaseWrapper(
             0,
         )
         return columns
+    }
+
+    private companion object {
+        /** Odd prime used to mix settings values into the data-change token (collision-resistant fold). */
+        const val SETTINGS_HASH_PRIME = 1_000_003L
     }
 }

--- a/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseController.kt
+++ b/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseController.kt
@@ -156,7 +156,11 @@ class RemoteDatabaseController(
         return provider.list()
     }
 
-    /** Uploads the open [database] as a new remote archive and makes it the active remote-backed database. */
+    /**
+     * Uploads the open [database] as a new remote archive and makes it the active remote-backed database.
+     * Pass [overwriteFileId] to replace an existing remote file in place (after the user confirmed a name
+     * collision) instead of creating a new one.
+     */
     suspend fun createRemote(
         providerId: String,
         config: String?,
@@ -164,10 +168,12 @@ class RemoteDatabaseController(
         localCachePath: DbLocation,
         database: MoneyManagerDatabaseWrapper,
         password: String,
+        overwriteFileId: String? = null,
         onProgress: (SyncProgress) -> Unit = {},
     ): RemoteDatabaseBinding {
         val provider = resolve(providerId, config)
-        val binding = syncService.createRemote(provider, remoteName, localCachePath, database, password, config, onProgress)
+        val binding =
+            syncService.createRemote(provider, remoteName, localCachePath, database, password, config, overwriteFileId, onProgress)
         session = Session(provider, binding, password)
         syncedRevision = binding.syncedRevision
         markSynced(database)

--- a/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseSyncService.kt
+++ b/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseSyncService.kt
@@ -35,7 +35,9 @@ class RemoteDatabaseSyncService(
 
     /**
      * Uploads [database] as a new remote archive named [remoteName], persists the resulting binding
-     * (so the database is remote-backed from now on) and returns it.
+     * (so the database is remote-backed from now on) and returns it. Pass [overwriteFileId] to replace
+     * an existing remote file in place (the caller having confirmed the name collision) instead of
+     * creating a new one.
      */
     suspend fun createRemote(
         provider: RemoteStorageProvider,
@@ -44,11 +46,12 @@ class RemoteDatabaseSyncService(
         database: MoneyManagerDatabaseWrapper,
         password: String,
         providerConfig: String? = null,
+        overwriteFileId: String? = null,
         onProgress: (SyncProgress) -> Unit = {},
     ): RemoteDatabaseBinding {
         val archive = shrinkAndPack(database, password, rebuildAfter = true, onProgress = onProgress)
         onProgress(SyncProgress("Uploading to cloud…", UPLOAD_FRACTION))
-        val file = provider.upload(fileId = null, name = remoteName, bytes = archive)
+        val file = provider.upload(fileId = overwriteFileId, name = remoteName, bytes = archive)
         onProgress(SyncProgress("Done", 1f))
         val binding =
             RemoteDatabaseBinding(

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppStartupHost.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppStartupHost.kt
@@ -28,7 +28,9 @@ import com.moneymanager.remotestorage.sync.RemoteDatabaseController
 import com.moneymanager.ui.components.DatabaseSchemaErrorDialog
 import com.moneymanager.ui.components.DatabaseStartupProgressScreen
 import com.moneymanager.ui.error.GlobalSchemaErrorState
+import com.moneymanager.ui.error.ProvideSchemaAwareScope
 import com.moneymanager.ui.error.SchemaErrorDetector
+import com.moneymanager.ui.screens.FirstRunDatabaseSetupScreen
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
@@ -47,6 +49,9 @@ private sealed class AppDatabaseState {
         val location: DbLocation,
         val error: Throwable,
     ) : AppDatabaseState()
+
+    /** Fresh run: no remembered database and no remote binding, so the user must choose one. */
+    data object ChoosingDatabase : AppDatabaseState()
 }
 
 private data class RemoteUnlockState(
@@ -85,10 +90,17 @@ fun AppStartupHost(
             remoteUnlock = RemoteUnlockState(prompt = "Unlock “${binding.remoteName}” from cloud storage")
             return@LaunchedEffect
         }
-        val location = resolveStartupLocation(databaseManager, localSettings)
+        // A corrupted persisted value (e.g. an invalid path) must not crash startup; treat it as absent.
+        val stored =
+            localSettings.getString(KEY_LAST_DATABASE)?.let { runCatching { dbLocationFromString(it) }.getOrNull() }
+        if (stored == null || !databaseManager.databaseExists(stored)) {
+            // Fresh run: no valid remembered database and no remote binding → the user must choose one.
+            databaseState = AppDatabaseState.ChoosingDatabase
+            return@LaunchedEffect
+        }
         val error =
             openAndLoad(
-                location = location,
+                location = stored,
                 databaseManager = databaseManager,
                 createAppServices = createAppServices,
                 databaseStateUpdater = { databaseState = it },
@@ -96,7 +108,7 @@ fun AppStartupHost(
                 onErrorLog = onErrorLog,
             )
         if (error == null) {
-            localSettings.putString(KEY_LAST_DATABASE, location.toString())
+            localSettings.putString(KEY_LAST_DATABASE, stored.toString())
         }
     }
 
@@ -194,6 +206,50 @@ fun AppStartupHost(
             )
         }
         is AppDatabaseState.Loading -> DatabaseStartupProgressScreen(state.progress)
+        is AppDatabaseState.ChoosingDatabase ->
+            // The setup screen (and the Google Drive dialog it reuses) need a schema-aware scope, which
+            // MoneyManagerApp only provides once a database is loaded — so provide one here too.
+            ProvideSchemaAwareScope {
+                FirstRunDatabaseSetupScreen(
+                    databaseManager = databaseManager,
+                    remoteController = remoteController,
+                    createAppServices = createAppServices,
+                    onLocalReady = { location ->
+                        scope.launch {
+                            val error =
+                                openAndLoad(
+                                    location = location,
+                                    databaseManager = databaseManager,
+                                    createAppServices = createAppServices,
+                                    databaseStateUpdater = { databaseState = it },
+                                    onInfoLog = onInfoLog,
+                                    onErrorLog = onErrorLog,
+                                )
+                            if (error == null) localSettings.putString(KEY_LAST_DATABASE, location.toString())
+                        }
+                    },
+                    onRemoteOpened = { location ->
+                        scope.launch {
+                            val error =
+                                openAndLoad(
+                                    location = location,
+                                    databaseManager = databaseManager,
+                                    createAppServices = createAppServices,
+                                    databaseStateUpdater = { databaseState = it },
+                                    onInfoLog = onInfoLog,
+                                    onErrorLog = onErrorLog,
+                                )
+                            if (error == null) localSettings.putString(KEY_LAST_DATABASE, location.toString())
+                        }
+                    },
+                    // createRemote already opened, seeded, uploaded and bound the database, so go straight to Loaded.
+                    onRemoteCreated = { location, services, database ->
+                        localSettings.putString(KEY_LAST_DATABASE, location.toString())
+                        databaseState = AppDatabaseState.Loaded(location, services, database)
+                    },
+                    onErrorLog = onErrorLog,
+                )
+            }
         is AppDatabaseState.Error -> {
             // Schema errors are handled by the recovery dialog below; show other failures so the
             // user isn't left on a blank screen.
@@ -328,23 +384,6 @@ private fun RemoteDatabaseUnlockDialog(
             }
         },
     )
-}
-
-/**
- * Resolves which database to open on startup: the last-opened one if it still exists, otherwise the
- * platform default.
- */
-private suspend fun resolveStartupLocation(
-    databaseManager: DatabaseManager,
-    localSettings: LocalSettings,
-): DbLocation {
-    // A corrupted persisted value (e.g. an invalid path) must not crash startup; fall back to default.
-    val stored = localSettings.getString(KEY_LAST_DATABASE)?.let { runCatching { dbLocationFromString(it) }.getOrNull() }
-    return if (stored != null && databaseManager.databaseExists(stored)) {
-        stored
-    } else {
-        databaseManager.getDefaultLocation()
-    }
 }
 
 /**

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CloudStorageCard.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/CloudStorageCard.kt
@@ -245,17 +245,20 @@ fun CloudStorageCard(
             currentDatabaseLocation.toString().substringAfterLast('/').substringAfterLast('\\'),
         )
 
+    // The setup dialog already warned about (and resolved) any name collision before calling this; a
+    // non-null [overwriteFileId] means the user chose to replace that existing archive in place.
     fun startCreate(
         type: RemoteStorageType,
         config: String?,
         name: String,
         password: String,
+        overwriteFileId: String?,
     ) {
         createType = null
         busy = true
         scope.launch {
             runCatching {
-                controller.createRemote(type.id, config, name, currentDatabaseLocation, database, password) {
+                controller.createRemote(type.id, config, name, currentDatabaseLocation, database, password, overwriteFileId) {
                     syncProgress = it
                 }
             }.onSuccess {
@@ -300,8 +303,11 @@ fun CloudStorageCard(
             defaultName = defaultArchiveName,
             onSignIn = { config -> controller.signInTo(type.id, config) },
             onList = { config -> controller.list(type.id, config) },
-            onCreate = { config, name, password -> startCreate(type, config, name, password) },
-            onOpen = { _, _, _ -> },
+            onCreate = { config, name, password, overwriteFileId ->
+                startCreate(type, config, name, password, overwriteFileId)
+            },
+            // The create dialog offers "Open" when the typed name clashes with an existing archive.
+            onOpen = { config, file, password -> startOpen(type, config, file, password) },
             onDismiss = { createType = null },
         )
     }
@@ -312,7 +318,7 @@ fun CloudStorageCard(
             defaultName = defaultArchiveName,
             onSignIn = { config -> controller.signInTo(type.id, config) },
             onList = { config -> controller.list(type.id, config) },
-            onCreate = { _, _, _ -> },
+            onCreate = { _, _, _, _ -> },
             onOpen = { config, file, password -> startOpen(type, config, file, password) },
             onDismiss = { openType = null },
         )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/FirstRunDatabaseSetupScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/FirstRunDatabaseSetupScreen.kt
@@ -1,0 +1,256 @@
+package com.moneymanager.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.moneymanager.database.DatabaseInitializationProgress
+import com.moneymanager.database.DatabaseManager
+import com.moneymanager.database.MoneyManagerDatabaseWrapper
+import com.moneymanager.domain.model.DEFAULT_DATABASE_NAME
+import com.moneymanager.domain.model.DbLocation
+import com.moneymanager.domain.model.defaultRemoteArchiveName
+import com.moneymanager.domain.model.remoteCacheLocation
+import com.moneymanager.remotestorage.RemoteFile
+import com.moneymanager.remotestorage.RemoteStorageType
+import com.moneymanager.remotestorage.sync.RemoteDatabaseController
+import com.moneymanager.remotestorage.sync.SyncProgress
+import com.moneymanager.ui.AppServices
+import com.moneymanager.ui.DatabasePickerMode
+import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import com.moneymanager.ui.rememberDatabaseLocationPicker
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+
+/**
+ * First-run chooser shown when there is no remembered database and no remote binding: the user must
+ * pick one of four options (no silent default). Local options reuse the platform database picker;
+ * remote options reuse the Google Drive setup dialog. Creating a new remote database opens a freshly
+ * seeded local working copy first, then uploads it (so [RemoteDatabaseController.createRemote] has an
+ * open database to push).
+ *
+ * Remote progress is shown **inline** (this screen stays composed) rather than by switching to the
+ * shared loading screen: the create/open coroutine runs on this screen's scope, so navigating away
+ * before it finishes would cancel it.
+ */
+@Composable
+fun FirstRunDatabaseSetupScreen(
+    databaseManager: DatabaseManager,
+    remoteController: RemoteDatabaseController?,
+    createAppServices: (MoneyManagerDatabaseWrapper) -> AppServices,
+    onLocalReady: (DbLocation) -> Unit,
+    onRemoteOpened: (DbLocation) -> Unit,
+    onRemoteCreated: (DbLocation, AppServices, MoneyManagerDatabaseWrapper) -> Unit,
+    onErrorLog: (String, Throwable) -> Unit,
+) {
+    val scope = rememberSchemaAwareCoroutineScope()
+    var busy by remember { mutableStateOf(false) }
+    var progress by remember { mutableStateOf<DatabaseInitializationProgress?>(null) }
+    var message by remember { mutableStateOf<String?>(null) }
+
+    var createRemoteType by remember { mutableStateOf<RemoteStorageType?>(null) }
+    var openRemoteType by remember { mutableStateOf<RemoteStorageType?>(null) }
+
+    // The picker delivers its result asynchronously on both platforms (JVM posts after the blocking AWT
+    // dialog; Android renders the dialog on the next recomposition). A null result = cancelled, so we stay
+    // on this screen — there is no skip.
+    val picker =
+        rememberDatabaseLocationPicker { location ->
+            if (location != null) onLocalReady(location)
+        }
+
+    // The setup dialog already warned about (and resolved) any name collision before calling this; a
+    // non-null [overwriteFileId] means the user chose to replace that existing archive in place.
+    fun startCreateRemote(
+        type: RemoteStorageType,
+        config: String?,
+        name: String,
+        password: String,
+        overwriteFileId: String?,
+    ) {
+        createRemoteType = null
+        busy = true
+        message = null
+        val cache = remoteCacheLocation(name)
+        scope.launch {
+            var database: MoneyManagerDatabaseWrapper? = null
+            try {
+                progress = DatabaseInitializationProgress("Creating database...", 0, 1)
+                // A new remote database starts as a freshly seeded local working copy that we then upload.
+                val opened = databaseManager.openDatabaseWithProgress(cache) { progress = it }
+                database = opened
+                progress = DatabaseInitializationProgress("Preparing application services...", 1, 1)
+                val services = createAppServices(opened)
+                services.deviceId
+                remoteController!!.createRemote(type.id, config, name, cache, opened, password, overwriteFileId) {
+                    progress = it.toInitializationProgress()
+                }
+                // createRemote persisted the binding, armed the session and captured the sync baseline,
+                // so the database is ready to use as-is — hand it straight to the host.
+                onRemoteCreated(cache, services, opened)
+            } catch (expected: CancellationException) {
+                throw expected
+            } catch (expected: Exception) {
+                onErrorLog("Failed to create remote database", expected)
+                // No binding is persisted until the upload succeeds, so clean up the orphan working copy.
+                runCatching {
+                    database?.close()
+                    databaseManager.deleteDatabase(cache)
+                }
+                message = "Couldn't create remote database: ${expected.message ?: expected::class.simpleName}"
+                progress = null
+                busy = false
+            }
+        }
+    }
+
+    fun startOpenRemote(
+        type: RemoteStorageType,
+        config: String?,
+        file: RemoteFile,
+        password: String,
+    ) {
+        openRemoteType = null
+        busy = true
+        message = null
+        scope.launch {
+            try {
+                progress = DatabaseInitializationProgress("Opening from cloud...", 0, 1)
+                val location =
+                    remoteController!!.openRemote(type.id, config, file, remoteCacheLocation(file.name), password) {
+                        progress = it.toInitializationProgress()
+                    }
+                onRemoteOpened(location)
+            } catch (expected: CancellationException) {
+                throw expected
+            } catch (expected: Exception) {
+                onErrorLog("Failed to open remote database", expected)
+                message = "Couldn't open remote database: ${expected.message ?: expected::class.simpleName}"
+                progress = null
+                busy = false
+            }
+        }
+    }
+
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(32.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = "Welcome to Money Manager",
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Choose a database to get started.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+
+                val buttonModifier = Modifier.fillMaxWidth().widthIn(max = 360.dp)
+                OutlinedButton(
+                    onClick = { picker.launch(DatabasePickerMode.CREATE) },
+                    enabled = !busy,
+                    modifier = buttonModifier,
+                ) { Text("New local database") }
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedButton(
+                    onClick = { picker.launch(DatabasePickerMode.OPEN) },
+                    enabled = !busy,
+                    modifier = buttonModifier,
+                ) { Text("Open existing local database") }
+
+                remoteController?.providerFactory?.types()?.forEach { type ->
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = { createRemoteType = type },
+                        enabled = !busy,
+                        modifier = buttonModifier,
+                    ) { Text("New database on ${type.displayName}") }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = { openRemoteType = type },
+                        enabled = !busy,
+                        modifier = buttonModifier,
+                    ) { Text("Open database from ${type.displayName}") }
+                }
+
+                progress?.let {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(it.text, style = MaterialTheme.typography.bodySmall, textAlign = TextAlign.Center)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    LinearProgressIndicator(
+                        progress = { it.fraction },
+                        modifier = buttonModifier,
+                    )
+                }
+
+                message?.let {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+    }
+
+    val defaultArchiveName = defaultRemoteArchiveName(DEFAULT_DATABASE_NAME)
+
+    createRemoteType?.let { type ->
+        GoogleDriveSetupDialog(
+            mode = GoogleDriveSetupMode.CREATE,
+            defaultName = defaultArchiveName,
+            onSignIn = { config -> remoteController!!.signInTo(type.id, config) },
+            onList = { config -> remoteController!!.list(type.id, config) },
+            onCreate = { config, name, password, overwriteFileId ->
+                startCreateRemote(type, config, name, password, overwriteFileId)
+            },
+            // The create dialog offers "Open" when the typed name clashes with an existing archive.
+            onOpen = { config, file, password -> startOpenRemote(type, config, file, password) },
+            onDismiss = { createRemoteType = null },
+        )
+    }
+
+    openRemoteType?.let { type ->
+        GoogleDriveSetupDialog(
+            mode = GoogleDriveSetupMode.OPEN,
+            defaultName = defaultArchiveName,
+            onSignIn = { config -> remoteController!!.signInTo(type.id, config) },
+            onList = { config -> remoteController!!.list(type.id, config) },
+            onCreate = { _, _, _, _ -> },
+            onOpen = { config, file, password -> startOpenRemote(type, config, file, password) },
+            onDismiss = { openRemoteType = null },
+        )
+    }
+}
+
+private fun SyncProgress.toInitializationProgress() = DatabaseInitializationProgress(message, (fraction * 100).toInt(), 100)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/GoogleDriveSetupDialog.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/GoogleDriveSetupDialog.kt
@@ -2,6 +2,7 @@ package com.moneymanager.ui.screens
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -36,7 +37,7 @@ fun GoogleDriveSetupDialog(
     defaultName: String,
     onSignIn: suspend (config: String?) -> Unit,
     onList: suspend (config: String?) -> List<RemoteFile>,
-    onCreate: (config: String?, name: String, password: String) -> Unit,
+    onCreate: (config: String?, name: String, password: String, overwriteFileId: String?) -> Unit,
     onOpen: (config: String?, file: RemoteFile, password: String) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -58,15 +59,25 @@ fun GoogleDriveSetupDialog(
         scope.launch {
             runCatching {
                 onSignIn(null)
-                if (mode == GoogleDriveSetupMode.OPEN) files = onList(null)
+                // List in both modes: OPEN needs the picker, CREATE needs it to warn about name clashes.
+                files = onList(null)
             }.onSuccess { connected = true }
                 .onFailure { error = it.message ?: "Google sign-in failed" }
             connecting = false
         }
     }
 
+    // In CREATE mode, the existing archive whose name matches what the user typed (a collision), if any.
+    val clash =
+        if (mode == GoogleDriveSetupMode.CREATE && connected) {
+            files.firstOrNull { it.name.equals(name.trim(), ignoreCase = true) }
+        } else {
+            null
+        }
     val createValid =
-        connected && name.isNotBlank() && password.isNotEmpty() && password == confirmPassword
+        connected && clash == null && name.isNotBlank() && password.isNotEmpty() && password == confirmPassword
+    val overwriteValid = connected && clash != null && password.isNotEmpty() && password == confirmPassword
+    val openClashValid = connected && clash != null && password.isNotEmpty()
     val openValid = connected && selected != null && password.isNotEmpty()
 
     AlertDialog(
@@ -89,11 +100,26 @@ fun GoogleDriveSetupDialog(
                 } else if (mode == GoogleDriveSetupMode.CREATE) {
                     Text("Connected to Google Drive.", color = MaterialTheme.colorScheme.primary)
                     OutlinedTextField(name, { name = it }, label = { Text("Archive name") }, singleLine = true)
+                    if (clash != null) {
+                        Text(
+                            "A database named “${clash.name}” already exists. Choose a different name, open " +
+                                "the existing one, or overwrite it.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    }
                     PasswordField(password, { password = it }, "Password")
+                    // Confirm matters only when encrypting new content (Upload/Overwrite); it is ignored
+                    // when opening the existing archive with its own password.
                     PasswordField(confirmPassword, { confirmPassword = it }, "Confirm password")
                     Text(
-                        "The database is compressed and encrypted with this password. Keep it safe — it can't " +
-                            "be recovered.",
+                        if (clash != null) {
+                            "Open uses the existing database's password. Overwrite replaces it and encrypts " +
+                                "the new database with the password above — this can't be undone."
+                        } else {
+                            "The database is compressed and encrypted with this password. Keep it safe — it " +
+                                "can't be recovered."
+                        },
                         style = MaterialTheme.typography.bodySmall,
                     )
                 } else {
@@ -121,9 +147,19 @@ fun GoogleDriveSetupDialog(
                     TextButton(onClick = ::connect, enabled = !connecting) {
                         Text("Sign in with Google")
                     }
+                // Name clash: let the user open the existing archive or overwrite it in place.
+                mode == GoogleDriveSetupMode.CREATE && clash != null ->
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        TextButton(onClick = { onOpen(null, clash, password) }, enabled = openClashValid) {
+                            Text("Open")
+                        }
+                        TextButton(onClick = { onCreate(null, name, password, clash.id) }, enabled = overwriteValid) {
+                            Text("Overwrite")
+                        }
+                    }
                 mode == GoogleDriveSetupMode.CREATE ->
                     TextButton(
-                        onClick = { onCreate(null, name, password) },
+                        onClick = { onCreate(null, name, password, null) },
                         enabled = createValid,
                     ) { Text("Upload") }
                 else ->


### PR DESCRIPTION
## Summary

Three related changes to the database/remote-storage onboarding flow:

### 1. First-run database chooser
On a fresh run (no remembered database in `KEY_LAST_DATABASE` and no active remote binding), the app no longer silently opens/creates the default database. Instead it shows a setup screen where the user **must** pick one of four options and names the new ones:

- **New local** / **Open existing local** — reuse the platform database picker (`rememberDatabaseLocationPicker`).
- **New remote** / **Open existing remote** — reuse the Google Drive setup dialog. Creating a new remote DB opens a freshly seeded local working copy first, then uploads it (so `createRemote` has an open DB to push).

Remote progress is shown **inline** (the screen stays composed) rather than switching to the shared loading screen — otherwise navigating away cancels the create/open coroutine running on the screen's scope. The branch is wrapped in `ProvideSchemaAwareScope`, which is otherwise only provided once a database is loaded.

### 2. Cloud "store new" name-collision handling
Previously, storing a new cloud DB with an existing name silently overwrote it (and on Google Drive actually created a *duplicate*, since Drive allows same-named files). Now the Google Drive setup dialog lists archives on sign-in in **both** modes and, in create mode, warns **live as you type** when the name clashes — offering **Open** (the existing archive) or **Overwrite** (in place) right there, or you can just pick a different name. `createRemote` gained an `overwriteFileId` to `PATCH` the existing file in place instead of creating a new one.

### 3. Default-currency change not detected for sync
Setting the default currency *does* go through the ImportEngine and is written to the `settings` table — but `dataChangeToken()` (the "is there anything to sync?" signal) only counted rows in the append-only `*_audit` tables, and `settings` is excluded from auditing. So the change was invisible: push-on-close (gated on `hasUnsyncedChanges`) skipped it, and another device downloading the DB saw a null default currency and re-prompted with the init dialog. `dataChangeToken()` now folds the `settings` row into the token via a rolling hash (only token equality is used by the sync layer).

## Test plan
- ✅ `lintFormat`, `detekt`
- ✅ JVM + Android compile
- ✅ `:app:db:core:jvmTest`, `:app:remotestorage:sync:jvmTest`
- ✅ Launched the JVM app on the fresh-run path — the chooser renders without the schema-scope crash
- ⚠️ The Google Drive create/open flows need interactive OAuth and weren't exercised end-to-end in CI; manual verification recommended (create with an existing name → Open/Overwrite; set default currency → confirm it syncs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * New guided setup screen for first-run users to create or open databases locally or remotely
  * Support for overwriting existing remote archives during creation
  * Google Drive name clash detection with open/overwrite options

* **Improvements**
  * Enhanced data change tracking across audit tables and application settings
  * Robust handling of corrupted persisted database location values at startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->