### PR TITLE
Generic account mappings: drop columnName, match the strategy's account value

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvAccountSelection.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvAccountSelection.kt
@@ -41,7 +41,6 @@ fun buildPendingAccountMappings(
                 null
             } else {
                 PendingAccountMappingKey(
-                    columnName = discoveredMapping.columnName,
                     pattern =
                         discoveredMapping.matchedPattern
                             ?: "^${Regex.escape(discoveredMapping.csvValue)}$",
@@ -53,7 +52,6 @@ fun buildPendingAccountMappings(
         .mapIndexed { index, mapping ->
             AccountMapping(
                 id = -(index + 1).toLong(),
-                columnName = mapping.columnName,
                 valuePattern = Regex(mapping.pattern, RegexOption.IGNORE_CASE),
                 accountId = mapping.accountId,
                 createdAt = now,
@@ -111,7 +109,6 @@ fun hasBlankNewAccountNames(
 }
 
 private data class PendingAccountMappingKey(
-    val columnName: String,
     val pattern: String,
     val accountId: AccountId,
 )

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -253,14 +253,13 @@ private suspend fun persistMappingsWithFallback(
         for (mapping in mappings) {
             try {
                 importEngine.createAccountMapping(
-                    columnName = mapping.columnName,
                     valuePattern = mapping.valuePattern,
                     accountId = mapping.accountId,
                     strategyId = mapping.strategyId,
                 )
             } catch (expectedMappingError: Exception) {
                 // Don't log the pattern itself — it's derived from bank-file payee/account values (PII).
-                logger.warn(expectedMappingError) { "Failed to save account mapping for column '${mapping.columnName}'" }
+                logger.warn(expectedMappingError) { "Failed to save account mapping for account id ${mapping.accountId.id}" }
             }
         }
     }

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -174,7 +174,6 @@ data class ExistingTransferInfo(
  * Represents a mapping discovered during import that can be persisted.
  * Used for auto-capturing mappings when new accounts are created.
  *
- * @property columnName The CSV column that was matched
  * @property csvValue The actual value from the CSV that led to this account
  * @property targetAccountName The name of the account that will be/was created from this value.
  *           For AccountLookupMapping, this equals csvValue. For RegexAccountMapping, this is the
@@ -185,7 +184,6 @@ data class ExistingTransferInfo(
  *           creating an exact-match pattern for csvValue.
  */
 data class DiscoveredAccountMapping(
-    val columnName: String,
     val csvValue: String,
     val targetAccountName: String,
     val matchedPattern: String? = null,
@@ -228,14 +226,13 @@ class CsvTransferMapper(
             emptyMap()
         }
 
-    // Index account mappings by column name for fast lookup. Only global mappings (strategyId null)
-    // and mappings scoped to THIS strategy apply; a strategy-specific match is ordered ahead of a
-    // global one so it wins in findPersistedMapping (which returns the first match per column).
-    private val accountMappingsByColumn: Map<String, List<AccountMapping>> =
+    // Only global mappings (strategyId null) and mappings scoped to THIS strategy apply; a
+    // strategy-specific match is ordered ahead of a global one so it wins in findPersistedMapping
+    // (which returns the first match).
+    private val scopedAccountMappings: List<AccountMapping> =
         accountMappings
             .filter { it.strategyId == null || it.strategyId == strategy.id }
             .sortedWith(compareBy({ it.strategyId == null }, { it.id }))
-            .groupBy { it.columnName }
 
     /**
      * Prepares an import by mapping all rows and collecting new accounts to create.
@@ -649,7 +646,7 @@ class CsvTransferMapper(
                 val csvValue = getColumnValue(mapping.columnName, values).trim()
 
                 // Check persisted mappings FIRST - this handles renamed accounts
-                val persistedMatch = findPersistedMapping(mapping.columnName, csvValue)
+                val persistedMatch = findPersistedMapping(csvValue)
                 if (persistedMatch != null) {
                     return persistedMatch
                 }
@@ -660,11 +657,10 @@ class CsvTransferMapper(
             }
             is ConditionalAccountMapping -> parseAccount(resolveConditional(mapping, values), values)
             is AccountLookupMapping -> {
-                val columnName = mapping.columnName
-                val csvValue = getColumnValue(columnName, values)
+                val csvValue = getColumnValue(mapping.columnName, values)
 
                 // Check persisted mappings FIRST - this handles renamed accounts
-                val persistedMatch = findPersistedMapping(columnName, csvValue)
+                val persistedMatch = findPersistedMapping(csvValue)
                 if (persistedMatch != null) {
                     return persistedMatch
                 }
@@ -679,8 +675,8 @@ class CsvTransferMapper(
                 // will actually be used (could be fallback column)
                 val result = getAccountNameFromRegexWithPattern(mapping, values)
 
-                // Check persisted mappings using the ACTUAL column/value that was resolved
-                val persistedMatch = findPersistedMapping(result.sourceColumnName, result.sourceColumnValue)
+                // Check persisted mappings using the ACTUAL value that was resolved
+                val persistedMatch = findPersistedMapping(result.sourceColumnValue)
                 if (persistedMatch != null) {
                     return persistedMatch
                 }
@@ -694,19 +690,16 @@ class CsvTransferMapper(
     }
 
     /**
-     * Finds a persisted account mapping that matches the given column and value.
-     * First matching mapping wins (ordered by id).
+     * Finds a persisted account mapping whose pattern matches the given account source value
+     * (the value the strategy's account field-mapping resolved for this row). First matching
+     * mapping wins: strategy-scoped mappings are tried before global ones, then id order — so
+     * mappings that share a pattern resolve deterministically.
      *
-     * @param columnName The CSV column name
      * @param value The value to match against
      * @return The mapped AccountId, or null if no match found
      */
-    private fun findPersistedMapping(
-        columnName: String,
-        value: String,
-    ): AccountId? {
-        val mappings = accountMappingsByColumn[columnName] ?: return null
-        for (mapping in mappings) {
+    private fun findPersistedMapping(value: String): AccountId? {
+        for (mapping in scopedAccountMappings) {
             if (mapping.valuePattern.containsMatchIn(value)) {
                 return mapping.accountId
             }
@@ -727,14 +720,14 @@ class CsvTransferMapper(
             is AccountLookupMapping -> {
                 val csvValue = getColumnValue(mapping.columnName, values)
                 // If a persisted mapping matched, don't create a new account
-                if (findPersistedMapping(mapping.columnName, csvValue) != null) {
+                if (findPersistedMapping(csvValue) != null) {
                     null
                 } else {
                     val name = getAccountName(mapping, values)
                     if (name.isNotBlank() && !accountExists(name)) {
                         // For AccountLookupMapping, csvValue == name (account name)
                         NewAccount(name, mapping.defaultCategoryId) to
-                            DiscoveredAccountMapping(mapping.columnName, csvValue, name)
+                            DiscoveredAccountMapping(csvValue, name)
                     } else {
                         null
                     }
@@ -743,15 +736,13 @@ class CsvTransferMapper(
             is RegexAccountMapping -> {
                 val result = getAccountNameFromRegexWithPattern(mapping, values)
                 // If a persisted mapping matched, don't create a new account
-                if (findPersistedMapping(result.sourceColumnName, result.sourceColumnValue) != null) {
+                if (findPersistedMapping(result.sourceColumnValue) != null) {
                     null
                 } else if (result.accountName.isNotBlank() && !accountExists(result.accountName)) {
                     // For RegexAccountMapping, accountName differs from sourceColumnValue
                     // (e.g., sourceColumnValue="Paxos Technology LTD", accountName="Paxos")
-                    // Use the actual source column that produced the value (important for fallback)
                     NewAccount(result.accountName, mapping.defaultCategoryId) to
                         DiscoveredAccountMapping(
-                            columnName = result.sourceColumnName,
                             csvValue = result.sourceColumnValue,
                             targetAccountName = result.accountName,
                             matchedPattern = result.matchedPattern,
@@ -763,14 +754,14 @@ class CsvTransferMapper(
             is TemplateAccountMapping -> {
                 val csvValue = getColumnValue(mapping.columnName, values).trim()
                 val name = templatedAccountName(mapping, csvValue)
-                if (findPersistedMapping(mapping.columnName, csvValue) != null ||
+                if (findPersistedMapping(csvValue) != null ||
                     name.isBlank() ||
                     accountExists(name)
                 ) {
                     null
                 } else {
                     NewAccount(name, mapping.defaultCategoryId) to
-                        DiscoveredAccountMapping(mapping.columnName, csvValue, name)
+                        DiscoveredAccountMapping(csvValue, name)
                 }
             }
             is ConditionalAccountMapping -> discoverNewAccount(resolveConditional(mapping, values), values)
@@ -962,7 +953,7 @@ class CsvTransferMapper(
                     !result.counterpartyIsPerson || result.accountName.isBlank() -> null
                     // A persisted account mapping intentionally remaps this counterparty (e.g. onto an
                     // existing account), so don't auto-create a Person/ownership from the regex name.
-                    findPersistedMapping(result.sourceColumnName, result.sourceColumnValue) != null -> null
+                    findPersistedMapping(result.sourceColumnValue) != null -> null
                     else -> result.accountName
                 }
             }

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/ApplyStrategyDialogTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/ApplyStrategyDialogTest.kt
@@ -31,14 +31,12 @@ class ApplyStrategyDialogTest {
                             listOf(
                                 transferWithDiscoveredMapping(
                                     DiscoveredAccountMapping(
-                                        columnName = "Payee",
                                         csvValue = "ACME LTD",
                                         targetAccountName = "Acme",
                                     ),
                                 ),
                                 transferWithDiscoveredMapping(
                                     DiscoveredAccountMapping(
-                                        columnName = "Description",
                                         csvValue = "PAYMENT TO ACME",
                                         targetAccountName = "Acme",
                                         matchedPattern = ".*ACME.*",
@@ -54,8 +52,8 @@ class ApplyStrategyDialogTest {
             )
 
         assertEquals(2, mappings.size)
-        assertTrue(mappings.any { it.columnName == "Payee" && it.valuePattern.pattern == "^\\QACME LTD\\E$" })
-        assertTrue(mappings.any { it.columnName == "Description" && it.valuePattern.pattern == ".*ACME.*" })
+        assertTrue(mappings.any { it.valuePattern.pattern == "^\\QACME LTD\\E$" })
+        assertTrue(mappings.any { it.valuePattern.pattern == ".*ACME.*" })
         assertTrue(mappings.all { it.accountId == selectedAccountId })
         assertTrue(mappings.all { it.createdAt == now && it.updatedAt == now })
     }
@@ -66,7 +64,6 @@ class ApplyStrategyDialogTest {
 
         val duplicateMapping =
             DiscoveredAccountMapping(
-                columnName = "Payee",
                 csvValue = "Coffee Shop",
                 targetAccountName = "Coffee Shop",
             )
@@ -104,7 +101,6 @@ class ApplyStrategyDialogTest {
                             listOf(
                                 transferWithDiscoveredMapping(
                                     DiscoveredAccountMapping(
-                                        columnName = "Payee",
                                         csvValue = "Coffee Shop",
                                         targetAccountName = "Coffee Shop",
                                     ),
@@ -135,7 +131,6 @@ class ApplyStrategyDialogTest {
                             listOf(
                                 transferWithDiscoveredMapping(
                                     DiscoveredAccountMapping(
-                                        columnName = "Payee",
                                         csvValue = "ACME LTD",
                                         targetAccountName = "Acme",
                                     ),

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvAccountMappingTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvAccountMappingTest.kt
@@ -112,7 +112,6 @@ class CsvAccountMappingTest {
 
     private fun createAccountMapping(
         id: Long,
-        columnName: String,
         pattern: String,
         accountId: AccountId,
         strategyId: CsvImportStrategyId? = null,
@@ -121,7 +120,6 @@ class CsvAccountMappingTest {
         return AccountMapping(
             id = id,
             strategyId = strategyId,
-            columnName = columnName,
             valuePattern = Regex(pattern, RegexOption.IGNORE_CASE),
             accountId = accountId,
             createdAt = now,
@@ -147,7 +145,7 @@ class CsvAccountMappingTest {
     @Test
     fun `global mapping applies under any strategy`() {
         val target = AccountId(30)
-        val mapper = mapperWith(listOf(createAccountMapping(1, "Payee", "^Foo$", target)))
+        val mapper = mapperWith(listOf(createAccountMapping(1, "^Foo$", target)))
         val result = mapper.mapRow(payeeRow())
         assertIs<MappingResult.Success>(result)
         assertEquals(target, result.transfer.targetAccountId)
@@ -157,7 +155,7 @@ class CsvAccountMappingTest {
     fun `mapping scoped to a different strategy is ignored`() {
         val target = AccountId(30)
         val otherStrategy = CsvImportStrategyId(Uuid.random())
-        val mapper = mapperWith(listOf(createAccountMapping(1, "Payee", "^Foo$", target, strategyId = otherStrategy)))
+        val mapper = mapperWith(listOf(createAccountMapping(1, "^Foo$", target, strategyId = otherStrategy)))
         val result = mapper.mapRow(payeeRow())
         assertIs<MappingResult.Success>(result)
         // Not matched: "Foo" is discovered as a new account instead of routing to the scoped target.
@@ -165,14 +163,14 @@ class CsvAccountMappingTest {
     }
 
     @Test
-    fun `strategy-specific mapping wins over a global one for the same column and value`() {
+    fun `strategy-specific mapping wins over a global one for the same value`() {
         val globalTarget = AccountId(30)
         val strategyTarget = AccountId(31)
         val mapper =
             mapperWith(
                 listOf(
-                    createAccountMapping(1, "Payee", "^Foo$", globalTarget),
-                    createAccountMapping(2, "Payee", "^Foo$", strategyTarget, strategyId = strategyId),
+                    createAccountMapping(1, "^Foo$", globalTarget),
+                    createAccountMapping(2, "^Foo$", strategyTarget, strategyId = strategyId),
                 ),
             )
         val result = mapper.mapRow(payeeRow())
@@ -200,7 +198,6 @@ class CsvAccountMappingTest {
         val mapping =
             createAccountMapping(
                 id = 1,
-                columnName = "Payee",
                 pattern = "^Nikolay Metchev & Olga Zakharenko$",
                 accountId = renamedAccountId,
             )
@@ -288,7 +285,6 @@ class CsvAccountMappingTest {
         val mapping =
             createAccountMapping(
                 id = 1,
-                columnName = "Payee",
                 pattern = ".*paxos.*",
                 accountId = paxosAccountId,
             )
@@ -329,7 +325,6 @@ class CsvAccountMappingTest {
         val mapping =
             createAccountMapping(
                 id = 1,
-                columnName = "Payee",
                 pattern = ".*paxos.*",
                 accountId = paxosAccountId,
             )
@@ -380,14 +375,12 @@ class CsvAccountMappingTest {
         val mapping1 =
             createAccountMapping(
                 id = 1,
-                columnName = "Payee",
                 pattern = ".*test.*",
                 accountId = account1Id,
             )
         val mapping2 =
             createAccountMapping(
                 id = 2,
-                columnName = "Payee",
                 pattern = ".*corp.*",
                 accountId = account2Id,
             )
@@ -434,7 +427,6 @@ class CsvAccountMappingTest {
         val mapping =
             createAccountMapping(
                 id = 1,
-                columnName = "Payee",
                 pattern = ".*paxos.*",
                 accountId = AccountId(99),
             )
@@ -484,7 +476,6 @@ class CsvAccountMappingTest {
         assertIs<MappingResult.Success>(result)
         assertEquals("New Vendor Inc", result.newAccountName)
         // Discovered mapping should be captured for auto-capture
-        assertEquals("Payee", result.discoveredMapping?.columnName)
         assertEquals("New Vendor Inc", result.discoveredMapping?.csvValue)
     }
 
@@ -506,7 +497,6 @@ class CsvAccountMappingTest {
         val mapping =
             createAccountMapping(
                 id = 1,
-                columnName = "Payee",
                 pattern = "^Vendor XYZ$",
                 accountId = targetAccountId,
             )
@@ -559,13 +549,11 @@ class CsvAccountMappingTest {
             listOf(
                 createAccountMapping(
                     id = 1,
-                    columnName = "Payee",
                     pattern = "^Nikolay Metchev & Olga Zakharenko$",
                     accountId = monzoAccountId,
                 ),
                 createAccountMapping(
                     id = 2,
-                    columnName = "Payee",
                     pattern = ".*paxos.*",
                     accountId = paxosAccountId,
                 ),
@@ -687,7 +675,6 @@ class CsvAccountMappingTest {
         val mapping =
             createAccountMapping(
                 id = 1,
-                columnName = "Name",
                 pattern = "^Generic Corp$",
                 accountId = specificAccountId,
             )
@@ -715,23 +702,23 @@ class CsvAccountMappingTest {
         assertEquals(specificAccountId, result.transfer.targetAccountId)
     }
 
-    // ============= Column-Specific Mappings =============
+    // ============= Column-Agnostic Mappings =============
 
     @Test
-    fun `mappings are column-specific and only match their designated column`() {
-        val payeeAccountId = AccountId(40)
+    fun `mapping matches whatever column the strategy reads accounts from`() {
+        // Mappings carry no column: the value tested is whatever the strategy's account
+        // field-mapping resolves. A global mapping therefore works across strategies that
+        // read accounts from differently named columns ("Payee" here, "Name" elsewhere).
+        val vendorAccountId = AccountId(40)
 
-        // Mapping for "Name" column, not "Payee"
         val mapping =
             createAccountMapping(
                 id = 1,
-                // Different column!
-                columnName = "Name",
-                pattern = ".*",
-                accountId = payeeAccountId,
+                pattern = "^Some Vendor$",
+                accountId = vendorAccountId,
             )
 
-        // Uses "Payee" column for target account
+        // This strategy reads the target account from the "Payee" column
         val mapper =
             CsvTransferMapper(
                 strategy = createStrategy(),
@@ -750,8 +737,43 @@ class CsvAccountMappingTest {
         val result = mapper.mapRow(row)
 
         assertIs<MappingResult.Success>(result)
-        // Mapping shouldn't match because it's for "Name" column, not "Payee"
-        assertEquals("Some Vendor", result.newAccountName)
+        assertEquals(vendorAccountId, result.transfer.targetAccountId)
+        assertNull(result.newAccountName)
+    }
+
+    @Test
+    fun `same global mapping fires for a strategy reading accounts from a different column`() {
+        // The same mapping as above, but under a strategy whose account source is the
+        // "Name" column (with "Type" fallback) instead of "Payee".
+        val vendorAccountId = AccountId(40)
+
+        val mapping =
+            createAccountMapping(
+                id = 1,
+                pattern = "^Some Vendor$",
+                accountId = vendorAccountId,
+            )
+
+        val mapper =
+            CsvTransferMapper(
+                strategy = createStrategyWithRegex(),
+                columns = columnsWithType,
+                existingAccounts = emptyMap(),
+                existingCurrencies = mapOf(testCurrencyId to testCurrency),
+                existingCurrenciesByCode = mapOf(testCurrency.code.uppercase() to testCurrency),
+                accountMappings = listOf(mapping),
+            )
+
+        val row =
+            CsvRow(
+                rowIndex = 1,
+                values = listOf("15/12/2024", "Payment", "-100.00", "Some Vendor", "Card payment"),
+            )
+        val result = mapper.mapRow(row)
+
+        assertIs<MappingResult.Success>(result)
+        assertEquals(vendorAccountId, result.transfer.targetAccountId)
+        assertNull(result.newAccountName)
     }
 
     // ============= DiscoveredAccountMapping for Auto-Capture =============
@@ -789,7 +811,6 @@ class CsvAccountMappingTest {
         assertEquals("Generic", result.newAccountName)
         // Discovered mapping should contain enough info for auto-capture
         val discovered = result.discoveredMapping
-        assertEquals("Name", discovered?.columnName)
         // CSV value is "Some generic vendor"
         assertEquals("Some generic vendor", discovered?.csvValue)
         // Target account name should be "Generic" so auto-capture can find the right account
@@ -822,7 +843,6 @@ class CsvAccountMappingTest {
         assertIs<MappingResult.Success>(result)
         assertEquals("New Payee Account", result.newAccountName)
         val discovered = result.discoveredMapping
-        assertEquals("Payee", discovered?.columnName)
         assertEquals("New Payee Account", discovered?.csvValue)
         // For AccountLookupMapping, csvValue == targetAccountName
         assertEquals("New Payee Account", discovered?.targetAccountName)
@@ -860,7 +880,6 @@ class CsvAccountMappingTest {
         // Fallback uses first non-blank from allColumns, which is the primary column value
         assertEquals("Special Vendor", result.newAccountName)
         val discovered = result.discoveredMapping
-        assertEquals("Name", discovered?.columnName)
         assertEquals("Special Vendor", discovered?.csvValue)
         // targetAccountName equals the fallback value (same as csvValue in this case)
         assertEquals("Special Vendor", discovered?.targetAccountName)
@@ -869,10 +888,10 @@ class CsvAccountMappingTest {
     }
 
     @Test
-    fun `RegexAccountMapping fallback to secondary column captures correct column and value`() {
+    fun `RegexAccountMapping fallback to secondary column captures the fallback value`() {
         // When the primary column is blank and fallback to a secondary column is used,
-        // the discovered mapping should capture the FALLBACK column name and value,
-        // not the primary column.
+        // the discovered mapping should capture the FALLBACK column's value,
+        // not the primary column's.
         val mapper =
             CsvTransferMapper(
                 strategy = createStrategyWithRegex(),
@@ -895,8 +914,6 @@ class CsvAccountMappingTest {
         // Account name comes from fallback column "Type"
         assertEquals("Card payment", result.newAccountName)
         val discovered = result.discoveredMapping
-        // Column should be "Type" (the fallback column that was used), NOT "Name"
-        assertEquals("Type", discovered?.columnName)
         // CSV value should be "Card payment" (the value from the fallback column)
         assertEquals("Card payment", discovered?.csvValue)
         assertEquals("Card payment", discovered?.targetAccountName)
@@ -911,7 +928,7 @@ class CsvAccountMappingTest {
         // Scenario:
         // 1. First import: Primary "Name" is blank, fallback "Type" = "Card payment" → creates account
         // 2. User renames account "Card payment" → "Credit Card Payments"
-        // 3. Mapping exists: columnName="Type", pattern="^Card payment$", accountId=renamedAccountId
+        // 3. Mapping exists: pattern="^Card payment$", accountId=renamedAccountId
         // 4. Second import: Same CSV with blank "Name" and "Type" = "Card payment"
         // 5. Should reuse the renamed account via the persisted mapping
 
@@ -923,11 +940,10 @@ class CsvAccountMappingTest {
                 openingDate = Clock.System.now(),
             )
 
-        // Persisted mapping for the fallback column "Type"
+        // Persisted mapping for the value the fallback column carries
         val mapping =
             createAccountMapping(
                 id = 1,
-                columnName = "Type",
                 pattern = "^Card payment$",
                 accountId = renamedAccountId,
             )

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/database/csv/WiseCsvMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/database/csv/WiseCsvMapperTest.kt
@@ -372,7 +372,6 @@ class WiseCsvMapperTest {
         assertEquals(AccountId(-1), result.transfer.sourceAccountId)
         assertEquals(listOf(NewAccount("Wise: BGN", -1L)), result.newAccounts)
         val discovered = result.discoveredMappings.single()
-        assertEquals("Source currency", discovered.columnName)
         assertEquals("BGN", discovered.csvValue)
         assertEquals("Wise: BGN", discovered.targetAccountName)
     }
@@ -383,7 +382,6 @@ class WiseCsvMapperTest {
         val mapping =
             AccountMapping(
                 id = 1,
-                columnName = "Source currency",
                 valuePattern = Regex("^EUR$"),
                 accountId = renamedAccount.id,
                 createdAt = Clock.System.now(),

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/AccountMappingExportService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/AccountMappingExportService.kt
@@ -56,7 +56,6 @@ class AccountMappingExportService(
                         accountsById[mapping.accountId]
                             ?: error("Missing account for id ${mapping.accountId.id} in AccountMapping")
                     AccountMappingExport(
-                        columnName = mapping.columnName,
                         valuePattern = mapping.valuePattern.pattern,
                         accountName = account.name,
                     )
@@ -118,17 +117,20 @@ class AccountMappingExportService(
 
         val now = Clock.System.now()
         val mappings =
-            export.mappings.mapNotNull { mappingExport ->
-                val account = accountsByName[mappingExport.accountName] ?: return@mapNotNull null
-                AccountMapping(
-                    id = 0,
-                    columnName = mappingExport.columnName,
-                    valuePattern = Regex(mappingExport.valuePattern, RegexOption.IGNORE_CASE),
-                    accountId = account.id,
-                    createdAt = now,
-                    updatedAt = now,
-                )
-            }
+            export.mappings
+                // Legacy exports carried a column per mapping, so the same pattern could appear once
+                // per column; without columns those would collide on the unique constraint. First wins.
+                .distinctBy { it.valuePattern }
+                .mapNotNull { mappingExport ->
+                    val account = accountsByName[mappingExport.accountName] ?: return@mapNotNull null
+                    AccountMapping(
+                        id = 0,
+                        valuePattern = Regex(mappingExport.valuePattern, RegexOption.IGNORE_CASE),
+                        accountId = account.id,
+                        createdAt = now,
+                        updatedAt = now,
+                    )
+                }
         if (mappings.isNotEmpty()) {
             importEngine.createAccountMappings(mappings)
         }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
@@ -186,7 +186,6 @@ class CsvStrategyExportService(
             .filter { it.strategyId == strategyId }
             .map { mapping ->
                 AccountMappingExport(
-                    columnName = mapping.columnName,
                     valuePattern = mapping.valuePattern.pattern,
                     accountName = accountsById[mapping.accountId]?.name ?: "Unknown Account",
                 )
@@ -428,20 +427,23 @@ class CsvStrategyExportService(
         // Fail loudly like the field-mapping path: silently dropping a mapping would import a strategy
         // that's missing part of itself with no signal to the caller.
         val accountMappings =
-            export.accountMappings.map { mappingExport ->
-                val account =
-                    accountsByName[mappingExport.accountName]
-                        ?: error("Account not found: ${mappingExport.accountName}")
-                AccountMapping(
-                    id = 0,
-                    strategyId = strategy.id,
-                    columnName = mappingExport.columnName,
-                    valuePattern = Regex(mappingExport.valuePattern, RegexOption.IGNORE_CASE),
-                    accountId = account.id,
-                    createdAt = now,
-                    updatedAt = now,
-                )
-            }
+            export.accountMappings
+                // Legacy exports carried a column per mapping, so the same pattern could appear once
+                // per column; without columns those would collide on the unique constraint. First wins.
+                .distinctBy { it.valuePattern }
+                .map { mappingExport ->
+                    val account =
+                        accountsByName[mappingExport.accountName]
+                            ?: error("Account not found: ${mappingExport.accountName}")
+                    AccountMapping(
+                        id = 0,
+                        strategyId = strategy.id,
+                        valuePattern = Regex(mappingExport.valuePattern, RegexOption.IGNORE_CASE),
+                        accountId = account.id,
+                        createdAt = now,
+                        updatedAt = now,
+                    )
+                }
 
         return CsvStrategyImportResult(strategy = strategy, accountMappings = accountMappings)
     }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/StrategyLibraryService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/StrategyLibraryService.kt
@@ -175,9 +175,9 @@ class StrategyLibraryService(
                 .getAllMappings()
                 .first()
                 .filter { it.strategyId == null }
-                .map { it.columnName to it.valuePattern.pattern }
+                .map { it.valuePattern.pattern }
                 .toSet()
-        val fresh = export.copy(mappings = export.mappings.filter { (it.columnName to it.valuePattern) !in existing })
+        val fresh = export.copy(mappings = export.mappings.filter { it.valuePattern !in existing })
         if (fresh.mappings.isNotEmpty()) {
             accountMappingExportService.importMappings(fresh, serviceResolutions)
         }

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/AccountMappingRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/AccountMappingRepositoryImplTest.kt
@@ -60,13 +60,11 @@ class AccountMappingRepositoryImplTest : DbTest() {
             val strategyId = createTestStrategy()
 
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex("global"),
                 accountId = account.id,
                 strategyId = null,
             )
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex("scoped"),
                 accountId = account.id,
                 strategyId = strategyId,
@@ -83,7 +81,6 @@ class AccountMappingRepositoryImplTest : DbTest() {
             val account = createTestAccount()
             val strategyId = createTestStrategy()
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex("scoped"),
                 accountId = account.id,
                 strategyId = strategyId,
@@ -107,14 +104,12 @@ class AccountMappingRepositoryImplTest : DbTest() {
             val account = createTestAccount()
 
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex("^Test Pattern$", RegexOption.IGNORE_CASE),
                 accountId = account.id,
             )
 
             val mappings = repositories.accountMappingRepository.getAllMappings().first()
             assertEquals(1, mappings.size)
-            assertEquals("Payee", mappings[0].columnName)
             assertEquals("^Test Pattern$", mappings[0].valuePattern.pattern)
             assertEquals(account.id, mappings[0].accountId)
         }
@@ -126,12 +121,10 @@ class AccountMappingRepositoryImplTest : DbTest() {
             val account2 = createTestAccount()
 
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex("pattern1"),
                 accountId = account1.id,
             )
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex("pattern2"),
                 accountId = account2.id,
             )
@@ -151,7 +144,6 @@ class AccountMappingRepositoryImplTest : DbTest() {
             val account2 = createTestAccount()
 
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex("original"),
                 accountId = account1.id,
             )
@@ -162,7 +154,6 @@ class AccountMappingRepositoryImplTest : DbTest() {
 
             val updated =
                 original.copy(
-                    columnName = "Name",
                     valuePattern = Regex("updated"),
                     accountId = account2.id,
                 )
@@ -170,7 +161,6 @@ class AccountMappingRepositoryImplTest : DbTest() {
 
             val result = repositories.accountMappingRepository.getMappingById(original.id).first()
             assertNotNull(result)
-            assertEquals("Name", result.columnName)
             assertEquals("updated", result.valuePattern.pattern)
             assertEquals(account2.id, result.accountId)
             assertTrue(result.updatedAt >= original.updatedAt)
@@ -182,7 +172,6 @@ class AccountMappingRepositoryImplTest : DbTest() {
             val account = createTestAccount()
 
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex("test"),
                 accountId = account.id,
             )
@@ -205,7 +194,6 @@ class AccountMappingRepositoryImplTest : DbTest() {
             val account = createTestAccount()
 
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex("test"),
                 accountId = account.id,
             )
@@ -228,7 +216,6 @@ class AccountMappingRepositoryImplTest : DbTest() {
 
             val complexPattern = "^Nikolay Metchev & Olga Zakharenko$"
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex(complexPattern),
                 accountId = account.id,
             )
@@ -244,7 +231,6 @@ class AccountMappingRepositoryImplTest : DbTest() {
             val account = createTestAccount()
 
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex("paxos"),
                 accountId = account.id,
             )
@@ -267,18 +253,16 @@ class AccountMappingRepositoryImplTest : DbTest() {
         }
 
     @Test
-    fun `multiple mappings for same column with different patterns are allowed`() =
+    fun `multiple mappings with different patterns are allowed`() =
         runTest {
             val account1 = createTestAccount()
             val account2 = createTestAccount()
 
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex("pattern1"),
                 accountId = account1.id,
             )
             repositories.accountMappingRepository.createMapping(
-                columnName = "Payee",
                 valuePattern = Regex("pattern2"),
                 accountId = account2.id,
             )

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/service/StrategyLibraryServiceTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/service/StrategyLibraryServiceTest.kt
@@ -54,7 +54,7 @@ class StrategyLibraryServiceTest : DbTest() {
                     updatedAt = now,
                 )
             engine.createCsvStrategy(strategy)
-            engine.createAccountMapping("Name", Regex("PAXOS.*", RegexOption.IGNORE_CASE), accountId, strategy.id)
+            engine.createAccountMapping(Regex("PAXOS.*", RegexOption.IGNORE_CASE), accountId, strategy.id)
 
             val key = StrategyKey(StrategyKind.CSV, "WiseTest")
             val entry = library.listLocal(version).first { it.key == key }
@@ -68,7 +68,7 @@ class StrategyLibraryServiceTest : DbTest() {
             val recreated = csvRepo.getStrategyByName("WiseTest").first()!!
             val mappings = mappingRepo.getAllMappings().first().filter { it.strategyId == recreated.id }
             assertEquals(1, mappings.size)
-            assertEquals("Name", mappings.single().columnName)
+            assertEquals("PAXOS.*", mappings.single().valuePattern.pattern)
 
             // Applying the same artifact again updates in place (keyed by name) — never a duplicate.
             library.applyIncoming(key, entry.json, emptyMap())

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/AccountMappingReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/AccountMappingReadRepositoryImpl.kt
@@ -42,7 +42,6 @@ class AccountMappingReadRepositoryImpl(
         AccountMapping(
             id = entity.id,
             strategyId = entity.strategy_id?.let { CsvImportStrategyId(Uuid.parse(it)) },
-            columnName = entity.column_name,
             valuePattern = Regex(entity.value_pattern, RegexOption.IGNORE_CASE),
             accountId = AccountId(entity.account_id),
             createdAt = Instant.fromEpochMilliseconds(entity.created_at),

--- a/app/db/read/src/commonTest/kotlin/com/moneymanager/database/json/AccountMappingExportCodecTest.kt
+++ b/app/db/read/src/commonTest/kotlin/com/moneymanager/database/json/AccountMappingExportCodecTest.kt
@@ -14,8 +14,8 @@ class AccountMappingExportCodecTest {
                 version = "1.0.0",
                 mappings =
                     listOf(
-                        AccountMappingExport(columnName = "Name", valuePattern = ".*Acme.*", accountName = "Acme Bank"),
-                        AccountMappingExport(columnName = "Payee", valuePattern = "^Paxos.*$", accountName = "Paxos"),
+                        AccountMappingExport(valuePattern = ".*Acme.*", accountName = "Acme Bank"),
+                        AccountMappingExport(valuePattern = "^Paxos.*$", accountName = "Paxos"),
                     ),
             )
 
@@ -40,5 +40,26 @@ class AccountMappingExportCodecTest {
 
         assertEquals("9.9.9", decoded.version)
         assertTrue(decoded.mappings.isEmpty())
+    }
+
+    @Test
+    fun `decode tolerates legacy exports carrying a columnName per mapping`() {
+        val json =
+            """
+            {
+                "version": "1.0.0",
+                "mappings": [
+                    {"columnName": "Name", "valuePattern": ".*Acme.*", "accountName": "Acme Bank"},
+                    {"columnName": "Payee", "valuePattern": ".*Acme.*", "accountName": "Acme Bank"}
+                ]
+            }
+            """.trimIndent()
+
+        val decoded = AccountMappingExportCodec.decode(json)
+
+        // columnName is ignored; the two legacy per-column entries decode to equal mappings.
+        assertEquals(2, decoded.mappings.size)
+        assertEquals(AccountMappingExport(valuePattern = ".*Acme.*", accountName = "Acme Bank"), decoded.mappings.first())
+        assertEquals(decoded.mappings[0], decoded.mappings[1])
     }
 }

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/accountMapping/AccountMapping.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/accountMapping/AccountMapping.sq
@@ -1,17 +1,18 @@
--- Maps CSV column value patterns to specific account IDs. A mapping is either global (strategy_id
--- NULL, applies to every import strategy) or scoped to a single CSV import strategy.
+-- Maps account source value patterns to specific account IDs. A mapping is either global
+-- (strategy_id NULL, applies to every import strategy) or scoped to a single CSV import strategy.
+-- The value tested against the pattern is whatever the strategy's account field-mappings resolve;
+-- which column that comes from is configured in the strategy, not here.
 -- Applied BEFORE name lookup during import to handle pattern-based routing and consolidation.
 CREATE TABLE account_mapping (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     strategy_id TEXT,
-    column_name TEXT NOT NULL,
     value_pattern TEXT NOT NULL,
     account_id INTEGER NOT NULL,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL,
     FOREIGN KEY (strategy_id) REFERENCES csv_import_strategy(id) ON DELETE CASCADE,
     FOREIGN KEY (account_id) REFERENCES account(id) ON DELETE CASCADE,
-    UNIQUE (strategy_id, column_name, value_pattern)
+    UNIQUE (strategy_id, value_pattern)
 );
 
 CREATE INDEX idx_account_mapping_account ON account_mapping(account_id);
@@ -20,5 +21,5 @@ CREATE INDEX idx_account_mapping_strategy ON account_mapping(strategy_id);
 -- The table UNIQUE treats NULL strategy_id as distinct, so it wouldn't stop duplicate global mappings.
 -- Enforce uniqueness of global (strategy_id IS NULL) mappings with a partial unique index.
 CREATE UNIQUE INDEX idx_account_mapping_global_unique
-    ON account_mapping(column_name, value_pattern)
+    ON account_mapping(value_pattern)
     WHERE strategy_id IS NULL;

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/AccountMappingWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/AccountMappingWriteRepositoryImpl.kt
@@ -22,7 +22,6 @@ class AccountMappingWriteRepositoryImpl(
     private val writeQueries = database.accountMappingWriteQueries
 
     override suspend fun createMapping(
-        columnName: String,
         valuePattern: Regex,
         accountId: AccountId,
         strategyId: CsvImportStrategyId?,
@@ -31,7 +30,6 @@ class AccountMappingWriteRepositoryImpl(
             val now = Clock.System.now()
             writeQueries.insert(
                 strategy_id = strategyId?.id?.toString(),
-                column_name = columnName,
                 value_pattern = valuePattern.pattern,
                 account_id = accountId.id,
                 created_at = now.toEpochMilliseconds(),
@@ -48,7 +46,6 @@ class AccountMappingWriteRepositoryImpl(
                 mappings.forEach { mapping ->
                     writeQueries.insert(
                         strategy_id = mapping.strategyId?.id?.toString(),
-                        column_name = mapping.columnName,
                         value_pattern = mapping.valuePattern.pattern,
                         account_id = mapping.accountId.id,
                         created_at = mapping.createdAt.toEpochMilliseconds(),
@@ -63,7 +60,6 @@ class AccountMappingWriteRepositoryImpl(
             val now = Clock.System.now()
             writeQueries.update(
                 strategy_id = mapping.strategyId?.id?.toString(),
-                column_name = mapping.columnName,
                 value_pattern = mapping.valuePattern.pattern,
                 account_id = mapping.accountId.id,
                 updated_at = now.toEpochMilliseconds(),

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/accountMapping/AccountMappingWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/accountMapping/AccountMappingWrite.sq
@@ -1,7 +1,7 @@
 -- Insert a new mapping (strategy_id NULL = global)
 insert:
-INSERT INTO account_mapping (strategy_id, column_name, value_pattern, account_id, created_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?);
+INSERT INTO account_mapping (strategy_id, value_pattern, account_id, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?);
 
 -- Get the last inserted row ID
 lastInsertRowId:
@@ -10,7 +10,7 @@ SELECT last_insert_rowid();
 -- Update an existing mapping
 update:
 UPDATE account_mapping
-SET strategy_id = ?, column_name = ?, value_pattern = ?, account_id = ?, updated_at = ?
+SET strategy_id = ?, value_pattern = ?, account_id = ?, updated_at = ?
 WHERE id = ?;
 
 -- Delete a mapping by ID

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportConfigIntents.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportConfigIntents.kt
@@ -82,7 +82,6 @@ sealed interface ApiStrategyMutation {
 sealed interface AccountMappingMutation {
     data class Create(
         val key: String,
-        val columnName: String,
         val valuePattern: Regex,
         val accountId: AccountId,
         val strategyId: CsvImportStrategyId? = null,

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
@@ -104,7 +104,6 @@ suspend fun ImportEngine.deleteApiStrategy(id: ApiImportStrategyId) {
 // region account mappings
 
 suspend fun ImportEngine.createAccountMapping(
-    columnName: String,
     valuePattern: Regex,
     accountId: AccountId,
     strategyId: CsvImportStrategyId? = null,
@@ -113,9 +112,9 @@ suspend fun ImportEngine.createAccountMapping(
         import(
             ImportBatch(
                 accountMappingMutations =
-                    listOf(AccountMappingMutation.Create(columnName, columnName, valuePattern, accountId, strategyId)),
+                    listOf(AccountMappingMutation.Create(valuePattern.pattern, valuePattern, accountId, strategyId)),
             ),
-        ).createdAccountMappingIds[columnName],
+        ).createdAccountMappingIds[valuePattern.pattern],
     )
 
 suspend fun ImportEngine.createAccountMappings(mappings: List<AccountMapping>) {

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -1093,7 +1093,7 @@ class ImportEngineImpl(
                 is AccountMappingMutation.Create ->
                     accountMappingIds.putUnique(
                         m.key,
-                        accountMappingRepository.createMapping(m.columnName, m.valuePattern, m.accountId, m.strategyId),
+                        accountMappingRepository.createMapping(m.valuePattern, m.accountId, m.strategyId),
                         "AccountMapping",
                     )
                 is AccountMappingMutation.CreateBatch -> accountMappingRepository.createMappings(m.mappings)

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/accountmapping/AccountMapping.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/accountmapping/AccountMapping.kt
@@ -7,20 +7,23 @@ import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
 import kotlin.time.Instant
 
 /**
- * Persisted mapping that routes CSV column values matching a regex pattern
+ * Persisted mapping that routes account source values matching a regex pattern
  * to a specific account ID during import.
  *
  * A mapping is either global ([strategyId] == null; applies to every import strategy, CSV and QIF)
  * or scoped to a single CSV import strategy. During matching, an import running strategy S uses the
  * global mappings plus S's mappings; a strategy-specific match wins over a global one.
  *
+ * The value tested against [valuePattern] is whatever the strategy's account field-mappings
+ * resolve — which column(s) that comes from is configured in the strategy, not the mapping, so
+ * a global mapping works across strategies that read accounts from differently named columns.
+ *
  * Applied BEFORE name lookup, to consolidate variations to a single account
  * (e.g., "Paxos Technology LTD" -> "Paxos" account).
  *
  * @property id Unique identifier for this mapping
  * @property strategyId The strategy this mapping is scoped to, or null for a global mapping
- * @property columnName The CSV column to match against (e.g., "Name", "Payee")
- * @property valuePattern Regex pattern for matching column values (case-insensitive by default)
+ * @property valuePattern Regex pattern for matching account source values (case-insensitive by default)
  * @property accountId Target account when pattern matches
  * @property createdAt When this mapping was created
  * @property updatedAt When this mapping was last modified
@@ -28,7 +31,6 @@ import kotlin.time.Instant
 data class AccountMapping(
     val id: Long,
     val strategyId: CsvImportStrategyId? = null,
-    val columnName: String,
     val valuePattern: Regex,
     val accountId: AccountId,
     val createdAt: Instant,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/accountmapping/export/AccountMappingExport.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/accountmapping/export/AccountMappingExport.kt
@@ -25,7 +25,6 @@ data class AccountMappingsExport(
  */
 @Serializable
 data class AccountMappingExport(
-    val columnName: String,
     val valuePattern: String,
     val accountName: String,
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/AccountMappingWriteRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/AccountMappingWriteRepository.kt
@@ -8,14 +8,12 @@ interface AccountMappingWriteRepository : AccountMappingReadRepository {
     /**
      * Creates a new mapping.
      *
-     * @param columnName The CSV column to match against
-     * @param valuePattern Regex pattern for matching column values
+     * @param valuePattern Regex pattern for matching account source values
      * @param accountId Target account when pattern matches
      * @param strategyId The strategy to scope this mapping to, or null for a global mapping
      * @return The ID of the created mapping
      */
     suspend fun createMapping(
-        columnName: String,
         valuePattern: Regex,
         accountId: AccountId,
         strategyId: CsvImportStrategyId? = null,

--- a/app/qifimporter/src/commonTest/kotlin/com/moneymanager/database/csv/SantanderQifMapperTest.kt
+++ b/app/qifimporter/src/commonTest/kotlin/com/moneymanager/database/csv/SantanderQifMapperTest.kt
@@ -11,7 +11,6 @@ import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.accountmapping.AccountMapping
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.model.csvstrategy.BuiltInCsvStrategies
-import com.moneymanager.domain.model.qif.QifColumns
 import com.moneymanager.qifimporter.QifCsvAdapter
 import com.moneymanager.qifimporter.qifCompatible
 import com.moneymanager.qifimporter.selectForQifContent
@@ -147,7 +146,6 @@ class SantanderQifMapperTest {
         val mapping =
             AccountMapping(
                 id = 1L,
-                columnName = QifColumns.COL_PAYEE,
                 valuePattern = Regex("ZAKHARENKO O"),
                 accountId = mapped.id,
                 createdAt = now,

--- a/app/remotestorage/googledrive/src/jvmAndroidMain/kotlin/com/moneymanager/remotestorage/googledrive/DriveImportFileSource.kt
+++ b/app/remotestorage/googledrive/src/jvmAndroidMain/kotlin/com/moneymanager/remotestorage/googledrive/DriveImportFileSource.kt
@@ -56,11 +56,12 @@ class DriveImportFileSource(
             if (!response.status.isSuccess()) {
                 val hint =
                     if (response.status.value == HTTP_FORBIDDEN) {
-                        " — the file's owner may have disabled downloads for viewers"
+                        " — this is usually a Google Docs/Sheets file (which has no raw content to download)" +
+                            " or the file's owner has disabled downloads for viewers"
                     } else {
                         ""
                     }
-                throw RemoteStorageException("Failed to download $fileRef from Google Drive (${response.status.value})$hint")
+                throw RemoteStorageException("Failed to download from Google Drive (${response.status.value})$hint")
             }
             response.body<ByteArray>()
         }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
@@ -169,6 +169,8 @@ fun ImportsScreen(
                     passThroughAccountRepository = passThroughAccountRepository,
                     accountMappingRepository = accountMappingRepository,
                     accountRepository = accountRepository,
+                    categoryRepository = categoryRepository,
+                    personRepository = personRepository,
                     accountMappingExportService = accountMappingExportService,
                     appVersion = appVersion,
                     importEngine = importEngine,
@@ -187,6 +189,8 @@ private fun MiscImportsTab(
     passThroughAccountRepository: PassThroughAccountReadRepository,
     accountMappingRepository: AccountMappingReadRepository,
     accountRepository: AccountReadRepository,
+    categoryRepository: CategoryReadRepository,
+    personRepository: PersonReadRepository,
     accountMappingExportService: AccountMappingExportService,
     appVersion: AppVersion,
     importEngine: ImportEngine,
@@ -217,6 +221,8 @@ private fun MiscImportsTab(
                 AccountMappingsScreen(
                     accountMappingRepository = accountMappingRepository,
                     accountRepository = accountRepository,
+                    categoryRepository = categoryRepository,
+                    personRepository = personRepository,
                     accountMappingExportService = accountMappingExportService,
                     appVersion = appVersion,
                 )

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/accountmapping/AccountMappingComponents.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/accountmapping/AccountMappingComponents.kt
@@ -139,15 +139,8 @@ internal fun AccountMappingRow(
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = "Column: ${mapping.columnName}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
                     text = "Pattern: ${mapping.valuePattern.pattern}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodyMedium,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
@@ -173,10 +166,9 @@ internal fun AccountMappingRow(
  * Dialog for creating or editing an account mapping. On create, the mapping is scoped to [strategyId]
  * (null = global). On edit, the existing mapping's own scope is preserved.
  *
- * When editing inside a strategy editor, [csvColumns]/[sampleRows] supply the CSV context: the column
- * name becomes a dropdown of the file's columns and the pattern is previewed against the sample rows
- * (same semantics as import: case-insensitive containsMatchIn). [categoryRepository]/[personRepository]
- * additionally enable creating the target account inline.
+ * When editing inside a strategy editor, [csvColumns]/[sampleRows] supply the CSV context: the pattern
+ * is previewed against the sample rows (same semantics as import: case-insensitive containsMatchIn).
+ * The target account can always be created inline via [categoryRepository]/[personRepository].
  */
 @Suppress("LongParameterList")
 @Composable
@@ -185,14 +177,13 @@ internal fun AccountMappingEditorDialog(
     accounts: List<Account>,
     strategyId: CsvImportStrategyId?,
     onDismiss: () -> Unit,
+    categoryRepository: CategoryReadRepository,
+    personRepository: PersonReadRepository,
     csvColumns: List<CsvColumn>? = null,
     sampleRows: List<CsvRow> = emptyList(),
-    categoryRepository: CategoryReadRepository? = null,
-    personRepository: PersonReadRepository? = null,
 ) {
     val importEngine = LocalImportEngine.current
     val isEditMode = existingMapping != null
-    var columnName by remember { mutableStateOf(existingMapping?.columnName.orEmpty()) }
     var patternText by remember { mutableStateOf(existingMapping?.valuePattern?.pattern.orEmpty()) }
     var selectedAccountId by remember { mutableStateOf(existingMapping?.accountId) }
     var isSaving by remember { mutableStateOf(false) }
@@ -200,33 +191,13 @@ internal fun AccountMappingEditorDialog(
     var showCreateAccountDialog by remember { mutableStateOf(false) }
     val scope = rememberSchemaAwareCoroutineScope()
 
-    val isFormValid = columnName.isNotBlank() && patternText.isNotBlank() && selectedAccountId != null
+    val isFormValid = patternText.isNotBlank() && selectedAccountId != null
 
     AlertDialog(
         onDismissRequest = { if (!isSaving) onDismiss() },
         title = { Text(if (isEditMode) "Edit Account Mapping" else "Add Account Mapping") },
         text = {
             Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                if (csvColumns != null) {
-                    ColumnNameDropdown(
-                        columns = csvColumns,
-                        columnName = columnName,
-                        onColumnSelected = { columnName = it },
-                        enabled = !isSaving,
-                    )
-                } else {
-                    OutlinedTextField(
-                        value = columnName,
-                        onValueChange = { columnName = it },
-                        label = { Text("Column Name") },
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                        enabled = !isSaving,
-                        isError = columnName.isBlank(),
-                        supportingText = { Text("CSV column to match against (e.g., Name, Payee)") },
-                    )
-                }
-
                 OutlinedTextField(
                     value = patternText,
                     onValueChange = { patternText = it },
@@ -236,8 +207,12 @@ internal fun AccountMappingEditorDialog(
                     enabled = !isSaving,
                     isError = patternText.isBlank(),
                     supportingText = {
-                        val preview = matchPreview(csvColumns, sampleRows, columnName, patternText)
-                        Text(preview ?: "Use ^value$ for exact match, or .*keyword.* for contains")
+                        val preview = matchPreview(csvColumns, sampleRows, patternText)
+                        Text(
+                            preview
+                                ?: "Matched against the account value the strategy reads. " +
+                                "Use ^value$ for exact match, or .*keyword.* for contains",
+                        )
                     },
                 )
 
@@ -247,19 +222,14 @@ internal fun AccountMappingEditorDialog(
                     selectedAccountId = selectedAccountId,
                     onAccountSelected = { selectedAccountId = it },
                     enabled = !isSaving,
-                    onCreateAccount =
-                        if (categoryRepository != null && personRepository != null) {
-                            { showCreateAccountDialog = true }
-                        } else {
-                            null
-                        },
+                    onCreateAccount = { showCreateAccountDialog = true },
                 )
 
                 errorMessage?.let {
                     Text(text = it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
                 }
 
-                if (showCreateAccountDialog && categoryRepository != null && personRepository != null) {
+                if (showCreateAccountDialog) {
                     CreateAccountDialog(
                         categoryRepository = categoryRepository,
                         personRepository = personRepository,
@@ -282,14 +252,12 @@ internal fun AccountMappingEditorDialog(
                                 if (existingMapping != null) {
                                     importEngine.updateAccountMapping(
                                         existingMapping.copy(
-                                            columnName = columnName,
                                             valuePattern = pattern,
                                             accountId = accountId,
                                         ),
                                     )
                                 } else {
                                     importEngine.createAccountMapping(
-                                        columnName = columnName,
                                         valuePattern = pattern,
                                         accountId = accountId,
                                         strategyId = strategyId,
@@ -323,81 +291,29 @@ internal fun AccountMappingEditorDialog(
 }
 
 /**
- * Dropdown of the CSV file's columns for the mapping's column name. An existing mapping may reference
- * a column that is no longer in the file; its name is still shown (flagged) so editing doesn't wipe it.
- */
-@Composable
-private fun ColumnNameDropdown(
-    columns: List<CsvColumn>,
-    columnName: String,
-    onColumnSelected: (String) -> Unit,
-    enabled: Boolean,
-) {
-    var expanded by remember { mutableStateOf(false) }
-    val known = columns.any { it.originalName == columnName }
-
-    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { if (enabled) expanded = it }) {
-        OutlinedTextField(
-            value = columnName.ifBlank { "Select column..." },
-            onValueChange = {},
-            readOnly = true,
-            label = { Text("Column Name") },
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
-            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
-            colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
-            enabled = enabled,
-            isError = columnName.isBlank(),
-            supportingText = {
-                if (columnName.isNotBlank() && !known) {
-                    Text("Not a column of this file", color = MaterialTheme.colorScheme.error)
-                } else {
-                    Text("CSV column to match against")
-                }
-            },
-        )
-        ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            columns.forEach { column ->
-                DropdownMenuItem(
-                    text = { Text(column.originalName) },
-                    onClick = {
-                        onColumnSelected(column.originalName)
-                        expanded = false
-                    },
-                )
-            }
-        }
-    }
-}
-
-/**
- * Human-readable preview of how many sample rows [patternText] would match in [columnName], mirroring
- * import semantics (case-insensitive [Regex.containsMatchIn]). Null when there is no CSV context to
- * preview against; a message for an invalid pattern.
+ * Human-readable preview of how many sample rows [patternText] would match in any column, mirroring
+ * import semantics (case-insensitive [Regex.containsMatchIn]). The import only tests the value the
+ * strategy's account field-mappings resolve, so this is an upper bound. Null when there is no CSV
+ * context to preview against; a message for an invalid pattern.
  */
 private fun matchPreview(
     csvColumns: List<CsvColumn>?,
     sampleRows: List<CsvRow>,
-    columnName: String,
     patternText: String,
 ): String? {
-    if (csvColumns == null || sampleRows.isEmpty() || columnName.isBlank() || patternText.isBlank()) return null
-    val columnIndex = csvColumns.firstOrNull { it.originalName == columnName }?.columnIndex ?: return null
+    if (csvColumns == null || sampleRows.isEmpty() || patternText.isBlank()) return null
     val regex =
         try {
             Regex(patternText, RegexOption.IGNORE_CASE)
         } catch (_: IllegalArgumentException) {
             return "Invalid regex pattern"
         }
-    val matches = sampleRows.count { row -> regex.containsMatchIn(row.values.getOrNull(columnIndex).orEmpty()) }
+    val matches = sampleRows.count { row -> row.values.any { regex.containsMatchIn(it) } }
     return "Matches $matches of ${sampleRows.size} rows"
 }
 
 /**
- * Simple dropdown for selecting an account. When [onCreateAccount] is provided, offers creating a new
- * account inline.
+ * Simple dropdown for selecting an account, with an inline "Create new account…" entry.
  */
 @Composable
 internal fun AccountDropdown(
@@ -405,7 +321,7 @@ internal fun AccountDropdown(
     selectedAccountId: AccountId?,
     onAccountSelected: (AccountId) -> Unit,
     enabled: Boolean,
-    onCreateAccount: (() -> Unit)? = null,
+    onCreateAccount: () -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val selectedAccount = accounts.find { it.id == selectedAccountId }
@@ -424,15 +340,13 @@ internal fun AccountDropdown(
             enabled = enabled,
         )
         ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            if (onCreateAccount != null) {
-                DropdownMenuItem(
-                    text = { Text("Create new account…", color = MaterialTheme.colorScheme.primary) },
-                    onClick = {
-                        onCreateAccount()
-                        expanded = false
-                    },
-                )
-            }
+            DropdownMenuItem(
+                text = { Text("Create new account…", color = MaterialTheme.colorScheme.primary) },
+                onClick = {
+                    onCreateAccount()
+                    expanded = false
+                },
+            )
             accounts.sortedBy { it.name }.forEach { account ->
                 DropdownMenuItem(
                     text = { Text(account.name) },

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/accountmapping/AccountMappingComponents.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/accountmapping/AccountMappingComponents.kt
@@ -55,6 +55,11 @@ import com.moneymanager.ui.components.CreateAccountDialog
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.launch
 
+/** Shown under the pattern field when there is no CSV sample to preview against. */
+private const val PATTERN_HINT =
+    "Matched against the account value the strategy reads. " +
+        "Use ^value$ for exact match, or .*keyword.* for contains"
+
 /**
  * Collapsible list of account mappings with add/edit/delete actions. Reused by the strategy editor
  * (strategy-scoped mappings) and, implicitly, mirrors the global Account Mappings screen's list.
@@ -208,11 +213,7 @@ internal fun AccountMappingEditorDialog(
                     isError = patternText.isBlank(),
                     supportingText = {
                         val preview = matchPreview(csvColumns, sampleRows, patternText)
-                        Text(
-                            preview
-                                ?: "Matched against the account value the strategy reads. " +
-                                "Use ^value$ for exact match, or .*keyword.* for contains",
-                        )
+                        Text(preview ?: PATTERN_HINT)
                     },
                 )
 

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/accountmapping/AccountMappingsScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/accountmapping/AccountMappingsScreen.kt
@@ -51,6 +51,8 @@ import com.moneymanager.domain.model.AppVersion
 import com.moneymanager.domain.model.accountmapping.AccountMapping
 import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.CategoryReadRepository
+import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.importengineapi.deleteAccountMapping
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
@@ -66,6 +68,8 @@ import kotlinx.coroutines.launch
 fun AccountMappingsScreen(
     accountMappingRepository: AccountMappingReadRepository,
     accountRepository: AccountReadRepository,
+    categoryRepository: CategoryReadRepository,
+    personRepository: PersonReadRepository,
     accountMappingExportService: AccountMappingExportService,
     appVersion: AppVersion,
     // Null when embedded (e.g. as the Imports → Misc sub-tab) so no dead back arrow is shown.
@@ -211,6 +215,8 @@ fun AccountMappingsScreen(
             accounts = accounts,
             strategyId = null,
             onDismiss = { editingMapping = null },
+            categoryRepository = categoryRepository,
+            personRepository = personRepository,
         )
     }
 
@@ -220,6 +226,8 @@ fun AccountMappingsScreen(
             accounts = accounts,
             strategyId = null,
             onDismiss = { showAddDialog = false },
+            categoryRepository = categoryRepository,
+            personRepository = personRepository,
         )
     }
 

--- a/app/ui/imports/importDirectory/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportDirectoriesScreen.kt
+++ b/app/ui/imports/importDirectory/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportDirectoriesScreen.kt
@@ -84,6 +84,8 @@ fun ImportDirectoriesScreen(
 
     var showAddDialog by remember { mutableStateOf(false) }
     var statusMessage by remember { mutableStateOf<String?>(null) }
+    // Per-file scan failures ("file name: reason") from the last download, shown under the status line.
+    var scanFailures by remember { mutableStateOf<List<String>>(emptyList()) }
     var scanningId by remember { mutableStateOf<ImportDirectoryId?>(null) }
     // done / total of the in-progress download, for the per-directory progress bar.
     var scanProgress by remember { mutableStateOf(0 to 0) }
@@ -148,17 +150,20 @@ fun ImportDirectoriesScreen(
         scanningId = directory.id
         scanProgress = 0 to 0
         statusMessage = null
+        scanFailures = emptyList()
         scope.launch {
             try {
-                if (directory.topLevel) {
-                    val downloaded = downloadFolder(directory).filesDownloaded
-                    val created = createSubdirectories(directory, directories.associateByTo(mutableMapOf()) { it.folderRef })
-                    statusMessage =
-                        "${directory.name}: downloaded $downloaded file(s); " +
-                        "created $created subfolder director${if (created == 1) "y" else "ies"}."
-                } else {
-                    statusMessage = "${directory.name}: downloaded ${downloadFolder(directory).filesDownloaded} file(s)."
-                }
+                val result = downloadFolder(directory)
+                scanFailures = result.failures
+                val failedSuffix = if (result.filesFailed > 0) ", ${result.filesFailed} failed" else ""
+                statusMessage =
+                    if (directory.topLevel) {
+                        val created = createSubdirectories(directory, directories.associateByTo(mutableMapOf()) { it.folderRef })
+                        "${directory.name}: downloaded ${result.filesDownloaded} file(s)$failedSuffix; " +
+                            "created $created subfolder director${if (created == 1) "y" else "ies"}."
+                    } else {
+                        "${directory.name}: downloaded ${result.filesDownloaded} file(s)$failedSuffix."
+                    }
             } catch (expected: Exception) {
                 statusMessage = "${directory.name}: failed — ${expected.message}"
             } finally {
@@ -169,6 +174,7 @@ fun ImportDirectoriesScreen(
 
     fun downloadAll() {
         statusMessage = null
+        scanFailures = emptyList()
         scope.launch {
             try {
                 val dirsByRef = directories.associateByTo(mutableMapOf()) { it.folderRef }
@@ -181,12 +187,21 @@ fun ImportDirectoriesScreen(
                 }
                 // Phase 2: download each included directory's own importable files (top-levels + leaves).
                 var downloaded = 0
+                var failed = 0
+                val failures = mutableListOf<String>()
                 for (dir in dirsByRef.values.filter { scannable(it) && !it.excluded }) {
                     scanningId = dir.id
                     scanProgress = 0 to 0
-                    downloaded += downloadFolder(dir).filesDownloaded
+                    val result = downloadFolder(dir)
+                    downloaded += result.filesDownloaded
+                    failed += result.filesFailed
+                    // Prefix with the directory so the same filename in two folders stays tellable apart.
+                    failures += result.failures.map { "${dir.name} — $it" }
                 }
-                statusMessage = "Created $created new director${if (created == 1) "y" else "ies"}; downloaded $downloaded file(s)."
+                scanFailures = failures
+                val failedSuffix = if (failed > 0) "; $failed failed" else ""
+                statusMessage =
+                    "Created $created new director${if (created == 1) "y" else "ies"}; downloaded $downloaded file(s)$failedSuffix."
             } catch (expected: Exception) {
                 statusMessage = "Download all failed — ${expected.message}"
             } finally {
@@ -225,6 +240,13 @@ fun ImportDirectoriesScreen(
         )
 
         statusMessage?.let { Text(it, style = MaterialTheme.typography.bodyMedium) }
+        scanFailures.forEach { failure ->
+            Text(
+                text = failure,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
 
         if (directories.isEmpty()) {
             Text("No import directories configured yet.", style = MaterialTheme.typography.bodyMedium)

--- a/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/StrategyCloudCard.kt
+++ b/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/StrategyCloudCard.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.CsvResolution
 import com.moneymanager.domain.CsvUnresolvedReference
 import com.moneymanager.domain.StrategyKey
+import com.moneymanager.domain.StrategyKind
 import com.moneymanager.domain.StrategyLibrary
 import com.moneymanager.domain.model.AppVersion
 import com.moneymanager.domain.repository.AccountReadRepository
@@ -204,7 +205,7 @@ fun StrategyCloudCard(
                                     // Any references the selected pulls can't resolve locally need the user first.
                                     val unresolved = mutableMapOf<StrategyKey, List<CsvUnresolvedReference>>()
                                     pull.forEachIndexed { index, key ->
-                                        syncProgress = SyncProgress("Checking ${key.name}…", index.toFloat() / pull.size)
+                                        syncProgress = SyncProgress("Checking ${key.displayLabel()}…", index.toFloat() / pull.size)
                                         val references = controller.previewPull(library, key).unresolvedReferences
                                         if (references.isNotEmpty()) unresolved[key] = references
                                     }
@@ -322,7 +323,7 @@ private fun StrategyItemList(
                     Spacer(Modifier.width(48.dp))
                 }
                 Text(
-                    text = "${item.key.name} (${item.key.kind.name.lowercase()})",
+                    text = item.key.displayLabel(),
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.weight(1f),
                 )
@@ -369,4 +370,16 @@ private fun statusLabel(status: StrategyItemStatus): String =
         StrategyItemStatus.REMOTE_AHEAD -> "Update available"
         StrategyItemStatus.AVAILABLE -> "New on Drive"
         StrategyItemStatus.CONFLICT -> "Conflict"
+    }
+
+/**
+ * Human-readable label for a library artifact. Strategies show their name plus the kind; the single
+ * global-mappings artifact has a fixed technical name, so it gets a friendly title instead.
+ */
+private fun StrategyKey.displayLabel(): String =
+    when (kind) {
+        StrategyKind.GLOBAL_MAPPINGS -> "Global account mappings"
+        StrategyKind.CSV -> "$name (CSV)"
+        StrategyKind.QIF -> "$name (QIF)"
+        StrategyKind.API -> "$name (API)"
     }


### PR DESCRIPTION
## Summary

A persisted account mapping is now just **(regex, target account, optional strategy scope)**. Which CSV/QIF column feeds the regex is no longer stored on the mapping — it's whatever the strategy's own account field-mappings resolve. This matters most for **global** mappings: previously a mapping keyed to `Payee` never fired for a strategy whose account column is `Name`; now the same mapping works across all strategies.

## Changes

- **Schema** (`AccountMapping.sq`): dropped `column_name`; uniqueness is `(strategy_id, value_pattern)` plus a pattern-only partial unique index for globals. BETA no-migration policy: DB is recreated.
- **Domain/repos/engine API**: `columnName` removed from `AccountMapping`, `AccountMappingExport`, the write repository, `AccountMappingMutation.Create`, and `ImportEngine.createAccountMapping`; `createdAccountMappingIds` is keyed by the pattern string.
- **Matcher** (`CsvTransferMapper`): the per-column index became a flat scoped list — strategy-specific mappings before global, then id order, first match wins (deterministic for formerly column-distinguished duplicates). Discovery/auto-capture (`DiscoveredAccountMapping`, `PendingAccountMappingKey`) no longer carries a column.
- **Export / Drive sync**: `columnName` removed from the serialized JSON. Legacy exports still decode (`ignoreUnknownKeys`); import paths and the strategy-library union filter dedupe by pattern (first wins) so old per-column duplicates can't collide on the new unique constraint.
- **UI**:
  - Mapping editor is now Pattern + Target Account; the sample-row match preview tests the pattern against all column values (documented as an upper bound).
  - The **global** Account Mappings screen gets inline "Create new account…" — the category/person repositories are now required dialog parameters, so the global and strategy editors share the identical dialog.
  - Cloud sync card shows **"Global account mappings"** instead of `global-account-mappings (global_mappings)`; strategies render as `Name (CSV/QIF/API)`.
- **Import directories**: per-file scan failures now surface in the UI with the file name and reason (previously only counted internally and logged); "Download all" prefixes failures with the directory name. The Drive 403 hint now explains the common Google Docs/Sheets-file cause.

## Behavioral note

Broad patterns are riskier than before: a global `.*` used to be fenced to one column but now intercepts every account resolution in every strategy. Ordering (strategy-scoped first, then id) keeps results deterministic.

## Testing

- Updated all affected test suites; new coverage: a global mapping fires under strategies reading accounts from different columns, and legacy JSON with `columnName` decodes with per-column duplicates collapsing to one mapping.
- `./gradlew build` (full pre-push build incl. detekt/ktlint/coverage) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)