### PR TITLE
Cancelled/refunded Curve pass-through transactions

### DIFF
--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
@@ -1774,13 +1774,14 @@ private suspend fun prepareValidTransactionItem(
             jsonPath = item.counterpartyJsonPath(setup.strategy.peopleMappings),
         )
     val data = item.toTransferData(currency)
-    // A pass-through (conduit) charge such as Curve, detected from the description (e.g. "CRV*…"). Only
-    // outgoing spends are routed: the transfer becomes the funding leg own -> conduit and the engine adds
-    // the spend leg conduit -> merchant. Detection + the conduit/merchant names come from user-editable
-    // config; routing here also avoids creating a "CRV*…" junk counterparty account. Declined items (no
-    // real movement) and zero-value items (handled as "Void") are never expanded into a spend leg.
+    // A pass-through (conduit) charge such as Curve, detected from the description (e.g. "CRV*…"). An
+    // outgoing spend becomes the funding leg own -> conduit and the engine adds the spend leg conduit ->
+    // merchant; an incoming refund/cancellation ("Refund: CRV*…") runs both legs the other way. Detection
+    // + the conduit/merchant names come from user-editable config; routing here also avoids creating a
+    // "CRV*…" junk counterparty account. Declined items (no real movement) and zero-value items (handled
+    // as "Void") are never expanded into a spend leg.
     val passThroughMatch =
-        if (!data.isIncoming && !item.isZeroAmount && item.declineReason.isNullOrBlank()) {
+        if (!item.isZeroAmount && item.declineReason.isNullOrBlank()) {
             setup.passThroughDetector?.detect(data.description)
         } else {
             null
@@ -1856,6 +1857,7 @@ private suspend fun prepareValidTransactionItem(
                         amount = amount,
                         spendDescription = match.merchantName,
                         relationshipTypeId = RelationshipTypeId(match.account.relationshipTypeId),
+                        incoming = data.isIncoming,
                     ),
             )
         }
