### PR TITLE
Split slow db:core tests into a parallel CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,41 @@ jobs:
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
           GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
         with:
-          command: build --stacktrace
+          # The slow :app:db:core:jvmTest is split into its own parallel `db-core-test`
+          # job below so it no longer serializes the main build. Keep the two in sync.
+          command: build --stacktrace -x :app:db:core:jvmTest
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Upload coverage and test results to Codecov
+        uses: ./.github/actions/codecov-upload
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit
+
+  db-core-test:
+    name: db:core Tests
+    runs-on: ubuntu-latest
+    needs: changes
+    # The :app:db:core:jvmTest suite is slow (~12 min), so it runs here in parallel
+    # with the main build (which excludes it via `-x :app:db:core:jvmTest`).
+    if: >-
+      needs.changes.outputs.code == 'true' &&
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Run :app:db:core:jvmTest with Gradle
+        uses: ./.github/actions/gradle-run
+        env:
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+        with:
+          # koverXmlReport depends on jvmTest, so this runs the tests and produces the
+          # per-module coverage XML that Codecov merges with the main build's report.
+          command: :app:db:core:koverXmlReport --stacktrace
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Upload coverage and test results to Codecov


### PR DESCRIPTION
## Summary

`:app:db:core:jvmTest` takes ~12 min and was serializing the main CI build. This splits it into its own parallel job so it overlaps with the rest of the build instead of blocking it.

- **Main `build` job** now excludes the suite: `build --stacktrace -x :app:db:core:jvmTest`
- **New `db-core-test` job** runs in parallel via `:app:db:core:koverXmlReport --stacktrace` — this transitively runs `jvmTest` *and* produces the per-module coverage XML, so Codecov still gets db:core coverage under the same `unit` flag (verified the dependency chain with `--dry-run`).
- Both jobs share the same `needs: changes` gating, `cache-read-only` logic, and OAuth secrets env.

## Note

If branch protection has required status checks, add **`db:core Tests`** to the required checks list so a failure there blocks merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)