### PR TITLE
CSV re-import: apply new account mappings retroactively

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -1,0 +1,306 @@
+package com.moneymanager.csvimporter
+
+import com.moneymanager.domain.Maintenance
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.accountmapping.AccountMapping
+import com.moneymanager.domain.model.csv.CsvImport
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.model.passthrough.PassThroughAccount
+import com.moneymanager.domain.repository.AccountMappingReadRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.importengineapi.AccountMergeRequest
+import com.moneymanager.importengineapi.ImportAccountIntent
+import com.moneymanager.importengineapi.ImportBatch
+import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.ImportOperation
+import com.moneymanager.importengineapi.LocalAccountKey
+import kotlinx.coroutines.flow.first
+import org.lighthousegames.logging.logging
+
+private val logger = logging()
+
+/** Why a duplicate account detected during re-import was not merged. */
+enum class ReimportSkipReason {
+    /** Different rows of the import resolve the duplicate to different target accounts. */
+    CONFLICTING_TARGETS,
+
+    /** Transfers exist between the duplicate and its target, which a merge cannot represent. */
+    TRANSFERS_BETWEEN,
+
+    /** The merge itself failed when executed (e.g. a concurrent write changed the accounts). */
+    MERGE_FAILED,
+}
+
+/** One duplicate-account merge the re-import will perform (or performed). */
+data class ReimportMerge(
+    val duplicateId: AccountId,
+    val duplicateName: String,
+    val targetId: AccountId,
+    val targetName: String,
+    /** Transfers on the duplicate account that the merge moves to the target. */
+    val transferCount: Long,
+)
+
+/** A duplicate account the re-import detected but will not (or could not) merge. */
+data class ReimportSkippedAccount(
+    val accountId: AccountId,
+    val accountName: String,
+    val reason: ReimportSkipReason,
+    val detail: String,
+)
+
+/** The read-only preview of what a re-import would do, shown for confirmation before executing. */
+data class ReimportPlan(
+    val merges: List<ReimportMerge>,
+    val skipped: List<ReimportSkippedAccount>,
+) {
+    val isEmpty: Boolean get() = merges.isEmpty() && skipped.isEmpty()
+}
+
+/** The outcome of an executed re-import. */
+data class CsvReimportResult(
+    val mergedAccounts: List<ReimportMerge>,
+    val skipped: List<ReimportSkippedAccount>,
+    /** Import-created accounts deleted because they ended up with no transfers. */
+    val deletedEmptyAccounts: List<String>,
+    /** Result of re-running the strategy over not-yet-imported/errored rows; null when there were none. */
+    val importResult: CsvImportResult?,
+)
+
+/** Raw merge detection output: duplicate → single target, plus duplicates with competing targets. */
+data class ReimportMergeCandidates(
+    val merges: Map<AccountId, AccountId>,
+    val conflicts: Map<AccountId, Set<AccountId>>,
+)
+
+/**
+ * Detects which import-created accounts the current account mappings consolidate onto another account.
+ *
+ * [baselinePrep] is the import's rows mapped with NO persisted account mappings (each row resolves by
+ * account name, i.e. to the duplicate the original import created); [mappedPrep] is the same rows
+ * mapped with the current mappings. A row/side where the baseline resolves to an import-created
+ * account and the mappings resolve to a different existing account marks that account as a duplicate
+ * of the mapped target. A duplicate whose rows disagree on the target is reported as a conflict and
+ * never merged partially.
+ */
+fun computeReimportMerges(
+    baselinePrep: ImportPreparation,
+    mappedPrep: ImportPreparation,
+    importCreatedAccounts: Set<AccountId>,
+): ReimportMergeCandidates {
+    val mappedByRow = mappedPrep.validTransfers.associateBy { it.rowIndex }
+    val targetsByDuplicate = mutableMapOf<AccountId, MutableSet<AccountId>>()
+
+    fun collect(
+        baselineId: AccountId,
+        mappedId: AccountId,
+    ) {
+        if (baselineId !in importCreatedAccounts) return
+        if (mappedId == baselineId || mappedId.id <= 0) return
+        targetsByDuplicate.getOrPut(baselineId) { mutableSetOf() }.add(mappedId)
+    }
+
+    for (baseline in baselinePrep.validTransfers) {
+        val mapped = mappedByRow[baseline.rowIndex] ?: continue
+        collect(baseline.transfer.sourceAccountId, mapped.transfer.sourceAccountId)
+        collect(baseline.transfer.targetAccountId, mapped.transfer.targetAccountId)
+    }
+
+    return ReimportMergeCandidates(
+        merges =
+            targetsByDuplicate
+                .filterValues { it.size == 1 }
+                .mapValues { (_, targets) -> targets.single() },
+        conflicts = targetsByDuplicate.filterValues { it.size > 1 },
+    )
+}
+
+/**
+ * Builds the read-only [ReimportPlan] for [csvImport] under [strategy]: which import-created accounts
+ * the current mappings consolidate away (as merges), and which detected duplicates cannot be merged.
+ * Safe to call from the UI to preview a re-import before [executeCsvReimport].
+ */
+@Suppress("LongParameterList")
+suspend fun planCsvReimport(
+    csvImport: CsvImport,
+    strategy: CsvImportStrategy,
+    sourceAccountOverride: AccountId?,
+    currencies: List<Currency>,
+    accountMappingRepository: AccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
+    csvImportRepository: CsvImportReadRepository,
+    passThroughAccounts: List<PassThroughAccount> = emptyList(),
+): ReimportPlan {
+    val allRows = csvImportRepository.getImportRows(csvImport.id, limit = csvImport.rowCount.coerceAtLeast(1), offset = 0)
+    if (allRows.isEmpty()) return ReimportPlan(emptyList(), emptyList())
+
+    val accounts = accountRepository.getAllAccounts().first()
+    val mappings = accountMappingRepository.getAllMappings().first()
+    val historicalAccountNames = accountRepository.getPreviousAccountNames()
+    val importCreated = csvImportRepository.getAccountsCreatedByImport(csvImport.id)
+    val effectiveSource = effectiveSourceFor(strategy, sourceAccountOverride)
+
+    fun prep(accountMappings: List<AccountMapping>) =
+        buildCsvMapper(
+            strategy,
+            csvImport.columns,
+            accounts,
+            currencies,
+            accountMappings,
+            effectiveSource,
+            passThroughAccounts,
+            historicalAccountNames,
+        ).prepareImport(allRows)
+
+    val candidates = computeReimportMerges(prep(emptyList()), prep(mappings), importCreated)
+
+    val accountsById = accounts.associateBy { it.id }
+    fun nameOf(id: AccountId): String = accountsById[id]?.name ?: "#${id.id}"
+
+    val merges = mutableListOf<ReimportMerge>()
+    val skipped = mutableListOf<ReimportSkippedAccount>()
+
+    for ((duplicate, targets) in candidates.conflicts) {
+        skipped +=
+            ReimportSkippedAccount(
+                accountId = duplicate,
+                accountName = nameOf(duplicate),
+                reason = ReimportSkipReason.CONFLICTING_TARGETS,
+                detail = "Rows map it to different accounts: ${targets.joinToString { nameOf(it) }}",
+            )
+    }
+    for ((duplicate, target) in candidates.merges) {
+        val between = accountRepository.getTransfersBetweenAccounts(duplicate, target)
+        if (between.isNotEmpty()) {
+            skipped +=
+                ReimportSkippedAccount(
+                    accountId = duplicate,
+                    accountName = nameOf(duplicate),
+                    reason = ReimportSkipReason.TRANSFERS_BETWEEN,
+                    detail = "${between.size} transaction(s) between '${nameOf(duplicate)}' and '${nameOf(target)}' — merge manually",
+                )
+            continue
+        }
+        merges +=
+            ReimportMerge(
+                duplicateId = duplicate,
+                duplicateName = nameOf(duplicate),
+                targetId = target,
+                targetName = nameOf(target),
+                transferCount = accountRepository.countTransfersByAccount(duplicate),
+            )
+    }
+    return ReimportPlan(merges = merges, skipped = skipped)
+}
+
+/**
+ * Executes a re-import of [csvImport] under [strategy] following a confirmed [plan]:
+ * 1. merges each planned duplicate into its target (reversible via the account-merge history) —
+ *    merging BEFORE re-running rows is required, otherwise dedupe would look for existing transfers
+ *    on the newly-mapped accounts, miss the ones still sitting on the duplicates, and import them twice;
+ * 2. re-runs the strategy over rows never imported or errored, which now resolve via the new mappings;
+ * 3. deletes import-created accounts left with no transfers;
+ * 4. refreshes materialized views.
+ */
+@Suppress("LongParameterList")
+suspend fun executeCsvReimport(
+    plan: ReimportPlan,
+    csvImport: CsvImport,
+    strategy: CsvImportStrategy,
+    sourceAccountOverride: AccountId?,
+    currencies: List<Currency>,
+    accountMappingRepository: AccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
+    csvImportRepository: CsvImportReadRepository,
+    maintenance: Maintenance,
+    importEngine: ImportEngine,
+    passThroughAccounts: List<PassThroughAccount> = emptyList(),
+): CsvReimportResult {
+    val merged = mutableListOf<ReimportMerge>()
+    val skipped = plan.skipped.toMutableList()
+
+    // One batch per merge so a surprise failure (races past the read-only pre-checks) downgrades to a
+    // per-account skip instead of aborting the remaining merges.
+    for (merge in plan.merges) {
+        try {
+            importEngine.import(
+                ImportBatch.manualEdits(
+                    accountMerges = listOf(AccountMergeRequest(deletedId = merge.duplicateId, survivingId = merge.targetId)),
+                ),
+            )
+            merged += merge
+        } catch (expected: Exception) {
+            logger.warn(expected) { "Re-import merge of '${merge.duplicateName}' into '${merge.targetName}' failed" }
+            skipped +=
+                ReimportSkippedAccount(
+                    accountId = merge.duplicateId,
+                    accountName = merge.duplicateName,
+                    reason = ReimportSkipReason.MERGE_FAILED,
+                    detail = expected.message ?: "Merge failed",
+                )
+        }
+    }
+
+    val importResult =
+        applyStagedCsv(
+            csvImport = csvImport,
+            strategy = strategy,
+            sourceAccountOverride = sourceAccountOverride,
+            currencies = currencies,
+            accountMappingRepository = accountMappingRepository,
+            accountRepository = accountRepository,
+            csvImportRepository = csvImportRepository,
+            maintenance = maintenance,
+            importEngine = importEngine,
+            refreshViews = false,
+            passThroughAccounts = passThroughAccounts,
+        )
+
+    val deletedEmptyAccounts = deleteEmptyImportCreatedAccounts(csvImport, accountRepository, csvImportRepository, importEngine)
+
+    maintenance.refreshMaterializedViews()
+
+    return CsvReimportResult(
+        mergedAccounts = merged,
+        skipped = skipped,
+        deletedEmptyAccounts = deletedEmptyAccounts,
+        importResult = importResult,
+    )
+}
+
+/**
+ * Deletes accounts this import created that hold no transfers (merged-away duplicates are already
+ * gone — this catches ones emptied without being merge targets). Returns the deleted names.
+ */
+private suspend fun deleteEmptyImportCreatedAccounts(
+    csvImport: CsvImport,
+    accountRepository: AccountReadRepository,
+    csvImportRepository: CsvImportReadRepository,
+    importEngine: ImportEngine,
+): List<String> {
+    val importCreated = csvImportRepository.getAccountsCreatedByImport(csvImport.id)
+    val remainingById = accountRepository.getAllAccounts().first().associateBy { it.id }
+    val emptyAccounts =
+        importCreated
+            .mapNotNull { remainingById[it] }
+            .filter { accountRepository.countTransfersByAccount(it.id) == 0L }
+    if (emptyAccounts.isEmpty()) return emptyList()
+
+    importEngine.import(
+        ImportBatch.manualEdits(
+            accounts =
+                emptyAccounts.map { account ->
+                    ImportAccountIntent(
+                        key = LocalAccountKey("reimport-delete-${account.id.id}"),
+                        source = Source.Csv(csvImport.id),
+                        operation = ImportOperation.DELETE,
+                        existingId = account.id,
+                    )
+                },
+        ),
+    )
+    return emptyAccounts.map { it.name }
+}

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -158,6 +158,7 @@ suspend fun planCsvReimport(
     val candidates = computeReimportMerges(prep(emptyList()), prep(mappings), importCreated)
 
     val accountsById = accounts.associateBy { it.id }
+
     fun nameOf(id: AccountId): String = accountsById[id]?.name ?: "#${id.id}"
 
     val merges = mutableListOf<ReimportMerge>()

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvReimportDetectionTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvReimportDetectionTest.kt
@@ -1,0 +1,275 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.csvimporter
+
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.accountmapping.AccountMapping
+import com.moneymanager.domain.model.csv.CsvColumn
+import com.moneymanager.domain.model.csv.CsvColumnId
+import com.moneymanager.domain.model.csv.CsvRow
+import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
+import com.moneymanager.domain.model.csvstrategy.AmountMode
+import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.model.csvstrategy.DateTimeParsingMapping
+import com.moneymanager.domain.model.csvstrategy.DirectColumnMapping
+import com.moneymanager.domain.model.csvstrategy.FieldMappingId
+import com.moneymanager.domain.model.csvstrategy.HardCodedAccountMapping
+import com.moneymanager.domain.model.csvstrategy.HardCodedCurrencyMapping
+import com.moneymanager.domain.model.csvstrategy.TransferField
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+/**
+ * Tests for [computeReimportMerges]: re-import detects import-created duplicate accounts that the
+ * current persisted mappings consolidate onto another account, by comparing the rows mapped without
+ * mappings (baseline — resolves to the duplicates by name) against the rows mapped with them.
+ */
+class CsvReimportDetectionTest {
+    private val currencyId = CurrencyId(1L)
+    private val currency = Currency(id = currencyId, code = "GBP", name = "British Pound")
+    private val sourceAccountId = AccountId(1)
+    private val strategyId = CsvImportStrategyId(Uuid.random())
+
+    private val columns =
+        listOf(
+            CsvColumn(CsvColumnId(Uuid.random()), 0, "Date"),
+            CsvColumn(CsvColumnId(Uuid.random()), 1, "Description"),
+            CsvColumn(CsvColumnId(Uuid.random()), 2, "Amount"),
+            CsvColumn(CsvColumnId(Uuid.random()), 3, "Payee"),
+        )
+
+    private fun strategy(): CsvImportStrategy {
+        val now = Clock.System.now()
+        return CsvImportStrategy(
+            id = strategyId,
+            name = "Test Strategy",
+            identificationColumns = setOf("Date", "Description", "Amount"),
+            fieldMappings =
+                mapOf(
+                    TransferField.SOURCE_ACCOUNT to
+                        HardCodedAccountMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.SOURCE_ACCOUNT,
+                            accountId = sourceAccountId,
+                        ),
+                    TransferField.TARGET_ACCOUNT to
+                        AccountLookupMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.TARGET_ACCOUNT,
+                            columnName = "Payee",
+                        ),
+                    TransferField.TIMESTAMP to
+                        DateTimeParsingMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.TIMESTAMP,
+                            dateColumnName = "Date",
+                            dateFormat = "dd/MM/yyyy",
+                        ),
+                    TransferField.DESCRIPTION to
+                        DirectColumnMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.DESCRIPTION,
+                            columnName = "Description",
+                        ),
+                    TransferField.AMOUNT to
+                        AmountParsingMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.AMOUNT,
+                            mode = AmountMode.SINGLE_COLUMN,
+                            amountColumnName = "Amount",
+                        ),
+                    TransferField.CURRENCY to
+                        HardCodedCurrencyMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.CURRENCY,
+                            currencyId = currencyId,
+                        ),
+                ),
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    private fun account(
+        id: Long,
+        name: String,
+    ) = Account(id = AccountId(id), name = name, openingDate = Clock.System.now())
+
+    private fun mapping(
+        id: Long,
+        pattern: String,
+        accountId: AccountId,
+        strategyId: CsvImportStrategyId? = null,
+    ): AccountMapping {
+        val now = Clock.System.now()
+        return AccountMapping(
+            id = id,
+            strategyId = strategyId,
+            valuePattern = Regex(pattern, RegexOption.IGNORE_CASE),
+            accountId = accountId,
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    private fun prep(
+        rows: List<CsvRow>,
+        accounts: List<Account>,
+        accountMappings: List<AccountMapping>,
+        historicalAccountNames: Map<String, AccountId> = emptyMap(),
+    ): ImportPreparation =
+        CsvTransferMapper(
+            strategy = strategy(),
+            columns = columns,
+            existingAccounts = accounts.associateBy { it.name },
+            existingCurrencies = mapOf(currencyId to currency),
+            existingCurrenciesByCode = mapOf(currency.code.uppercase() to currency),
+            accountMappings = accountMappings,
+            historicalAccountNames = historicalAccountNames,
+        ).prepareImport(rows)
+
+    private fun row(
+        index: Long,
+        payee: String,
+    ) = CsvRow(rowIndex = index, values = listOf("15/12/2024", "Payment", "-50.00", payee))
+
+    @Test
+    fun `new global mapping consolidating an import-created account yields a merge candidate`() {
+        val duplicate = account(10, "Amazon.com")
+        val trueAccount = account(20, "Amazon")
+        val accounts = listOf(duplicate, trueAccount)
+        val rows = listOf(row(1, "Amazon.com"), row(2, "Amazon.com"))
+        val mappings = listOf(mapping(1, "^Amazon\\.com$", trueAccount.id))
+
+        val candidates =
+            computeReimportMerges(
+                baselinePrep = prep(rows, accounts, emptyList()),
+                mappedPrep = prep(rows, accounts, mappings),
+                importCreatedAccounts = setOf(duplicate.id),
+            )
+
+        assertEquals(mapOf(duplicate.id to trueAccount.id), candidates.merges)
+        assertTrue(candidates.conflicts.isEmpty())
+    }
+
+    @Test
+    fun `mapping scoped to a different strategy produces no candidate`() {
+        val duplicate = account(10, "Amazon.com")
+        val trueAccount = account(20, "Amazon")
+        val accounts = listOf(duplicate, trueAccount)
+        val rows = listOf(row(1, "Amazon.com"))
+        val mappings = listOf(mapping(1, "^Amazon\\.com$", trueAccount.id, strategyId = CsvImportStrategyId(Uuid.random())))
+
+        val candidates =
+            computeReimportMerges(
+                baselinePrep = prep(rows, accounts, emptyList()),
+                mappedPrep = prep(rows, accounts, mappings),
+                importCreatedAccounts = setOf(duplicate.id),
+            )
+
+        assertTrue(candidates.merges.isEmpty())
+        assertTrue(candidates.conflicts.isEmpty())
+    }
+
+    @Test
+    fun `mapping redirecting an account this import did not create produces no candidate`() {
+        val duplicate = account(10, "Amazon.com")
+        val trueAccount = account(20, "Amazon")
+        val accounts = listOf(duplicate, trueAccount)
+        val rows = listOf(row(1, "Amazon.com"))
+        val mappings = listOf(mapping(1, "^Amazon\\.com$", trueAccount.id))
+
+        val candidates =
+            computeReimportMerges(
+                baselinePrep = prep(rows, accounts, emptyList()),
+                mappedPrep = prep(rows, accounts, mappings),
+                // "Amazon.com" exists but was created manually or by another import.
+                importCreatedAccounts = emptySet(),
+            )
+
+        assertTrue(candidates.merges.isEmpty())
+        assertTrue(candidates.conflicts.isEmpty())
+    }
+
+    @Test
+    fun `duplicate whose rows resolve to different targets is a conflict not a merge`() {
+        val duplicate = account(10, "Amazon.com")
+        val targetA = account(20, "Amazon")
+        val targetB = account(30, "Amazon Prime")
+        val accounts = listOf(duplicate, targetA, targetB)
+        val rows = listOf(row(1, "Amazon.com order"), row(2, "Amazon.com subscription"))
+        // Both rows resolve to "Amazon.com order"/"Amazon.com subscription"... use patterns splitting them.
+        val mappings =
+            listOf(
+                mapping(1, "order", targetA.id),
+                mapping(2, "subscription", targetB.id),
+            )
+        // Baseline: both payee values are new names; make them resolve to the SAME import-created
+        // account by mapping them via historical names of the duplicate.
+        val historical =
+            mapOf(
+                "amazon.com order" to duplicate.id,
+                "amazon.com subscription" to duplicate.id,
+            )
+
+        val candidates =
+            computeReimportMerges(
+                baselinePrep = prep(rows, accounts, emptyList(), historical),
+                mappedPrep = prep(rows, accounts, mappings, historical),
+                importCreatedAccounts = setOf(duplicate.id),
+            )
+
+        assertTrue(candidates.merges.isEmpty())
+        assertEquals(mapOf(duplicate.id to setOf(targetA.id, targetB.id)), candidates.conflicts)
+    }
+
+    @Test
+    fun `renamed duplicate still detected via historical account names`() {
+        // The import created "Amazon.com"; the user renamed it to "Shopping". Baseline resolution
+        // falls back to the historical name and still lands on the import-created account.
+        val renamedDuplicate = account(10, "Shopping")
+        val trueAccount = account(20, "Amazon")
+        val accounts = listOf(renamedDuplicate, trueAccount)
+        val rows = listOf(row(1, "Amazon.com"))
+        val mappings = listOf(mapping(1, "^Amazon\\.com$", trueAccount.id))
+        val historical = mapOf("amazon.com" to renamedDuplicate.id)
+
+        val candidates =
+            computeReimportMerges(
+                baselinePrep = prep(rows, accounts, emptyList(), historical),
+                mappedPrep = prep(rows, accounts, mappings, historical),
+                importCreatedAccounts = setOf(renamedDuplicate.id),
+            )
+
+        assertEquals(mapOf(renamedDuplicate.id to trueAccount.id), candidates.merges)
+    }
+
+    @Test
+    fun `rows unaffected by mappings produce no candidates`() {
+        val duplicate = account(10, "Amazon.com")
+        val other = account(30, "Tesco")
+        val trueAccount = account(20, "Amazon")
+        val accounts = listOf(duplicate, other, trueAccount)
+        val rows = listOf(row(1, "Amazon.com"), row(2, "Tesco"))
+        val mappings = listOf(mapping(1, "^Amazon\\.com$", trueAccount.id))
+
+        val candidates =
+            computeReimportMerges(
+                baselinePrep = prep(rows, accounts, emptyList()),
+                mappedPrep = prep(rows, accounts, mappings),
+                importCreatedAccounts = setOf(duplicate.id, other.id),
+            )
+
+        // Tesco resolves identically in both preparations, so only Amazon.com is a candidate.
+        assertEquals(mapOf(duplicate.id to trueAccount.id), candidates.merges)
+        assertTrue(candidates.conflicts.isEmpty())
+    }
+}

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/entitySource/EntitySourceSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/entitySource/EntitySourceSelect.sq
@@ -1,3 +1,11 @@
+-- Accounts (entity_type_id = 1) whose creation was recorded against the given CSV import — the
+-- accounts the import auto-created, used by re-import to scope merges/deletes to them.
+selectAccountIdsCreatedByCsvImport:
+SELECT DISTINCT entity_source.entity_id
+FROM entity_source
+JOIN csv_entity_source ON entity_source.id = csv_entity_source.id
+WHERE csv_entity_source.csv_import_id = ? AND entity_source.entity_type_id = 1;
+
 selectEntitySourceForRevision:
 SELECT id, source_type_id
 FROM entity_source

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportReadRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportReadRepositoryImpl.kt
@@ -7,6 +7,7 @@ import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.coroutines.mapToOneOrNull
 import com.moneymanager.database.MoneyManagerDatabaseWrapper
 import com.moneymanager.database.csv.CsvTableManager
+import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvColumnId
 import com.moneymanager.domain.model.csv.CsvImport
@@ -30,6 +31,7 @@ class CsvImportReadRepositoryImpl(
     private val coroutineContext: CoroutineContext = Dispatchers.Default,
 ) : CsvImportReadRepository {
     private val csvImportSelectQueries = database.csvImportSelectQueries
+    private val entitySourceSelectQueries = database.entitySourceSelectQueries
     private val tableManager = CsvTableManager(database)
 
     override fun getAllImports(): Flow<List<CsvImport>> =
@@ -88,6 +90,15 @@ class CsvImportReadRepositoryImpl(
                 limit = limit,
                 offset = offset,
             )
+        }
+
+    override suspend fun getAccountsCreatedByImport(id: CsvImportId): Set<AccountId> =
+        withContext(coroutineContext) {
+            entitySourceSelectQueries
+                .selectAccountIdsCreatedByCsvImport(id.id.toString())
+                .executeAsList()
+                .map { AccountId(it) }
+                .toSet()
         }
 
     override suspend fun findImportsByChecksum(checksum: String): List<CsvImport> =

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/CsvImportReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/CsvImportReadRepository.kt
@@ -2,6 +2,7 @@
 
 package com.moneymanager.domain.repository
 
+import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.csv.CsvRow
@@ -32,6 +33,12 @@ interface CsvImportReadRepository {
         limit: Int,
         offset: Int,
     ): List<CsvRow>
+
+    /**
+     * Ids of the accounts this import auto-created (from CSV provenance). Used by re-import to
+     * scope account merges/deletions to import-created accounts only.
+     */
+    suspend fun getAccountsCreatedByImport(id: CsvImportId): Set<AccountId>
 
     /**
      * Finds imports that match the given file checksum.

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvReimportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvReimportE2ETest.kt
@@ -1,0 +1,362 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.ui.screens
+
+import com.moneymanager.csvimporter.CsvTransferMapper
+import com.moneymanager.csvimporter.ReimportSkipReason
+import com.moneymanager.csvimporter.executeCsvReimport
+import com.moneymanager.csvimporter.planCsvReimport
+import com.moneymanager.csvimporter.runCsvImport
+import com.moneymanager.database.port.DbMaintenance
+import com.moneymanager.di.database.DatabaseComponent
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.DbLocation
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.csv.CsvImport
+import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
+import com.moneymanager.domain.model.csvstrategy.AmountMode
+import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.model.csvstrategy.DateTimeParsingMapping
+import com.moneymanager.domain.model.csvstrategy.DirectColumnMapping
+import com.moneymanager.domain.model.csvstrategy.FieldMappingId
+import com.moneymanager.domain.model.csvstrategy.HardCodedAccountMapping
+import com.moneymanager.domain.model.csvstrategy.HardCodedCurrencyMapping
+import com.moneymanager.domain.model.csvstrategy.TransferField
+import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.createAccountMapping
+import com.moneymanager.importer.ImportEngineImpl
+import com.moneymanager.test.database.createAccount
+import com.moneymanager.test.database.createTestDatabaseLocation
+import com.moneymanager.test.database.createTestDatabaseManager
+import com.moneymanager.test.database.deleteTestDatabase
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * End-to-end test of CSV re-import against a real database: a CSV import creates a duplicate payee
+ * account; the user then adds a global account mapping pointing its value at a pre-existing account;
+ * re-importing merges the duplicate into the true account (reversibly), moves its transactions, and
+ * does not re-create transfers. A duplicate with transactions to the target is skipped, not merged.
+ */
+class CsvReimportE2ETest {
+    private var testDbLocation: DbLocation? = null
+
+    @AfterTest
+    fun cleanup() {
+        testDbLocation?.let { deleteTestDatabase(it) }
+    }
+
+    private class Fixture(
+        val dc: DatabaseComponent,
+        val importEngine: ImportEngine,
+        val sourceAccountId: AccountId,
+        val trueAccountId: AccountId,
+        val csvImport: CsvImport,
+        val strategy: CsvImportStrategy,
+    )
+
+    /**
+     * Imports a two-row CSV whose payee "Amazon.com" auto-creates a duplicate account, while the
+     * true account "Amazon" already exists.
+     */
+    private suspend fun setUpImportedCsv(): Fixture {
+        testDbLocation = createTestDatabaseLocation()
+        val databaseManager = createTestDatabaseManager()
+        val db = databaseManager.openDatabase(testDbLocation!!)
+        val dc = DatabaseComponent.create(db)
+        val importEngine = createImportEngine(dc)
+
+        val sourceAccountId =
+            dc.accountRepository.createAccount(
+                Account(id = AccountId(0), name = "Card", openingDate = Clock.System.now()),
+            )
+        val trueAccountId =
+            dc.accountRepository.createAccount(
+                Account(id = AccountId(0), name = "Amazon", openingDate = Clock.System.now()),
+            )
+
+        val headers = listOf("Date", "Description", "Amount", "Payee")
+        val csvImportId =
+            dc.csvImportRepository.createImport(
+                fileName = "reimport_test.csv",
+                headers = headers,
+                rows =
+                    listOf(
+                        listOf("15/12/2024", "Order 1", "-50.00", DUPLICATE_NAME),
+                        listOf("16/12/2024", "Order 2", "-25.00", DUPLICATE_NAME),
+                    ),
+                fileChecksum = "reimport_test_checksum",
+                fileLastModified = Instant.fromEpochMilliseconds(1_700_000_000_000L),
+            )
+        val csvImport = dc.csvImportRepository.getImport(csvImportId).first() ?: error("import not found")
+        val rows = dc.csvImportRepository.getImportRows(csvImportId, limit = 1000, offset = 0)
+
+        val currencies = dc.currencyRepository.getAllCurrencies().first()
+        val gbp = currencies.first { it.code == "GBP" }
+        val strategy = createStrategy(sourceAccountId, gbp.id)
+
+        val mapper =
+            CsvTransferMapper(
+                strategy = strategy,
+                columns = csvImport.columns,
+                existingAccounts =
+                    dc.accountRepository
+                        .getAllAccounts()
+                        .first()
+                        .associateBy { it.name },
+                existingCurrencies = currencies.associateBy { it.id },
+                existingCurrenciesByCode = currencies.associateBy { it.code.uppercase() },
+                accountMappings = emptyList(),
+                sourceAccountOverride = sourceAccountId,
+            )
+        runCsvImport(
+            csvImport = csvImport,
+            rows = rows,
+            columns = csvImport.columns,
+            strategy = strategy,
+            basePrep = mapper.prepareImport(rows),
+            selectedExistingAccounts = emptyMap(),
+            selectedNewAccountNames = emptyMap(),
+            selectedSourceAccountId = sourceAccountId,
+            currencies = currencies,
+            accountMappingRepository = dc.accountMappingRepository,
+            accountRepository = dc.accountRepository,
+            maintenance = DbMaintenance(dc.maintenanceService),
+            importEngine = importEngine,
+        )
+
+        return Fixture(dc, importEngine, sourceAccountId, trueAccountId, csvImport, strategy)
+    }
+
+    private suspend fun Fixture.duplicateAccountId(): AccountId? =
+        dc.accountRepository
+            .getAllAccounts()
+            .first()
+            .firstOrNull { it.name == DUPLICATE_NAME }
+            ?.id
+
+    @Test
+    fun `re-import merges duplicate into mapped account reversibly and deletes it`() =
+        runBlocking {
+            val fixture = setUpImportedCsv()
+            val dc = fixture.dc
+            val duplicateId = fixture.duplicateAccountId() ?: error("duplicate account not created")
+            assertEquals(2L, dc.accountRepository.countTransfersByAccount(duplicateId))
+            assertEquals(0L, dc.accountRepository.countTransfersByAccount(fixture.trueAccountId))
+
+            // The user notices the duplicate and adds a global mapping to the true account.
+            fixture.importEngine.createAccountMapping(
+                valuePattern = Regex("^Amazon\\.com$", RegexOption.IGNORE_CASE),
+                accountId = fixture.trueAccountId,
+            )
+
+            val currencies = dc.currencyRepository.getAllCurrencies().first()
+            val plan =
+                planCsvReimport(
+                    csvImport = fixture.csvImport,
+                    strategy = fixture.strategy,
+                    sourceAccountOverride = fixture.sourceAccountId,
+                    currencies = currencies,
+                    accountMappingRepository = dc.accountMappingRepository,
+                    accountRepository = dc.accountRepository,
+                    csvImportRepository = dc.csvImportRepository,
+                )
+            assertEquals(1, plan.merges.size)
+            assertEquals(duplicateId, plan.merges.single().duplicateId)
+            assertEquals(fixture.trueAccountId, plan.merges.single().targetId)
+            assertEquals(2L, plan.merges.single().transferCount)
+            assertTrue(plan.skipped.isEmpty())
+
+            val result =
+                executeCsvReimport(
+                    plan = plan,
+                    csvImport = fixture.csvImport,
+                    strategy = fixture.strategy,
+                    sourceAccountOverride = fixture.sourceAccountId,
+                    currencies = currencies,
+                    accountMappingRepository = dc.accountMappingRepository,
+                    accountRepository = dc.accountRepository,
+                    csvImportRepository = dc.csvImportRepository,
+                    maintenance = DbMaintenance(dc.maintenanceService),
+                    importEngine = fixture.importEngine,
+                )
+
+            assertEquals(1, result.mergedAccounts.size)
+            assertTrue(result.skipped.isEmpty())
+            // The merge itself removed the duplicate; nothing was separately empty.
+            assertTrue(result.deletedEmptyAccounts.isEmpty())
+            // All rows were already imported, so the re-run had nothing to do (no double import).
+            assertNull(result.importResult)
+
+            // Transfers moved to the true account and the duplicate is gone.
+            assertEquals(2L, dc.accountRepository.countTransfersByAccount(fixture.trueAccountId))
+            assertNull(fixture.duplicateAccountId())
+
+            // The merge is recorded and reversible.
+            val reversibleMerges = dc.accountRepository.getReversibleMerges().first()
+            assertEquals(1, reversibleMerges.size)
+        }
+
+    @Test
+    fun `duplicate with transactions to the target account is skipped not merged`() =
+        runBlocking {
+            val fixture = setUpImportedCsv()
+            val dc = fixture.dc
+            val duplicateId = fixture.duplicateAccountId() ?: error("duplicate account not created")
+
+            // A transfer BETWEEN the duplicate and the true account makes a merge unrepresentable
+            // (it would become a self-transfer), so re-import must skip it.
+            val currencies = dc.currencyRepository.getAllCurrencies().first()
+            val gbp = currencies.first { it.code == "GBP" }
+            dc.transactionRepository.createTransfers(
+                transfers =
+                    listOf(
+                        Transfer(
+                            id = TransferId(0),
+                            timestamp = Clock.System.now(),
+                            description = "Between accounts",
+                            sourceAccountId = duplicateId,
+                            targetAccountId = fixture.trueAccountId,
+                            amount = Money(1000, gbp),
+                        ),
+                    ),
+                sources = listOf(Source.Manual),
+            )
+
+            fixture.importEngine.createAccountMapping(
+                valuePattern = Regex("^Amazon\\.com$", RegexOption.IGNORE_CASE),
+                accountId = fixture.trueAccountId,
+            )
+
+            val plan =
+                planCsvReimport(
+                    csvImport = fixture.csvImport,
+                    strategy = fixture.strategy,
+                    sourceAccountOverride = fixture.sourceAccountId,
+                    currencies = currencies,
+                    accountMappingRepository = dc.accountMappingRepository,
+                    accountRepository = dc.accountRepository,
+                    csvImportRepository = dc.csvImportRepository,
+                )
+            assertTrue(plan.merges.isEmpty())
+            assertEquals(1, plan.skipped.size)
+            assertEquals(ReimportSkipReason.TRANSFERS_BETWEEN, plan.skipped.single().reason)
+
+            val result =
+                executeCsvReimport(
+                    plan = plan,
+                    csvImport = fixture.csvImport,
+                    strategy = fixture.strategy,
+                    sourceAccountOverride = fixture.sourceAccountId,
+                    currencies = currencies,
+                    accountMappingRepository = dc.accountMappingRepository,
+                    accountRepository = dc.accountRepository,
+                    csvImportRepository = dc.csvImportRepository,
+                    maintenance = DbMaintenance(dc.maintenanceService),
+                    importEngine = fixture.importEngine,
+                )
+
+            assertTrue(result.mergedAccounts.isEmpty())
+            assertEquals(1, result.skipped.size)
+            // The duplicate keeps its transactions and must not be deleted.
+            assertEquals(duplicateId, fixture.duplicateAccountId())
+            assertEquals(3L, dc.accountRepository.countTransfersByAccount(duplicateId))
+        }
+
+    private fun createImportEngine(dc: DatabaseComponent): ImportEngine =
+        ImportEngineImpl(
+            transactionRepository = dc.transactionRepository,
+            accountRepository = dc.accountRepository,
+            accountAttributeRepository = dc.accountAttributeRepository,
+            personRepository = dc.personRepository,
+            personAttributeRepository = dc.personAttributeRepository,
+            ownershipRepository = dc.personAccountOwnershipRepository,
+            categoryRepository = dc.categoryRepository,
+            currencyRepository = dc.currencyRepository,
+            attributeTypeRepository = dc.attributeTypeRepository,
+            relationshipTypeRepository = dc.relationshipTypeRepository,
+            csvImportStrategyRepository = dc.csvImportStrategyRepository,
+            apiImportStrategyRepository = dc.apiImportStrategyRepository,
+            accountMappingRepository = dc.accountMappingRepository,
+            csvImportRepository = dc.csvImportRepository,
+            qifImportRepository = dc.qifImportRepository,
+            apiSessionRepository = dc.apiSessionRepository,
+            settingsRepository = dc.settingsRepository,
+            importDirectoryRepository = dc.importDirectoryRepository,
+            passThroughAccountRepository = dc.passThroughAccountRepository,
+        )
+
+    private fun createStrategy(
+        sourceAccountId: AccountId,
+        currencyId: CurrencyId,
+    ): CsvImportStrategy {
+        val now = Clock.System.now()
+        return CsvImportStrategy(
+            id = CsvImportStrategyId(Uuid.random()),
+            name = "Reimport Test Strategy",
+            identificationColumns = setOf("Date", "Description", "Amount"),
+            fieldMappings =
+                mapOf(
+                    TransferField.SOURCE_ACCOUNT to
+                        HardCodedAccountMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.SOURCE_ACCOUNT,
+                            accountId = sourceAccountId,
+                        ),
+                    TransferField.TARGET_ACCOUNT to
+                        AccountLookupMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.TARGET_ACCOUNT,
+                            columnName = "Payee",
+                        ),
+                    TransferField.TIMESTAMP to
+                        DateTimeParsingMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.TIMESTAMP,
+                            dateColumnName = "Date",
+                            dateFormat = "dd/MM/yyyy",
+                        ),
+                    TransferField.DESCRIPTION to
+                        DirectColumnMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.DESCRIPTION,
+                            columnName = "Description",
+                        ),
+                    TransferField.AMOUNT to
+                        AmountParsingMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.AMOUNT,
+                            mode = AmountMode.SINGLE_COLUMN,
+                            amountColumnName = "Amount",
+                        ),
+                    TransferField.CURRENCY to
+                        HardCodedCurrencyMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.CURRENCY,
+                            currencyId = currencyId,
+                        ),
+                ),
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    private companion object {
+        const val DUPLICATE_NAME = "Amazon.com"
+    }
+}

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
@@ -49,6 +49,7 @@ import com.moneymanager.ui.components.csv.CsvPreviewTable
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.csv.ApplyStrategyDialog
+import com.moneymanager.ui.screens.csv.ReimportDialog
 import com.moneymanager.ui.util.displayDateTime
 import kotlinx.coroutines.launch
 
