### PR TITLE
Use typesafe-conventions plugin in build-logic (#578)

### DIFF
--- a/gradle/build-logic/build.gradle.kts
+++ b/gradle/build-logic/build.gradle.kts
@@ -39,16 +39,10 @@ configurations.all {
 }
 
 dependencies {
+    // develocity is consumed as an API by BuildScan.kt (not applied as a plugin), so it stays explicit.
     compileOnly(libs.develocity.gradle.plugin)
-    implementation(libs.android.gradle.plugin)
-    implementation(libs.compose.gradle.plugin)
-    implementation(libs.detekt.gradle.plugin)
-    implementation(libs.kotlin.compose.compiler.gradle.plugin)
-    implementation(libs.kotlin.gradle.plugin)
-    implementation(libs.kover.gradle.plugin)
-    implementation(libs.ktlint.gradle.plugin)
-    implementation(libs.mappie.gradle.plugin)
-    implementation(libs.metro.gradle.plugin)
-    implementation(libs.sort.dependencies.gradle.plugin)
+    // Every other plugin marker is contributed automatically by the typesafe-conventions plugin when a
+    // convention plugin applies it via `alias(libs.plugins.*)`, so those manual entries are redundant.
+    // sqldelight is applied directly in module build scripts (no convention plugin), so it stays.
     implementation(libs.sqldelight.gradle.plugin)
 }

--- a/gradle/build-logic/settings.gradle.kts
+++ b/gradle/build-logic/settings.gradle.kts
@@ -6,6 +6,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("dev.panuszewski.typesafe-conventions") version "0.11.1"
+}
+
 dependencyResolutionManagement {
     repositories {
         google()
@@ -15,11 +19,8 @@ dependencyResolutionManagement {
         // org.gradle.experimental:gradle-public-api, which is published only here.
         maven("https://repo.gradle.org/gradle/libs-releases")
     }
-    versionCatalogs {
-        create("libs") {
-            from(files("../libs.versions.toml"))
-        }
-    }
+    // The `libs` version catalog is auto-imported from the parent build by the
+    // typesafe-conventions plugin, so it must not be created here.
 }
 
 rootProject.name = "build-logic"

--- a/gradle/build-logic/settings.gradle.kts
+++ b/gradle/build-logic/settings.gradle.kts
@@ -7,6 +7,8 @@ pluginManagement {
 }
 
 plugins {
+    // Version is hardcoded (not a catalog alias) because type-safe `libs.plugins.*` accessors only
+    // become available *after* this very plugin is applied — a bootstrap chicken-and-egg.
     id("dev.panuszewski.typesafe-conventions") version "0.11.1"
 }
 

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
@@ -5,17 +5,16 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 plugins {
-    id("com.android.application")
-    id("moneymanager.kotlin-convention")
-    id("org.jetbrains.compose")
-    id("org.jetbrains.kotlin.plugin.compose")
+    alias(libs.plugins.android.application)
+    alias(conventions.plugins.moneymanager.kotlin.convention)
+    alias(libs.plugins.compose)
+    alias(libs.plugins.compose.compiler)
 }
 
-val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
-val jvmTargetVersion = libs.findVersion("jvm-target").get().toString()
+val jvmTargetVersion = libs.versions.jvm.target.get()
 
 configure<KotlinAndroidProjectExtension> {
-    jvmToolchain(libs.findVersion("jvm-toolchain").get().toString().toInt())
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     compilerOptions {
         jvmTarget.set(JvmTarget.fromTarget(jvmTargetVersion))
@@ -23,11 +22,11 @@ configure<KotlinAndroidProjectExtension> {
 }
 
 configure<ApplicationExtension> {
-    compileSdk = libs.findVersion("android-compileSdk").get().toString().toInt()
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {
-        minSdk = libs.findVersion("android-minSdk").get().toString().toInt()
-        targetSdk = libs.findVersion("android-targetSdk").get().toString().toInt()
+        minSdk = libs.versions.android.minSdk.get().toInt()
+        targetSdk = libs.versions.android.targetSdk.get().toInt()
     }
 
     buildTypes {

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
@@ -2,12 +2,11 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 plugins {
-    id("moneymanager.kotlin-convention")
-    id("org.jetbrains.kotlin.multiplatform")
-    id("com.android.kotlin.multiplatform.library")
+    alias(conventions.plugins.moneymanager.kotlin.convention)
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.kotlin.multiplatform.library)
 }
 
-val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 // Android emulator API level sync: update with .github/workflows/build.yml,
 // .idea/runConfigurations/Android_Tests.xml, and AGENTS.md.
 val androidTestManagedDeviceNames = listOf("pixel6api36")
@@ -17,11 +16,11 @@ fun KotlinMultiplatformExtension.configureAndroidTarget() {
         // Use group (set by kotlin-convention based on project path)
         // Sanitize hyphens in group name for valid Android package name
         namespace = "com.moneymanager.${project.group.toString().replace("-", ".")}"
-        compileSdk = libs.findVersion("android-compileSdk").get().toString().toInt()
-        minSdk = libs.findVersion("android-minSdk").get().toString().toInt()
+        compileSdk = libs.versions.android.compileSdk.get().toInt()
+        minSdk = libs.versions.android.minSdk.get().toInt()
 
         compilerOptions {
-            jvmTarget.set(JvmTarget.fromTarget(libs.findVersion("jvm-target").get().toString()))
+            jvmTarget.set(JvmTarget.fromTarget(libs.versions.jvm.target.get()))
         }
 
         lint {
@@ -61,7 +60,7 @@ fun KotlinMultiplatformExtension.configureAndroidTarget() {
 kotlin {
     jvm()
 
-    jvmToolchain(libs.findVersion("jvm-toolchain").get().toString().toInt())
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     compilerOptions {
         freeCompilerArgs.add("-Xexpect-actual-classes")
@@ -70,7 +69,7 @@ kotlin {
     sourceSets {
         getByName("jvmMain") {
             dependencies {
-                runtimeOnly(libs.findLibrary("kotlinx-coroutines-swing").get())
+                runtimeOnly(libs.kotlinx.coroutines.swing)
             }
         }
         getByName("commonTest") {

--- a/gradle/build-logic/src/main/kotlin/moneymanager.compose-multiplatform-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.compose-multiplatform-convention.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    id("moneymanager.android-convention")
-    id("moneymanager.kotlin-multiplatform-convention")
-    id("org.jetbrains.compose")
+    alias(conventions.plugins.moneymanager.android.convention)
+    alias(conventions.plugins.moneymanager.kotlin.multiplatform.convention)
+    alias(libs.plugins.compose)
 }
 
 // Workaround: Compose Multiplatform 1.10.0 doesn't configure outputDirectory for

--- a/gradle/build-logic/src/main/kotlin/moneymanager.coroutines-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.coroutines-convention.gradle.kts
@@ -1,26 +1,24 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 plugins {
-    id("moneymanager.kotlin-multiplatform-convention")
+    alias(conventions.plugins.moneymanager.kotlin.multiplatform.convention)
 }
-
-val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
 configure<KotlinMultiplatformExtension> {
     sourceSets {
         getByName("commonMain") {
             dependencies {
-                implementation(libs.findLibrary("kotlinx-coroutines-core").get())
+                implementation(libs.kotlinx.coroutines.core)
             }
         }
         getByName("jvmMain") {
             dependencies {
-                runtimeOnly(libs.findLibrary("kotlinx-coroutines-swing").get())
+                runtimeOnly(libs.kotlinx.coroutines.swing)
             }
         }
         getByName("androidMain") {
             dependencies {
-                runtimeOnly(libs.findLibrary("kotlinx-coroutines-android").get())
+                runtimeOnly(libs.kotlinx.coroutines.android)
             }
         }
     }

--- a/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-convention.gradle.kts
@@ -6,13 +6,11 @@ import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("com.squareup.sort-dependencies")
-    id("dev.detekt")
-    id("org.jetbrains.kotlinx.kover")
-    id("org.jlleitschuh.gradle.ktlint")
+    alias(libs.plugins.sort.dependencies)
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.kover)
+    alias(libs.plugins.ktlint)
 }
-
-val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
 // "group:name:version" coordinate for a catalog library (catalog deps only carry module + version).
 val MinimalExternalModuleDependency.versionedModule: String
@@ -29,9 +27,9 @@ fun DependencySubstitutions.substitute(dependency: Provider<MinimalExternalModul
 }
 
 // Pin an arbitrary (transitive-only) module coordinate to a catalog [versions] version.
-fun DependencySubstitutions.substitute(coordinate: String, versionRef: String) {
+fun DependencySubstitutions.substitute(coordinate: String, version: Provider<String>) {
     substitute(module(coordinate))
-        .using(module("$coordinate:${libs.findVersion(versionRef).get().requiredVersion}"))
+        .using(module("$coordinate:${version.get()}"))
 }
 
 // Align divergent transitive deps to a single version across every module's compile/runtime/lint
@@ -49,42 +47,42 @@ configurations.matching {
     resolutionStrategy {
         dependencySubstitution {
             // Catalog libraries pinned to their catalog version.
-            substitute(libs.findLibrary("androidx-activity").get())
-            substitute(libs.findLibrary("androidx-test-runner").get())
-            substitute(libs.findLibrary("diamondedge-logging").get())
-            substitute(libs.findLibrary("slf4j-api").get())
-            substitute(libs.findLibrary("kotlinx-coroutines-core").get())
-            substitute(libs.findLibrary("kotlinx-serialization-core").get())
+            substitute(libs.androidx.activity.asProvider())
+            substitute(libs.androidx.test.runner)
+            substitute(libs.diamondedge.logging)
+            substitute(libs.slf4j.api)
+            substitute(libs.kotlinx.coroutines.core)
+            substitute(libs.kotlinx.serialization.core)
 
             // Transitive-only coordinates pinned to a catalog [versions] entry.
-            substitute("androidx.annotation:annotation", "androidx-annotation")
-            substitute("androidx.annotation:annotation-jvm", "androidx-annotation")
-            substitute("androidx.collection:collection", "androidx-collection")
-            substitute("androidx.concurrent:concurrent-futures", "androidx-concurrent-futures")
-            substitute("androidx.lifecycle:lifecycle-common", "androidx-lifecycle")
-            substitute("androidx.lifecycle:lifecycle-common-jvm", "androidx-lifecycle")
-            substitute("androidx.lifecycle:lifecycle-runtime", "androidx-lifecycle")
-            substitute("androidx.lifecycle:lifecycle-runtime-android", "androidx-lifecycle")
-            substitute("androidx.lifecycle:lifecycle-runtime-compose", "androidx-lifecycle")
-            substitute("androidx.lifecycle:lifecycle-runtime-compose-android", "androidx-lifecycle")
-            substitute("androidx.lifecycle:lifecycle-runtime-ktx", "androidx-lifecycle")
-            substitute("androidx.lifecycle:lifecycle-runtime-ktx-android", "androidx-lifecycle")
-            substitute("androidx.navigationevent:navigationevent", "androidx-navigationevent")
-            substitute("androidx.navigationevent:navigationevent-compose", "androidx-navigationevent")
-            substitute("androidx.savedstate:savedstate", "androidx-savedstate")
-            substitute("androidx.savedstate:savedstate-compose", "androidx-savedstate")
-            substitute("androidx.test.services:storage", "androidx-test-services-storage")
-            substitute("androidx.tracing:tracing", "androidx-tracing")
-            substitute("org.jetbrains:annotations", "jetbrains-annotations")
-            substitute("org.jetbrains.kotlinx:atomicfu", "atomicfu")
-            substitute("org.jetbrains.kotlinx:atomicfu-jvm", "atomicfu")
-            substitute("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", "kotlinx-coroutines")
-            substitute("org.jetbrains.kotlinx:kotlinx-coroutines-android", "kotlinx-coroutines")
-            substitute("org.jetbrains.kotlinx:kotlinx-coroutines-bom", "kotlinx-coroutines")
-            substitute("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm", "kotlinx-serialization")
-            substitute("org.jetbrains.kotlinx:kotlinx-serialization-json", "kotlinx-serialization")
-            substitute("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm", "kotlinx-serialization")
-            substitute("org.jetbrains.kotlinx:kotlinx-serialization-bom", "kotlinx-serialization")
+            substitute("androidx.annotation:annotation", libs.versions.androidx.annotation)
+            substitute("androidx.annotation:annotation-jvm", libs.versions.androidx.annotation)
+            substitute("androidx.collection:collection", libs.versions.androidx.collection)
+            substitute("androidx.concurrent:concurrent-futures", libs.versions.androidx.concurrent.futures)
+            substitute("androidx.lifecycle:lifecycle-common", libs.versions.androidx.lifecycle)
+            substitute("androidx.lifecycle:lifecycle-common-jvm", libs.versions.androidx.lifecycle)
+            substitute("androidx.lifecycle:lifecycle-runtime", libs.versions.androidx.lifecycle)
+            substitute("androidx.lifecycle:lifecycle-runtime-android", libs.versions.androidx.lifecycle)
+            substitute("androidx.lifecycle:lifecycle-runtime-compose", libs.versions.androidx.lifecycle)
+            substitute("androidx.lifecycle:lifecycle-runtime-compose-android", libs.versions.androidx.lifecycle)
+            substitute("androidx.lifecycle:lifecycle-runtime-ktx", libs.versions.androidx.lifecycle)
+            substitute("androidx.lifecycle:lifecycle-runtime-ktx-android", libs.versions.androidx.lifecycle)
+            substitute("androidx.navigationevent:navigationevent", libs.versions.androidx.navigationevent)
+            substitute("androidx.navigationevent:navigationevent-compose", libs.versions.androidx.navigationevent)
+            substitute("androidx.savedstate:savedstate", libs.versions.androidx.savedstate)
+            substitute("androidx.savedstate:savedstate-compose", libs.versions.androidx.savedstate)
+            substitute("androidx.test.services:storage", libs.versions.androidx.test.services.storage)
+            substitute("androidx.tracing:tracing", libs.versions.androidx.tracing)
+            substitute("org.jetbrains:annotations", libs.versions.jetbrains.annotations)
+            substitute("org.jetbrains.kotlinx:atomicfu", libs.versions.atomicfu)
+            substitute("org.jetbrains.kotlinx:atomicfu-jvm", libs.versions.atomicfu)
+            substitute("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", libs.versions.kotlinx.coroutines)
+            substitute("org.jetbrains.kotlinx:kotlinx-coroutines-android", libs.versions.kotlinx.coroutines)
+            substitute("org.jetbrains.kotlinx:kotlinx-coroutines-bom", libs.versions.kotlinx.coroutines)
+            substitute("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm", libs.versions.kotlinx.serialization)
+            substitute("org.jetbrains.kotlinx:kotlinx-serialization-json", libs.versions.kotlinx.serialization)
+            substitute("org.jetbrains.kotlinx:kotlinx-serialization-json-jvm", libs.versions.kotlinx.serialization)
+            substitute("org.jetbrains.kotlinx:kotlinx-serialization-bom", libs.versions.kotlinx.serialization)
         }
     }
 }
@@ -96,7 +94,7 @@ configurations.matching {
 configurations.all {
     resolutionStrategy {
         dependencySubstitution {
-            libs.findBundle("build-tool-pins").get().get().forEach { substitute(it) }
+            libs.bundles.build.tool.pins.get().forEach { substitute(it) }
         }
     }
 }
@@ -106,7 +104,7 @@ configurations.all {
 group = project.path.removePrefix(":").replace(":", ".")
 
 tasks {
-    val jvmTargetVersion = libs.findVersion("jvm-target").get().toString()
+    val jvmTargetVersion = libs.versions.jvm.target.get()
 
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         compilerOptions {

--- a/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-multiplatform-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-multiplatform-convention.gradle.kts
@@ -1,21 +1,19 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 plugins {
-    id("moneymanager.kotlin-convention")
-    id("org.jetbrains.kotlin.multiplatform")
+    alias(conventions.plugins.moneymanager.kotlin.convention)
+    alias(libs.plugins.kotlin.multiplatform)
 }
-
-val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
 configure<KotlinMultiplatformExtension> {
     jvm()
 
-    jvmToolchain(libs.findVersion("jvm-toolchain").get().toString().toInt())
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 
     sourceSets {
         getByName("jvmMain") {
             dependencies {
-                runtimeOnly(libs.findLibrary("kotlinx-coroutines-swing").get())
+                runtimeOnly(libs.kotlinx.coroutines.swing)
             }
         }
     }

--- a/gradle/build-logic/src/main/kotlin/moneymanager.mappie-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.mappie-convention.gradle.kts
@@ -2,21 +2,19 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import tech.mappie.NamingConvention
 
 plugins {
-    id("moneymanager.kotlin-multiplatform-convention")
-    id("tech.mappie.plugin")
+    alias(conventions.plugins.moneymanager.kotlin.multiplatform.convention)
+    alias(libs.plugins.mappie)
 }
 
 mappie {
     namingConvention = NamingConvention.LENIENT
 }
 
-val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
-
 configure<KotlinMultiplatformExtension> {
     sourceSets {
         getByName("commonMain") {
             dependencies {
-                implementation(libs.findLibrary("mappie-api").get())
+                implementation(libs.mappie.api)
             }
         }
     }

--- a/gradle/build-logic/src/main/kotlin/moneymanager.metro-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.metro-convention.gradle.kts
@@ -1,17 +1,15 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 plugins {
-    id("moneymanager.kotlin-multiplatform-convention")
-    id("dev.zacsweers.metro")
+    alias(conventions.plugins.moneymanager.kotlin.multiplatform.convention)
+    alias(libs.plugins.metro)
 }
-
-val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
 configure<KotlinMultiplatformExtension> {
     sourceSets {
         getByName("commonMain") {
             dependencies {
-                implementation(libs.findLibrary("metro-runtime").get())
+                implementation(libs.metro.runtime)
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ slf4j = "2.0.18"
 sort-dependencies = "0.19.0"
 sqldelight = "2.3.2"
 turbine = "1.2.1"
+typesafe-conventions = "0.11.1"
 # Build-tool transitive-alignment versions: pin tooling transitives (Gradle plugins, annotation
 # processors, AGP test platform) to one version across all build classpaths. Consumed via the
 # build-tool-pins bundle in moneymanager.kotlin-convention and gradle/build-logic/build.gradle.kts.
@@ -300,3 +301,4 @@ metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 mokkery = { id = "dev.mokkery", version.ref = "mokkery" }
 sort-dependencies = { id = "com.squareup.sort-dependencies", version.ref = "sort-dependencies" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
+typesafe-conventions = { id = "dev.panuszewski.typesafe-conventions", version.ref = "typesafe-conventions" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,6 @@ slf4j = "2.0.18"
 sort-dependencies = "0.19.0"
 sqldelight = "2.3.2"
 turbine = "1.2.1"
-typesafe-conventions = "0.11.1"
 # Build-tool transitive-alignment versions: pin tooling transitives (Gradle plugins, annotation
 # processors, AGP test platform) to one version across all build classpaths. Consumed via the
 # build-tool-pins bundle in moneymanager.kotlin-convention and gradle/build-logic/build.gradle.kts.
@@ -301,4 +300,3 @@ metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 mokkery = { id = "dev.mokkery", version.ref = "mokkery" }
 sort-dependencies = { id = "com.squareup.sort-dependencies", version.ref = "sort-dependencies" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
-typesafe-conventions = { id = "dev.panuszewski.typesafe-conventions", version.ref = "typesafe-conventions" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,13 +17,17 @@ dependencyResolutionManagement {
 }
 
 pluginManagement {
-    includeBuild("gradle/build-logic")
     repositories {
         google()
         mavenCentral()
         gradlePluginPortal()
     }
 }
+
+// Included at the top level (not inside pluginManagement) because the typesafe-conventions plugin
+// applied in build-logic requires the included build to be aware of the build hierarchy, which an
+// early-evaluated pluginManagement { includeBuild(...) } is not.
+includeBuild("gradle/build-logic")
 
 buildscript {
     repositories {


### PR DESCRIPTION
Closes #578.

Adopts the [typesafe-conventions-gradle-plugin](https://github.com/radoslaw-panuszewski/typesafe-conventions-gradle-plugin) (`0.11.1`) so `gradle/build-logic` convention plugins use the same type-safe accessors as ordinary build scripts, instead of the verbose `extensions.getByType<VersionCatalogsExtension>().named("libs")` + `findLibrary`/`findVersion`/`findBundle` pattern.

## Changes
- **`gradle/libs.versions.toml`** — add the `typesafe-conventions` version + plugin entry.
- **`gradle/build-logic/settings.gradle.kts`** — apply the settings plugin; remove the manual `versionCatalogs { create("libs") }` (the plugin auto-imports `libs` from the parent build; keeping it collides with "catalog already exists").
- **Root `settings.gradle.kts`** — move `includeBuild("gradle/build-logic")` out of `pluginManagement` to the top level (the plugin rejects early-evaluated included builds).
- **All convention plugins** — migrate to type-safe `libs.*` / `libs.versions.*` / `libs.bundles.*`; convert external `id("...")` to `alias(libs.plugins.*)` and inter-convention refs to `alias(conventions.plugins.moneymanager.*)`.
- **`gradle/build-logic/build.gradle.kts`** — drop 10 now-redundant `implementation(libs.*.gradle.plugin)` lines (markers are contributed automatically by `alias(...)`); keep `develocity` (used by `BuildScan.kt`) and `sqldelight` (applied directly in module scripts).

## Notes
- Verified on **Gradle 9.6 / JDK 25** (plugin advertises 8.8+; Gradle 9 isn't explicitly documented).
- For a catalog library whose name prefixes others (`androidx-activity` vs `androidx-activity-compose`), `libs.androidx.activity` is a group accessor — the base is `libs.androidx.activity.asProvider()`.

## Verification
- `./gradlew build` passes all modules, `buildHealth`, `detekt`, and `ktlint`. The only failure was a `ComposeTimeoutException` in `SchemaAwareCoroutineScopeE2ETest` — a known flaky Compose-desktop timeout under full-build load that **passes on isolated re-run** (this change touches only build configuration, not runtime code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build configuration consistency, reducing the chance of plugin and dependency resolution issues.
  * Ensured Android device test compilation is included in the normal build process.
  * Updated project setup so plugin repositories and included build logic are applied more reliably.

* **Refactor**
  * Standardized build scripts to use shared version and plugin references, simplifying maintenance across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->