### PR TITLE
CSV strategy editor: single-column toggle + auto-detected, validated date formats

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/DateFormatDetector.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/DateFormatDetector.kt
@@ -74,6 +74,32 @@ object DateFormatDetector {
             LocalTime.Format { byUnicodePattern(pattern) }.parse(value)
         }
 
+    /** Whether [pattern] is a valid combined date+time format that parses [value] (after trimming). */
+    fun parsesAsDateTime(
+        pattern: String,
+        value: String,
+    ): Boolean = tryParse { LocalDateTime.Format { byUnicodePattern(pattern) }.parse(value.trim()) }
+
+    /** Whether [pattern] is a valid date-only format that parses [value] (after trimming). */
+    fun parsesAsDate(
+        pattern: String,
+        value: String,
+    ): Boolean = tryParse { LocalDate.Format { byUnicodePattern(pattern) }.parse(value.trim()) }
+
+    /** Whether [pattern] is a valid time-only format that parses [value] (after trimming). */
+    fun parsesAsTime(
+        pattern: String,
+        value: String,
+    ): Boolean = tryParse { LocalTime.Format { byUnicodePattern(pattern) }.parse(value.trim()) }
+
+    private inline fun tryParse(block: () -> Unit): Boolean =
+        try {
+            block()
+            true
+        } catch (_: Exception) {
+            false
+        }
+
     private inline fun firstMatching(
         candidates: List<String>,
         samples: List<String>,

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/DateFormatDetector.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/DateFormatDetector.kt
@@ -1,0 +1,97 @@
+@file:OptIn(kotlinx.datetime.format.FormatStringsInDatetimeFormats::class)
+
+package com.moneymanager.csvimporter
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.format.byUnicodePattern
+
+/**
+ * Guesses the date/time format string for a CSV column from its sample values.
+ *
+ * Candidates are tried in priority order and the first one that parses **every** non-blank sample is
+ * returned, so the UI can pre-fill the format field instead of making the user hand-write a
+ * [byUnicodePattern]. Parsing goes through the very same `kotlinx.datetime` pattern engine the
+ * importer uses ([CsvTransferMapper]), so a detected format is guaranteed to parse at import time.
+ *
+ * Ambiguous numeric layouts (e.g. `05/06/2026`) resolve to the higher-priority candidate; this app
+ * is UK-centric, so day-first (`dd/MM/yyyy`) is preferred over month-first.
+ */
+object DateFormatDetector {
+    /** Combined date+time patterns, most common first. */
+    val dateTimeCandidates: List<String> =
+        listOf(
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy-MM-dd'T'HH:mm:ss",
+            "yyyy-MM-dd HH:mm",
+            "yyyy-MM-dd'T'HH:mm",
+            "dd/MM/yyyy HH:mm:ss",
+            "dd/MM/yyyy HH:mm",
+            "MM/dd/yyyy HH:mm:ss",
+            "MM/dd/yyyy HH:mm",
+            "dd-MM-yyyy HH:mm:ss",
+            "dd.MM.yyyy HH:mm:ss",
+        )
+
+    /** Date-only patterns, most common first. */
+    val dateCandidates: List<String> =
+        listOf(
+            "yyyy-MM-dd",
+            "dd/MM/yyyy",
+            "MM/dd/yyyy",
+            "dd-MM-yyyy",
+            "dd.MM.yyyy",
+            "yyyy/MM/dd",
+            "d/M/yyyy",
+            "M/d/yyyy",
+        )
+
+    /** Time-only patterns, most common first. */
+    val timeCandidates: List<String> =
+        listOf(
+            "HH:mm:ss",
+            "HH:mm",
+            "H:mm:ss",
+            "H:mm",
+        )
+
+    /** Detects a combined date+time format, or null if no candidate parses every sample. */
+    fun detectDateTime(samples: List<String>): String? =
+        firstMatching(dateTimeCandidates, samples) { pattern, value ->
+            LocalDateTime.Format { byUnicodePattern(pattern) }.parse(value)
+        }
+
+    /** Detects a date-only format, or null if no candidate parses every sample. */
+    fun detectDate(samples: List<String>): String? =
+        firstMatching(dateCandidates, samples) { pattern, value ->
+            LocalDate.Format { byUnicodePattern(pattern) }.parse(value)
+        }
+
+    /** Detects a time-only format, or null if no candidate parses every sample. */
+    fun detectTime(samples: List<String>): String? =
+        firstMatching(timeCandidates, samples) { pattern, value ->
+            LocalTime.Format { byUnicodePattern(pattern) }.parse(value)
+        }
+
+    private inline fun firstMatching(
+        candidates: List<String>,
+        samples: List<String>,
+        parse: (pattern: String, value: String) -> Any,
+    ): String? {
+        val values = samples.map { it.trim() }.filter { it.isNotEmpty() }.take(MAX_SAMPLES)
+        if (values.isEmpty()) return null
+        return candidates.firstOrNull { pattern ->
+            values.all { value ->
+                try {
+                    parse(pattern, value)
+                    true
+                } catch (_: Exception) {
+                    false
+                }
+            }
+        }
+    }
+
+    private const val MAX_SAMPLES = 50
+}

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/DateFormatDetectorTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/DateFormatDetectorTest.kt
@@ -2,9 +2,26 @@ package com.moneymanager.csvimporter
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class DateFormatDetectorTest {
+    @Test
+    fun `parses checks match the sample against the given pattern`() {
+        assertTrue(DateFormatDetector.parsesAsDateTime("yyyy-MM-dd HH:mm:ss", "2026-06-14 13:38:54"))
+        assertFalse(DateFormatDetector.parsesAsDateTime("yyyy-MM-dd HH:mm:ss", "14/06/2026"))
+        assertTrue(DateFormatDetector.parsesAsDate("dd/MM/yyyy", " 14/06/2026 "))
+        assertFalse(DateFormatDetector.parsesAsDate("dd/MM/yyyy", "2026-06-14"))
+        assertTrue(DateFormatDetector.parsesAsTime("HH:mm:ss", "13:38:54"))
+        assertFalse(DateFormatDetector.parsesAsTime("HH:mm:ss", "not a time"))
+    }
+
+    @Test
+    fun `parses returns false for an invalid pattern instead of throwing`() {
+        assertFalse(DateFormatDetector.parsesAsDate("nonsense pattern", "2026-06-14"))
+    }
+
     @Test
     fun `detects crypto-com combined timestamp`() {
         val samples = listOf("2026-06-14 13:38:54", "2026-05-01 06:59:26", "2026-06-14 11:15:34")

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/DateFormatDetectorTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/DateFormatDetectorTest.kt
@@ -1,0 +1,59 @@
+package com.moneymanager.csvimporter
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DateFormatDetectorTest {
+    @Test
+    fun `detects crypto-com combined timestamp`() {
+        val samples = listOf("2026-06-14 13:38:54", "2026-05-01 06:59:26", "2026-06-14 11:15:34")
+        assertEquals("yyyy-MM-dd HH:mm:ss", DateFormatDetector.detectDateTime(samples))
+    }
+
+    @Test
+    fun `detects ISO T-separated timestamp`() {
+        assertEquals("yyyy-MM-dd'T'HH:mm:ss", DateFormatDetector.detectDateTime(listOf("2026-06-14T13:38:54")))
+    }
+
+    @Test
+    fun `day-first beats month-first for unambiguous dates`() {
+        assertEquals("dd/MM/yyyy", DateFormatDetector.detectDate(listOf("14/06/2026", "01/02/2026")))
+    }
+
+    @Test
+    fun `falls through to month-first when day-first cannot parse`() {
+        // 13 is not a valid month, so dd/MM/yyyy is ruled out and MM/dd/yyyy wins.
+        assertEquals("MM/dd/yyyy", DateFormatDetector.detectDate(listOf("06/13/2026")))
+    }
+
+    @Test
+    fun `detects ISO date`() {
+        assertEquals("yyyy-MM-dd", DateFormatDetector.detectDate(listOf("2026-06-14", "2026-01-02")))
+    }
+
+    @Test
+    fun `detects time formats`() {
+        assertEquals("HH:mm:ss", DateFormatDetector.detectTime(listOf("13:38:54")))
+        assertEquals("HH:mm", DateFormatDetector.detectTime(listOf("13:38")))
+    }
+
+    @Test
+    fun `trims surrounding whitespace before matching`() {
+        assertEquals("yyyy-MM-dd HH:mm:ss", DateFormatDetector.detectDateTime(listOf("  2026-06-14 13:38:54  ")))
+    }
+
+    @Test
+    fun `ignores blank samples but requires at least one value`() {
+        assertEquals("yyyy-MM-dd", DateFormatDetector.detectDate(listOf("", "2026-06-14", "   ")))
+        assertNull(DateFormatDetector.detectDate(listOf("", "   ")))
+        assertNull(DateFormatDetector.detectDate(emptyList()))
+    }
+
+    @Test
+    fun `returns null when no candidate parses every sample`() {
+        assertNull(DateFormatDetector.detectDate(listOf("not a date")))
+        // Mixed layouts: no single pattern parses both.
+        assertNull(DateFormatDetector.detectDate(listOf("2026-06-14", "14/06/2026")))
+    }
+}

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AmountDateTab.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AmountDateTab.kt
@@ -242,7 +242,7 @@ private fun DateTimeSection(
             label = "Date+time format (e.g., yyyy-MM-dd HH:mm:ss)",
             sample = getSampleValue(csvColumns, firstRow, state.dateColumnName),
             enabled = enabled,
-            isError = state.dateTimeFormat.isBlank(),
+            validate = DateFormatDetector::parsesAsDateTime,
             onAutoDetect = {
                 DateFormatDetector.detectDateTime(columnSamples(state.dateColumnName))?.let { state.dateTimeFormat = it }
             },
@@ -257,7 +257,7 @@ private fun DateTimeSection(
             label = "Date format (e.g., dd/MM/yyyy)",
             sample = getSampleValue(csvColumns, firstRow, state.dateColumnName),
             enabled = enabled,
-            isError = state.dateFormat.isBlank(),
+            validate = DateFormatDetector::parsesAsDate,
             onAutoDetect = {
                 DateFormatDetector.detectDate(columnSamples(state.dateColumnName))?.let { state.dateFormat = it }
             },
@@ -290,7 +290,7 @@ private fun DateTimeSection(
                 label = "Time format (e.g., HH:mm:ss)",
                 sample = getSampleValue(csvColumns, firstRow, state.timeColumnName),
                 enabled = enabled,
-                isError = state.timeFormat.isBlank(),
+                validate = DateFormatDetector::parsesAsTime,
                 onAutoDetect = {
                     DateFormatDetector.detectTime(columnSamples(state.timeColumnName))?.let { state.timeFormat = it }
                 },
@@ -302,6 +302,10 @@ private fun DateTimeSection(
 /**
  * A date/time format text field with a "Sample: …" hint and an inline "Auto-detect" action that
  * re-guesses the pattern from the column's values.
+ *
+ * Turns red when the format is blank, or when it cannot parse the displayed sample value — so a
+ * mistyped or wrong pattern is caught immediately. [validate] reports whether the current format
+ * successfully parses a given sample.
  */
 @Composable
 private fun FormatField(
@@ -310,9 +314,11 @@ private fun FormatField(
     label: String,
     sample: String?,
     enabled: Boolean,
-    isError: Boolean,
+    validate: (format: String, sample: String) -> Boolean,
     onAutoDetect: () -> Unit,
 ) {
+    val trimmedSample = sample?.trim().orEmpty()
+    val sampleUnparseable = value.isNotBlank() && trimmedSample.isNotEmpty() && !validate(value, trimmedSample)
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
@@ -320,14 +326,17 @@ private fun FormatField(
         modifier = Modifier.fillMaxWidth(),
         singleLine = true,
         enabled = enabled,
-        isError = isError,
+        isError = value.isBlank() || sampleUnparseable,
         trailingIcon = {
             TextButton(onClick = onAutoDetect, enabled = enabled) {
                 Text("Auto-detect")
             }
         },
         supportingText = {
-            sample?.let { Text("Sample: $it") }
+            when {
+                sampleUnparseable -> Text("Sample \"$trimmedSample\" does not match this format")
+                sample != null -> Text("Sample: $sample")
+            }
         },
     )
 }

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AmountDateTab.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AmountDateTab.kt
@@ -11,10 +11,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.csvimporter.DateFormatDetector
 import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.repository.CurrencyReadRepository
@@ -28,6 +31,7 @@ import com.moneymanager.ui.screens.csvstrategy.getSampleValue
 internal fun AmountDateTab(
     state: CsvStrategyEditorState,
     csvColumns: List<CsvColumn>,
+    rows: List<CsvRow>,
     firstRow: CsvRow?,
     enabled: Boolean,
     currencyRepository: CurrencyReadRepository,
@@ -165,28 +169,97 @@ internal fun AmountDateTab(
         }
 
         Spacer(modifier = Modifier.height(16.dp))
-        Text("Date Column", style = MaterialTheme.typography.titleSmall)
-        ColumnDropdown(
-            columns = csvColumns,
-            selectedColumn = state.dateColumnName,
-            onColumnSelected = { state.dateColumnName = it },
-            label = "Column containing transaction date",
-            sampleValue = getSampleValue(csvColumns, firstRow, state.dateColumnName),
+        DateTimeSection(state, csvColumns, rows, firstRow, enabled)
+    }
+}
+
+/**
+ * Date/time parsing controls. A single checkbox toggles between the two mutually exclusive layouts —
+ * a combined date+time column or separate date/time columns — so only the fields relevant to the
+ * chosen layout are shown. Format fields auto-fill from the selected column's sample values via
+ * [DateFormatDetector] until the user edits them; the "Auto-detect" action re-runs detection on demand.
+ */
+@Composable
+private fun DateTimeSection(
+    state: CsvStrategyEditorState,
+    csvColumns: List<CsvColumn>,
+    rows: List<CsvRow>,
+    firstRow: CsvRow?,
+    enabled: Boolean,
+) {
+    fun columnSamples(columnName: String?): List<String> {
+        val index = csvColumns.find { it.originalName == columnName }?.columnIndex ?: return emptyList()
+        return rows.mapNotNull { it.values.getOrNull(index) }
+    }
+
+    // Auto-fill the active format from the chosen column's samples until the user takes over.
+    LaunchedEffect(state.dateColumnName, state.dateTimeInOneColumn, rows) {
+        if (state.dateTimeInOneColumn) {
+            if (!state.combinedFormatTouched) {
+                DateFormatDetector.detectDateTime(columnSamples(state.dateColumnName))?.let { state.dateTimeFormat = it }
+            }
+        } else if (!state.dateFormatTouched) {
+            DateFormatDetector.detectDate(columnSamples(state.dateColumnName))?.let { state.dateFormat = it }
+        }
+    }
+    LaunchedEffect(state.timeColumnName, rows) {
+        if (!state.dateTimeInOneColumn && state.timeColumnName != null && !state.timeFormatTouched) {
+            DateFormatDetector.detectTime(columnSamples(state.timeColumnName))?.let { state.timeFormat = it }
+        }
+    }
+
+    Text("Date & Time", style = MaterialTheme.typography.titleSmall)
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Checkbox(
+            checked = state.dateTimeInOneColumn,
+            onCheckedChange = { state.dateTimeInOneColumn = it },
             enabled = enabled,
-            isError = state.dateColumnName == null,
         )
-        Spacer(modifier = Modifier.height(4.dp))
-        OutlinedTextField(
-            value = state.dateFormat,
-            onValueChange = { state.dateFormat = it },
-            label = { Text("Date Format (e.g., dd/MM/yyyy)") },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
+        Text(
+            "Date and time are in a single column",
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+
+    Spacer(modifier = Modifier.height(4.dp))
+    ColumnDropdown(
+        columns = csvColumns,
+        selectedColumn = state.dateColumnName,
+        onColumnSelected = { state.dateColumnName = it },
+        label = if (state.dateTimeInOneColumn) "Column containing date and time" else "Column containing transaction date",
+        sampleValue = getSampleValue(csvColumns, firstRow, state.dateColumnName),
+        enabled = enabled,
+        isError = state.dateColumnName == null,
+    )
+    Spacer(modifier = Modifier.height(4.dp))
+    if (state.dateTimeInOneColumn) {
+        FormatField(
+            value = state.dateTimeFormat,
+            onValueChange = {
+                state.dateTimeFormat = it
+                state.combinedFormatTouched = true
+            },
+            label = "Date+time format (e.g., yyyy-MM-dd HH:mm:ss)",
+            sample = getSampleValue(csvColumns, firstRow, state.dateColumnName),
             enabled = enabled,
-            supportingText = {
-                getSampleValue(csvColumns, firstRow, state.dateColumnName)?.let {
-                    Text("Sample: $it")
-                }
+            isError = state.dateTimeFormat.isBlank(),
+            onAutoDetect = {
+                DateFormatDetector.detectDateTime(columnSamples(state.dateColumnName))?.let { state.dateTimeFormat = it }
+            },
+        )
+    } else {
+        FormatField(
+            value = state.dateFormat,
+            onValueChange = {
+                state.dateFormat = it
+                state.dateFormatTouched = true
+            },
+            label = "Date format (e.g., dd/MM/yyyy)",
+            sample = getSampleValue(csvColumns, firstRow, state.dateColumnName),
+            enabled = enabled,
+            isError = state.dateFormat.isBlank(),
+            onAutoDetect = {
+                DateFormatDetector.detectDate(columnSamples(state.dateColumnName))?.let { state.dateFormat = it }
             },
         )
 
@@ -206,37 +279,55 @@ internal fun AmountDateTab(
             sampleValue = getSampleValue(csvColumns, firstRow, state.timeColumnName),
             enabled = enabled,
         )
-        if (state.timeColumnName != null && state.dateTimeFormat.isBlank()) {
+        if (state.timeColumnName != null) {
             Spacer(modifier = Modifier.height(4.dp))
-            OutlinedTextField(
+            FormatField(
                 value = state.timeFormat,
-                onValueChange = { state.timeFormat = it },
-                label = { Text("Time Format (e.g., HH:mm:ss)") },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
+                onValueChange = {
+                    state.timeFormat = it
+                    state.timeFormatTouched = true
+                },
+                label = "Time format (e.g., HH:mm:ss)",
+                sample = getSampleValue(csvColumns, firstRow, state.timeColumnName),
                 enabled = enabled,
-                supportingText = {
-                    getSampleValue(csvColumns, firstRow, state.timeColumnName)?.let {
-                        Text("Sample: $it")
-                    }
+                isError = state.timeFormat.isBlank(),
+                onAutoDetect = {
+                    DateFormatDetector.detectTime(columnSamples(state.timeColumnName))?.let { state.timeFormat = it }
                 },
             )
         }
-
-        Spacer(modifier = Modifier.height(4.dp))
-        OutlinedTextField(
-            value = state.dateTimeFormat,
-            onValueChange = { state.dateTimeFormat = it },
-            label = { Text("Combined date+time format (optional)") },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-            enabled = enabled,
-            supportingText = {
-                Text(
-                    "When set, the date column holds both date and time " +
-                        "(e.g., yyyy-MM-dd HH:mm:ss) and the separate time column is ignored.",
-                )
-            },
-        )
     }
+}
+
+/**
+ * A date/time format text field with a "Sample: …" hint and an inline "Auto-detect" action that
+ * re-guesses the pattern from the column's values.
+ */
+@Composable
+private fun FormatField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    sample: String?,
+    enabled: Boolean,
+    isError: Boolean,
+    onAutoDetect: () -> Unit,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label) },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+        enabled = enabled,
+        isError = isError,
+        trailingIcon = {
+            TextButton(onClick = onAutoDetect, enabled = enabled) {
+                Text("Auto-detect")
+            }
+        },
+        supportingText = {
+            sample?.let { Text("Sample: $it") }
+        },
+    )
 }

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AmountDateTab.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AmountDateTab.kt
@@ -192,6 +192,10 @@ private fun DateTimeSection(
         return rows.mapNotNull { it.values.getOrNull(index) }
     }
 
+    // The first value with content drives both the "Sample:" hint and the format validation, so an
+    // empty leading cell doesn't hide a format that fails to parse real rows.
+    fun firstNonBlankSample(columnName: String?): String? = columnSamples(columnName).firstOrNull { it.isNotBlank() }
+
     // Auto-fill the active format from the chosen column's samples until the user takes over.
     LaunchedEffect(state.dateColumnName, state.dateTimeInOneColumn, rows) {
         if (state.dateTimeInOneColumn) {
@@ -240,7 +244,7 @@ private fun DateTimeSection(
                 state.combinedFormatTouched = true
             },
             label = "Date+time format (e.g., yyyy-MM-dd HH:mm:ss)",
-            sample = getSampleValue(csvColumns, firstRow, state.dateColumnName),
+            sample = firstNonBlankSample(state.dateColumnName),
             enabled = enabled,
             validate = DateFormatDetector::parsesAsDateTime,
             onAutoDetect = {
@@ -255,7 +259,7 @@ private fun DateTimeSection(
                 state.dateFormatTouched = true
             },
             label = "Date format (e.g., dd/MM/yyyy)",
-            sample = getSampleValue(csvColumns, firstRow, state.dateColumnName),
+            sample = firstNonBlankSample(state.dateColumnName),
             enabled = enabled,
             validate = DateFormatDetector::parsesAsDate,
             onAutoDetect = {
@@ -288,7 +292,7 @@ private fun DateTimeSection(
                     state.timeFormatTouched = true
                 },
                 label = "Time format (e.g., HH:mm:ss)",
-                sample = getSampleValue(csvColumns, firstRow, state.timeColumnName),
+                sample = firstNonBlankSample(state.timeColumnName),
                 enabled = enabled,
                 validate = DateFormatDetector::parsesAsTime,
                 onAutoDetect = {

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AmountDateTab.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AmountDateTab.kt
@@ -243,7 +243,7 @@ private fun DateTimeSection(
                 state.dateTimeFormat = it
                 state.combinedFormatTouched = true
             },
-            label = "Date+time format (e.g., yyyy-MM-dd HH:mm:ss)",
+            label = "Date+Time Format (e.g., yyyy-MM-dd HH:mm:ss)",
             sample = firstNonBlankSample(state.dateColumnName),
             enabled = enabled,
             validate = DateFormatDetector::parsesAsDateTime,
@@ -258,7 +258,7 @@ private fun DateTimeSection(
                 state.dateFormat = it
                 state.dateFormatTouched = true
             },
-            label = "Date format (e.g., dd/MM/yyyy)",
+            label = "Date Format (e.g., dd/MM/yyyy)",
             sample = firstNonBlankSample(state.dateColumnName),
             enabled = enabled,
             validate = DateFormatDetector::parsesAsDate,
@@ -291,7 +291,7 @@ private fun DateTimeSection(
                     state.timeFormat = it
                     state.timeFormatTouched = true
                 },
-                label = "Time format (e.g., HH:mm:ss)",
+                label = "Time Format (e.g., HH:mm:ss)",
                 sample = firstNonBlankSample(state.timeColumnName),
                 enabled = enabled,
                 validate = DateFormatDetector::parsesAsTime,

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorScreen.kt
@@ -287,6 +287,7 @@ fun CsvStrategyEditorScreen(
                     AmountDateTab(
                         state = state,
                         csvColumns = csvColumns,
+                        rows = rows,
                         firstRow = firstRow,
                         enabled = !state.isSaving,
                         currencyRepository = currencyRepository,

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorState.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorState.kt
@@ -43,6 +43,20 @@ internal class CsvStrategyEditorState(
     var timeColumnName by mutableStateOf(initial?.timeColumnName)
     var timeFormat by mutableStateOf(initial?.timeFormat ?: "HH:mm:ss")
     var dateTimeFormat by mutableStateOf(initial?.dateTimeFormat.orEmpty())
+
+    /**
+     * When true, a single column holds both the date and time ([dateTimeFormat] drives parsing);
+     * when false, the date (and optional time) live in separate columns. Seeded from whether the
+     * loaded strategy had a combined format.
+     */
+    var dateTimeInOneColumn by mutableStateOf(!initial?.dateTimeFormat.isNullOrBlank())
+
+    // Whether the user has hand-edited a format field. While false, the editor auto-fills the format
+    // from the selected column's sample values (see AmountDateTab). Editing an existing strategy
+    // starts "touched" so a saved format is never silently overwritten.
+    var combinedFormatTouched by mutableStateOf(initial != null)
+    var dateFormatTouched by mutableStateOf(initial != null)
+    var timeFormatTouched by mutableStateOf(initial != null)
     var descriptionColumnName by mutableStateOf(initial?.descriptionColumnName)
     var descriptionFallbackColumns by mutableStateOf(initial?.descriptionFallbackColumns.orEmpty())
     var amountColumnName by mutableStateOf(initial?.amountColumnName)
@@ -132,9 +146,18 @@ internal class CsvStrategyEditorState(
     val accountsHasError: Boolean
         get() = !targetAccountValid
 
+    private val dateTimeFormatValid: Boolean
+        get() = if (dateTimeInOneColumn) dateTimeFormat.isNotBlank() else dateFormat.isNotBlank()
+
     /** Whether the Amount & Date tab has an unsatisfied required field. */
     val amountDateHasError: Boolean
-        get() = amountColumnName == null || dateColumnName == null || !feeValid || !currencyValid || !timezoneValid
+        get() =
+            amountColumnName == null ||
+                dateColumnName == null ||
+                !dateTimeFormatValid ||
+                !feeValid ||
+                !currencyValid ||
+                !timezoneValid
 
     /** Whether the Advanced tab has an unsatisfied required field. */
     val advancedHasError: Boolean
@@ -155,6 +178,7 @@ internal class CsvStrategyEditorState(
                 identificationColumns.isNotEmpty() &&
                 targetAccountValid &&
                 dateColumnName != null &&
+                dateTimeFormatValid &&
                 descriptionColumnName != null &&
                 amountColumnName != null &&
                 feeValid &&
@@ -169,7 +193,9 @@ internal class CsvStrategyEditorState(
             identificationColumns = identificationColumns,
             dateColumnName = dateColumnName,
             dateFormat = dateFormat,
-            timeColumnName = timeColumnName,
+            // The two modes are mutually exclusive: a combined format ignores any separate time
+            // column, so null it out to keep the saved mapping consistent with the chosen mode.
+            timeColumnName = if (dateTimeInOneColumn) null else timeColumnName,
             timeFormat = timeFormat,
             descriptionColumnName = descriptionColumnName,
             descriptionFallbackColumns = descriptionFallbackColumns,
@@ -177,7 +203,7 @@ internal class CsvStrategyEditorState(
             flipAccountsOnPositive = flipAccountsOnPositive,
             feeColumnName = feeColumnName,
             feeConditions = feeConditions,
-            dateTimeFormat = dateTimeFormat,
+            dateTimeFormat = if (dateTimeInOneColumn) dateTimeFormat else "",
             sourceAccountMode = sourceAccountMode,
             selectedAccountId = selectedAccountId,
             sourceTemplateColumnName = sourceTemplateColumnName,


### PR DESCRIPTION
## What

Improves the date/time section of the CSV import strategy editor (Amount & Date tab).

### Single toggle instead of three free-text fields
The editor previously exposed *Date Format*, *Time Format*, and *Combined date+time format* boxes at once — nothing stopped you filling all three, and the combined-vs-separate behaviour was implicit. These are replaced by one **"Date and time are in a single column"** checkbox:
- **checked** → one column + one date+time format field (drives `dateTimeFormat`)
- **unchecked** → date column + date format, plus an optional time column + time format

The two modes are mutually exclusive; `toFormState()` nulls out the unused mode's fields so the saved mapping stays consistent.

### Auto-detected formats
New `DateFormatDetector` (in `app/csvimporter`) guesses the pattern from the column's sample values using the **same kotlinx-datetime engine the importer parses with**, so anything detected is guaranteed to parse at import time. `yyyy-MM-dd HH:mm:ss` (crypto.com / Wise) is among the candidates, alongside ISO, `dd/MM/yyyy`, etc. Format fields auto-fill on column selection until hand-edited, with an inline **Auto-detect** action to re-run.

### Sample validation
A format field turns red — with an explanatory hint — when the entered pattern can't parse the column's **first non-blank** sample value, not just when it's blank. So a mistyped or wrong format is caught immediately.

## Why
Motivated by a crypto.com card-transactions CSV whose `Timestamp (UTC)` column (`2026-06-14 13:38:54`) failed with a date-only format. The new toggle + auto-detect make that case (and similar combined-timestamp exports) work without hand-writing a Unicode pattern.

## Testing
- New `DateFormatDetectorTest` (incl. the crypto.com sample, ambiguity resolution, parse-check helpers).
- Existing strategy round-trip tests still pass; `:app:ui:imports:csv` compiles; `lintFormat` clean.
- Full `./gradlew build` not yet run locally — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV date and time fields can now be auto-detected from sample values, including combined date-time, date-only, and time-only formats.
  * The import editor now supports switching between a single combined date-time column and separate date and time columns.
  * Format fields now show inline sample validation and an **Auto-detect** action.

* **Bug Fixes**
  * Improved validation for date and time formats during CSV setup.
  * Better handling of blank values, whitespace, and mismatched format patterns when parsing sample data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->