### PR TITLE
Trim test currency seeding: USD+EUR instead of the full platform list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,46 +80,11 @@ jobs:
           GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
           GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
         with:
-          # The slow :app:db:core:jvmTest is split into its own parallel `db-core-test` job below
-          # so it no longer serializes the main build (that job also produces db:core's coverage
-          # XML, hence the koverXmlReport exclusion). Keep the two in sync. `koverXmlReport`
-          # name-matches into every module and produces the per-module unit-coverage XMLs.
-          command: build koverXmlReport --stacktrace -x :app:db:core:jvmTest -x :app:db:core:koverXmlReport
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
-
-      - name: Upload coverage and test results to Codecov
-        uses: ./.github/actions/codecov-upload
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unit
-
-  db-core-test:
-    name: db:core Tests
-    runs-on: ubuntu-latest
-    needs: [changes, lint-format]
-    # The :app:db:core:jvmTest suite is the slowest single test task, so it runs here in
-    # parallel with the main build (which excludes it via `-x :app:db:core:jvmTest`).
-    if: >-
-      !cancelled() &&
-      needs.changes.outputs.code == 'true' &&
-      (needs.lint-format.result == 'success' || needs.lint-format.result == 'skipped') &&
-      (github.event_name == 'pull_request' ||
-       (github.event_name == 'push' && github.ref == 'refs/heads/main'))
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Run :app:db:core:jvmTest with Gradle
-        uses: ./.github/actions/gradle-run
-        env:
-          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-        with:
-          # koverXmlReport depends on jvmTest, so this runs the tests and produces the
-          # per-module coverage XML that Codecov merges with the main build's report.
-          command: :app:db:core:koverXmlReport --stacktrace
+          # `koverXmlReport` name-matches into every module and produces the per-module
+          # unit-coverage XMLs. db:core's tests run here too: the dedicated `db-core-test` job was
+          # removed once parallel test forks + minimal test currency seeding cut its ~12 min
+          # jvmTest down to ~1-2 min.
+          command: build koverXmlReport --stacktrace
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 

--- a/app/db/core/src/androidMain/kotlin/com/moneymanager/database/AndroidDatabaseManager.kt
+++ b/app/db/core/src/androidMain/kotlin/com/moneymanager/database/AndroidDatabaseManager.kt
@@ -3,6 +3,7 @@ package com.moneymanager.database
 import android.content.Context
 import androidx.sqlite.db.SupportSQLiteDatabase
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import com.moneymanager.currency.Currency
 import com.moneymanager.database.sql.seed.MoneyManagerDatabase
 import com.moneymanager.domain.model.DEFAULT_DATABASE_NAME
 import com.moneymanager.domain.model.DbLocation