@@ -1866,18 +1868,20 @@ private suspend fun prepareValidTransactionItem(
         responseId = responseId,
         requestId = context.requestId,
         item = item,
-        // Pass-through: funding leg own -> conduit. Otherwise the normal own/counterparty pairing.
+        // Pass-through: funding leg own -> conduit (or conduit -> own for an incoming
+        // refund/cancellation). Otherwise the normal own/counterparty pairing.
         source =
-            if (passThrough != null) {
-                ownAccountRef
-            } else if (data.isIncoming) {
-                counterpartyRef!!
-            } else {
-                ownAccountRef
+            when {
+                passThrough != null -> if (data.isIncoming) passThrough.conduit else ownAccountRef
+                data.isIncoming -> counterpartyRef!!
+                else -> ownAccountRef
             },
         target =
-            passThrough?.conduit
-                ?: if (data.isIncoming) ownAccountRef else counterpartyRef!!,
+            when {
+                passThrough != null -> if (data.isIncoming) ownAccountRef else passThrough.conduit
+                data.isIncoming -> ownAccountRef
+                else -> counterpartyRef!!
+            },
         timestamp = item.created,
         description = data.description,
         amount = amount,

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -503,9 +503,11 @@ suspend fun runCsvImport(
                         relationshipTypeId = RelationshipTypeId(WellKnownIds.FEE_RELATIONSHIP_TYPE_ID),
                     )
                 }
-            // Pass-through (conduit) row: the mapper already routed the transfer's target to the conduit
-            // (funding leg). Resolve the merchant account the mapper created and let the engine add the
-            // spend leg conduit -> merchant. accountsByName carries the created conduit + merchant ids.
+            // Pass-through (conduit) row: the mapper already routed the transfer's conduit side — the
+            // target for an outgoing charge, the source for an incoming refund/cancellation. Resolve the
+            // merchant account the mapper created and let the engine add the spend leg (conduit ->
+            // merchant, or merchant -> conduit when incoming). accountsByName carries the created
+            // conduit + merchant ids.
             val passThrough =
                 row.passThrough?.let { pt ->
                     val merchantId = accountsByName[pt.merchantName]?.id
@@ -513,11 +515,15 @@ suspend fun runCsvImport(
                         null
                     } else {
                         ImportPassThrough(
-                            conduit = AccountRef.Existing(row.transfer.targetAccountId),
+                            conduit =
+                                AccountRef.Existing(
+                                    if (pt.incoming) row.transfer.sourceAccountId else row.transfer.targetAccountId,
+                                ),
                             merchantTarget = AccountRef.Existing(merchantId),
                             amount = row.transfer.amount,
                             spendDescription = pt.merchantName,
                             relationshipTypeId = RelationshipTypeId(pt.relationshipTypeId),
+                            incoming = pt.incoming,
                         )
                     }
                 }

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -79,9 +79,10 @@ sealed interface MappingResult {
          */
         val personalCounterpartyName: String? = null,
         /**
-         * Set when the row is a pass-through (conduit) charge (e.g. Curve): the transfer's target is the
-         * conduit account (funding leg) and [CsvPassThrough.merchantName] is the real merchant the engine
-         * routes the spend leg to. Null for ordinary rows.
+         * Set when the row is a pass-through (conduit) charge (e.g. Curve): the transfer's counterparty
+         * side (target, or source when [CsvPassThrough.incoming]) is the conduit account (funding leg)
+         * and [CsvPassThrough.merchantName] is the real merchant the engine routes the spend leg to.
+         * Null for ordinary rows.
          */
         val passThrough: CsvPassThrough? = null,
     ) : MappingResult {
@@ -109,12 +110,15 @@ data class NewAccount(
 /**
  * Pass-through routing for a row whose charge passes through a conduit account (e.g. Curve). The
  * transfer itself is the funding leg (card -> [conduitName]); the engine synthesises the spend leg
- * ([conduitName] -> [merchantName]) and links them via [relationshipTypeId].
+ * ([conduitName] -> [merchantName]) and links them via [relationshipTypeId]. When [incoming] (a
+ * refund/cancellation back onto the card) both legs run the other way: funding [conduitName] -> card,
+ * spend [merchantName] -> [conduitName].
  */
 data class CsvPassThrough(
     val conduitName: String,
     val merchantName: String,
     val relationshipTypeId: Long,
+    val incoming: Boolean = false,
 )
 
 /**
@@ -367,17 +371,19 @@ class CsvTransferMapper(
             // Parse description
             val description = parseDescription(descriptionMapping, values)
 
-            // Detect a pass-through (conduit) charge, e.g. Curve, from the description. Only outgoing
-            // spends (target = merchant, i.e. no flip) are routed: the transfer becomes the funding leg
-            // card -> conduit, and the engine adds the spend leg conduit -> merchant. Detection + the
-            // conduit/merchant names come entirely from user-editable config (the engine stays agnostic).
-            val passThroughMatch = if (!flipAccounts) passThroughDetector?.detect(description) else null
+            // Detect a pass-through (conduit) charge, e.g. Curve, from the description. An outgoing
+            // spend (no flip) becomes the funding leg card -> conduit and the engine adds the spend leg
+            // conduit -> merchant; an incoming refund/cancellation (flipAccounts) runs both legs the
+            // other way, so the conduit replaces the row's counterparty on whichever side it sits.
+            // Detection + the conduit/merchant names come entirely from user-editable config (the
+            // engine stays agnostic).
+            val passThroughMatch = passThroughDetector?.detect(description)
+            val conduitAccountId =
+                passThroughMatch?.let { existingAccounts[it.account.conduitAccountName]?.id ?: AccountId(-1) }
+            val effectiveSourceAccountId =
+                if (conduitAccountId != null && flipAccounts) conduitAccountId else sourceAccountId
             val effectiveTargetAccountId =
-                if (passThroughMatch != null) {
-                    existingAccounts[passThroughMatch.account.conduitAccountName]?.id ?: AccountId(-1)
-                } else {
-                    targetAccountId
-                }
+                if (conduitAccountId != null && !flipAccounts) conduitAccountId else targetAccountId
 
             // Detect a personal counterparty (resolved from the target mapping regardless of any
             // account flip — the counterparty is the same account on whichever side it ends up). A
@@ -399,7 +405,7 @@ class CsvTransferMapper(
                     id = TransferId(0L),
                     timestamp = timestamp,
                     description = description,
-                    sourceAccountId = sourceAccountId,
+                    sourceAccountId = effectiveSourceAccountId,
                     targetAccountId = effectiveTargetAccountId,
                     amount = amount,
                 )
@@ -417,8 +423,8 @@ class CsvTransferMapper(
 
             // Determine which new accounts need to be created and capture mapping info.
             // The source side participates only when it is resolved per-row (no UI override). For a
-            // pass-through row the target side is replaced by the conduit + merchant accounts (so the
-            // raw "CRV*…" junk account is never discovered), and no account mapping is auto-captured.
+            // pass-through row the counterparty side is replaced by the conduit + merchant accounts (so
+            // the raw "CRV*…" junk account is never discovered), and no account mapping is auto-captured.
             val discoveries =
                 buildList {
                     if (sourceAccountOverride == null) {
@@ -460,6 +466,7 @@ class CsvTransferMapper(
                             conduitName = it.account.conduitAccountName,
                             merchantName = it.merchantName,
                             relationshipTypeId = it.account.relationshipTypeId,
+                            incoming = flipAccounts,
                         )
                     },
             )

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvTransferMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvTransferMapperTest.kt
@@ -212,7 +212,7 @@ class CsvTransferMapperTest {
                 listOf(
                     PassThroughRule(
                         detectionPattern = "(?i)^(?:Refund: |Refund reversal: |Cancellation: )?CRV\\*",
-                        merchantPattern = "(?i)^(?:Refund: |Refund reversal: |Cancellation: )?CRV\\*\\s*(.+?)(?:\\s{2,}.*)?\$",
+                        merchantPattern = "(?i)^(?:Refund: |Refund reversal: |Cancellation: )?CRV\\*\\s*(.+?)(?:\\s{2,}.*)?$",
                     ),
                 ),
         )

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvTransferMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvTransferMapperTest.kt
@@ -202,6 +202,79 @@ class CsvTransferMapperTest {
         assertEquals(setOf("Curve", "Sainsburys"), newNames)
     }
 
+    // Mirrors the seeded Curve rule incl. Crypto.com's cancellation prefixes.
+    private val curveWithCancellations =
+        PassThroughAccount(
+            id = PassThroughAccountId(1),
+            name = "Curve",
+            conduitAccountName = "Curve",
+            rules =
+                listOf(
+                    PassThroughRule(
+                        detectionPattern = "(?i)^(?:Refund: |Refund reversal: |Cancellation: )?CRV\\*",
+                        merchantPattern = "(?i)^(?:Refund: |Refund reversal: |Cancellation: )?CRV\\*\\s*(.+?)(?:\\s{2,}.*)?\$",
+                    ),
+                ),
+        )
+
+    @Test
+    fun `mapRow routes an incoming Curve refund through the conduit on the source side`() {
+        val strategy = createStrategy(flipAccountsOnPositive = true)
+        val curveAccountId = AccountId(5)
+        val curveAccount = Account(id = curveAccountId, name = "Curve", openingDate = Clock.System.now())
+        val mapper =
+            CsvTransferMapper(
+                strategy = strategy,
+                columns = columns,
+                existingAccounts = mapOf("Curve" to curveAccount),
+                existingCurrencies = mapOf(testCurrencyId to testCurrency),
+                existingCurrenciesByCode = mapOf(testCurrency.code.uppercase() to testCurrency),
+                passThroughDetector = PassThroughDetector(listOf(curveWithCancellations)),
+            )
+
+        // A cancelled charge refunded onto the card: positive amount, so the row is incoming (flipped).
+        val row = CsvRow(rowIndex = 1, values = listOf("15/12/2024", "Refund: Crv*Navan", "363.58", "Refund: Crv*Navan"))
+        val result = mapper.mapRow(row)
+
+        assertIs<MappingResult.Success>(result)
+        // The funding leg runs conduit -> card: the conduit replaces the row's source account.
+        assertEquals(curveAccountId, result.transfer.sourceAccountId)
+        assertEquals(testSourceAccountId, result.transfer.targetAccountId)
+        assertEquals(true, result.passThrough?.incoming)
+        // The merchant is the bare name, so the refund hits the same account as the original charge.
+        assertEquals("Navan", result.passThrough?.merchantName)
+        // Only the merchant is new; no junk "Refund: Crv*Navan" account is created.
+        assertEquals(setOf("Navan"), result.newAccounts.map { it.name }.toSet())
+    }
+
+    @Test
+    fun `mapRow routes an outgoing Curve refund reversal through the conduit like an ordinary charge`() {
+        val strategy = createStrategy(flipAccountsOnPositive = true)
+        val mapper =
+            CsvTransferMapper(
+                strategy = strategy,
+                columns = columns,
+                existingAccounts = emptyMap(),
+                existingCurrencies = mapOf(testCurrencyId to testCurrency),
+                existingCurrenciesByCode = mapOf(testCurrency.code.uppercase() to testCurrency),
+                passThroughDetector = PassThroughDetector(listOf(curveWithCancellations)),
+            )
+
+        // A refund reversal is negative (money leaves the card again), so it takes the outgoing path.
+        val row =
+            CsvRow(
+                rowIndex = 1,
+                values = listOf("15/12/2024", "Refund reversal: Crv*Navan", "-363.58", "Refund reversal: Crv*Navan"),
+            )
+        val result = mapper.mapRow(row)
+
+        assertIs<MappingResult.Success>(result)
+        assertEquals(testSourceAccountId, result.transfer.sourceAccountId)
+        assertEquals(false, result.passThrough?.incoming)
+        assertEquals("Navan", result.passThrough?.merchantName)
+        assertEquals(setOf("Curve", "Navan"), result.newAccounts.map { it.name }.toSet())
+    }
+
     @Test
     fun `mapRow returns error for invalid date format`() {
         val strategy = createStrategy()

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -615,7 +615,7 @@ class ImportEngineDbTest : DbTest() {
         repositories.transferRelationshipRepository
             .getByTransfer(transferId)
             .first()
-            .filter { it.relationshipType.name == "reversal" }
+            .filter { it.relationshipType.name == WellKnownIds.REVERSAL_RELATIONSHIP_TYPE_NAME }
 
     @Test
     fun passThrough_incomingRefund_reversesLegsAndLinksToChargeInSameBatch() =
@@ -688,7 +688,8 @@ class ImportEngineDbTest : DbTest() {
             val reversal = reversalLinksOf(refundSpendId).single()
             assertEquals(refundSpendId, reversal.id1)
             assertEquals(chargeSpendId, reversal.id2)
-            assertEquals(RelationshipTypeId(WellKnownIds.REVERSAL_RELATIONSHIP_TYPE_ID), reversal.relationshipType.id)
+            // The seeded reversal relationship type carries id 4 (see StaticSeed.sq).
+            assertEquals(RelationshipTypeId(4), reversal.relationshipType.id)
         }
 
     @Test

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -9,6 +9,7 @@ import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.RelationshipTypeId
 import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.importengineapi.AccountMatchKey
 import com.moneymanager.importengineapi.AccountMergeRequest
@@ -37,6 +38,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Instant
 
 class ImportEngineDbTest : DbTest() {
@@ -548,6 +550,325 @@ class ImportEngineDbTest : DbTest() {
                     .single()
             assertEquals(fundingId, relationship.id1)
             assertEquals("pass-through", relationship.relationshipType.name)
+        }
+
+    /** A pass-through row: the funding leg card <-> Curve plus the [ImportPassThrough] spend leg. */
+    private fun passThroughRow(
+        rowIndex: Long,
+        cardId: AccountId,
+        curve: LocalAccountKey,
+        merchant: LocalAccountKey,
+        amount: Money,
+        timestamp: Instant,
+        description: String,
+        incoming: Boolean,
+        merchantName: String = "Navan",
+    ) = ImportTransfer(
+        rowKey = ImportRowKey.CsvRow(rowIndex),
+        fromAccount = if (incoming) AccountRef.Local(curve) else AccountRef.Existing(cardId),
+        toAccount = if (incoming) AccountRef.Existing(cardId) else AccountRef.Local(curve),
+        source = Source.SampleGenerator,
+        timestamp = timestamp,
+        description = description,
+        amount = amount,
+        passThrough =
+            ImportPassThrough(
+                conduit = AccountRef.Local(curve),
+                merchantTarget = AccountRef.Local(merchant),
+                amount = amount,
+                spendDescription = merchantName,
+                relationshipTypeId = RelationshipTypeId(WellKnownIds.PASS_THROUGH_RELATIONSHIP_TYPE_ID),
+                incoming = incoming,
+            ),
+    )
+
+    private fun passThroughAccountIntents(
+        curve: LocalAccountKey,
+        merchant: LocalAccountKey,
+        merchantName: String = "Navan",
+    ) = listOf(
+        ImportAccountIntent(
+            key = curve,
+            match = AccountMatchKey.ByName("Curve"),
+            name = "Curve",
+            openingDate = baseTime,
+            source = Source.SampleGenerator,
+        ),
+        ImportAccountIntent(
+            key = merchant,
+            match = AccountMatchKey.ByName(merchantName),
+            name = merchantName,
+            openingDate = baseTime,
+            source = Source.SampleGenerator,
+        ),
+    )
+
+    /** The spend leg linked to [fundingId] via its pass-through relationship. */
+    private suspend fun spendLegOf(fundingId: TransferId): TransferId =
+        repositories.transferRelationshipRepository
+            .getByTransfer(fundingId)
+            .first()
+            .single { it.relationshipType.name == "pass-through" }
+            .id2
+
+    private suspend fun reversalLinksOf(transferId: TransferId) =
+        repositories.transferRelationshipRepository
+            .getByTransfer(transferId)
+            .first()
+            .filter { it.relationshipType.name == "reversal" }
+
+    @Test
+    fun passThrough_incomingRefund_reversesLegsAndLinksToChargeInSameBatch() =
+        runTest {
+            val cardId = createSourceAccount()
+            val currency = gbp()
+            val curve = LocalAccountKey("curve")
+            val merchant = LocalAccountKey("merchant")
+            val amount = Money(36358, currency)
+
+            val result =
+                engine().import(
+                    ImportBatch(
+                        transfers =
+                            listOf(
+                                passThroughRow(0, cardId, curve, merchant, amount, baseTime, "Crv*Navan", incoming = false),
+                                passThroughRow(
+                                    1,
+                                    cardId,
+                                    curve,
+                                    merchant,
+                                    amount,
+                                    baseTime.plus(1.hours),
+                                    "Refund: Crv*Navan",
+                                    incoming = true,
+                                ),
+                            ),
+                        dedupePolicy = DedupePolicy.None,
+                        accountsToCreate = passThroughAccountIntents(curve, merchant),
+                    ),
+                )
+            assertEquals(2, result.transfersImported)
+
+            val accounts = repositories.accountRepository.getAllAccounts().first()
+            val curveId = accounts.first { it.name == "Curve" }.id
+            val merchantId = accounts.first { it.name == "Navan" }.id
+
+            // The refund's funding leg runs conduit -> card and its spend leg merchant -> conduit.
+            val refundFundingId = result.createdTransferIds.getValue(ImportRowKey.CsvRow(1))
+            val refundFunding =
+                repositories.transactionRepository
+                    .getTransactionById(refundFundingId.id)
+                    .first()!!
+            assertEquals(curveId, refundFunding.sourceAccountId)
+            assertEquals(cardId, refundFunding.targetAccountId)
+            val refundSpendId = spendLegOf(refundFundingId)
+            val refundSpend = repositories.transactionRepository.getTransactionById(refundSpendId.id).first()!!
+            assertEquals(merchantId, refundSpend.sourceAccountId)
+            assertEquals(curveId, refundSpend.targetAccountId)
+
+            // Charge + refund cancel out on both the conduit and the merchant.
+            listOf(curveId, merchantId).forEach { accountId ->
+                val net =
+                    repositories.transactionRepository
+                        .getTransactionsByAccount(accountId)
+                        .first()
+                        .sumOf { t ->
+                            when (accountId) {
+                                t.targetAccountId -> t.amount.amount
+                                t.sourceAccountId -> -t.amount.amount
+                                else -> 0L
+                            }
+                        }
+                assertEquals(0L, net, "account $accountId should net to zero")
+            }
+
+            // The refund's spend leg (id1) links to the original charge's spend leg (id2).
+            val chargeSpendId = spendLegOf(result.createdTransferIds.getValue(ImportRowKey.CsvRow(0)))
+            val reversal = reversalLinksOf(refundSpendId).single()
+            assertEquals(refundSpendId, reversal.id1)
+            assertEquals(chargeSpendId, reversal.id2)
+        }
+
+    @Test
+    fun passThrough_refundInLaterImport_linksToPersistedCharge() =
+        runTest {
+            val cardId = createSourceAccount()
+            val currency = gbp()
+            val curve = LocalAccountKey("curve")
+            val merchant = LocalAccountKey("merchant")
+            val amount = Money(36358, currency)
+
+            val first =
+                engine().import(
+                    ImportBatch(
+                        transfers =
+                            listOf(passThroughRow(0, cardId, curve, merchant, amount, baseTime, "Crv*Navan", incoming = false)),
+                        dedupePolicy = DedupePolicy.None,
+                        accountsToCreate = passThroughAccountIntents(curve, merchant),
+                    ),
+                )
+            val second =
+                engine().import(
+                    ImportBatch(
+                        transfers =
+                            listOf(
+                                passThroughRow(
+                                    0,
+                                    cardId,
+                                    curve,
+                                    merchant,
+                                    amount,
+                                    baseTime.plus(1.hours),
+                                    "Refund: Crv*Navan",
+                                    incoming = true,
+                                ),
+                            ),
+                        dedupePolicy = DedupePolicy.None,
+                        accountsToCreate = passThroughAccountIntents(curve, merchant),
+                    ),
+                )
+
+            val chargeSpendId = spendLegOf(first.createdTransferIds.getValue(ImportRowKey.CsvRow(0)))
+            val refundSpendId = spendLegOf(second.createdTransferIds.getValue(ImportRowKey.CsvRow(0)))
+            val reversal = reversalLinksOf(refundSpendId).single()
+            assertEquals(refundSpendId, reversal.id1)
+            assertEquals(chargeSpendId, reversal.id2)
+        }
+
+    @Test
+    fun passThrough_chainOfRefundsAndReversals_linksPairwiseConsumingEachLegOnce() =
+        runTest {
+            val cardId = createSourceAccount()
+            val currency = gbp()
+            val curve = LocalAccountKey("curve")
+            val merchant = LocalAccountKey("merchant")
+            val amount = Money(36358, currency)
+
+            // The observed Crypto.com sequence: charge, refund, refund reversal, refund again.
+            val result =
+                engine().import(
+                    ImportBatch(
+                        transfers =
+                            listOf(
+                                passThroughRow(0, cardId, curve, merchant, amount, baseTime, "Crv*Navan", incoming = false),
+                                passThroughRow(
+                                    1,
+                                    cardId,
+                                    curve,
+                                    merchant,
+                                    amount,
+                                    baseTime.plus(1.hours),
+                                    "Refund: Crv*Navan",
+                                    incoming = true,
+                                ),
+                                passThroughRow(
+                                    2,
+                                    cardId,
+                                    curve,
+                                    merchant,
+                                    amount,
+                                    baseTime.plus(2.hours),
+                                    "Refund reversal: Crv*Navan",
+                                    incoming = false,
+                                ),
+                                passThroughRow(
+                                    3,
+                                    cardId,
+                                    curve,
+                                    merchant,
+                                    amount,
+                                    baseTime.plus(3.hours),
+                                    "Refund: Crv*Navan",
+                                    incoming = true,
+                                ),
+                            ),
+                        dedupePolicy = DedupePolicy.None,
+                        accountsToCreate = passThroughAccountIntents(curve, merchant),
+                    ),
+                )
+
+            val spendIds =
+                (0L..3L).map { spendLegOf(result.createdTransferIds.getValue(ImportRowKey.CsvRow(it))) }
+            // Pairwise: refund -> charge, reversal -> refund, second refund -> reversal.
+            (1..3).forEach { i ->
+                val reversal = reversalLinksOf(spendIds[i]).single { it.id1 == spendIds[i] }
+                assertEquals(spendIds[i - 1], reversal.id2, "row $i should reverse row ${i - 1}")
+            }
+            // Each leg is consumed at most once: exactly 3 links, all id2s distinct.
+            val allLinks = spendIds.flatMap { reversalLinksOf(it) }.distinct()
+            assertEquals(3, allLinks.size)
+            assertEquals(3, allLinks.map { it.id2 }.toSet().size)
+        }
+
+    @Test
+    fun passThrough_refundWithDifferentAmount_getsNoReversalLink() =
+        runTest {
+            val cardId = createSourceAccount()
+            val currency = gbp()
+            val curve = LocalAccountKey("curve")
+            val merchant = LocalAccountKey("merchant")
+
+            val result =
+                engine().import(
+                    ImportBatch(
+                        transfers =
+                            listOf(
+                                passThroughRow(0, cardId, curve, merchant, Money(36358, currency), baseTime, "Crv*Navan", incoming = false),
+                                passThroughRow(
+                                    1,
+                                    cardId,
+                                    curve,
+                                    merchant,
+                                    Money(12345, currency),
+                                    baseTime.plus(1.hours),
+                                    "Refund: Crv*Navan",
+                                    incoming = true,
+                                ),
+                            ),
+                        dedupePolicy = DedupePolicy.None,
+                        accountsToCreate = passThroughAccountIntents(curve, merchant),
+                    ),
+                )
+
+            val refundSpendId = spendLegOf(result.createdTransferIds.getValue(ImportRowKey.CsvRow(1)))
+            assertTrue(reversalLinksOf(refundSpendId).isEmpty())
+        }
+
+    @Test
+    fun passThrough_repeatChargesSameDirection_getNoReversalLink() =
+        runTest {
+            val cardId = createSourceAccount()
+            val currency = gbp()
+            val curve = LocalAccountKey("curve")
+            val merchant = LocalAccountKey("merchant")
+            val amount = Money(1400, currency)
+
+            val result =
+                engine().import(
+                    ImportBatch(
+                        transfers =
+                            listOf(
+                                passThroughRow(0, cardId, curve, merchant, amount, baseTime, "Crv*Zipcar Trip Oct05", incoming = false),
+                                passThroughRow(
+                                    1,
+                                    cardId,
+                                    curve,
+                                    merchant,
+                                    amount,
+                                    baseTime.plus(1.hours),
+                                    "Crv*Zipcar Trip Oct05",
+                                    incoming = false,
+                                ),
+                            ),
+                        dedupePolicy = DedupePolicy.None,
+                        accountsToCreate = passThroughAccountIntents(curve, merchant),
+                    ),
+                )
+
+            (0L..1L).forEach { row ->
+                val spendId = spendLegOf(result.createdTransferIds.getValue(ImportRowKey.CsvRow(row)))
+                assertTrue(reversalLinksOf(spendId).isEmpty(), "row $row must not link")
+            }
         }
 
     @Test

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -682,11 +682,13 @@ class ImportEngineDbTest : DbTest() {
                 assertEquals(0L, net, "account $accountId should net to zero")
             }
 
-            // The refund's spend leg (id1) links to the original charge's spend leg (id2).
+            // The refund's spend leg (id1) links to the original charge's spend leg (id2) via the
+            // seeded reversal relationship type.
             val chargeSpendId = spendLegOf(result.createdTransferIds.getValue(ImportRowKey.CsvRow(0)))
             val reversal = reversalLinksOf(refundSpendId).single()
             assertEquals(refundSpendId, reversal.id1)
             assertEquals(chargeSpendId, reversal.id2)
+            assertEquals(RelationshipTypeId(WellKnownIds.REVERSAL_RELATIONSHIP_TYPE_ID), reversal.relationshipType.id)
         }
 
     @Test

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -804,6 +804,48 @@ class ImportEngineDbTest : DbTest() {
         }
 
     @Test
+    fun passThrough_refundInLaterChunk_linksAcrossChunkBoundary() =
+        runTest {
+            val cardId = createSourceAccount()
+            val currency = gbp()
+            val curve = LocalAccountKey("curve")
+            val merchant = LocalAccountKey("merchant")
+            val amount = Money(36358, currency)
+
+            // batchSize = 1 puts every row in its own chunk (own transaction), so the refund's in-batch
+            // reversal target lives in an earlier chunk and must resolve to the already-created real id.
+            val result =
+                engine().import(
+                    ImportBatch(
+                        transfers =
+                            listOf(
+                                passThroughRow(0, cardId, curve, merchant, amount, baseTime, "Crv*Navan", incoming = false),
+                                passThroughRow(
+                                    1,
+                                    cardId,
+                                    curve,
+                                    merchant,
+                                    amount,
+                                    baseTime.plus(1.hours),
+                                    "Refund: Crv*Navan",
+                                    incoming = true,
+                                ),
+                            ),
+                        dedupePolicy = DedupePolicy.None,
+                        accountsToCreate = passThroughAccountIntents(curve, merchant),
+                    ),
+                    batchSize = 1,
+                )
+            assertEquals(2, result.transfersImported)
+
+            val chargeSpendId = spendLegOf(result.createdTransferIds.getValue(ImportRowKey.CsvRow(0)))
+            val refundSpendId = spendLegOf(result.createdTransferIds.getValue(ImportRowKey.CsvRow(1)))
+            val reversal = reversalLinksOf(refundSpendId).single()
+            assertEquals(refundSpendId, reversal.id1)
+            assertEquals(chargeSpendId, reversal.id2)
+        }
+
+    @Test
     fun passThrough_refundWithDifferentAmount_getsNoReversalLink() =
         runTest {
             val cardId = createSourceAccount()

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionReadRepositoryImpl.kt
@@ -15,9 +15,11 @@ import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AccountRow
 import com.moneymanager.domain.model.AttributeType
 import com.moneymanager.domain.model.AttributeTypeId
+import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.PageWithTargetIndex
 import com.moneymanager.domain.model.PagingInfo
 import com.moneymanager.domain.model.PagingResult
+import com.moneymanager.domain.model.RelationshipTypeId
 import com.moneymanager.domain.model.TransactionId
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferAttribute
@@ -108,6 +110,26 @@ class TransactionReadRepositoryImpl(
             ).asFlow()
             .mapToList(Dispatchers.Default)
             .map { loadAttributesForTransfers(it) }
+
+    override suspend fun getUnreversedTransfersBetween(
+        sourceAccountId: AccountId,
+        targetAccountId: AccountId,
+        amount: Money,
+        maxTimestamp: Instant,
+        reversalTypeId: RelationshipTypeId,
+    ): List<Transfer> =
+        withContext(Dispatchers.Default) {
+            transferSelectQueries
+                .selectUnreversedTransfersBetweenAccountsByAmount(
+                    sourceAccountId = sourceAccountId.id,
+                    targetAccountId = targetAccountId.id,
+                    amount = amount.amount,
+                    currencyId = amount.currency.id.id,
+                    maxTimestamp = maxTimestamp.toEpochMilliseconds(),
+                    reversalTypeId = reversalTypeId.id,
+                    TransferMapper::mapRaw,
+                ).executeAsList()
+        }
 
     override fun getTransfersMissingCompanion(
         matchAttributeName: String,

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
@@ -274,6 +274,36 @@ WHERE (source_account_id = :accountA AND target_account_id = :accountB)
    OR (source_account_id = :accountB AND target_account_id = :accountA)
 ORDER BY timestamp DESC;
 
+-- Candidate originals for a reversal (refund/cancellation) link: directed transfers of the same amount
+-- not yet reversed (never id2 of a :reversalTypeId relationship), newest first. Used by the import
+-- engine to pair a pass-through refund's spend leg with the charge it reverses.
+selectUnreversedTransfersBetweenAccountsByAmount:
+SELECT
+    transfer.id,
+    transfer.revision_id,
+    transfer.timestamp,
+    transfer.description,
+    transfer.source_account_id,
+    transfer.target_account_id,
+    transfer.amount,
+    currency.id AS currency_id,
+    currency.code AS currency_code,
+    currency.name AS currency_name,
+    currency.scale_factor AS currency_scale_factor
+FROM transfer
+JOIN currency ON transfer.currency_id = currency.id
+WHERE transfer.source_account_id = :sourceAccountId
+  AND transfer.target_account_id = :targetAccountId
+  AND transfer.amount = :amount
+  AND transfer.currency_id = :currencyId
+  AND transfer.timestamp <= :maxTimestamp
+  AND NOT EXISTS (
+      SELECT 1 FROM transfer_relationship
+      WHERE transfer_relationship.id2 = transfer.id
+        AND transfer_relationship.relationship_type_id = :reversalTypeId
+  )
+ORDER BY transfer.timestamp DESC, transfer.id DESC;
+
 -- Current revision of a single transfer, for recording its source after a merge/unmerge reassignment.
 selectRevisionById:
 SELECT revision_id FROM transfer WHERE id = ?;

--- a/app/db/seed/src/commonMain/sqldelight/com/moneymanager/database/sql/seed/StaticSeed.sq
+++ b/app/db/seed/src/commonMain/sqldelight/com/moneymanager/database/sql/seed/StaticSeed.sq
@@ -41,20 +41,25 @@ INSERT INTO attribute_type (id, name) VALUES (-7, 'counterparty-name-key');
 INSERT INTO relationship_type (id, name) VALUES (1, 'reconciled');
 INSERT INTO relationship_type (id, name) VALUES (2, 'fee');
 INSERT INTO relationship_type (id, name) VALUES (3, 'pass-through');
+INSERT INTO relationship_type (id, name) VALUES (4, 'reversal');
 
 -- Built-in "Curve" pass-through (conduit) definition — the only Curve-specific data in the codebase.
 -- A wrapper card whose charges are forwarded to an underlying funding card (Crypto.com, Monzo); the
 -- underlying statement carries the real merchant behind a "CRV*" marker on the description. The single
--- rule covers both Crypto.com ("Crv*Sainsburys") and Monzo ("CRV*NATIONAL LOTTERY   London   GBR"):
--- detection (?i)^CRV\* , merchant (?i)^CRV\*\s*(.+?)(?:\s{2,}.*)?$ -> $1 . pass_through_account is in
--- EXCLUDED_FROM_AUDIT (config table, no triggers). FK relationship_type_id -> the type seeded above.
+-- rule covers both Crypto.com ("Crv*Sainsburys") and Monzo ("CRV*NATIONAL LOTTERY   London   GBR"),
+-- including the cancellation rows Crypto.com emits with a prefixed description ("Refund: Crv*Navan",
+-- "Refund reversal: Crv*Navan", "Cancellation: Crv*Zipcar Annual Plan") — these are routed back through
+-- the conduit in the opposite direction (merchant -> conduit -> card) and the merchant pattern still
+-- extracts the bare merchant so refunds hit the same merchant account as the original charge.
+-- pass_through_account is in EXCLUDED_FROM_AUDIT (config table, no triggers). FK relationship_type_id ->
+-- the type seeded above.
 -- Seeded DISABLED (enabled = 0): the definition is visible/editable under Imports -> Misc -> Pass-through,
 -- but does not change any import's behaviour until the user turns it on. This keeps imports unchanged by
 -- default (a pass-through is a per-user card setup) and avoids rerouting unrelated "CRV*" rows.
 INSERT INTO pass_through_account (id, name, conduit_account_name, relationship_type_id, enabled, rules_json)
 VALUES (
     1, 'Curve', 'Curve', 3, 0,
-    '[{"detectionPattern":"(?i)^CRV\\*","merchantPattern":"(?i)^CRV\\*\\s*(.+?)(?:\\s{2,}.*)?$","merchantTemplate":"$1"}]'
+    '[{"detectionPattern":"(?i)^(?:Refund: |Refund reversal: |Cancellation: )?CRV\\*","merchantPattern":"(?i)^(?:Refund: |Refund reversal: |Cancellation: )?CRV\\*\\s*(.+?)(?:\\s{2,}.*)?$","merchantTemplate":"$1"}]'
 );
 
 -- GBP gets a fixed id (1) here so the build-time-generated QIF strategies can reference it as a

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
@@ -278,7 +278,7 @@ data class ImportFee(
  * amount: a funding leg (the transfer's own `fromAccount` → [conduit]) and a spend leg
  * ([conduit] → [merchantTarget]), linked via a [relationshipTypeId] (`pass-through`) relationship. The
  * engine expands this into the second [Transfer] in the same batch — like [ImportFee], producers don't
- * allocate ids. The conduit nets to zero, so the spend is counted once.
+ * allocate ids. The conduit nets to zero, so the spend is counted once (in either direction).
  *
  * This is fully generic: the engine never inspects the merchant text or knows the conduit's name —
  * detection + extraction happen in the importers via [PassThroughDetector] and user-editable config.
@@ -290,6 +290,9 @@ data class ImportFee(
  *   the main transfer's description.
  * @property relationshipTypeId The `pass-through` relationship type linking funding (id1) to spend (id2).
  * @property rowKey Provenance key for the spend leg; when null the engine falls back to the main row key.
+ * @property incoming True for a refund/cancellation arriving back on the card: the funding leg (the main
+ *   transfer, built by the producer) is [conduit] → card and the engine's spend leg is
+ *   [merchantTarget] → [conduit].
  */
 data class ImportPassThrough(
     val conduit: AccountRef,
@@ -298,6 +301,7 @@ data class ImportPassThrough(
     val spendDescription: String,
     val relationshipTypeId: RelationshipTypeId,
     val rowKey: ImportRowKey? = null,
+    val incoming: Boolean = false,
 )
 
 /**

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
@@ -6,6 +6,7 @@ import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.NewRelationship
+import com.moneymanager.domain.model.RelationshipTypeId
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.ImportStatus
@@ -37,13 +38,41 @@ data class ExistingTransferInfo(
  * @property inBatchMatchIndex For an in-batch DUPLICATE (it matched an earlier accepted transfer in the
  *   same batch that has no id yet), the index of that earlier transfer in the classified list; the
  *   engine resolves it to the earlier transfer's created id. Null otherwise.
+ * @property reversalLink For a pass-through row that reverses an earlier movement (a refund/cancellation,
+ *   or a re-booking that undoes one), the spend leg it reverses. Resolved by the engine after
+ *   classification; the deduper never sets it.
  */
 data class Classified(
     val transfer: ImportTransfer,
     val status: ImportStatus,
     val existing: TransferId?,
     val inBatchMatchIndex: Int? = null,
+    val reversalLink: ReversalLink? = null,
 )
+
+/**
+ * A `reversal` relationship to create from a new pass-through spend leg (id1) to the spend leg it
+ * reverses (id2).
+ *
+ * @property target The reversed spend leg: an existing (persisted) transfer, or the spend leg of an
+ *   earlier row in the same to-import list (index into that list), resolved to its temp id at write time.
+ * @property typeId The `reversal` relationship type id.
+ */
+data class ReversalLink(
+    val target: ReversalTarget,
+    val typeId: RelationshipTypeId,
+)
+
+/** See [ReversalLink.target]. */
+sealed interface ReversalTarget {
+    data class Existing(
+        val id: TransferId,
+    ) : ReversalTarget
+
+    data class BatchRow(
+        val toImportIndex: Int,
+    ) : ReversalTarget
+}
 
 /**
  * Deduplicates incoming transfers against existing ones according to a [DedupePolicy]. Account

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -82,9 +82,6 @@ import com.moneymanager.importengineapi.personalCounterpartyKey
 import kotlinx.coroutines.flow.first
 import kotlin.time.Instant
 
-/** The seeded `relationship_type` name linking a reversing movement (id1) to the one it reverses (id2). */
-private const val REVERSAL_RELATIONSHIP_TYPE_NAME = "reversal"
-
 /**
  * Database-backed [ImportEngine]. Takes a fully-built [ImportBatch] and performs the whole import:
  * creates (or reuses) accounts, people and ownerships, resolves transfer account references,
@@ -431,7 +428,7 @@ class ImportEngineImpl(
      */
     private suspend fun resolveReversalLinks(toImport: List<Classified>): List<Classified> {
         if (toImport.none { it.transfer.passThrough != null }) return toImport
-        val reversalTypeId = relationshipTypeRepository.getOrCreate(REVERSAL_RELATIONSHIP_TYPE_NAME)
+        val reversalTypeId = relationshipTypeRepository.getOrCreate(WellKnownIds.REVERSAL_RELATIONSHIP_TYPE_NAME)
         val claimedExisting = mutableSetOf<TransferId>()
         val claimedInBatch = mutableSetOf<Int>()
         val batchSpendLegs = mutableListOf<BatchSpendLeg>()

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -80,6 +80,10 @@ import com.moneymanager.importengineapi.forRow
 import com.moneymanager.importengineapi.normalizeNameKey
 import com.moneymanager.importengineapi.personalCounterpartyKey
 import kotlinx.coroutines.flow.first
+import kotlin.time.Instant
+
+/** The seeded `relationship_type` name linking a reversing movement (id1) to the one it reverses (id2). */
+private const val REVERSAL_RELATIONSHIP_TYPE_NAME = "reversal"
 
 /**
  * Database-backed [ImportEngine]. Takes a fully-built [ImportBatch] and performs the whole import:
@@ -375,7 +379,7 @@ class ImportEngineImpl(
         val existing = loadExisting(resolvedTransfers, batch)
         val classified = ImportDeduper(batch.dedupePolicy, existing).classify(resolvedTransfers)
 
-        val toImport = classified.filter { it.status == ImportStatus.IMPORTED }
+        val toImport = resolveReversalLinks(classified.filter { it.status == ImportStatus.IMPORTED })
         val toUpdate = classified.filter { it.status == ImportStatus.UPDATED }
         val duplicates = classified.count { it.status == ImportStatus.DUPLICATE }
         val excluded = resolvedTransfers.count { it.excludedFromBalances }
@@ -414,6 +418,79 @@ class ImportEngineImpl(
             orderedRowOutcomes = orderedRowOutcomes,
         )
     }
+
+    /**
+     * Pairs each pass-through row with the movement it reverses: the nearest not-yet-reversed spend leg
+     * running in the OPPOSITE direction between the same conduit and merchant accounts with the same
+     * amount, at or before the row's timestamp. An incoming refund thus links to the original charge, a
+     * subsequent "refund reversal" (outgoing again) links to the refund it undoes, and so on — each pair
+     * consumes one earlier leg (a leg is reversed at most once, enforced against the DB via the query's
+     * NOT EXISTS and within this batch via the claimed sets). Candidates come from the DB and from
+     * earlier rows in [toImport]; on a timestamp tie the in-batch leg wins (it is the later write).
+     * Rows without a match are imported unlinked.
+     */
+    private suspend fun resolveReversalLinks(toImport: List<Classified>): List<Classified> {
+        if (toImport.none { it.transfer.passThrough != null }) return toImport
+        val reversalTypeId = relationshipTypeRepository.getOrCreate(REVERSAL_RELATIONSHIP_TYPE_NAME)
+        val claimedExisting = mutableSetOf<TransferId>()
+        val claimedInBatch = mutableSetOf<Int>()
+        val batchSpendLegs = mutableListOf<BatchSpendLeg>()
+        return toImport.mapIndexed { index, classified ->
+            val t = classified.transfer
+            val passThrough = t.passThrough ?: return@mapIndexed classified
+            val conduit = passThrough.conduit.requireExistingId()
+            val merchant = passThrough.merchantTarget.requireExistingId()
+            val spendSource = if (passThrough.incoming) merchant else conduit
+            val spendTarget = if (passThrough.incoming) conduit else merchant
+            val timestamp = requireNotNull(t.timestamp)
+            val amount = passThrough.amount
+
+            // The reversed candidate runs the opposite way: its source/target are this leg's swapped.
+            val inBatchMatch =
+                batchSpendLegs
+                    .filter { leg ->
+                        leg.toImportIndex !in claimedInBatch &&
+                            leg.source == spendTarget &&
+                            leg.target == spendSource &&
+                            leg.amount == amount &&
+                            leg.timestamp <= timestamp
+                    }.maxWithOrNull(compareBy({ it.timestamp }, { it.toImportIndex }))
+            val existingMatch =
+                transactionRepository
+                    .getUnreversedTransfersBetween(spendTarget, spendSource, amount, timestamp, reversalTypeId)
+                    .firstOrNull { it.id !in claimedExisting }
+
+            val link =
+                when {
+                    inBatchMatch != null && (existingMatch == null || existingMatch.timestamp <= inBatchMatch.timestamp) -> {
+                        claimedInBatch += inBatchMatch.toImportIndex
+                        ReversalLink(ReversalTarget.BatchRow(inBatchMatch.toImportIndex), reversalTypeId)
+                    }
+                    existingMatch != null -> {
+                        claimedExisting += existingMatch.id
+                        ReversalLink(ReversalTarget.Existing(existingMatch.id), reversalTypeId)
+                    }
+                    else -> null
+                }
+            batchSpendLegs += BatchSpendLeg(index, spendSource, spendTarget, amount, timestamp)
+            if (link == null) classified else classified.copy(reversalLink = link)
+        }
+    }
+
+    /** A pass-through spend leg produced by an earlier row in the current to-import list. */
+    private class BatchSpendLeg(
+        val toImportIndex: Int,
+        val source: AccountId,
+        val target: AccountId,
+        val amount: Money,
+        val timestamp: Instant,
+    )
+
+    private fun AccountRef.requireExistingId(): AccountId =
+        when (this) {
+            is AccountRef.Existing -> id
+            is AccountRef.Local -> error("Unresolved account reference: $key")
+        }
 
     // endregion
 
@@ -852,7 +929,7 @@ class ImportEngineImpl(
         val createdIds = mutableListOf<TransferId>()
         var written = 0
         chunks.forEachIndexed { index, chunk ->
-            val payload = buildCreatePayload(chunk)
+            val payload = buildCreatePayload(chunk, chunkStartIndex = index * effectiveBatchSize)
             // Updates ride with the final create chunk (one transaction in the common single-chunk case).
             val (updates, updateSources) =
                 if (index == chunks.lastIndex) buildUpdates(toUpdate) else emptyList<TransferUpdate>() to emptyList()
@@ -891,7 +968,10 @@ class ImportEngineImpl(
         val mainResultIndices: List<Int>,
     )
 
-    private fun buildCreatePayload(chunk: List<Classified>): CreatePayload {
+    private fun buildCreatePayload(
+        chunk: List<Classified>,
+        chunkStartIndex: Int,
+    ): CreatePayload {
         // Assign negative temp ids so newAttributes/newRelationships can be keyed before real ids exist.
         // A main transfer carrying a fee expands into two transfers (main + fee) created in this same
         // chunk; the fee is linked to the main via a `fee` relationship resolved by the repository's
@@ -901,8 +981,12 @@ class ImportEngineImpl(
         val newRelationships = mutableMapOf<TransferId, List<NewRelationship>>()
         val orderedSources = mutableListOf<Source>()
         val mainResultIndices = mutableListOf<Int>()
+        // Spend-leg temp ids keyed by to-import index, for reversal links targeting an earlier row of
+        // this chunk. Temp ids only resolve within one importTransfers call, so a link whose target
+        // landed in an earlier chunk is dropped (only possible with an explicit small batchSize).
+        val spendTempIdByImportIndex = mutableMapOf<Int, TransferId>()
         var tempCounter = 0
-        chunk.forEach { classified ->
+        chunk.forEachIndexed { chunkIndex, classified ->
             val t = classified.transfer
             val mainTempId = TransferId(-(++tempCounter).toLong())
             val fee = t.fee
@@ -959,18 +1043,33 @@ class ImportEngineImpl(
             if (fee != null && feeTempId != null) {
                 addLeg(feeTempId, fee.description, fee.source, fee.target, fee.amount, fee.rowKey)
             }
-            // The pass-through spend leg (conduit -> merchant), same amount as the funding leg (the main
-            // transfer, card -> conduit), linked via the pass-through relationship so the conduit nets to
-            // zero and the spend is counted once.
+            // The pass-through spend leg, same amount as the funding leg (the main transfer), linked via
+            // the pass-through relationship so the conduit nets to zero and the spend is counted once.
+            // Outgoing charge: funding card -> conduit, spend conduit -> merchant. Incoming
+            // refund/cancellation: funding conduit -> card, spend merchant -> conduit.
             if (passThrough != null && spendTempId != null) {
                 addLeg(
                     spendTempId,
                     passThrough.spendDescription,
-                    passThrough.conduit,
-                    passThrough.merchantTarget,
+                    if (passThrough.incoming) passThrough.merchantTarget else passThrough.conduit,
+                    if (passThrough.incoming) passThrough.conduit else passThrough.merchantTarget,
                     passThrough.amount,
                     passThrough.rowKey,
                 )
+                spendTempIdByImportIndex[chunkStartIndex + chunkIndex] = spendTempId
+                // Reversal pairing: this spend leg (id1) reverses an earlier one (id2) — either an
+                // existing transfer or an earlier row's spend leg created in this same chunk.
+                val reversalLink = classified.reversalLink
+                if (reversalLink != null) {
+                    val reversalTargetId =
+                        when (val target = reversalLink.target) {
+                            is ReversalTarget.Existing -> target.id
+                            is ReversalTarget.BatchRow -> spendTempIdByImportIndex[target.toImportIndex]
+                        }
+                    if (reversalTargetId != null) {
+                        newRelationships[spendTempId] = listOf(NewRelationship(reversalTargetId, reversalLink.typeId))
+                    }
+                }
             }
         }
         return CreatePayload(transfersToCreate, newAttributes, newRelationships, orderedSources, mainResultIndices)

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -924,9 +924,12 @@ class ImportEngineImpl(
 
         val total = toImport.size
         val createdIds = mutableListOf<TransferId>()
+        // Spend-leg real ids from already-written chunks, keyed by to-import index, so later chunks can
+        // resolve reversal targets that point across a chunk boundary.
+        val resolvedSpendLegIds = mutableMapOf<Int, TransferId>()
         var written = 0
         chunks.forEachIndexed { index, chunk ->
-            val payload = buildCreatePayload(chunk, chunkStartIndex = index * effectiveBatchSize)
+            val payload = buildCreatePayload(chunk, chunkStartIndex = index * effectiveBatchSize, resolvedSpendLegIds)
             // Updates ride with the final create chunk (one transaction in the common single-chunk case).
             val (updates, updateSources) =
                 if (index == chunks.lastIndex) buildUpdates(toUpdate) else emptyList<TransferUpdate>() to emptyList()
@@ -941,6 +944,9 @@ class ImportEngineImpl(
                 )
             // Keep only the main transfers' ids (fee transfers are interleaved), aligned to [toImport].
             createdIds += payload.mainResultIndices.map { allCreatedIds[it] }
+            payload.spendResultIndices.forEach { (importIndex, resultIndex) ->
+                resolvedSpendLegIds[importIndex] = allCreatedIds[resultIndex]
+            }
             written += chunk.size
             onProgress?.invoke(
                 ImportProgress(
@@ -963,11 +969,17 @@ class ImportEngineImpl(
         val sources: List<Source>,
         // Indices into [transfers] of each main transfer, so callers map results back to chunk order.
         val mainResultIndices: List<Int>,
+        // Pass-through spend legs: to-import index -> index into [transfers], so callers can record the
+        // created spend-leg ids and later chunks can resolve cross-chunk reversal targets to real ids.
+        val spendResultIndices: Map<Int, Int>,
     )
 
     private fun buildCreatePayload(
         chunk: List<Classified>,
         chunkStartIndex: Int,
+        // Real spend-leg ids created by earlier chunks, keyed by to-import index, so a reversal target
+        // that landed in a previous chunk (its temp id is no longer resolvable) still links by real id.
+        priorSpendLegIds: Map<Int, TransferId>,
     ): CreatePayload {
         // Assign negative temp ids so newAttributes/newRelationships can be keyed before real ids exist.
         // A main transfer carrying a fee expands into two transfers (main + fee) created in this same
@@ -979,9 +991,10 @@ class ImportEngineImpl(
         val orderedSources = mutableListOf<Source>()
         val mainResultIndices = mutableListOf<Int>()
         // Spend-leg temp ids keyed by to-import index, for reversal links targeting an earlier row of
-        // this chunk. Temp ids only resolve within one importTransfers call, so a link whose target
-        // landed in an earlier chunk is dropped (only possible with an explicit small batchSize).
+        // this chunk; targets from earlier chunks resolve through [priorSpendLegIds] instead (temp ids
+        // only resolve within one importTransfers call).
         val spendTempIdByImportIndex = mutableMapOf<Int, TransferId>()
+        val spendResultIndices = mutableMapOf<Int, Int>()
         var tempCounter = 0
         chunk.forEachIndexed { chunkIndex, classified ->
             val t = classified.transfer
@@ -1054,14 +1067,18 @@ class ImportEngineImpl(
                     passThrough.rowKey,
                 )
                 spendTempIdByImportIndex[chunkStartIndex + chunkIndex] = spendTempId
-                // Reversal pairing: this spend leg (id1) reverses an earlier one (id2) — either an
-                // existing transfer or an earlier row's spend leg created in this same chunk.
+                spendResultIndices[chunkStartIndex + chunkIndex] = transfersToCreate.lastIndex
+                // Reversal pairing: this spend leg (id1) reverses an earlier one (id2) — an existing
+                // transfer, an earlier row's spend leg in this chunk (temp id), or an earlier chunk's
+                // spend leg (already-created real id).
                 val reversalLink = classified.reversalLink
                 if (reversalLink != null) {
                     val reversalTargetId =
                         when (val target = reversalLink.target) {
                             is ReversalTarget.Existing -> target.id
-                            is ReversalTarget.BatchRow -> spendTempIdByImportIndex[target.toImportIndex]
+                            is ReversalTarget.BatchRow ->
+                                spendTempIdByImportIndex[target.toImportIndex]
+                                    ?: priorSpendLegIds[target.toImportIndex]
                         }
                     if (reversalTargetId != null) {
                         newRelationships[spendTempId] = listOf(NewRelationship(reversalTargetId, reversalLink.typeId))
@@ -1069,7 +1086,7 @@ class ImportEngineImpl(
                 }
             }
         }
-        return CreatePayload(transfersToCreate, newAttributes, newRelationships, orderedSources, mainResultIndices)
+        return CreatePayload(transfersToCreate, newAttributes, newRelationships, orderedSources, mainResultIndices, spendResultIndices)
     }
 
     private fun buildUpdates(toUpdate: List<Classified>): Pair<List<TransferUpdate>, List<Source>> {

--- a/app/importer/src/commonTest/kotlin/com/moneymanager/importer/PassThroughDetectorTest.kt
+++ b/app/importer/src/commonTest/kotlin/com/moneymanager/importer/PassThroughDetectorTest.kt
@@ -9,7 +9,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class PassThroughDetectorTest {
-    // Mirrors the seeded "Curve" definition: one rule covering both Crypto.com and Monzo descriptions.
+    // Mirrors the seeded "Curve" definition: one rule covering both Crypto.com and Monzo descriptions,
+    // including Crypto.com's cancellation prefixes (Refund / Refund reversal / Cancellation).
     private fun curve(enabled: Boolean = true) =
         PassThroughAccount(
             id = PassThroughAccountId(1),
@@ -19,8 +20,8 @@ class PassThroughDetectorTest {
             rules =
                 listOf(
                     PassThroughRule(
-                        detectionPattern = "(?i)^CRV\\*",
-                        merchantPattern = "(?i)^CRV\\*\\s*(.+?)(?:\\s{2,}.*)?$",
+                        detectionPattern = "(?i)^(?:Refund: |Refund reversal: |Cancellation: )?CRV\\*",
+                        merchantPattern = "(?i)^(?:Refund: |Refund reversal: |Cancellation: )?CRV\\*\\s*(.+?)(?:\\s{2,}.*)?$",
                     ),
                 ),
         )
@@ -37,6 +38,37 @@ class PassThroughDetectorTest {
         // The real Monzo fixture: tx_0000ArZLnhQRNHoXG3sUaH.
         val match = PassThroughDetector(listOf(curve())).detect("CRV*NATIONAL LOTTERY   London        GBR")
         assertEquals("NATIONAL LOTTERY", match?.merchantName)
+    }
+
+    @Test
+    fun refundPrefix_matchesAndExtractsBareMerchant() {
+        // A cancelled charge refunded onto the card must hit the same merchant account as the charge.
+        val match = PassThroughDetector(listOf(curve())).detect("Refund: Crv*Navan")
+        assertEquals("Navan", match?.merchantName)
+        assertEquals("Curve", match?.account?.conduitAccountName)
+    }
+
+    @Test
+    fun refundReversalPrefix_matchesAndExtractsBareMerchant() {
+        val match = PassThroughDetector(listOf(curve())).detect("Refund reversal: Crv*Navan")
+        assertEquals("Navan", match?.merchantName)
+    }
+
+    @Test
+    fun cancellationPrefix_matchesAndExtractsBareMerchant() {
+        val match = PassThroughDetector(listOf(curve())).detect("Cancellation: Crv*Zipcar Annual Plan")
+        assertEquals("Zipcar Annual Plan", match?.merchantName)
+    }
+
+    @Test
+    fun refundPrefix_withMultiWordMerchant() {
+        val match = PassThroughDetector(listOf(curve())).detect("Refund: Crv*Paypal *Ubertrip 3")
+        assertEquals("Paypal *Ubertrip 3", match?.merchantName)
+    }
+
+    @Test
+    fun refundWithoutCurveMarker_doesNotMatch() {
+        assertNull(PassThroughDetector(listOf(curve())).detect("Refund: Something else"))
     }
 
     @Test

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/WellKnownIds.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/WellKnownIds.kt
@@ -45,8 +45,10 @@ object WellKnownIds {
     const val PASS_THROUGH_RELATIONSHIP_TYPE_ID: Long = 3
 
     /**
-     * "reversal" relationship type: id1 is the reversing movement (a refund/cancellation) and id2 the
-     * earlier movement it reverses — for pass-through rows, the two spend legs on the merchant account.
+     * "reversal" relationship type (seeded id 4): id1 is the reversing movement (a refund/cancellation)
+     * and id2 the earlier movement it reverses — for pass-through rows, the two spend legs on the
+     * merchant account. The engine resolves it by name (get-or-create), so databases seeded before the
+     * type existed self-heal on first use.
      */
-    const val REVERSAL_RELATIONSHIP_TYPE_ID: Long = 4
+    const val REVERSAL_RELATIONSHIP_TYPE_NAME: String = "reversal"
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/WellKnownIds.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/WellKnownIds.kt
@@ -43,4 +43,10 @@ object WellKnownIds {
      * [com.moneymanager.domain.model.passthrough.PassThroughAccount].
      */
     const val PASS_THROUGH_RELATIONSHIP_TYPE_ID: Long = 3
+
+    /**
+     * "reversal" relationship type: id1 is the reversing movement (a refund/cancellation) and id2 the
+     * earlier movement it reverses — for pass-through rows, the two spend legs on the merchant account.
+     */
+    const val REVERSAL_RELATIONSHIP_TYPE_ID: Long = 4
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionReadRepository.kt
@@ -5,9 +5,11 @@ package com.moneymanager.domain.repository
 import com.moneymanager.domain.model.AccountBalance
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AccountRow
+import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.PageWithTargetIndex
 import com.moneymanager.domain.model.PagingInfo
 import com.moneymanager.domain.model.PagingResult
+import com.moneymanager.domain.model.RelationshipTypeId
 import com.moneymanager.domain.model.TransactionId
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
@@ -44,6 +46,19 @@ interface TransactionReadRepository {
         matchValuePattern: String,
         linkAttributeName: String,
     ): Flow<List<TransferMissingCompanion>>
+
+    /**
+     * Directed transfers [sourceAccountId] → [targetAccountId] of exactly [amount] at or before
+     * [maxTimestamp] that are not yet the target (id2) of a [reversalTypeId] relationship, newest
+     * first. Used by the import engine to pair a refund/cancellation with the movement it reverses.
+     */
+    suspend fun getUnreversedTransfersBetween(
+        sourceAccountId: AccountId,
+        targetAccountId: AccountId,
+        amount: Money,
+        maxTimestamp: Instant,
+        reversalTypeId: RelationshipTypeId,
+    ): List<Transfer>
 
     suspend fun getRunningBalanceByAccountPaginated(
         accountId: AccountId,


### PR DESCRIPTION
## Problem

Crypto.com card exports emit **cancelled Curve charges** as rows with prefixed descriptions — the only three prefixes observed across all real card CSVs:

| Row | Amount |
|---|---|
| `Crv*Navan` (original charge) | −363.58 |
| `Refund: Crv*Navan` | +363.58 |
| `Refund reversal: Crv*Navan` | −363.58 |
| `Cancellation: Crv*Zipcar Annual Plan` | +39.09 |

These missed the seeded Curve detection regex `(?i)^CRV\*`, and incoming (positive) rows skipped pass-through detection entirely — so imports created junk counterparty accounts literally named `Refund: Crv*Paypal *Ubertrip 3`, and the Curve conduit / merchant accounts no longer netted to zero.

## Changes

**Direction-aware pass-through**
- `ImportPassThrough.incoming` (default `false`): an incoming refund/cancellation routes **merchant → conduit → card** (funding leg conduit→card, engine spend leg merchant→conduit).
- CSV: `CsvTransferMapper` now detects on both directions and substitutes the conduit on the **source** side for flipped rows; `CsvImportApplier` picks the conduit ref by direction. QIF inherits via the CSV engine.
- API: `ApiSessionImportService` drops the `!isIncoming` gate (zero-amount and declined guards kept) and branches the funding-leg routing.
- `Refund reversal:` rows are negative, so they flow through the existing outgoing path unchanged — correctly re-booking the spend.

**Seed**
- Curve `rules_json` widened with an optional `(?:Refund: |Refund reversal: |Cancellation: )?` prefix; merchant extraction still yields the bare name (`Navan`) so refunds hit the *same* merchant account as the original charge.
- New `relationship_type` seed: id 4 `reversal` (+ `WellKnownIds.REVERSAL_RELATIONSHIP_TYPE_ID`).

**Reversal linking**
- The engine's new `resolveReversalLinks` pairs each new pass-through spend leg (id1) with the nearest earlier **unconsumed opposite-direction** spend leg (id2) with the same conduit/merchant/amount — symmetric consume-once matching, both in-batch and against the DB via the new `selectUnreversedTransfersBetweenAccountsByAmount` query (`NOT EXISTS` guard: a leg is reversed at most once).
- The observed charge → refund → refund reversal → refund chain links pairwise; repeat same-direction charges never link.

## Tests

- `PassThroughDetectorTest`: all real prefix samples + non-matches.
- `CsvTransferMapperTest`: incoming refund (conduit on source, `incoming=true`, no junk account) and outgoing refund reversal.
- `ImportEngineDbTest`: incoming legs + net-to-zero, same-batch link, cross-import link (exercises the SQL path), 4-row chain with consume-once, amount mismatch → no link, repeat charges → no link.

## Note for existing databases

BETA, no migrations (#426): live DBs keep the old Curve rule. Update `rules_json` via Imports → Misc → Pass-through (or SQL), or recreate the DB. Pre-existing junk `Refund: Crv*…` accounts need a re-import to clean up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refunds and cancellations are now recognized as pass-through transactions, with direction handled correctly for incoming and outgoing cases.
  * Imported transactions can now be linked to earlier related transactions as reversals, improving relationship tracking.

* **Bug Fixes**
  * Fixed Curve import matching so refund, reversal, and cancellation descriptions are parsed correctly.
  * Prevented duplicate or incorrect reversal links when multiple related transactions appear across imports or in the same batch.
  * Improved handling of imported merchant/account names to avoid creating unwanted placeholder entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->