### PR TITLE
CSV re-import updates already-imported transfers when strategy values change

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class)
+@file:OptIn(ExperimentalTime::class)
 
 package com.moneymanager.csvimporter
 
@@ -32,6 +32,7 @@ import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
 import kotlinx.coroutines.flow.first
 import org.lighthousegames.logging.logging
+import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 private val logger = logging()

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -7,6 +7,7 @@ import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.model.accountmapping.AccountMapping
@@ -238,7 +239,10 @@ suspend fun planCsvReimport(
 
     val mappedPrep = prep(mappings)
     val candidates = computeReimportMerges(prep(emptyList()), mappedPrep, importCreated)
-    val rewrites = computeReimportRewrites(allRows, mappedPrep, relationshipRepository)
+    val rewrites =
+        computeReimportRewrites(allRows, mappedPrep, relationshipRepository) { transferId ->
+            transactionRepository.getTransactionById(transferId.id).first()
+        }
     val valueUpdates =
         computeReimportValueUpdates(
             allRows = allRows,
@@ -292,7 +296,8 @@ suspend fun planCsvReimport(
  * the strategy's amount/currency/date/description mappings changed since the row was imported. Only
  * value fields are compared; account differences are the domain of merges (and a persisted transfer
  * whose account was mapped away is matched pre-merge, so comparing accounts here would misfire).
- * Pass-through rows are excluded — their shape is owned by the rewrite path.
+ * Pass-through rows are excluded — value changes there invalidate every leg of the chain, so they
+ * are handled by the rewrite path instead (see [computeReimportRewrites]).
  */
 internal suspend fun computeReimportValueUpdates(
     allRows: List<CsvRow>,
@@ -338,31 +343,48 @@ private fun Money.display(): String = "${toDisplayValue()} ${currency.code}"
 
 /**
  * Finds already-imported rows whose current preparation routes them through a pass-through conduit
- * chain their existing transfer does not reflect (imported before the definitions existed, or with a
- * shorter chain). Compares the number of pass-through legs hanging off the row's transfer with the
- * chain length the current configuration produces. Only IMPORTED rows are considered — a DUPLICATE
- * row's transfer belongs to another row and must not be deleted.
+ * chain their existing transfer does not reflect: imported before the definitions existed, with a
+ * shorter chain (compared via the number of pass-through legs hanging off the row's transfer), or —
+ * when the chain itself still matches — with transfer values (amount/currency/date/description) the
+ * current strategy now computes differently, which invalidates every leg of the chain. Only IMPORTED
+ * rows are considered — a DUPLICATE row's transfer belongs to another row and must not be deleted.
+ * [existingTransferLookup] loads a row's persisted funding transfer for the value comparison; a null
+ * result skips that comparison.
  */
 internal suspend fun computeReimportRewrites(
     allRows: List<CsvRow>,
     mappedPrep: ImportPreparation,
     relationshipRepository: TransferRelationshipReadRepository,
+    existingTransferLookup: suspend (TransferId) -> Transfer?,
 ): List<ReimportRewrite> {
     val rowsByIndex = allRows.associateBy { it.rowIndex }
-    return mappedPrep.validTransfers.mapNotNull { mapped -> rewriteFor(mapped, rowsByIndex, relationshipRepository) }
+    return mappedPrep.validTransfers.mapNotNull { mapped ->
+        rewriteFor(mapped, rowsByIndex, relationshipRepository, existingTransferLookup)
+    }
 }
 
 private suspend fun rewriteFor(
     mapped: CsvTransferWithAttributes,
     rowsByIndex: Map<Long, CsvRow>,
     relationshipRepository: TransferRelationshipReadRepository,
+    existingTransferLookup: suspend (TransferId) -> Transfer?,
 ): ReimportRewrite? {
     val passThrough = mapped.passThrough ?: return null
     val row = rowsByIndex[mapped.rowIndex] ?: return null
     if (row.importStatus != ImportStatus.IMPORTED) return null
     val transferId = row.transferId ?: return null
     val linked = collectLinkedLegs(transferId, relationshipRepository)
-    if (linked.passThroughLegCount == passThrough.conduitNames.size) return null
+    val chainChanged = linked.passThroughLegCount != passThrough.conduitNames.size
+    // A value change (e.g. the strategy's amount/currency columns moved) must propagate to every
+    // spend leg of the chain, so the row is rewritten rather than updated in place.
+    val valuesChanged =
+        !chainChanged &&
+            existingTransferLookup(transferId)?.let { existing ->
+                existing.amount != mapped.transfer.amount ||
+                    existing.timestamp != mapped.transfer.timestamp ||
+                    existing.description != mapped.transfer.description
+            } == true
+    if (!chainChanged && !valuesChanged) return null
     return ReimportRewrite(
         rowIndex = row.rowIndex,
         transferIdsToDelete = linked.transferIds,

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -1,8 +1,11 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
 package com.moneymanager.csvimporter
 
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.WellKnownIds
@@ -15,8 +18,10 @@ import com.moneymanager.domain.model.passthrough.PassThroughAccount
 import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.importengineapi.AccountMergeRequest
+import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.CsvImportMutation
 import com.moneymanager.importengineapi.DedupePolicy
 import com.moneymanager.importengineapi.ImportAccountIntent
@@ -27,6 +32,7 @@ import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
 import kotlinx.coroutines.flow.first
 import org.lighthousegames.logging.logging
+import kotlin.time.Instant
 
 private val logger = logging()
 
@@ -43,6 +49,9 @@ enum class ReimportSkipReason {
 
     /** Deleting a row's old transfers for a pass-through rewrite failed; the row was left as-is. */
     REWRITE_FAILED,
+
+    /** Updating a row's transfer to its recomputed values failed; the transfer was left as-is. */
+    UPDATE_FAILED,
 }
 
 /** One duplicate-account merge the re-import will perform (or performed). */
@@ -84,14 +93,37 @@ data class ReimportRewrite(
     val merchantName: String,
 )
 
+/**
+ * One already-imported row whose recomputed values under the current strategy differ from its
+ * persisted transfer (e.g. the strategy's amount/currency columns changed): the transfer is updated
+ * in place. Accounts are deliberately NOT part of the update — account changes are the domain of
+ * merges (and pass-through rewrites), so the persisted accounts are re-sent unchanged.
+ */
+data class ReimportValueUpdate(
+    val rowIndex: Long,
+    val transferId: TransferId,
+    /** The row's statement description, for the preview. */
+    val description: String,
+    /** Human-readable "field: old → new" lines, for the preview. */
+    val changes: List<String>,
+    val newTimestamp: Instant,
+    val newDescription: String,
+    val newAmount: Money,
+    /** The persisted transfer's accounts, re-sent unchanged (the engine update requires them). */
+    val sourceAccountId: AccountId,
+    val targetAccountId: AccountId,
+)
+
 /** The read-only preview of what a re-import would do, shown for confirmation before executing. */
 data class ReimportPlan(
     val merges: List<ReimportMerge>,
     val skipped: List<ReimportSkippedAccount>,
     /** Already-imported rows to reroute through a pass-through conduit chain. */
     val rewrites: List<ReimportRewrite> = emptyList(),
+    /** Already-imported rows whose transfer values (amount/currency/date/description) changed. */
+    val valueUpdates: List<ReimportValueUpdate> = emptyList(),
 ) {
-    val isEmpty: Boolean get() = merges.isEmpty() && skipped.isEmpty() && rewrites.isEmpty()
+    val isEmpty: Boolean get() = merges.isEmpty() && skipped.isEmpty() && rewrites.isEmpty() && valueUpdates.isEmpty()
 }
 
 /** The outcome of an executed re-import. */
@@ -104,6 +136,8 @@ data class CsvReimportResult(
     val importResult: CsvImportResult?,
     /** Rows rewritten through a pass-through conduit chain (old transfers deleted + row re-imported). */
     val rewrittenRows: List<ReimportRewrite> = emptyList(),
+    /** Rows whose transfers were updated in place to the recomputed values. */
+    val updatedRows: List<ReimportValueUpdate> = emptyList(),
 )
 
 /** Raw merge detection output: duplicate → single target, plus duplicates with competing targets. */
@@ -161,9 +195,11 @@ fun computeReimportMerges(
 
 /**
  * Builds the read-only [ReimportPlan] for [csvImport] under [strategy]: which import-created accounts
- * the current mappings consolidate away (as merges), which detected duplicates cannot be merged, and
+ * the current mappings consolidate away (as merges), which detected duplicates cannot be merged,
  * which already-imported rows the current pass-through configuration reroutes through a conduit chain
- * (as rewrites). Safe to call from the UI to preview a re-import before [executeCsvReimport].
+ * (as rewrites), and which already-imported rows now map to different transfer values — a changed
+ * amount/currency/date/description column — and will be updated in place (as value updates).
+ * Safe to call from the UI to preview a re-import before [executeCsvReimport].
  */
 @Suppress("LongParameterList")
 suspend fun planCsvReimport(
@@ -174,6 +210,7 @@ suspend fun planCsvReimport(
     accountMappingRepository: AccountMappingReadRepository,
     accountRepository: AccountReadRepository,
     csvImportRepository: CsvImportReadRepository,
+    transactionRepository: TransactionReadRepository,
     relationshipRepository: TransferRelationshipReadRepository,
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
 ): ReimportPlan {
@@ -201,6 +238,13 @@ suspend fun planCsvReimport(
     val mappedPrep = prep(mappings)
     val candidates = computeReimportMerges(prep(emptyList()), mappedPrep, importCreated)
     val rewrites = computeReimportRewrites(allRows, mappedPrep, relationshipRepository)
+    val valueUpdates =
+        computeReimportValueUpdates(
+            allRows = allRows,
+            mappedPrep = mappedPrep,
+            rewrittenRowIndexes = rewrites.map { it.rowIndex }.toSet(),
+            transactionRepository = transactionRepository,
+        )
 
     val accountsById = accounts.associateBy { it.id }
 
@@ -239,8 +283,57 @@ suspend fun planCsvReimport(
                 transferCount = accountRepository.countTransfersByAccount(duplicate),
             )
     }
-    return ReimportPlan(merges = merges, skipped = skipped, rewrites = rewrites)
+    return ReimportPlan(merges = merges, skipped = skipped, rewrites = rewrites, valueUpdates = valueUpdates)
 }
+
+/**
+ * Finds already-imported rows whose recomputed transfer values differ from the persisted transfer —
+ * the strategy's amount/currency/date/description mappings changed since the row was imported. Only
+ * value fields are compared; account differences are the domain of merges (and a persisted transfer
+ * whose account was mapped away is matched pre-merge, so comparing accounts here would misfire).
+ * Pass-through rows are excluded — their shape is owned by the rewrite path.
+ */
+internal suspend fun computeReimportValueUpdates(
+    allRows: List<CsvRow>,
+    mappedPrep: ImportPreparation,
+    rewrittenRowIndexes: Set<Long>,
+    transactionRepository: TransactionReadRepository,
+): List<ReimportValueUpdate> {
+    val rowsByIndex = allRows.associateBy { it.rowIndex }
+    return mappedPrep.validTransfers.mapNotNull { mapped ->
+        if (mapped.passThrough != null || mapped.rowIndex in rewrittenRowIndexes) return@mapNotNull null
+        val row = rowsByIndex[mapped.rowIndex] ?: return@mapNotNull null
+        if (row.importStatus != ImportStatus.IMPORTED && row.importStatus != ImportStatus.UPDATED) return@mapNotNull null
+        val transferId = row.transferId ?: return@mapNotNull null
+        val existing = transactionRepository.getTransactionById(transferId.id).first() ?: return@mapNotNull null
+        val changes =
+            buildList {
+                if (mapped.transfer.amount != existing.amount) {
+                    add("amount ${existing.amount.display()} → ${mapped.transfer.amount.display()}")
+                }
+                if (mapped.transfer.timestamp != existing.timestamp) {
+                    add("date ${existing.timestamp} → ${mapped.transfer.timestamp}")
+                }
+                if (mapped.transfer.description != existing.description) {
+                    add("description '${existing.description}' → '${mapped.transfer.description}'")
+                }
+            }
+        if (changes.isEmpty()) return@mapNotNull null
+        ReimportValueUpdate(
+            rowIndex = mapped.rowIndex,
+            transferId = transferId,
+            description = mapped.transfer.description,
+            changes = changes,
+            newTimestamp = mapped.transfer.timestamp,
+            newDescription = mapped.transfer.description,
+            newAmount = mapped.transfer.amount,
+            sourceAccountId = existing.sourceAccountId,
+            targetAccountId = existing.targetAccountId,
+        )
+    }
+}
+
+private fun Money.display(): String = "${toDisplayValue()} ${currency.code}"
 
 /**
  * Finds already-imported rows whose current preparation routes them through a pass-through conduit
@@ -323,15 +416,18 @@ private suspend fun collectLinkedLegs(
 
 /**
  * Executes a re-import of [csvImport] under [strategy] following a confirmed [plan]:
- * 1. merges each planned duplicate into its target (reversible via the account-merge history) —
+ * 1. updates each planned value-changed row's transfer in place (amount/currency/date/description) —
+ *    BEFORE the merges, while the persisted account ids the updates re-send still exist (a merge
+ *    deletes the duplicate account and moves its transfers, updated ones included);
+ * 2. merges each planned duplicate into its target (reversible via the account-merge history) —
  *    merging BEFORE re-running rows is required, otherwise dedupe would look for existing transfers
  *    on the newly-mapped accounts, miss the ones still sitting on the duplicates, and import them twice;
- * 2. rewrites each planned pass-through row: deletes its old transfer(s) and resets the row's status —
+ * 3. rewrites each planned pass-through row: deletes its old transfer(s) and resets the row's status —
  *    deleting BEFORE re-running rows for the same reason (dedupe must not match the stale transfer);
- * 3. re-runs the strategy over rows never imported, errored, or just reset, which now resolve via the
+ * 4. re-runs the strategy over rows never imported, errored, or just reset, which now resolve via the
  *    new mappings and route through the current pass-through chains;
- * 4. deletes import-created accounts left with no transfers (e.g. the raw "CRV*…" merchants);
- * 5. refreshes materialized views.
+ * 5. deletes import-created accounts left with no transfers (e.g. the raw "CRV*…" merchants);
+ * 6. refreshes materialized views.
  */
 @Suppress("LongParameterList")
 suspend fun executeCsvReimport(
@@ -349,6 +445,8 @@ suspend fun executeCsvReimport(
 ): CsvReimportResult {
     val merged = mutableListOf<ReimportMerge>()
     val skipped = plan.skipped.toMutableList()
+
+    val updatedRows = applyValueUpdates(plan.valueUpdates, csvImport, importEngine, skipped)
 
     // One batch per merge so a surprise failure (races past the read-only pre-checks) downgrades to a
     // per-account skip instead of aborting the remaining merges.
@@ -429,7 +527,73 @@ suspend fun executeCsvReimport(
         deletedEmptyAccounts = deletedEmptyAccounts,
         importResult = importResult,
         rewrittenRows = rewritten,
+        updatedRows = updatedRows,
     )
+}
+
+/**
+ * Applies the planned in-place transfer updates: one atomic batch (updates + row-status writeback to
+ * UPDATED) with a per-row fallback so one bad row downgrades to a skip instead of blocking the rest.
+ * Returns the updates that were applied; failures are appended to [skipped].
+ */
+private suspend fun applyValueUpdates(
+    valueUpdates: List<ReimportValueUpdate>,
+    csvImport: CsvImport,
+    importEngine: ImportEngine,
+    skipped: MutableList<ReimportSkippedAccount>,
+): List<ReimportValueUpdate> {
+    if (valueUpdates.isEmpty()) return emptyList()
+
+    fun batchFor(updates: List<ReimportValueUpdate>) =
+        ImportBatch(
+            transfers =
+                updates.map { update ->
+                    ImportTransfer(
+                        source = Source.Csv(csvImport.id, update.rowIndex),
+                        operation = ImportOperation.UPDATE,
+                        existingId = update.transferId,
+                        fromAccount = AccountRef.Existing(update.sourceAccountId),
+                        toAccount = AccountRef.Existing(update.targetAccountId),
+                        timestamp = update.newTimestamp,
+                        description = update.newDescription,
+                        amount = update.newAmount,
+                    )
+                },
+            dedupePolicy = DedupePolicy.None,
+            csvImportMutations =
+                listOf(
+                    CsvImportMutation.UpdateRowStatuses(
+                        id = csvImport.id,
+                        status = ImportStatus.UPDATED.name,
+                        rowTransferMap = updates.associate { it.rowIndex to it.transferId },
+                    ),
+                ),
+        )
+
+    try {
+        importEngine.import(batchFor(valueUpdates))
+        return valueUpdates
+    } catch (expected: Exception) {
+        logger.warn(expected) { "Bulk re-import value update failed, falling back to per-row updates" }
+    }
+
+    val updated = mutableListOf<ReimportValueUpdate>()
+    for (update in valueUpdates) {
+        try {
+            importEngine.import(batchFor(listOf(update)))
+            updated += update
+        } catch (expected: Exception) {
+            logger.warn(expected) { "Re-import value update of row ${update.rowIndex} ('${update.description}') failed" }
+            skipped +=
+                ReimportSkippedAccount(
+                    accountId = null,
+                    accountName = update.description,
+                    reason = ReimportSkipReason.UPDATE_FAILED,
+                    detail = expected.message ?: "Update failed",
+                )
+        }
+    }
+    return updated
 }
 
 /**

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvReimportDetectionTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvReimportDetectionTest.kt
@@ -6,6 +6,7 @@ import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.RelationshipType
 import com.moneymanager.domain.model.RelationshipTypeId
 import com.moneymanager.domain.model.TransferId
@@ -435,7 +436,7 @@ class CsvReimportDetectionTest {
             val mappedPrep = prep(rows, accounts, emptyList(), passThroughAccounts = listOf(curve))
 
             val rewrites =
-                computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(emptyMap()))
+                computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(emptyMap())) { null }
 
             val rewrite = rewrites.single()
             assertEquals(1L, rewrite.rowIndex)
@@ -456,9 +457,39 @@ class CsvReimportDetectionTest {
                     TransferId(100) to listOf(TransferRelationship(TransferId(100), TransferId(101), passThroughType)),
                 )
 
-            val rewrites = computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(relationships))
+            val rewrites = computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(relationships)) { null }
 
             assertTrue(rewrites.isEmpty())
+        }
+
+    @Test
+    fun `pass-through row with matching chain but changed transfer values is rewritten`() =
+        runTest {
+            val accounts = listOf(account(5, "Curve"), account(10, "Amazoncouk 1234"))
+            val rows = listOf(importedRow("Crv*Amazoncouk 1234"))
+            val mappedPrep = prep(rows, accounts, emptyList(), passThroughAccounts = listOf(curve))
+            val relationships =
+                mapOf(
+                    TransferId(100) to listOf(TransferRelationship(TransferId(100), TransferId(101), passThroughType)),
+                )
+            val recomputed = mappedPrep.validTransfers.single().transfer
+
+            // Persisted funding leg identical to the recomputed row → nothing to rewrite.
+            val unchanged =
+                computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(relationships)) {
+                    recomputed.copy(id = TransferId(100))
+                }
+            assertTrue(unchanged.isEmpty())
+
+            // Persisted funding leg carries a different amount (e.g. the strategy's amount/currency
+            // columns changed) → the whole chain is rewritten, old legs deleted.
+            val staleExisting = recomputed.copy(id = TransferId(100), amount = Money(9999, currency))
+            val rewrites =
+                computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(relationships)) { staleExisting }
+
+            val rewrite = rewrites.single()
+            assertEquals(listOf(TransferId(100), TransferId(101)), rewrite.transferIdsToDelete)
+            assertEquals(listOf("Curve"), rewrite.conduitNames)
         }
 
     @Test
@@ -486,7 +517,7 @@ class CsvReimportDetectionTest {
                     TransferId(100) to listOf(TransferRelationship(TransferId(100), TransferId(101), passThroughType)),
                 )
 
-            val rewrites = computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(relationships))
+            val rewrites = computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(relationships)) { null }
 
             val rewrite = rewrites.single()
             assertEquals(listOf("Curve", "PayPal"), rewrite.conduitNames)
@@ -512,7 +543,7 @@ class CsvReimportDetectionTest {
                 )
             val mappedPrep = prep(rows, accounts, emptyList(), passThroughAccounts = listOf(curve))
 
-            val rewrites = computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(emptyMap()))
+            val rewrites = computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(emptyMap())) { null }
 
             assertTrue(rewrites.isEmpty())
         }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -601,6 +601,7 @@ fun MoneyManagerApp(
                                             personRepository = services.people.personRepository,
                                             passThroughAccountRepository = services.imports.passThroughAccountRepository,
                                             maintenance = services.imports.maintenance,
+                                            transactionRepository = services.transactions.transactionRepository,
                                             transferSourceRepository = services.transactions.transferSourceRepository,
                                             transferRelationshipRepository = services.transactions.transferRelationshipRepository,
                                             importEngine = services.transactions.importEngine,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvReimportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvReimportE2ETest.kt
@@ -18,6 +18,7 @@ import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.CsvImport
+import com.moneymanager.domain.model.csv.ImportStatus
 import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
 import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
@@ -90,15 +91,15 @@ class CsvReimportE2ETest {
                 Account(id = AccountId(0), name = "Amazon", openingDate = Clock.System.now()),
             )
 
-        val headers = listOf("Date", "Description", "Amount", "Payee")
+        val headers = listOf("Date", "Description", "Amount", "Payee", "Local Amount")
         val csvImportId =
             dc.csvImportRepository.createImport(
                 fileName = "reimport_test.csv",
                 headers = headers,
                 rows =
                     listOf(
-                        listOf("15/12/2024", "Order 1", "-50.00", DUPLICATE_NAME),
-                        listOf("16/12/2024", "Order 2", "-25.00", DUPLICATE_NAME),
+                        listOf("15/12/2024", "Order 1", "-50.00", DUPLICATE_NAME, "-40.00"),
+                        listOf("16/12/2024", "Order 2", "-25.00", DUPLICATE_NAME, "-20.00"),
                     ),
                 fileChecksum = "reimport_test_checksum",
                 fileLastModified = Instant.fromEpochMilliseconds(1_700_000_000_000L),
@@ -175,6 +176,7 @@ class CsvReimportE2ETest {
                     accountMappingRepository = dc.accountMappingRepository,
                     accountRepository = dc.accountRepository,
                     csvImportRepository = dc.csvImportRepository,
+                    transactionRepository = dc.transactionRepository,
                     relationshipRepository = dc.transferRelationshipRepository,
                 )
             assertEquals(1, plan.merges.size)
@@ -253,6 +255,7 @@ class CsvReimportE2ETest {
                     accountMappingRepository = dc.accountMappingRepository,
                     accountRepository = dc.accountRepository,
                     csvImportRepository = dc.csvImportRepository,
+                    transactionRepository = dc.transactionRepository,
                     relationshipRepository = dc.transferRelationshipRepository,
                 )
             assertTrue(plan.merges.isEmpty())
@@ -278,6 +281,107 @@ class CsvReimportE2ETest {
             // The duplicate keeps its transactions and must not be deleted.
             assertEquals(duplicateId, fixture.duplicateAccountId())
             assertEquals(3L, dc.accountRepository.countTransfersByAccount(duplicateId))
+        }
+
+    @Test
+    fun `re-import updates transfers in place when amount and currency mappings changed`() =
+        runBlocking {
+            val fixture = setUpImportedCsv()
+            val dc = fixture.dc
+
+            val rowsBefore = dc.csvImportRepository.getImportRows(fixture.csvImport.id, limit = 1000, offset = 0)
+            val transferIdsBefore = rowsBefore.mapNotNull { it.transferId }
+            assertEquals(2, transferIdsBefore.size)
+
+            // The user edits the strategy to read the amount from a different column in a different currency.
+            val currencies = dc.currencyRepository.getAllCurrencies().first()
+            val usd = currencies.first { it.code == "USD" }
+            val changedStrategy =
+                fixture.strategy.copy(
+                    fieldMappings =
+                        fixture.strategy.fieldMappings +
+                            mapOf(
+                                TransferField.AMOUNT to
+                                    AmountParsingMapping(
+                                        id = FieldMappingId(Uuid.random()),
+                                        fieldType = TransferField.AMOUNT,
+                                        mode = AmountMode.SINGLE_COLUMN,
+                                        amountColumnName = "Local Amount",
+                                    ),
+                                TransferField.CURRENCY to
+                                    HardCodedCurrencyMapping(
+                                        id = FieldMappingId(Uuid.random()),
+                                        fieldType = TransferField.CURRENCY,
+                                        currencyId = usd.id,
+                                    ),
+                            ),
+                )
+
+            val plan =
+                planCsvReimport(
+                    csvImport = fixture.csvImport,
+                    strategy = changedStrategy,
+                    sourceAccountOverride = fixture.sourceAccountId,
+                    currencies = currencies,
+                    accountMappingRepository = dc.accountMappingRepository,
+                    accountRepository = dc.accountRepository,
+                    csvImportRepository = dc.csvImportRepository,
+                    transactionRepository = dc.transactionRepository,
+                    relationshipRepository = dc.transferRelationshipRepository,
+                )
+            assertTrue(plan.merges.isEmpty())
+            assertTrue(plan.skipped.isEmpty())
+            assertEquals(2, plan.valueUpdates.size)
+            assertTrue(plan.valueUpdates.all { it.changes.isNotEmpty() })
+
+            val result =
+                executeCsvReimport(
+                    plan = plan,
+                    csvImport = fixture.csvImport,
+                    strategy = changedStrategy,
+                    sourceAccountOverride = fixture.sourceAccountId,
+                    currencies = currencies,
+                    accountMappingRepository = dc.accountMappingRepository,
+                    accountRepository = dc.accountRepository,
+                    csvImportRepository = dc.csvImportRepository,
+                    maintenance = DbMaintenance(dc.maintenanceService),
+                    importEngine = fixture.importEngine,
+                )
+            assertEquals(2, result.updatedRows.size)
+            assertTrue(result.skipped.isEmpty())
+            // All rows were already imported, so nothing was re-imported (no duplicates created).
+            assertNull(result.importResult)
+
+            // The same transfers now carry the new column's values in the new currency.
+            val rowsAfter = dc.csvImportRepository.getImportRows(fixture.csvImport.id, limit = 1000, offset = 0)
+            assertEquals(transferIdsBefore, rowsAfter.mapNotNull { it.transferId })
+            assertTrue(rowsAfter.all { it.importStatus == ImportStatus.UPDATED })
+            val amountsById =
+                transferIdsBefore.associateWith { id ->
+                    dc.transactionRepository
+                        .getTransactionById(id.id)
+                        .first()
+                        ?.amount
+                }
+            assertEquals(
+                setOf(Money(4000, usd), Money(2000, usd)),
+                amountsById.values.filterNotNull().toSet(),
+            )
+
+            // Re-planning right after finds nothing left to update.
+            val secondPlan =
+                planCsvReimport(
+                    csvImport = fixture.csvImport,
+                    strategy = changedStrategy,
+                    sourceAccountOverride = fixture.sourceAccountId,
+                    currencies = currencies,
+                    accountMappingRepository = dc.accountMappingRepository,
+                    accountRepository = dc.accountRepository,
+                    csvImportRepository = dc.csvImportRepository,
+                    transactionRepository = dc.transactionRepository,
+                    relationshipRepository = dc.transferRelationshipRepository,
+                )
+            assertTrue(secondPlan.valueUpdates.isEmpty())
         }
 
     private fun createImportEngine(dc: DatabaseComponent): ImportEngine =

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
@@ -42,6 +42,7 @@ import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
+import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.domain.repository.TransferSourceReadRepository
 import com.moneymanager.importengineapi.ImportEngine
@@ -67,6 +68,7 @@ fun CsvImportDetailScreen(
     personRepository: PersonReadRepository,
     passThroughAccountRepository: PassThroughAccountReadRepository,
     maintenance: Maintenance,
+    transactionRepository: TransactionReadRepository,
     transferSourceRepository: TransferSourceReadRepository,
     transferRelationshipRepository: TransferRelationshipReadRepository,
     importEngine: ImportEngine,
@@ -454,6 +456,7 @@ fun CsvImportDetailScreen(
             currencyRepository = currencyRepository,
             personRepository = personRepository,
             passThroughAccountRepository = passThroughAccountRepository,
+            transactionRepository = transactionRepository,
             transferRelationshipRepository = transferRelationshipRepository,
             maintenance = maintenance,
             importEngine = importEngine,
@@ -468,6 +471,9 @@ fun CsvImportDetailScreen(
                         if (moved > 0) append(" ($moved transaction(s) moved)")
                         if (result.rewrittenRows.isNotEmpty()) {
                             append(", ${result.rewrittenRows.size} row(s) rerouted through pass-through accounts")
+                        }
+                        if (result.updatedRows.isNotEmpty()) {
+                            append(", ${result.updatedRows.size} transaction(s) updated to new values")
                         }
                         result.importResult?.let { append(", ${it.successCount} row(s) imported") }
                         if (result.deletedEmptyAccounts.isNotEmpty()) {

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
@@ -42,6 +42,7 @@ import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
+import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.ui.components.AccountPicker
@@ -55,11 +56,14 @@ import org.lighthousegames.logging.logging
 
 private val logger = logging()
 
+private const val VALUE_UPDATE_PREVIEW_LIMIT = 20
+
 /**
- * Re-imports an already-imported CSV so newly added account mappings take effect retroactively:
- * shows a read-only preview of the duplicate-account merges the current mappings imply, then (on
- * confirm) merges them, re-runs the strategy over never-imported/errored rows, and deletes
- * import-created accounts left empty.
+ * Re-imports an already-imported CSV so strategy/mapping changes take effect retroactively: shows a
+ * read-only preview of the duplicate-account merges the current mappings imply and the transactions
+ * whose values the current strategy now computes differently, then (on confirm) merges/updates them,
+ * re-runs the strategy over never-imported/errored rows, and deletes import-created accounts left
+ * empty.
  */
 @Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 @Composable
@@ -74,6 +78,7 @@ fun ReimportDialog(
     currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
     passThroughAccountRepository: PassThroughAccountReadRepository,
+    transactionRepository: TransactionReadRepository,
     transferRelationshipRepository: TransferRelationshipReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
@@ -128,6 +133,7 @@ fun ReimportDialog(
                     accountMappingRepository = accountMappingRepository,
                     accountRepository = accountRepository,
                     csvImportRepository = csvImportRepository,
+                    transactionRepository = transactionRepository,
                     relationshipRepository = transferRelationshipRepository,
                     passThroughAccounts = passThroughAccounts,
                 )
@@ -276,6 +282,36 @@ private fun ReimportPlanPreview(
         } else {
             Text(
                 text = "No duplicate accounts to merge under the current account mappings.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (plan.valueUpdates.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Transactions to update to the strategy's current values (${plan.valueUpdates.size}):",
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            plan.valueUpdates.take(VALUE_UPDATE_PREVIEW_LIMIT).forEach { update ->
+                Text(
+                    text = "• ${update.description}: ${update.changes.joinToString("; ")}",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            if (plan.valueUpdates.size > VALUE_UPDATE_PREVIEW_LIMIT) {
+                Text(
+                    text = "…and ${plan.valueUpdates.size - VALUE_UPDATE_PREVIEW_LIMIT} more",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text =
+                    "Each transaction is updated in place — including over any manual edits made to " +
+                        "its amount, date or description.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )


### PR DESCRIPTION
## What

CSV re-import now reprocesses the **full** import: already-imported rows whose recomputed transfer values differ under the current strategy are updated in place, instead of being silently skipped.

## Why

Re-import previously handled only account merges, pass-through rewrites, and never-imported/errored rows. Changing a strategy's amount/currency/date/description mappings — e.g. switching the Crypto.com strategy from `Amount`/`Currency` to `Native Amount`/`Native Currency` — had no effect on the transfers those rows had already created.

## How

- `computeReimportValueUpdates` (`CsvReimport.kt`) recomputes every `IMPORTED`/`UPDATED` row under the current strategy and diffs amount, currency, timestamp and description against the persisted transfer. Matching is by the row's stored transfer id — no dedupe heuristics, so no duplicate risk.
- `executeCsvReimport` applies the diffs as in-place engine `UPDATE` intents (same transfer ids, audit-trailed) in one atomic batch with a per-row fallback, **before** the merges while the re-sent account ids still exist, and marks the rows `UPDATED`.
- Accounts are deliberately excluded from the diff (account moves are the merge feature's domain); pass-through rows stay with the rewrite path.
- `ReimportDialog` previews the pending updates (first 20, with an "…and N more" count) and warns that manual edits to those transfers are overwritten; the completion message reports the update count.

## Testing

New E2E test in `CsvReimportE2ETest`: import, change the strategy's amount column + hard-coded currency, plan detects both rows, execute updates the same transfer ids to the new values with `UPDATED` statuses, and a second plan finds nothing left to update. `./gradlew build buildHealth` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV re-import now detects when existing transfers’ values (amount/currency/timestamp/description) have changed and applies those updates in place.
  * The re-import preview and completion message now surface planned value updates (with a capped “more” list) and include them in results.
* **Bug Fixes**
  * Value-only re-imports keep the affected transaction links intact, and update failures are reported as skipped items.
* **Tests**
  * Added end-to-end coverage for in-place value updates and updated related re-import test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->