### PR TITLE
Build-speed quick wins: gate R8, scope lint, parallel test forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
             artifact-path: app/main/jvm/build/compose/binaries/main-release/deb/*.deb
           - platform: Android
             os: ubuntu-latest
-            task: :app:main:android:assembleRelease
+            task: :app:main:android:assembleRelease -PbuildRelease=true
             artifact-name: android-apk
             artifact-path: app/main/android/build/outputs/apk/release/*.apk
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,11 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 | `./gradlew buildHealth` | Check dependency health |
 | `./gradlew detekt` | Static analysis |
 
+Build-speed flags (off by default): the Android release variant (R8/minified) only exists with
+`-PbuildRelease=true` (CI main/release workflows pass it), and `build` only compiles Android
+device-test sources with `-PcompileDeviceTests=true` (the CI emulator job compiles them anyway).
+`-PtestMaxParallelForks=N` overrides the parallel test-fork default (e.g. `=1` to serialize).
+
 **Pre-push**: Always run `./gradlew build` locally before pushing.
 
 ## Project Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,11 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 | `./gradlew buildHealth` | Check dependency health |
 | `./gradlew detekt` | Static analysis |
 
+Build-speed flags (off by default): the Android release variant (R8/minified) only exists with
+`-PbuildRelease=true` (CI main/release workflows pass it), and `build` only compiles Android
+device-test sources with `-PcompileDeviceTests=true` (the CI emulator job compiles them anyway).
+`-PtestMaxParallelForks=N` overrides the parallel test-fork default (e.g. `=1` to serialize).
+
 **Pre-push**: Always run `./gradlew build` locally before pushing.
 
 ## Project Structure

--- a/app/main/android/build.gradle.kts
+++ b/app/main/android/build.gradle.kts
@@ -60,8 +60,3 @@ dependencies {
     implementation(projects.app.ui.foundation)
     implementation(projects.utils.localsettings)
 }
-
-// Run release build as part of build to catch release issues early
-tasks.named("build") {
-    dependsOn("assembleRelease")
-}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,10 @@ android.nonTransitiveRClass=true
 
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 
+# Explicit Kotlin compile-daemon heap: unset, it derives from the machine and competes with the
+# 4g Gradle JVM and forked test JVMs on 16GB CI runners.
+kotlin.daemon.jvmargs=-Xmx3g
+
 # Configuration cache for faster builds
 org.gradle.configuration-cache=true
 
@@ -25,6 +29,3 @@ org.gradle.caching=true
 
 # Parallel execution for faster builds
 org.gradle.parallel=true
-
-# Configure on demand for faster multi-project builds
-org.gradle.configureondemand=true

--- a/gradle/build-logic/src/main/kotlin/LintPolicy.kt
+++ b/gradle/build-logic/src/main/kotlin/LintPolicy.kt
@@ -1,0 +1,15 @@
+import com.android.build.api.dsl.Lint
+
+/**
+ * Shared Android lint policy: warnings are fatal, but only main sources of a single variant are
+ * analyzed. Lint on test sources and re-linting of dependencies added ~2 lintAnalyze* tasks per
+ * module across 40+ Android modules for little signal.
+ */
+fun Lint.moneyManagerLintPolicy() {
+    warningsAsErrors = true
+    abortOnError = true
+    checkTestSources = false
+    ignoreTestSources = true
+    checkDependencies = false
+    checkReleaseBuilds = false
+}

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -48,9 +49,23 @@ configure<ApplicationExtension> {
     lint {
         warningsAsErrors = true
         abortOnError = true
+        checkTestSources = false
+        ignoreTestSources = true
+        checkDependencies = false
+        checkReleaseBuilds = false
         // API 37 is currently beta, so stay on the latest stable SDK while keeping other lint warnings fatal.
         disable += "GradleDependency"
         disable += "OldTargetApi"
+    }
+}
+
+// R8 minification + resource shrinking of the release variant costs minutes on every build, so the
+// variant only exists when explicitly requested: the release workflow and the main-branch CI job
+// pass -PbuildRelease=true; PR and local builds assemble debug only.
+val buildRelease = providers.gradleProperty("buildRelease").map(String::toBoolean).getOrElse(false)
+configure<ApplicationAndroidComponentsExtension> {
+    beforeVariants(selector().withBuildType("release")) { variant ->
+        variant.enable = buildRelease
     }
 }
 

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-application-convention.gradle.kts
@@ -47,12 +47,7 @@ configure<ApplicationExtension> {
     }
 
     lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkTestSources = false
