### PR TITLE
Download a top-level import directory's own files, not just subfolders

### DIFF
--- a/app/ui/imports/importDirectory/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportDirectoriesScreen.kt
+++ b/app/ui/imports/importDirectory/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportDirectoriesScreen.kt
@@ -155,7 +155,7 @@ fun ImportDirectoriesScreen(
                     val created = createSubdirectories(directory, directories.associateByTo(mutableMapOf()) { it.folderRef })
                     statusMessage =
                         "${directory.name}: downloaded $downloaded file(s); " +
-                            "created $created subfolder director${if (created == 1) "y" else "ies"}."
+                        "created $created subfolder director${if (created == 1) "y" else "ies"}."
                 } else {
                     statusMessage = "${directory.name}: downloaded ${downloadFolder(directory).filesDownloaded} file(s)."
                 }

--- a/app/ui/imports/importDirectory/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportDirectoriesScreen.kt
+++ b/app/ui/imports/importDirectory/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportDirectoriesScreen.kt
@@ -142,8 +142,8 @@ fun ImportDirectoriesScreen(
             onProgress = { done, total -> scanProgress = done to total },
         )
 
-    // Per-row action: a top-level folder only discovers + creates child directories; a discovered
-    // subfolder downloads its own files.
+    // Per-row action: a top-level folder both downloads its OWN importable files and discovers +
+    // creates child directories for any subfolders; a discovered subfolder just downloads its files.
     fun downloadDirectory(directory: ImportDirectory) {
         scanningId = directory.id
         scanProgress = 0 to 0
@@ -151,8 +151,11 @@ fun ImportDirectoriesScreen(
         scope.launch {
             try {
                 if (directory.topLevel) {
+                    val downloaded = downloadFolder(directory).filesDownloaded
                     val created = createSubdirectories(directory, directories.associateByTo(mutableMapOf()) { it.folderRef })
-                    statusMessage = "${directory.name}: created $created subfolder director${if (created == 1) "y" else "ies"}."
+                    statusMessage =
+                        "${directory.name}: downloaded $downloaded file(s); " +
+                            "created $created subfolder director${if (created == 1) "y" else "ies"}."
                 } else {
                     statusMessage = "${directory.name}: downloaded ${downloadFolder(directory).filesDownloaded} file(s)."
                 }
@@ -216,8 +219,8 @@ fun ImportDirectoriesScreen(
         }
 
         Text(
-            "\"Find subfolders\" on a top-level folder discovers its importable subfolders; download those to " +
-                "fetch files, then use each row's import link. Tick \"Exclude\" to skip a folder.",
+            "\"Download & find subfolders\" on a top-level folder fetches its own files AND discovers importable " +
+                "subfolders; download those too, then use each row's import link. Tick \"Exclude\" to skip a folder.",
             style = MaterialTheme.typography.bodyMedium,
         )
 
@@ -331,8 +334,9 @@ private fun ImportDirectoryRow(
         ).joinToString(" and ").ifEmpty { "No" }.let { "$it files downloaded" }
 
     val onWrongDevice = directory.provider == ImportDirectoryProvider.LOCAL && directory.deviceId != deviceId
-    // Top-level folders discover + create child directories; discovered subfolders download their files.
-    val actionLabel = if (directory.topLevel) "Find subfolders" else "Download"
+    // Top-level folders download their own files AND discover/create child directories for subfolders;
+    // discovered subfolders just download their files.
+    val actionLabel = if (directory.topLevel) "Download & find subfolders" else "Download"
 
     Card(modifier = Modifier.fillMaxWidth().padding(start = indent)) {
         Column(


### PR DESCRIPTION
## Problem

In the Import Directories screen, the per-row action on a **top-level** folder (the one you pick) only ran `createSubdirectories` — it discovered importable subfolders and created child rows, but **never downloaded the CSV/QIF files sitting directly in the picked folder**.

So a folder like `crypto.com` that contains *both* subfolders *and* loose CSV files would only ever surface its subfolders; the direct CSV files were silently ignored.

(Note: "Download all" already fetched these, because its phase-2 loop iterates every directory including top-levels — but the single-row button did not.)

## Fix

The top-level branch of `downloadDirectory` (`ImportDirectoriesScreen.kt`) now **downloads the folder's own files AND discovers subfolders**:

```kotlin
if (directory.topLevel) {
    val downloaded = downloadFolder(directory).filesDownloaded
    val created = createSubdirectories(directory, ...)
    statusMessage = "...: downloaded $downloaded file(s); created $created subfolder ..."
}
```

- Button relabeled **"Find subfolders" → "Download & find subfolders"**.
- Help text and inline comments updated to match.

The scanner (`scanImportDirectory`) and discovery (`discoverImportableFolders`) were already correct — this is a UI-handler-only change, consistent with how "Download all" already behaves.

## Testing

- `:app:ui:imports:importDirectory:compileKotlinJvm` passes.
- Manual: open Imports → Directories, click "Download & find subfolders" on a top-level folder containing loose CSVs → the files now stage into the CSV/QIF imports tabs in addition to subfolder rows being created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Top-level import folders now support a combined action to download files and discover/create subfolders in one step.
  * The primary action label for top-level folders has been updated to better reflect this workflow.

* **Bug Fixes**
  * Status messages now show both downloaded files and created subfolders, giving clearer progress feedback.
  * Guidance text was updated so the on-screen instructions match the new folder import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->