### PR TITLE
Re-prompt cloud consent when the Google refresh token expires

### DIFF
--- a/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseController.kt
+++ b/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseController.kt
@@ -147,6 +147,20 @@ class RemoteDatabaseController(
         resolve(providerId, config)
     }
 
+    /**
+     * Forces a fresh interactive sign-in (full consent) for [providerId]/[config], replacing any stored
+     * credentials. Unlike [signInTo], this does not short-circuit when a refresh token is already on disk:
+     * a stored token that the provider still reports as "signed in" can nonetheless be expired or revoked
+     * (Google rejects it with `invalid_grant` only when it is actually used), so recovering from such a
+     * failure requires re-running consent unconditionally to mint a new refresh token.
+     */
+    suspend fun reconnect(
+        providerId: String,
+        config: String?,
+    ) {
+        providerFactory.create(providerId, config).signIn()
+    }
+
     /** Lists the archives stored by [providerId] (signing in if needed) for an open-from-remote picker. */
     suspend fun list(
         providerId: String,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppStartupHost.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppStartupHost.kt
@@ -24,6 +24,7 @@ import com.moneymanager.domain.model.DbLocation
 import com.moneymanager.domain.model.dbLocationFromString
 import com.moneymanager.localsettings.KEY_LAST_DATABASE
 import com.moneymanager.localsettings.LocalSettings
+import com.moneymanager.remotestorage.RemoteAuthException
 import com.moneymanager.remotestorage.sync.RemoteDatabaseController
 import com.moneymanager.ui.components.DatabaseSchemaErrorDialog
 import com.moneymanager.ui.components.DatabaseStartupProgressScreen
@@ -57,6 +58,11 @@ private sealed class AppDatabaseState {
 private data class RemoteUnlockState(
     val prompt: String,
     val error: String? = null,
+    // True when the restore failed because the cloud connection (refresh token) expired/was revoked:
+    // the password is fine, but the user must re-run Google consent before the download can succeed.
+    val needsReconnect: Boolean = false,
+    // The password already entered this run, retained so the post-reconnect retry needn't re-prompt.
+    val password: String = "",
 )
 
 private fun initialDatabaseProgress() =
@@ -276,45 +282,89 @@ fun AppStartupHost(
     }
 
     remoteUnlock?.let { unlock ->
+        val binding = remoteController?.activeBinding()
+
+        // Hydrates the bound database with [password]. A failed Google connection (expired/revoked refresh
+        // token) is surfaced distinctly from a bad password so the dialog can offer to re-run consent
+        // rather than wrongly blaming the password.
+        suspend fun restoreWithPassword(password: String) {
+            // A non-null binding implies a non-null controller (the binding came from it), smart-casting both.
+            if (binding == null) return
+            databaseState =
+                AppDatabaseState.Loading(DatabaseInitializationProgress("Restoring from cloud…", 0, 100))
+            try {
+                val location =
+                    remoteController.restore(binding, password) { progress ->
+                        databaseState =
+                            AppDatabaseState.Loading(
+                                DatabaseInitializationProgress(progress.message, (progress.fraction * 100).toInt(), 100),
+                            )
+                    }
+                val error =
+                    openAndLoad(
+                        location = location,
+                        databaseManager = databaseManager,
+                        createAppServices = createAppServices,
+                        databaseStateUpdater = { databaseState = it },
+                        onInfoLog = onInfoLog,
+                        onErrorLog = onErrorLog,
+                    )
+                if (error == null) {
+                    localSettings.putString(KEY_LAST_DATABASE, location.toString())
+                } else {
+                    remoteUnlock = unlock.copy(password = password, error = error.message ?: "Failed to open database")
+                }
+            } catch (expected: CancellationException) {
+                throw expected
+            } catch (authExpired: RemoteAuthException) {
+                onErrorLog("Cloud authentication expired while restoring database", authExpired)
+                databaseState = AppDatabaseState.Loading(initialDatabaseProgress())
+                remoteUnlock =
+                    unlock.copy(
+                        needsReconnect = true,
+                        password = password,
+                        error = "Your Google Drive connection has expired or was revoked.",
+                    )
+            } catch (expected: Exception) {
+                onErrorLog("Failed to restore database from cloud", expected)
+                databaseState = AppDatabaseState.Loading(initialDatabaseProgress())
+                remoteUnlock = unlock.copy(error = "Wrong password, or download failed")
+            }
+        }
+
         RemoteDatabaseUnlockDialog(
             state = unlock,
             onUnlock = { password ->
-                val binding = remoteController?.activeBinding()
                 if (binding != null) {
                     // Close the dialog immediately so the restore progress bar is clearly visible; it is
                     // only reopened (with an error) if the password was wrong or the download failed.
                     remoteUnlock = null
+                    scope.launch { restoreWithPassword(password) }
+                }
+            },
+            onReconnect = {
+                if (binding != null) {
+                    remoteUnlock = null
                     scope.launch {
                         databaseState =
-                            AppDatabaseState.Loading(DatabaseInitializationProgress("Restoring from cloud…", 0, 100))
+                            AppDatabaseState.Loading(
+                                DatabaseInitializationProgress("Reconnecting to ${binding.remoteName}…", 0, 100),
+                            )
                         try {
-                            val location =
-                                remoteController.restore(binding, password) { progress ->
-                                    databaseState =
-                                        AppDatabaseState.Loading(
-                                            DatabaseInitializationProgress(progress.message, (progress.fraction * 100).toInt(), 100),
-                                        )
-                                }
-                            val error =
-                                openAndLoad(
-                                    location = location,
-                                    databaseManager = databaseManager,
-                                    createAppServices = createAppServices,
-                                    databaseStateUpdater = { databaseState = it },
-                                    onInfoLog = onInfoLog,
-                                    onErrorLog = onErrorLog,
-                                )
-                            if (error == null) {
-                                localSettings.putString(KEY_LAST_DATABASE, location.toString())
-                            } else {
-                                remoteUnlock = unlock.copy(error = error.message ?: "Failed to open database")
-                            }
+                            // Full interactive consent mints a fresh refresh token; then retry the restore
+                            // with the password the user already supplied (held on the dialog state).
+                            remoteController.reconnect(binding.providerId, binding.providerConfig)
+                            restoreWithPassword(unlock.password)
                         } catch (expected: CancellationException) {
                             throw expected
                         } catch (expected: Exception) {
-                            onErrorLog("Failed to restore database from cloud", expected)
+                            onErrorLog("Failed to reconnect to cloud storage", expected)
                             databaseState = AppDatabaseState.Loading(initialDatabaseProgress())
-                            remoteUnlock = unlock.copy(error = "Wrong password, or download failed")
+                            remoteUnlock =
+                                unlock.copy(
+                                    needsReconnect = true,
+                                    error = "Reconnect failed: ${expected.message ?: "could not sign in"}",
+                                )
                         }
                     }
                 }
@@ -360,6 +410,7 @@ fun AppStartupHost(
 private fun RemoteDatabaseUnlockDialog(
     state: RemoteUnlockState,
     onUnlock: (String) -> Unit,
+    onReconnect: () -> Unit,
 ) {
     var password by remember { mutableStateOf("") }
     AlertDialog(
@@ -368,19 +419,29 @@ private fun RemoteDatabaseUnlockDialog(
         title = { Text(state.prompt) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(
-                    value = password,
-                    onValueChange = { password = it },
-                    label = { Text("Password") },
-                    singleLine = true,
-                    visualTransformation = PasswordVisualTransformation(),
-                )
+                if (state.needsReconnect) {
+                    // The password is already known to be correct; only the cloud sign-in needs renewing,
+                    // so prompt for re-consent instead of showing the password field again.
+                    Text("Reconnect to your Google account to finish restoring this database.")
+                } else {
+                    OutlinedTextField(
+                        value = password,
+                        onValueChange = { password = it },
+                        label = { Text("Password") },
+                        singleLine = true,
+                        visualTransformation = PasswordVisualTransformation(),
+                    )
+                }
                 state.error?.let { Text(it) }
             }
         },
         confirmButton = {
-            TextButton(onClick = { onUnlock(password) }, enabled = password.isNotEmpty()) {
-                Text("Unlock")
+            if (state.needsReconnect) {
+                TextButton(onClick = onReconnect) { Text("Reconnect to Google Drive") }
+            } else {
+                TextButton(onClick = { onUnlock(password) }, enabled = password.isNotEmpty()) {
+                    Text("Unlock")
+                }
             }
         },
     )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppStartupHost.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppStartupHost.kt
@@ -282,19 +282,20 @@ fun AppStartupHost(
     }
 
     remoteUnlock?.let { unlock ->
-        val binding = remoteController?.activeBinding()
+        // The dialog only shows for a remote-backed database, so a controller is always present here.
+        val controller = remoteController ?: return@let
+        val binding = controller.activeBinding()
 
         // Hydrates the bound database with [password]. A failed Google connection (expired/revoked refresh
         // token) is surfaced distinctly from a bad password so the dialog can offer to re-run consent
         // rather than wrongly blaming the password.
         suspend fun restoreWithPassword(password: String) {
-            // A non-null binding implies a non-null controller (the binding came from it), smart-casting both.
             if (binding == null) return
             databaseState =
                 AppDatabaseState.Loading(DatabaseInitializationProgress("Restoring from cloud…", 0, 100))
             try {
                 val location =
-                    remoteController.restore(binding, password) { progress ->
+                    controller.restore(binding, password) { progress ->
                         databaseState =
                             AppDatabaseState.Loading(
                                 DatabaseInitializationProgress(progress.message, (progress.fraction * 100).toInt(), 100),
@@ -312,7 +313,9 @@ fun AppStartupHost(
                 if (error == null) {
                     localSettings.putString(KEY_LAST_DATABASE, location.toString())
                 } else {
-                    remoteUnlock = unlock.copy(password = password, error = error.message ?: "Failed to open database")
+                    // A non-auth failure: leave reconnect mode so the password field returns.
+                    remoteUnlock =
+                        unlock.copy(needsReconnect = false, password = "", error = error.message ?: "Failed to open database")
                 }
             } catch (expected: CancellationException) {
                 throw expected
@@ -328,7 +331,8 @@ fun AppStartupHost(
             } catch (expected: Exception) {
                 onErrorLog("Failed to restore database from cloud", expected)
                 databaseState = AppDatabaseState.Loading(initialDatabaseProgress())
-                remoteUnlock = unlock.copy(error = "Wrong password, or download failed")
+                // A non-auth failure (e.g. wrong password): leave reconnect mode so the password field returns.
+                remoteUnlock = unlock.copy(needsReconnect = false, password = "", error = "Wrong password, or download failed")
             }
         }
 
@@ -353,7 +357,7 @@ fun AppStartupHost(
                         try {
                             // Full interactive consent mints a fresh refresh token; then retry the restore
                             // with the password the user already supplied (held on the dialog state).
-                            remoteController.reconnect(binding.providerId, binding.providerConfig)
+                            controller.reconnect(binding.providerId, binding.providerConfig)
                             restoreWithPassword(unlock.password)
                         } catch (expected: CancellationException) {
                             throw expected


### PR DESCRIPTION
## Problem

When a cloud-backed (Google Drive) database is restored on startup and the stored **refresh token has expired or been revoked**, the app fails with a misleading **"Wrong password, or download failed"** message — even though the password is fine. (Reported from a real `invalid_grant: Token has been expired or revoked` failure during restore.)

The root cause: `isSignedIn()` only checks whether a refresh token is *present*, not whether it is still valid. So `resolve()` skips the consent flow, and the stale token only fails later inside `hydrate()` as a `RemoteAuthException`, which the restore catch block then mislabels as a password error.

## Change

- **`RemoteDatabaseController.reconnect()`** (new) — forces a fresh interactive consent **unconditionally**. Unlike `signInTo()`, it does not short-circuit when a stored-but-revoked token reports "signed in", which is exactly the case that needs a new refresh token.
- **`AppStartupHost`** — the restore path now catches `RemoteAuthException` distinctly from a wrong password. The unlock dialog flips into a reconnect state (*"Your Google Drive connection has expired or was revoked"*) with a **"Reconnect to Google Drive"** button. Clicking it runs `reconnect()` and then automatically retries the restore using the password already entered (held in-memory on the dialog state). Restore logic is refactored into a shared `restoreWithPassword()` so the initial unlock and the post-reconnect retry share one path.

## Notes / follow-up

- Cross-platform: the new path lives in `commonMain`; `reconnect()` triggers the JVM loopback consent or the Android native consent sheet via the existing `provider.signIn()`.
- Out of scope: the in-session "Download from cloud" button (`onReloadFromRemote`) still surfaces an auth failure as a generic error. Can be extended to the same reconnect handling in a follow-up.
- Unrelated to the code: users seeing weekly token expiry should set their Google OAuth consent screen to **In production** (the "Testing" status expires refresh tokens after 7 days).

## Testing

`./gradlew build` passes locally (full build + tests + coverage + dependency health).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reconnect flow for cloud restore when remote access has expired or been revoked.
  * Users can now re-authorize their cloud account directly from the unlock screen and retry restoring their data without re-entering everything.

* **Bug Fixes**
  * Improved restore error handling to show clearer guidance when unlock fails.
  * Preserves the entered password during reconnect-required scenarios so restore can be retried more smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->