-        ignoreTestSources = true
-        checkDependencies = false
-        checkReleaseBuilds = false
+        moneyManagerLintPolicy()
         // API 37 is currently beta, so stay on the latest stable SDK while keeping other lint warnings fatal.
         disable += "GradleDependency"
         disable += "OldTargetApi"

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
@@ -24,14 +24,7 @@ fun KotlinMultiplatformExtension.configureAndroidTarget() {
         }
 
         lint {
-            warningsAsErrors = true
-            abortOnError = true
-            // Lint on test sources and re-linting of dependencies added ~2 lintAnalyze* tasks per
-            // module across 40+ Android modules for little signal; lint main sources only.
-            checkTestSources = false
-            ignoreTestSources = true
-            checkDependencies = false
-            checkReleaseBuilds = false
+            moneyManagerLintPolicy()
         }
 
         // Enable instrumented tests with Gradle Managed Device

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
@@ -26,6 +26,12 @@ fun KotlinMultiplatformExtension.configureAndroidTarget() {
         lint {
             warningsAsErrors = true
             abortOnError = true
+            // Lint on test sources and re-linting of dependencies added ~2 lintAnalyze* tasks per
+            // module across 40+ Android modules for little signal; lint main sources only.
+            checkTestSources = false
+            ignoreTestSources = true
+            checkDependencies = false
+            checkReleaseBuilds = false
         }
 
         // Enable instrumented tests with Gradle Managed Device
@@ -87,9 +93,13 @@ ktlint {
     android.set(true)
 }
 
-// Include instrumented test compilation in the build task to catch compile errors early
-tasks.named("build") {
-    dependsOn("compileAndroidDeviceTest")
+// Instrumented test sources are compiled by the CI emulator job (connectedAndroidDeviceTest) on
+// every PR, so `build` skips them by default; opt in locally with -PcompileDeviceTests=true to
+// catch device-test compile errors early.
+if (providers.gradleProperty("compileDeviceTests").map(String::toBoolean).getOrElse(false)) {
+    tasks.named("build") {
+        dependsOn("compileAndroidDeviceTest")
+    }
 }
 
 // Configure build scan integration for Android device tests

--- a/gradle/build-logic/src/main/kotlin/moneymanager.compose-multiplatform-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.compose-multiplatform-convention.gradle.kts
@@ -19,6 +19,10 @@ tasks.matching {
 // (they pass in isolation). Retry a failed test a couple of times so a load-induced flake doesn't
 // fail the build; a test that only ever fails still fails after its retries are exhausted.
 tasks.withType<Test>().configureEach {
+    // Keep Compose Desktop tests in a single fork, overriding the parallel-forks default from
+    // moneymanager.kotlin-convention (this plugin applies after it, so this action runs last):
+    // parallel Skiko/AWT test JVMs make the CPU-starvation flakes above much more likely.
+    maxParallelForks = 1
     retry {
         maxRetries.set(2)
         // A test that passes on retry is treated as passed (the point of retrying flakes).

--- a/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-convention.gradle.kts
@@ -123,7 +123,8 @@ tasks {
         // DBs, no shared state). Compose Desktop UI modules override this back to 1 in
         // moneymanager.compose-multiplatform-convention (Skiko/AWT tests flake under contention).
         // -PtestMaxParallelForks=N overrides for debugging (e.g. =1 to serialize).
-        maxParallelForks = providers.gradleProperty("testMaxParallelForks").orNull?.toInt()
+        maxParallelForks = providers.gradleProperty("testMaxParallelForks").orNull
+            ?.let { it.toIntOrNull() ?: error("Invalid -PtestMaxParallelForks value '$it': expected an integer") }
             ?: Runtime.getRuntime().availableProcessors().coerceAtMost(8)
     }
 

--- a/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.kotlin-convention.gradle.kts
@@ -118,6 +118,15 @@ tasks {
         exclude { it.file.absolutePath.contains("/build/generated/") }
     }
 
+    withType<Test>().configureEach {
+        // Test classes are distributed across forked JVMs; suites here are isolated (own temp-dir
+        // DBs, no shared state). Compose Desktop UI modules override this back to 1 in
+        // moneymanager.compose-multiplatform-convention (Skiko/AWT tests flake under contention).
+        // -PtestMaxParallelForks=N overrides for debugging (e.g. =1 to serialize).
+        maxParallelForks = providers.gradleProperty("testMaxParallelForks").orNull?.toInt()
+            ?: Runtime.getRuntime().availableProcessors().coerceAtMost(8)
+    }
+
     withType<JavaCompile>().configureEach {
         targetCompatibility = jvmTargetVersion
         options.compilerArgs.addAll(listOf("-Xlint:all", "-Werror"))


### PR DESCRIPTION
## What

First of three build-speed PRs (from a full audit of CI logs, the Gradle task graph, and test-suite timings). CI wall clock is ~12.5–13 min per PR; this PR attacks the Gradle-side costs without touching CI structure:

- **Android release variant (R8/resource shrinking) is gated behind `-PbuildRelease=true`.** It ran on every PR and local `build`, costing ~2.5–3.5 min of single-threaded R8 on the critical path. `release.yml` passes the property; a main-branch `android-release` CI job follows in the CI-restructure PR so R8 breakage still surfaces on main.
- **`compileAndroidDeviceTest` is no longer wired into `build`** (opt in with `-PcompileDeviceTests=true`). The CI emulator job compiles device tests on every PR anyway — this was ~25 redundant Kotlin compilations per build.
- **AGP lint scoped to main sources** (`checkTestSources=false`, `ignoreTestSources=true`, `checkDependencies=false`, `checkReleaseBuilds=false`): drops ~2 `lintAnalyze*` tasks per Android module across 40+ modules. Trade-off: lint findings inside test sources are no longer reported.
- **JVM test tasks fork per available core** (capped at 8, `-PtestMaxParallelForks=N` to override). Compose Desktop modules stay single-fork — their Skiko/AWT tests already flake under CPU contention (hence the existing test-retry). Test isolation audited: every db test uses its own temp-dir SQLite file, DI graphs are per-test, no ports/global state.
- **`kotlin.daemon.jvmargs=-Xmx3g`** so the Kotlin daemon stops sizing itself off the machine and competing with the 4g Gradle JVM + test forks on 16GB runners.
- **Removed `org.gradle.configureondemand`** (deprecated no-op under isolated projects).

## Measured locally

- `:app:db:core:jvmTest`: **~12 min → 209 s wall** (1203 s of serialized test time across 8 forks; expect ~3–4× on the 4-core CI runner).
- Kover coverage verified **byte-identical** between forked and single-fork runs (all five counter types).
- `build --dry-run`: no `minifyReleaseWithR8`/`assembleRelease`/`lintAnalyze*AndroidTest`/`lintAnalyze*HostTest` scheduled; `:app:main:android:assembleRelease -PbuildRelease=true` still schedules R8.
- Full `./gradlew build` green.

## Follow-ups (separate PRs)

1. CI restructure: buildHealth off the root `build` task into a parallel job, config-cache reuse via `cache-encryption-key`, `aosp_atd` emulator image, device coverage main-only, auto-format job gating.
2. db:core test seeding trim (~2 s of fixed setup per test seeding all ~233 currencies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional build flags to speed up Android and test runs, including controls for release builds, device tests, and test parallelism.

* **Bug Fixes**
  * Improved build stability by making Android release assembly opt-in and reducing flaky test behavior during concurrent execution.
  * Adjusted build settings to avoid unnecessary work during routine builds.

* **Documentation**
  * Updated build docs with guidance on the new performance-related flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->