@@ -19,6 +20,9 @@ private val DEFAULT_DB_LOCATION = DbLocation(DEFAULT_DATABASE_NAME)
  */
 class AndroidDatabaseManager(
     private val context: Context,
+    // Deferred so the platform currency list is only computed when a fresh database is seeded;
+    // tests inject a minimal list (see :test:app:db's createTestDatabaseManager).
+    private val currenciesToSeed: () -> List<Currency> = { DatabaseConfig.allCurrencies },
 ) : DatabaseManager {
     override suspend fun openDatabase(location: DbLocation): MoneyManagerDatabaseWrapper = openDatabaseWithProgress(location) {}
 
@@ -86,7 +90,7 @@ class AndroidDatabaseManager(
             onProgress(DatabaseInitializationProgress("Applying database settings...", 4, 6))
             if (isNewDatabase) {
                 onProgress(DatabaseInitializationProgress("Adding default currencies...", 5, 6))
-                DatabaseConfig.seedCurrencies(database)
+                DatabaseConfig.seedCurrencies(database, currenciesToSeed())
             } else {
                 onProgress(DatabaseInitializationProgress("Preparing repositories...", 5, 6))
             }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/DatabaseConfig.kt
@@ -43,15 +43,19 @@ object DatabaseConfig {
     private const val GBP_CODE = "GBP"
 
     /**
-     * Seeds the platform's currencies (every code except [GBP_CODE]) for a freshly created database,
-     * recording SYSTEM provenance for each. Uses the runtime platform currency list (java.util.Currency)
+     * Seeds [currencies] (every code except [GBP_CODE]) for a freshly created database, recording
+     * SYSTEM provenance for each. Defaults to the runtime platform currency list (java.util.Currency)
      * so the seeded set matches the device — Android exposes more ISO 4217 codes than the JVM, so this
-     * cannot be frozen at build time. Runs after Schema.create (which already seeded the lookups,
-     * the system device, and GBP).
+     * cannot be frozen at build time. Tests pass a minimal list instead: seeding ~230 currencies
+     * (with audit triggers) per test dominated DB-test setup time. Runs after Schema.create (which
+     * already seeded the lookups, the system device, and GBP).
      */
-    fun seedCurrencies(database: MoneyManagerDatabaseWrapper) {
+    fun seedCurrencies(
+        database: MoneyManagerDatabaseWrapper,
+        currencies: List<Currency> = allCurrencies,
+    ) {
         with(database) {
-            allCurrencies.forEach { currency ->
+            currencies.forEach { currency ->
                 if (currency.code == GBP_CODE) return@forEach
                 val scaleFactor = CurrencyScaleFactors.getScaleFactor(currency.code)
                 currencyWriteQueries.insert(currency.code, currency.displayName, scaleFactor.toLong())

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/CurrencyRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/CurrencyRepositoryImplTest.kt
@@ -12,6 +12,10 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class CurrencyRepositoryImplTest : DbTest() {
+    // These tests assert against the full platform currency list, so opt out of the
+    // minimal test seeding.
+    override val seedAllCurrencies: Boolean = true
+
     // Number of seeded currencies from DatabaseConfig
     private val seededCurrencyCount = DatabaseConfig.allCurrencies.size
 

--- a/app/db/core/src/jvmMain/kotlin/com/moneymanager/database/JvmDatabaseManager.kt
+++ b/app/db/core/src/jvmMain/kotlin/com/moneymanager/database/JvmDatabaseManager.kt
@@ -1,6 +1,7 @@
 package com.moneymanager.database
 
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.moneymanager.currency.Currency
 import com.moneymanager.database.sql.seed.MoneyManagerDatabase
 import com.moneymanager.domain.model.DEFAULT_DATABASE_PATH
 import com.moneymanager.domain.model.DbLocation
@@ -19,7 +20,11 @@ private val DbLocation.jdbcUrl: String
  * Manages SQLite database files on the file system.
  * Stateless - does not track open databases.
  */
-class JvmDatabaseManager : DatabaseManager {
+class JvmDatabaseManager(
+    // Deferred so the platform currency list is only computed when a fresh database is seeded;
+    // tests inject a minimal list (see :test:app:db's createTestDatabaseManager).
+    private val currenciesToSeed: () -> List<Currency> = { DatabaseConfig.allCurrencies },
+) : DatabaseManager {
     override suspend fun openDatabase(location: DbLocation): MoneyManagerDatabaseWrapper = openDatabaseWithProgress(location) {}
 
     override suspend fun openDatabaseWithProgress(
@@ -75,7 +80,7 @@ class JvmDatabaseManager : DatabaseManager {
 
             if (isNewDatabase) {
                 onProgress(DatabaseInitializationProgress("Adding default currencies...", 6, 7))
-                DatabaseConfig.seedCurrencies(database)
+                DatabaseConfig.seedCurrencies(database, currenciesToSeed())
             } else {
                 onProgress(DatabaseInitializationProgress("Preparing repositories...", 6, 7))
             }

--- a/test/app/db/build.gradle.kts
+++ b/test/app/db/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
                 api(projects.app.model.core)
 
                 implementation(libs.kotlinx.coroutines.test)
+                implementation(projects.utils.currency)
             }
         }
         getByName("jvmMain") {
@@ -30,13 +31,8 @@ kotlin {
                 api(kotlin("test-junit"))
                 api(projects.app.db.write)
 
-                implementation(libs.androidx.test.core)
                 implementation(libs.androidx.test.monitor)
                 implementation(libs.kotlinx.coroutines.core)
-                // The Android AppComponentParams carries a GoogleAccessTokenSource (googledrive) whose
-                // httpClient is a Ktor client — both referenced by the test double in TestDatabaseHelper.
-                implementation(libs.ktor.client.core)
-                implementation(projects.app.remotestorage.googledrive)
             }
         }
     }

--- a/test/app/db/src/androidMain/kotlin/com/moneymanager/test/database/TestDatabaseHelper.kt
+++ b/test/app/db/src/androidMain/kotlin/com/moneymanager/test/database/TestDatabaseHelper.kt
@@ -1,12 +1,7 @@
 package com.moneymanager.test.database
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
-import com.moneymanager.di.AppComponentParams
 import com.moneymanager.domain.model.DbLocation
-import com.moneymanager.remotestorage.googledrive.GoogleAccessTokenSource
-import com.moneymanager.remotestorage.googledrive.buildBearerDriveClient
-import io.ktor.client.HttpClient
 
 actual fun createTestDatabaseLocation(): DbLocation {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -19,22 +14,4 @@ actual fun createTestDatabaseLocation(): DbLocation {
 actual fun deleteTestDatabase(location: DbLocation) {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     context.deleteDatabase(location.name)
-}
-
-actual fun createTestAppComponentParams(): AppComponentParams =
-    AppComponentParams(ApplicationProvider.getApplicationContext(), NoopGoogleAccessTokenSource)
-
-/** Tests never exercise Google Drive sign-in; this satisfies the Android [AppComponentParams] field. */
-private object NoopGoogleAccessTokenSource : GoogleAccessTokenSource {
-    override val httpClient: HttpClient by lazy { buildBearerDriveClient(loadToken = { null }, refreshToken = { null }) }
-
-    override suspend fun isSignedIn(): Boolean = false
-
-    override suspend fun signIn(): Unit = throw UnsupportedOperationException("Google Drive sign-in is not used in tests")
-
-    override suspend fun signOut() = Unit
-
-    override suspend fun accessToken(): String? = null
-
-    override suspend fun accessTokenExpiresAtEpochMs(): Long? = null
 }

--- a/test/app/db/src/androidMain/kotlin/com/moneymanager/test/database/TestDatabaseManagerFactory.kt
+++ b/test/app/db/src/androidMain/kotlin/com/moneymanager/test/database/TestDatabaseManagerFactory.kt
@@ -4,7 +4,11 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.moneymanager.database.AndroidDatabaseManager
 import com.moneymanager.database.DatabaseManager
 
-actual fun createTestDatabaseManager(): DatabaseManager {
+actual fun createTestDatabaseManager(seedAllCurrencies: Boolean): DatabaseManager {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
-    return AndroidDatabaseManager(context)
+    return if (seedAllCurrencies) {
+        AndroidDatabaseManager(context)
+    } else {
+        AndroidDatabaseManager(context, currenciesToSeed = { minimalTestCurrencies })
+    }
 }

--- a/test/app/db/src/commonMain/kotlin/com/moneymanager/test/database/DbTest.kt
+++ b/test/app/db/src/commonMain/kotlin/com/moneymanager/test/database/DbTest.kt
@@ -4,7 +4,6 @@ package com.moneymanager.test.database
 
 import com.moneymanager.database.MoneyManagerDatabaseWrapper
 import com.moneymanager.database.sql.entitySource.EntitySourceWriteQueries
-import com.moneymanager.di.AppComponent
 import com.moneymanager.di.database.DatabaseComponent
 import com.moneymanager.domain.model.DbLocation
 import com.moneymanager.domain.model.Source
@@ -20,13 +19,14 @@ open class DbTest {
     protected lateinit var repositories: DatabaseComponent
     protected lateinit var entitySourceQueries: EntitySourceWriteQueries
 
+    /** Override (= true) in tests that assert against the full platform currency list. */
+    protected open val seedAllCurrencies: Boolean = false
+
     @BeforeTest
     fun setup() =
         runTest {
             testDbLocation = createTestDatabaseLocation()
-            val component = AppComponent.create(createTestAppComponentParams())
-            val databaseManager = component.databaseManager
-            database = databaseManager.openDatabase(testDbLocation)
+            database = createTestDatabaseManager(seedAllCurrencies).openDatabase(testDbLocation)
             repositories = DatabaseComponent.create(database)
             entitySourceQueries = database.entitySourceWriteQueries
         }

--- a/test/app/db/src/commonMain/kotlin/com/moneymanager/test/database/TestCurrencies.kt
+++ b/test/app/db/src/commonMain/kotlin/com/moneymanager/test/database/TestCurrencies.kt
@@ -1,0 +1,11 @@
+package com.moneymanager.test.database
+
+import com.moneymanager.currency.Currency
+
+/**
+ * Currencies seeded into fresh test databases when [createTestDatabaseManager] is called with
+ * `seedAllCurrencies = false`. GBP is always present (seeded with a fixed id by Schema.create),
+ * so together tests see GBP, USD and EUR. Seeding the full platform list (~230+ codes, each
+ * firing audit triggers) dominated per-test DB setup time.
+ */
+internal val minimalTestCurrencies = listOf(Currency("USD"), Currency("EUR"))

--- a/test/app/db/src/commonMain/kotlin/com/moneymanager/test/database/TestDatabaseHelper.kt
+++ b/test/app/db/src/commonMain/kotlin/com/moneymanager/test/database/TestDatabaseHelper.kt
@@ -1,15 +1,7 @@
 package com.moneymanager.test.database
 
-import com.moneymanager.di.AppComponentParams
 import com.moneymanager.domain.model.DbLocation
 
 expect fun createTestDatabaseLocation(): DbLocation
 
 expect fun deleteTestDatabase(location: DbLocation)
-
-/**
- * Creates AppComponentParams for testing.
- * On JVM, returns an empty params.
- * On Android, uses ApplicationProvider to get test context.
- */
-expect fun createTestAppComponentParams(): AppComponentParams

--- a/test/app/db/src/commonMain/kotlin/com/moneymanager/test/database/TestDatabaseManagerFactory.kt
+++ b/test/app/db/src/commonMain/kotlin/com/moneymanager/test/database/TestDatabaseManagerFactory.kt
@@ -4,5 +4,8 @@ import com.moneymanager.database.DatabaseManager
 
 /**
  * Creates a platform-specific DatabaseManager for testing.
+ *
+ * @param seedAllCurrencies seed the full platform currency list into fresh databases instead of
+ * [minimalTestCurrencies]; only needed by tests that assert against the complete list.
  */
-expect fun createTestDatabaseManager(): DatabaseManager
+expect fun createTestDatabaseManager(seedAllCurrencies: Boolean = false): DatabaseManager

--- a/test/app/db/src/jvmMain/kotlin/com/moneymanager/test/database/TestDatabaseHelper.kt
+++ b/test/app/db/src/jvmMain/kotlin/com/moneymanager/test/database/TestDatabaseHelper.kt
@@ -1,6 +1,5 @@
 package com.moneymanager.test.database
 
-import com.moneymanager.di.AppComponentParams
 import com.moneymanager.domain.model.DbLocation
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -19,5 +18,3 @@ actual fun deleteTestDatabase(location: DbLocation) {
         // Ignore cleanup errors
     }
 }
-
-actual fun createTestAppComponentParams(): AppComponentParams = AppComponentParams()

--- a/test/app/db/src/jvmMain/kotlin/com/moneymanager/test/database/TestDatabaseManagerFactory.kt
+++ b/test/app/db/src/jvmMain/kotlin/com/moneymanager/test/database/TestDatabaseManagerFactory.kt
@@ -3,4 +3,9 @@ package com.moneymanager.test.database
 import com.moneymanager.database.DatabaseManager
 import com.moneymanager.database.JvmDatabaseManager
 
-actual fun createTestDatabaseManager(): DatabaseManager = JvmDatabaseManager()
+actual fun createTestDatabaseManager(seedAllCurrencies: Boolean): DatabaseManager =
+    if (seedAllCurrencies) {
+        JvmDatabaseManager()
+    } else {
+        JvmDatabaseManager(currenciesToSeed = { minimalTestCurrencies })
+    }


### PR DESCRIPTION
## What

Third and final build-speed PR (follows #625, #626). ~Half of the db:core suite's runtime was a fixed per-test setup floor: every `DbTest` seeded all ~230 platform currencies (~900 statements, each currency INSERT firing audit triggers) into a fresh database.

- `DatabaseConfig.seedCurrencies` takes the currency list as a parameter, defaulting to the platform list — production call sites are untouched, and the JVM-vs-Android platform difference (233 vs ~307 codes) is preserved.
- `JvmDatabaseManager`/`AndroidDatabaseManager` gain an optional `currenciesToSeed` constructor parameter (deferred lambda, only evaluated when a fresh DB is seeded).
- `createTestDatabaseManager(seedAllCurrencies = false)` seeds only USD+EUR — GBP is always present via `Schema.create`'s fixed-id seed — so tests see GBP/USD/EUR. Grep-verified that's all any test uses, except `CurrencyRepositoryImplTest`, which asserts against the complete platform list and overrides `seedAllCurrencies = true` (stays platform-correct on both JVM and the emulator).
- `DbTest` now uses `createTestDatabaseManager()` directly; the `AppComponent` bootstrap path and the now-unused `createTestAppComponentParams` helper are deleted, along with the Android googledrive/ktor test deps that existed only for its no-op token source.
- **The dedicated "db:core Tests" CI job is removed** — it existed for a ~12 min serialized suite; at ~1–2 min the split no longer buys wall-clock (qodana is the long pole) and just duplicated compilation on a second runner. The build job runs `build koverXmlReport` with no exclusions now.
  ⚠️ **Branch protection**: remove **"db:core Tests"** from required checks after merging.

## Measured locally

- db:core serialized test time: **1203s → 503s** (58% cut), on top of the parallel-forks win from #625. First CI run of this PR: the db:core job (before removal) finished in 3m23s total, most of it setup/compile.
- Full `./gradlew build buildHealth` green — including the ui:core Compose E2E suite (which inherits minimal seeding via the shared factory) and dependency health after the test-dep cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database initialization so currency data can be seeded more flexibly across platforms.
  * Updated build coverage generation to include database-core test coverage in the main workflow.

* **Tests**
  * Added support for lighter-weight test databases with a smaller default currency set.
  * Enabled opt-in full currency seeding for tests that need broader coverage.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->