@@ -81,6 +82,7 @@ fun CsvImportDetailScreen(
     var isLoading by remember { mutableStateOf(true) }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showApplyStrategyDialog by remember { mutableStateOf(false) }
+    var showReimportDialog by remember { mutableStateOf(false) }
     var isDeleting by remember { mutableStateOf(false) }
     var importSuccessMessage by remember { mutableStateOf<String?>(null) }
     var importFailedRows by remember { mutableStateOf<List<String>>(emptyList()) }
@@ -174,6 +176,21 @@ fun CsvImportDetailScreen(
                         text = "Apply Strategy",
                         color =
                             if (hasMatchingStrategy) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                            },
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                TextButton(
+                    onClick = { showReimportDialog = true },
+                    enabled = !isDeleting && import?.lastAppliedStrategyId != null && rows.isNotEmpty(),
+                ) {
+                    Text(
+                        text = "Re-import",
+                        color =
+                            if (import?.lastAppliedStrategyId != null) {
                                 MaterialTheme.colorScheme.primary
                             } else {
                                 MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
@@ -416,6 +433,47 @@ fun CsvImportDetailScreen(
                     result.failedRows.map { failed ->
                         "Row ${failed.rowIndex}: ${failed.errorMessage}"
                     }
+                rowsRefreshTrigger++
+            },
+        )
+    }
+
+    // Re-import dialog: applies newly added account mappings retroactively (merge duplicates,
+    // import remaining rows, delete emptied import-created accounts).
+    if (showReimportDialog && import != null) {
+        ReimportDialog(
+            csvImport = import!!,
+            rows = rows,
+            csvImportRepository = csvImportRepository,
+            csvImportStrategyRepository = csvImportStrategyRepository,
+            accountMappingRepository = accountMappingRepository,
+            accountRepository = accountRepository,
+            categoryRepository = categoryRepository,
+            currencyRepository = currencyRepository,
+            personRepository = personRepository,
+            passThroughAccountRepository = passThroughAccountRepository,
+            maintenance = maintenance,
+            importEngine = importEngine,
+            onDismiss = { showReimportDialog = false },
+            onComplete = { result ->
+                showReimportDialog = false
+                importSuccessMessage =
+                    buildString {
+                        append("Re-import complete: ")
+                        append("${result.mergedAccounts.size} account(s) merged")
+                        val moved = result.mergedAccounts.sumOf { it.transferCount }
+                        if (moved > 0) append(" ($moved transaction(s) moved)")
+                        result.importResult?.let { append(", ${it.successCount} row(s) imported") }
+                        if (result.deletedEmptyAccounts.isNotEmpty()) {
+                            append(", ${result.deletedEmptyAccounts.size} empty account(s) deleted")
+                        }
+                    }
+                importFailedRows =
+                    result.skipped.map { skip -> "${skip.accountName}: ${skip.detail}" } +
+                        result.importResult?.failedRows.orEmpty().map { failed ->
+                            "Row ${failed.rowIndex}: ${failed.errorMessage}"
+                        }
+                failedRowIndexes = result.importResult?.failedRows.orEmpty().map { it.rowIndex }.toSet()
                 rowsRefreshTrigger++
             },
         )

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
@@ -470,10 +470,15 @@ fun CsvImportDetailScreen(
                     }
                 importFailedRows =
                     result.skipped.map { skip -> "${skip.accountName}: ${skip.detail}" } +
-                        result.importResult?.failedRows.orEmpty().map { failed ->
-                            "Row ${failed.rowIndex}: ${failed.errorMessage}"
-                        }
-                failedRowIndexes = result.importResult?.failedRows.orEmpty().map { it.rowIndex }.toSet()
+                    result.importResult?.failedRows.orEmpty().map { failed ->
+                        "Row ${failed.rowIndex}: ${failed.errorMessage}"
+                    }
+                failedRowIndexes =
+                    result.importResult
+                        ?.failedRows
+                        .orEmpty()
+                        .map { it.rowIndex }
+                        .toSet()
                 rowsRefreshTrigger++
             },
         )

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
@@ -259,7 +259,9 @@ private fun ReimportPlanPreview(
             }
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = "Merges move ALL of the duplicate's transactions (from any import) and can be undone from the account merge history.",
+                text =
+                    "Merges move ALL of the duplicate's transactions (from any import) and can be undone " +
+                        "from the account merge history.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
@@ -47,6 +47,7 @@ import com.moneymanager.ui.components.AccountPicker
 import com.moneymanager.ui.components.LoadingTextButton
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.lighthousegames.logging.logging
@@ -128,6 +129,8 @@ fun ReimportDialog(
                     passThroughAccounts = passThroughAccounts,
                 )
             errorMessage = null
+        } catch (expected: CancellationException) {
+            throw expected
         } catch (expected: Exception) {
             logger.error(expected) { "Re-import preview failed: ${expected.message}" }
             errorMessage = "Failed to prepare re-import: ${expected.message}"
@@ -214,6 +217,8 @@ fun ReimportDialog(
                                     passThroughAccounts = passThroughAccounts,
                                 )
                             onComplete(result)
+                        } catch (expected: CancellationException) {
+                            throw expected
                         } catch (expected: Exception) {
                             logger.error(expected) { "Re-import failed: ${expected.message}" }
                             errorMessage = "Re-import failed: ${expected.message}"

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
@@ -1,0 +1,307 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.ui.screens.csv
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.moneymanager.csvimporter.CsvReimportResult
+import com.moneymanager.csvimporter.ReimportPlan
+import com.moneymanager.csvimporter.StrategyMatcher
+import com.moneymanager.csvimporter.executeCsvReimport
+import com.moneymanager.csvimporter.needsSourceAccountOverride
+import com.moneymanager.csvimporter.planCsvReimport
+import com.moneymanager.domain.Maintenance
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.csv.CsvImport
+import com.moneymanager.domain.model.csv.CsvRow
+import com.moneymanager.domain.model.csv.ImportStatus
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.repository.AccountMappingReadRepository
+import com.moneymanager.domain.repository.AccountReadRepository
+import com.moneymanager.domain.repository.CategoryReadRepository
+import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
+import com.moneymanager.domain.repository.CurrencyReadRepository
+import com.moneymanager.domain.repository.PassThroughAccountReadRepository
+import com.moneymanager.domain.repository.PersonReadRepository
+import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.ui.components.AccountPicker
+import com.moneymanager.ui.components.LoadingTextButton
+import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import org.lighthousegames.logging.logging
+
+private val logger = logging()
+
+/**
+ * Re-imports an already-imported CSV so newly added account mappings take effect retroactively:
+ * shows a read-only preview of the duplicate-account merges the current mappings imply, then (on
+ * confirm) merges them, re-runs the strategy over never-imported/errored rows, and deletes
+ * import-created accounts left empty.
+ */
+@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
+@Composable
+fun ReimportDialog(
+    csvImport: CsvImport,
+    rows: List<CsvRow>,
+    csvImportRepository: CsvImportReadRepository,
+    csvImportStrategyRepository: CsvImportStrategyReadRepository,
+    accountMappingRepository: AccountMappingReadRepository,
+    accountRepository: AccountReadRepository,
+    categoryRepository: CategoryReadRepository,
+    currencyRepository: CurrencyReadRepository,
+    personRepository: PersonReadRepository,
+    passThroughAccountRepository: PassThroughAccountReadRepository,
+    maintenance: Maintenance,
+    importEngine: ImportEngine,
+    onDismiss: () -> Unit,
+    onComplete: (CsvReimportResult) -> Unit,
+) {
+    val scope = rememberSchemaAwareCoroutineScope()
+    val currencies by currencyRepository
+        .getAllCurrencies()
+        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val passThroughAccounts by passThroughAccountRepository
+        .getEnabled()
+        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+
+    var strategy by remember { mutableStateOf<CsvImportStrategy?>(null) }
+    var strategyResolved by remember { mutableStateOf(false) }
+    var selectedSourceAccountId by remember { mutableStateOf<AccountId?>(null) }
+    var plan by remember { mutableStateOf<ReimportPlan?>(null) }
+    var isRunning by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    // Resolve the strategy that was last applied; fall back to column matching if it was deleted.
+    LaunchedEffect(csvImport.id) {
+        val byId =
+            csvImport.lastAppliedStrategyId?.let { strategyId ->
+                csvImportStrategyRepository.getStrategyById(strategyId).first()
+            }
+        strategy = byId
+            ?: StrategyMatcher.findMatchingStrategy(
+                csvImport.columns.map { it.originalName },
+                csvImportStrategyRepository.getAllStrategies().first(),
+            )
+        strategyResolved = true
+    }
+
+    // A source-account picker is only needed to import remaining rows; merges don't use it.
+    val hasUnimportedRows = rows.any { it.importStatus == null || it.importStatus == ImportStatus.ERROR }
+    val needsSourcePicker = strategy?.needsSourceAccountOverride() == true && hasUnimportedRows
+    val sourceReady = !needsSourcePicker || selectedSourceAccountId != null
+
+    // Build the read-only merge preview once the inputs are ready.
+    LaunchedEffect(strategy, selectedSourceAccountId, currencies, passThroughAccounts) {
+        val currentStrategy = strategy ?: return@LaunchedEffect
+        if (currencies.isEmpty()) return@LaunchedEffect
+        try {
+            plan =
+                planCsvReimport(
+                    csvImport = csvImport,
+                    strategy = currentStrategy,
+                    sourceAccountOverride = selectedSourceAccountId,
+                    currencies = currencies,
+                    accountMappingRepository = accountMappingRepository,
+                    accountRepository = accountRepository,
+                    csvImportRepository = csvImportRepository,
+                    passThroughAccounts = passThroughAccounts,
+                )
+            errorMessage = null
+        } catch (expected: Exception) {
+            logger.error(expected) { "Re-import preview failed: ${expected.message}" }
+            errorMessage = "Failed to prepare re-import: ${expected.message}"
+            plan = null
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = { if (!isRunning) onDismiss() },
+        title = { Text("Re-import ${csvImport.originalFileName}") },
+        text = {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState()),
+            ) {
+                when {
+                    !strategyResolved -> CircularProgressIndicator()
+                    strategy == null ->
+                        Text(
+                            text = "No strategy matches this import. Create or restore a matching strategy first.",
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                    else -> {
+                        Text(
+                            text = "Strategy: ${strategy?.name}",
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        if (needsSourcePicker) {
+                            AccountPicker(
+                                selectedAccountId = selectedSourceAccountId,
+                                onAccountSelected = { selectedSourceAccountId = it },
+                                label = "Source Account (for not-yet-imported rows)",
+                                accountRepository = accountRepository,
+                                categoryRepository = categoryRepository,
+                                personRepository = personRepository,
+                                enabled = !isRunning,
+                                isError = selectedSourceAccountId == null,
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                        }
+
+                        when (val currentPlan = plan) {
+                            null -> if (errorMessage == null) CircularProgressIndicator()
+                            else -> ReimportPlanPreview(currentPlan, hasUnimportedRows)
+                        }
+                    }
+                }
+
+                errorMessage?.let {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = it,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            LoadingTextButton(
+                onClick = {
+                    val currentStrategy = strategy ?: return@LoadingTextButton
+                    val currentPlan = plan ?: return@LoadingTextButton
+                    isRunning = true
+                    errorMessage = null
+                    scope.launch {
+                        try {
+                            val result =
+                                executeCsvReimport(
+                                    plan = currentPlan,
+                                    csvImport = csvImport,
+                                    strategy = currentStrategy,
+                                    sourceAccountOverride = selectedSourceAccountId,
+                                    currencies = currencies,
+                                    accountMappingRepository = accountMappingRepository,
+                                    accountRepository = accountRepository,
+                                    csvImportRepository = csvImportRepository,
+                                    maintenance = maintenance,
+                                    importEngine = importEngine,
+                                    passThroughAccounts = passThroughAccounts,
+                                )
+                            onComplete(result)
+                        } catch (expected: Exception) {
+                            logger.error(expected) { "Re-import failed: ${expected.message}" }
+                            errorMessage = "Re-import failed: ${expected.message}"
+                            isRunning = false
+                        }
+                    }
+                },
+                enabled = !isRunning && strategy != null && plan != null && sourceReady,
+                loading = isRunning,
+                label = "Re-import",
+                loadingIndicatorModifier = Modifier.padding(end = 8.dp),
+                showLabelWhenLoading = true,
+            )
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                enabled = !isRunning,
+            ) {
+                Text("Cancel")
+            }
+        },
+    )
+}
+
+@Composable
+private fun ReimportPlanPreview(
+    plan: ReimportPlan,
+    hasUnimportedRows: Boolean,
+) {
+    Column {
+        if (plan.merges.isNotEmpty()) {
+            Text(
+                text = "Duplicate accounts to merge:",
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            plan.merges.forEach { merge ->
+                Text(
+                    text = "• ${merge.duplicateName} → ${merge.targetName} (${merge.transferCount} transaction(s))",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Merges move ALL of the duplicate's transactions (from any import) and can be undone from the account merge history.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        } else {
+            Text(
+                text = "No duplicate accounts to merge under the current account mappings.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (plan.skipped.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Not merged:",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            plan.skipped.forEach { skip ->
+                Text(
+                    text = "• ${skip.accountName}: ${skip.detail}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+
+        if (hasUnimportedRows) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Rows not yet imported (or in error) will also be imported using the current mappings.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = "Accounts created by this import that end up with no transactions will be deleted.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -21,6 +21,7 @@ exclude:
     paths:
       - app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/MonzoImportAuditE2ETest.kt
       - app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvAccountSourceAuditE2ETest.kt
+      - app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvReimportE2ETest.kt
   - name: UnnecessaryModuleDependencyInspection
   - name: RedundantSuppression
     paths:


### PR DESCRIPTION
## Summary

When a CSV import creates duplicate accounts (e.g. "Amazon.com" when "Amazon" already exists), account mappings (#617/#619) only help *future* imports. This adds a **Re-import** action to an already-imported CSV that applies newly added global/strategy mappings retroactively:

1. **Merge** — each account this import created whose value now resolves (via the current mappings) to a different existing account is merged into it using the reversible account-merge machinery: all its transactions move, the duplicate is deleted, and the merge can be undone from the merge history.
2. **Re-run** — rows never imported (or in ERROR) are then imported under the new mappings. Merging first is load-bearing: otherwise dedupe looks for existing transfers on the newly-mapped accounts, misses the ones on the duplicate, and double-imports.
3. **Cleanup** — accounts created by this import that end up with zero transactions are deleted. Manually created accounts are never touched.

The `ReimportDialog` shows a read-only preview of the planned merges ("Amazon.com → Amazon, 12 transactions") before executing, and reports skipped duplicates with reasons (transfers between the pair would make a merge a self-transfer; rows disagreeing on the target).

## How it works

- **Detection** (`computeReimportMerges`, pure): map all stored rows twice — baseline with no persisted mappings (resolves by name/historical name, i.e. to the duplicate) vs the current mappings — and diff per row/side. Only accounts created by this import qualify, found via a new provenance query `selectAccountIdsCreatedByCsvImport` over `csv_entity_source`.
- **Orchestration** (`planCsvReimport` / `executeCsvReimport` in `app/csvimporter/CsvReimport.kt`): DB-free — read repositories + `ImportBatch.manualEdits` (accountMerges / account DELETE intents) through the ImportEngine, one batch per merge so a surprise failure downgrades to a per-account skip.

## Tests

- `CsvReimportDetectionTest` (unit, 6 cases): global mapping → candidate; other-strategy mapping ignored; non-import-created account ignored; conflicting targets → conflict; renamed duplicate via historical names; unaffected rows ignored.
- `CsvReimportE2ETest` (real DB): end-to-end merge + reversible-merge record + no double import; transfers-between → skipped, duplicate preserved.

## Notes for review

- Merges move **all** of a duplicate's transactions (from any import), not just this CSV's — intentional, so the duplicate account disappears entirely; the preview dialog makes this explicit.
- Full `./gradlew build` green (tests, detekt, verifyNoWriteRepositoryUsage, buildHealth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV re-import support with a preview of merges, skipped items, and rows that will be imported again.
  * Added an on-screen re-import dialog and action from the CSV import details view.
  * Re-import now applies updated account mappings retroactively and cleans up empty duplicate accounts after merging.

* **Bug Fixes**
  * Improved re-import handling so duplicate accounts are only merged when it’s safe, with conflicts and transfer-related cases shown as skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->