### PR TITLE
CI restructure: parallel buildHealth, config-cache reuse, ATD emulator, coverage main-only

### DIFF
--- a/.github/actions/gradle-run/action.yml
+++ b/.github/actions/gradle-run/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Whether the Gradle cache should be read-only'
     required: false
     default: 'false'
+  cache-encryption-key:
+    description: 'AES key for configuration-cache data; empty disables config-cache save/restore'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -17,6 +21,7 @@ runs:
       uses: ./.github/actions/gradle-setup
       with:
         cache-read-only: ${{ inputs.cache-read-only }}
+        cache-encryption-key: ${{ inputs.cache-encryption-key }}
 
     - name: Run Gradle
       shell: bash

--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Whether the Gradle cache should be read-only'
     required: false
     default: 'false'
+  cache-encryption-key:
+    description: 'AES key for configuration-cache data; empty disables config-cache save/restore'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -29,7 +33,7 @@ runs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
       with:
-        # Gradle version sync: keep this aligned with gradle/wrapper/gradle-wrapper.properties
-        # and .github/workflows/build.yml.
-        gradle-version: 9.6.1
+        # No gradle-version pin: ./gradlew uses the wrapper's version anyway, so a pin here only
+        # downloads a second, unused distribution.
         cache-read-only: ${{ inputs.cache-read-only }}
+        cache-encryption-key: ${{ inputs.cache-encryption-key }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,10 +55,15 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
-    needs: changes
-    # Runs on PRs and pushes to main (not on releases/* pushes).
+    needs: [changes, lint-format]
+    # Runs on PRs and pushes to main (not on releases/* pushes). Heavy jobs wait for the cheap
+    # lint-format job: when it pushes formatting fixes, the resulting `synchronize` event cancels
+    # this run before the heavy jobs have burned minutes. `!cancelled()` is required so a SKIPPED
+    # lint-format (push/dispatch events) doesn't auto-skip this job.
     if: >-
+      !cancelled() &&
       needs.changes.outputs.code == 'true' &&
+      (needs.lint-format.result == 'success' || needs.lint-format.result == 'skipped') &&
       (github.event_name == 'pull_request' ||
        (github.event_name == 'push' && github.ref == 'refs/heads/main'))
 
@@ -75,10 +80,13 @@ jobs:
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
           GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
         with:
-          # The slow :app:db:core:jvmTest is split into its own parallel `db-core-test`
-          # job below so it no longer serializes the main build. Keep the two in sync.
-          command: build --stacktrace -x :app:db:core:jvmTest
+          # The slow :app:db:core:jvmTest is split into its own parallel `db-core-test` job below
+          # so it no longer serializes the main build (that job also produces db:core's coverage
+          # XML, hence the koverXmlReport exclusion). Keep the two in sync. `koverXmlReport`
+          # name-matches into every module and produces the per-module unit-coverage XMLs.
+          command: build koverXmlReport --stacktrace -x :app:db:core:jvmTest -x :app:db:core:koverXmlReport
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
       - name: Upload coverage and test results to Codecov
         uses: ./.github/actions/codecov-upload
@@ -89,11 +97,13 @@ jobs:
   db-core-test:
     name: db:core Tests
     runs-on: ubuntu-latest
-    needs: changes
-    # The :app:db:core:jvmTest suite is slow (~12 min), so it runs here in parallel
-    # with the main build (which excludes it via `-x :app:db:core:jvmTest`).
+    needs: [changes, lint-format]
+    # The :app:db:core:jvmTest suite is the slowest single test task, so it runs here in
+    # parallel with the main build (which excludes it via `-x :app:db:core:jvmTest`).
     if: >-
+      !cancelled() &&
       needs.changes.outputs.code == 'true' &&
+      (needs.lint-format.result == 'success' || needs.lint-format.result == 'skipped') &&
       (github.event_name == 'pull_request' ||
        (github.event_name == 'push' && github.ref == 'refs/heads/main'))
 
@@ -111,6 +121,7 @@ jobs:
           # per-module coverage XML that Codecov merges with the main build's report.
           command: :app:db:core:koverXmlReport --stacktrace
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
       - name: Upload coverage and test results to Codecov
         uses: ./.github/actions/codecov-upload
@@ -122,9 +133,11 @@ jobs:
     name: Android Instrumented Tests
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: changes
+    needs: [changes, lint-format]
     if: >-
+      !cancelled() &&
       needs.changes.outputs.code == 'true' &&
+      (needs.lint-format.result == 'success' || needs.lint-format.result == 'skipped') &&
       (github.event_name == 'pull_request' ||
        (github.event_name == 'push' && github.ref == 'refs/heads/main'))
 
@@ -143,6 +156,7 @@ jobs:
         uses: ./.github/actions/gradle-setup
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
       - name: AVD cache
         uses: actions/cache@v6
@@ -153,7 +167,7 @@ jobs:
             ~/.android/adb*
           # Android emulator API level sync: update with the Gradle managed device,
           # .idea/runConfigurations/Android_Tests.xml, and AGENTS.md.
-          key: avd-pixel6-api36-${{ runner.os }}
+          key: avd-pixel6-api36-aosp-atd-${{ runner.os }}
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
@@ -161,10 +175,12 @@ jobs:
         with:
           # Android emulator API level sync: update with the Gradle managed device,
           # .idea/runConfigurations/Android_Tests.xml, and AGENTS.md.
+          # aosp_atd is the headless test-optimized image — same source as the local
+          # Gradle managed device (systemImageSource = "aosp-atd").
           api-level: 36
           arch: x86_64
           profile: pixel_6
-          target: google_apis
+          target: aosp_atd
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
@@ -179,14 +195,16 @@ jobs:
           api-level: 36
           arch: x86_64
           profile: pixel_6
-          target: google_apis
+          target: aosp_atd
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
-          script: ./gradlew connectedAndroidDeviceTest createAndroidDeviceTestCoverageReport --stacktrace --console=plain
+          # JaCoCo coverage instrumentation slows every instrumented test, so PRs run the tests
+          # uninstrumented; pushes to main collect and upload the instrumented coverage.
+          script: ./gradlew connectedAndroidDeviceTest${{ github.ref == 'refs/heads/main' && ' createAndroidDeviceTestCoverageReport -PandroidCoverage=true' || '' }} --stacktrace --console=plain
 
       - name: Upload coverage and test results to Codecov
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         uses: ./.github/actions/codecov-upload
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -203,11 +221,71 @@ jobs:
             **/build/outputs/androidTest-results/**
           retention-days: 7
 
+  build-health:
+    name: Dependency Health
+    runs-on: ubuntu-latest
+    needs: [changes, lint-format]
+    # DAGP's buildHealth aggregation over every module used to run inside the main build job
+    # (root `build` depended on it); as its own job it gates PRs off the critical path.
+    if: >-
+      !cancelled() &&
+      needs.changes.outputs.code == 'true' &&
+      (needs.lint-format.result == 'success' || needs.lint-format.result == 'skipped') &&
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'push' && github.ref == 'refs/heads/main'))
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Run buildHealth with Gradle
+        uses: ./.github/actions/gradle-run
+        env:
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+        with:
+          command: buildHealth --stacktrace
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+
+  android-release:
+    name: Android Release Build
+    runs-on: ubuntu-latest
+    needs: [changes, lint-format]
+    # The R8/minified release APK is no longer built on PRs (-PbuildRelease gates the variant),
+    # so build it on every push to main: R8 breakage surfaces there, and release.yml's
+    # check-build gate then blocks tagging a broken commit. Keep the command identical to
+    # release.yml's Android matrix entry so they share a configuration-cache entry.
+    if: >-
+      !cancelled() &&
+      needs.changes.outputs.code == 'true' &&
+      (needs.lint-format.result == 'success' || needs.lint-format.result == 'skipped') &&
+      github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Build release APK with Gradle
+        uses: ./.github/actions/gradle-run
+        env:
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+        with:
+          command: :app:main:android:assembleRelease -PbuildRelease=true --stacktrace
+          cache-read-only: false
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+
   qodana:
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, lint-format]
+    # Unlike the other heavy jobs this one also runs on workflow_dispatch, so it has no
+    # event-name condition.
+    if: >-
+      !cancelled() &&
+      needs.changes.outputs.code == 'true' &&
+      (needs.lint-format.result == 'success' || needs.lint-format.result == 'skipped')
     permissions:
       contents: write
       pull-requests: write
@@ -226,6 +304,7 @@ jobs:
         with:
           command: jvmMainClasses
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Restore Qodana cache (read-only on non-main branches)
         if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/releases/')
         uses: actions/cache/restore@v6
@@ -286,10 +365,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
-        with:
-          # Gradle version sync: keep this aligned with gradle/wrapper/gradle-wrapper.properties
-          # and .github/actions/gradle-setup/action.yml.
-          gradle-version: 9.5.0
+        # No gradle-version pin: ./gradlew uses the wrapper's version, so a pin here only
+        # downloads a second, unused distribution.
 
       - name: Run lintFormat
         run: ./gradlew lintFormat --no-daemon -Dktlint.ignoreFailures=true --continue

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,8 @@ jobs:
       # system image explicitly before the emulator runner (whose sdkmanager call is pinned to
       # the stable channel and would fail to find it). The emulator itself stays on stable.
       - name: Install aosp_atd system image (dev channel)
-        run: sdkmanager --install 'system-images;android-36;aosp_atd;x86_64' --channel=2
+        # sdkmanager is not on PATH in plain steps (the emulator runner sets it up internally).
+        run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-36;aosp_atd;x86_64' --channel=2
 
       - name: AVD cache
         uses: actions/cache@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,13 +158,6 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
-      # The API-36 ATD images are only published on the dev channel (channel-2), so install the
-      # system image explicitly before the emulator runner (whose sdkmanager call is pinned to
-      # the stable channel and would fail to find it). The emulator itself stays on stable.
-      - name: Install aosp_atd system image (dev channel)
-        # sdkmanager is not on PATH in plain steps (the emulator runner sets it up internally).
-        run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install 'system-images;android-36;aosp_atd;x86_64' --channel=2
-
       - name: AVD cache
         uses: actions/cache@v6
         id: avd-cache
@@ -188,6 +181,8 @@ jobs:
           arch: x86_64
           profile: pixel_6
           target: aosp_atd
+          # The API-36 ATD images are only published on the dev sdkmanager channel.
+          channel: dev
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
@@ -203,6 +198,8 @@ jobs:
           arch: x86_64
           profile: pixel_6
           target: aosp_atd
+          # The API-36 ATD images are only published on the dev sdkmanager channel.
+          channel: dev
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,6 +241,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false  # read-only job, no git push
 
       - name: Run buildHealth with Gradle
         uses: ./.github/actions/gradle-run
@@ -269,6 +271,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false  # read-only job, no git push
 
       - name: Build release APK with Gradle
         uses: ./.github/actions/gradle-run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,6 +158,12 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
+      # The API-36 ATD images are only published on the dev channel (channel-2), so install the
+      # system image explicitly before the emulator runner (whose sdkmanager call is pinned to
+      # the stable channel and would fail to find it). The emulator itself stays on stable.
+      - name: Install aosp_atd system image (dev channel)
+        run: sdkmanager --install 'system-images;android-36;aosp_atd;x86_64' --channel=2
+
       - name: AVD cache
         uses: actions/cache@v6
         id: avd-cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 
 | Command | Description |
 |---------|-------------|
-| `./gradlew build` | Build all, run tests, coverage, dependency health |
+| `./gradlew build` | Build all and run tests (coverage/dependency health run as separate CI jobs) |
 | `./gradlew :app:main:jvm:run` | Run JVM application |
 | `./gradlew :app:main:android:installDebug` | Install Android debug APK |
 | `./gradlew :app:ui:core:pixel6api36AndroidDeviceTest` | Run Android UI tests on managed device |
@@ -30,9 +30,10 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 Build-speed flags (off by default): the Android release variant (R8/minified) only exists with
 `-PbuildRelease=true` (CI main/release workflows pass it), and `build` only compiles Android
 device-test sources with `-PcompileDeviceTests=true` (the CI emulator job compiles them anyway).
-`-PtestMaxParallelForks=N` overrides the parallel test-fork default (e.g. `=1` to serialize).
+`-PtestMaxParallelForks=N` overrides the parallel test-fork default (e.g. `=1` to serialize), and
+`-PandroidCoverage=true` enables JaCoCo coverage for instrumented tests (main-branch CI passes it).
 
-**Pre-push**: Always run `./gradlew build` locally before pushing.
+**Pre-push**: Always run `./gradlew build buildHealth` locally before pushing.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 
 | Command | Description |
 |---------|-------------|
-| `./gradlew build` | Build all, run tests, coverage, dependency health |
+| `./gradlew build` | Build all and run tests (coverage/dependency health run as separate CI jobs) |
 | `./gradlew :app:main:jvm:run` | Run JVM application |
 | `./gradlew :app:main:android:installDebug` | Install Android debug APK |
 | `./gradlew :app:ui:core:pixel6api34AndroidDeviceTest` | Run Android UI tests on managed device |
@@ -30,9 +30,10 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 Build-speed flags (off by default): the Android release variant (R8/minified) only exists with
 `-PbuildRelease=true` (CI main/release workflows pass it), and `build` only compiles Android
 device-test sources with `-PcompileDeviceTests=true` (the CI emulator job compiles them anyway).
-`-PtestMaxParallelForks=N` overrides the parallel test-fork default (e.g. `=1` to serialize).
+`-PtestMaxParallelForks=N` overrides the parallel test-fork default (e.g. `=1` to serialize), and
+`-PandroidCoverage=true` enables JaCoCo coverage for instrumented tests (main-branch CI passes it).
 
-**Pre-push**: Always run `./gradlew build` locally before pushing.
+**Pre-push**: Always run `./gradlew build buildHealth` locally before pushing.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Money Manager is a Kotlin Multiplatform personal finance app targeting JVM and A
 | `./gradlew build` | Build all and run tests (coverage/dependency health run as separate CI jobs) |
 | `./gradlew :app:main:jvm:run` | Run JVM application |
 | `./gradlew :app:main:android:installDebug` | Install Android debug APK |
-| `./gradlew :app:ui:core:pixel6api34AndroidDeviceTest` | Run Android UI tests on managed device |
+| `./gradlew :app:ui:core:pixel6api36AndroidDeviceTest` | Run Android UI tests on managed device |
 | `./gradlew lintFormat` | Format code (ktlint + sort dependencies) |
 | `./gradlew buildHealth` | Check dependency health |
 | `./gradlew detekt` | Static analysis |
@@ -188,7 +188,7 @@ different databases can use different Google accounts.
 - Use `runComposeUiTest` for UI tests
 - Android tests require manifest with `ComponentActivity` declaration
 - Share test sources via `kotlin.srcDir("src/commonTest/kotlin")`
-- **Android Device Tests**: Use `:app:ui:core:pixel6api34AndroidDeviceTest` for UI tests on managed device emulator
+- **Android Device Tests**: Use `:app:ui:core:pixel6api36AndroidDeviceTest` for UI tests on managed device emulator
 - **Test Stability**: Always call `waitForIdle()` after `waitUntilDoesNotExist()` to ensure recompositions complete before test ends
 
 ### Platform Support

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,13 +27,6 @@ if (providers.gradleProperty("org.gradle.unsafe.isolated-projects").orNull != "t
     pluginManager.apply("com.osacky.doctor")
 }
 
-tasks.register("build") {
-    description = "Builds all subprojects and runs buildHealth"
-    group = "build"
-    dependsOn("buildHealth")
-    dependsOn("koverXmlReport")
-}
-
 tasks.register("lintFormat") {
     description = "Runs all formatting tasks"
     group = "formatting"

--- a/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
+++ b/gradle/build-logic/src/main/kotlin/moneymanager.android-convention.gradle.kts
@@ -29,8 +29,9 @@ fun KotlinMultiplatformExtension.configureAndroidTarget() {
 
         // Enable instrumented tests with Gradle Managed Device
         withDeviceTest {
-            // Enable code coverage for instrumented tests
-            enableCoverage = true
+            // JaCoCo instrumentation slows every instrumented test run, so coverage is opt-in:
+            // the main-branch CI job passes -PandroidCoverage=true; PR runs skip it.
+            enableCoverage = providers.gradleProperty("androidCoverage").map(String::toBoolean).getOrElse(false)
 
             managedDevices {
                 localDevices {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,7 @@ schemaspy = "7.0.2"
 slf4j = "2.0.18"
 sort-dependencies = "0.19.0"
 sqldelight = "2.4.0-SNAPSHOT"
-test-retry = "1.6.2"
+test-retry = "1.6.5"
 turbine = "1.2.1"
 # Build-tool transitive-alignment versions: pin tooling transitives (Gradle plugins, annotation
 # processors, AGP test platform) to one version across all build classpaths. Consumed via the


### PR DESCRIPTION
## What

Second of three build-speed PRs (follows #625). This one restructures CI so the wall clock is set by real work, not redundant or serialized work:

- **`buildHealth` moves off the root `build` task into its own parallel "Dependency Health" job.** DAGP aggregation over 46 modules was on the critical path of every PR and local build. Local `./gradlew build` is faster; the pre-push rule becomes `./gradlew build buildHealth` (docs updated). The build job now requests per-module `koverXmlReport` explicitly — a side upgrade: modules other than db:core get unit coverage uploaded for the first time (expect a one-time Codecov % shift). The old root kover aggregate was provably empty (all-zero counters, no aggregation deps), so nothing is lost.
- **Heavy jobs are gated on the fast lint-format job** (`needs: [changes, lint-format]` with `!cancelled()` semantics so push/dispatch runs still work). Previously, when lint-format auto-pushed formatting fixes, the resulting synchronize event cancelled ~5 min of in-flight parallel work and restarted everything (~2× wall time). Now only ~1–2 min is at risk.
  ⚠️ **Branch protection**: please add **"Auto-format PR"** and **"Dependency Health"** to required checks — a failed lint-format now skips the heavy jobs, and skipped required checks count as passing.
- **Configuration-cache reuse in CI**: `gradle/actions/setup-gradle` only persists config-cache data when `cache-encryption-key` is set. The new `GRADLE_CACHE_ENCRYPTION_KEY` repo secret (already created) is plumbed through the composite actions; main writes entries, PRs restore them (~1 min of "Calculating task graph" saved per job).
- **Emulator switches to `aosp_atd`** — the headless test-optimized image, the same source the local Gradle managed device already uses (`systemImageSource = "aosp-atd"`), replacing the heavier `google_apis` image. AVD cache key bumped.
- **Instrumented coverage is main-only**: JaCoCo instrumentation slows every device test, so `enableCoverage` is now gated on `-PandroidCoverage=true`, which only the main-branch run passes; the instrumented Codecov upload is main-only too (PR coverage for the `instrumented` flag comes via carryforward/main).
- **New main-only `android-release` job** builds the R8 release APK on every push to main, since PRs no longer build it (#625). `release.yml`'s check-build gate then blocks tagging a broken commit.
- **Dead Gradle distribution downloads removed**: the `gradle-version` pins in the composite action and lint-format job downloaded a distribution `./gradlew` never uses (lint-format even pinned 9.5.0 vs wrapper 9.6.1).

## Verification

- `./gradlew build --dry-run`: zero `buildHealth`/`projectHealth`/`koverXmlReport` tasks scheduled; `buildHealth` still resolves standalone.
- The new CI build command dry-runs correctly (per-module kover reports scheduled, db:core's excluded).
- Full `./gradlew build buildHealth` green locally.
- Workflow/action YAML validated.
- After merge, watch the first push-to-main run: it populates the config cache and the new AVD snapshot; PR runs after that should show "Reusing configuration cache".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opt-in Android instrumented test coverage in CI and local builds.
  * Introduced a new build health check job to keep pull requests moving faster.
  * Added Gradle cache encryption support for selected CI jobs.

* **Bug Fixes**
  * Improved CI job gating to reduce unnecessary cancellations and flaky runs.
  * Updated release and test workflows to run only on the appropriate branches/events.

* **Documentation**
  * Clarified build and pre-push instructions to match the new CI split.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->