### PR TITLE
Determinate progress reporting in the CSV re-import dialog

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -32,6 +32,7 @@ import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.ImportFee
 import com.moneymanager.importengineapi.ImportPassThrough
+import com.moneymanager.importengineapi.ImportProgress
 import com.moneymanager.importengineapi.ImportRowKey
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.PassThroughDetector
@@ -136,6 +137,7 @@ suspend fun bulkApplyCsv(
  * run result (null when there are no rows left to import). Unlike [bulkApplyCsv] the strategy is given,
  * not auto-matched — used by the import-directory scanner, which pins one strategy per directory.
  * [refreshViews] = false lets a caller batch many files and refresh once at the end.
+ * [onProgress]/[engineBatchSize] are forwarded to the engine so a caller can show per-chunk progress.
  */
 @Suppress("LongParameterList")
 suspend fun applyStagedCsv(
@@ -150,6 +152,8 @@ suspend fun applyStagedCsv(
     importEngine: ImportEngine,
     refreshViews: Boolean,
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
+    onProgress: (suspend (ImportProgress) -> Unit)? = null,
+    engineBatchSize: Int = Int.MAX_VALUE,
 ): CsvImportResult? {
     val allRows = csvImportRepository.getImportRows(csvImport.id, limit = csvImport.rowCount.coerceAtLeast(1), offset = 0)
     val rows = allRows.filter { it.importStatus == null || it.importStatus == ImportStatus.ERROR }
@@ -191,6 +195,8 @@ suspend fun applyStagedCsv(
         importEngine = importEngine,
         refreshViews = refreshViews,
         passThroughAccounts = passThroughAccounts,
+        onProgress = onProgress,
+        engineBatchSize = engineBatchSize,
     )
 }
 
@@ -360,6 +366,8 @@ suspend fun runCsvImport(
     importEngine: ImportEngine,
     refreshViews: Boolean = true,
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
+    onProgress: (suspend (ImportProgress) -> Unit)? = null,
+    engineBatchSize: Int = Int.MAX_VALUE,
 ): CsvImportResult {
     logger.info { "Starting CSV import with ${basePrep.validTransfers.size} valid transfers" }
 
@@ -564,7 +572,7 @@ suspend fun runCsvImport(
                 },
         )
 
-    val importResult = importEngine.import(batch)
+    val importResult = importEngine.import(batch, onProgress = onProgress, batchSize = engineBatchSize)
 
     // Write back per-row CSV statuses from the engine outcome.
     val importedStatuses = mutableMapOf<Long, TransferId?>()

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -29,6 +29,7 @@ import com.moneymanager.importengineapi.ImportAccountIntent
 import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.ImportOperation
+import com.moneymanager.importengineapi.ImportProgress
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
 import kotlinx.coroutines.flow.first
@@ -37,6 +38,15 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 private val logger = logging()
+
+/** How often the per-row plan-phase scans report progress. */
+private const val PLAN_PROGRESS_EVERY_ROWS = 25
+
+/** Engine write-chunk size for the re-run of remaining rows, so it reports per-chunk progress. */
+private const val REIMPORT_ENGINE_BATCH_SIZE = 250
+
+/** Default number of in-place transfer updates applied per engine batch. */
+internal const val REIMPORT_VALUE_UPDATE_CHUNK = 100
 
 /** Why a duplicate account detected during re-import was not merged. */
 enum class ReimportSkipReason {
@@ -202,6 +212,7 @@ fun computeReimportMerges(
  * (as rewrites), and which already-imported rows now map to different transfer values — a changed
  * amount/currency/date/description column — and will be updated in place (as value updates).
  * Safe to call from the UI to preview a re-import before [executeCsvReimport].
+ * [onProgress] reports the plan phases (with per-row counts for the row scans) for a progress UI.
  */
 @Suppress("LongParameterList")
 suspend fun planCsvReimport(
@@ -215,7 +226,9 @@ suspend fun planCsvReimport(
     transactionRepository: TransactionReadRepository,
     relationshipRepository: TransferRelationshipReadRepository,
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
+    onProgress: (suspend (ImportProgress) -> Unit)? = null,
 ): ReimportPlan {
+    onProgress?.invoke(ImportProgress("Loading rows"))
     val allRows = csvImportRepository.getImportRows(csvImport.id, limit = csvImport.rowCount.coerceAtLeast(1), offset = 0)
     if (allRows.isEmpty()) return ReimportPlan(emptyList(), emptyList())
 
@@ -237,10 +250,12 @@ suspend fun planCsvReimport(
             historicalAccountNames,
         ).prepareImport(allRows)
 
+    onProgress?.invoke(ImportProgress("Analyzing rows (pass 1 of 2)"))
     val mappedPrep = prep(mappings)
+    onProgress?.invoke(ImportProgress("Analyzing rows (pass 2 of 2)"))
     val candidates = computeReimportMerges(prep(emptyList()), mappedPrep, importCreated)
     val rewrites =
-        computeReimportRewrites(allRows, mappedPrep, relationshipRepository) { transferId ->
+        computeReimportRewrites(allRows, mappedPrep, relationshipRepository, onProgress) { transferId ->
             transactionRepository.getTransactionById(transferId.id).first()
         }
     val valueUpdates =
@@ -249,6 +264,7 @@ suspend fun planCsvReimport(
             mappedPrep = mappedPrep,
             rewrittenRowIndexes = rewrites.map { it.rowIndex }.toSet(),
             transactionRepository = transactionRepository,
+            onProgress = onProgress,
         )
 
     val accountsById = accounts.associateBy { it.id }
@@ -258,6 +274,7 @@ suspend fun planCsvReimport(
     val merges = mutableListOf<ReimportMerge>()
     val skipped = mutableListOf<ReimportSkippedAccount>()
 
+    onProgress?.invoke(ImportProgress("Checking duplicate accounts"))
     for ((duplicate, targets) in candidates.conflicts) {
         skipped +=
             ReimportSkippedAccount(
@@ -304,42 +321,70 @@ internal suspend fun computeReimportValueUpdates(
     mappedPrep: ImportPreparation,
     rewrittenRowIndexes: Set<Long>,
     transactionRepository: TransactionReadRepository,
+    onProgress: (suspend (ImportProgress) -> Unit)? = null,
 ): List<ReimportValueUpdate> {
     val rowsByIndex = allRows.associateBy { it.rowIndex }
-    return mappedPrep.validTransfers.mapNotNull { mapped ->
-        if (mapped.passThrough != null || mapped.rowIndex in rewrittenRowIndexes) return@mapNotNull null
-        val row = rowsByIndex[mapped.rowIndex] ?: return@mapNotNull null
-        if (row.importStatus != ImportStatus.IMPORTED && row.importStatus != ImportStatus.UPDATED) return@mapNotNull null
-        val transferId = row.transferId ?: return@mapNotNull null
-        val existing = transactionRepository.getTransactionById(transferId.id).first() ?: return@mapNotNull null
-        val changes =
-            buildList {
-                if (mapped.transfer.amount != existing.amount) {
-                    add("amount ${existing.amount.display()} → ${mapped.transfer.amount.display()}")
-                }
-                if (mapped.transfer.timestamp != existing.timestamp) {
-                    add("date ${existing.timestamp} → ${mapped.transfer.timestamp}")
-                }
-                if (mapped.transfer.description != existing.description) {
-                    add("description '${existing.description}' → '${mapped.transfer.description}'")
-                }
-            }
-        if (changes.isEmpty()) return@mapNotNull null
-        ReimportValueUpdate(
-            rowIndex = mapped.rowIndex,
-            transferId = transferId,
-            description = mapped.transfer.description,
-            changes = changes,
-            newTimestamp = mapped.transfer.timestamp,
-            newDescription = mapped.transfer.description,
-            newAmount = mapped.transfer.amount,
-            sourceAccountId = existing.sourceAccountId,
-            targetAccountId = existing.targetAccountId,
-        )
+    val updates = mutableListOf<ReimportValueUpdate>()
+    val total = mappedPrep.validTransfers.size
+    mappedPrep.validTransfers.forEachIndexed { index, mapped ->
+        emitRowProgress(onProgress, "Checking rows for value changes", index, total)
+        valueUpdateFor(mapped, rowsByIndex, rewrittenRowIndexes, transactionRepository)?.let { updates += it }
     }
+    return updates
+}
+
+private suspend fun valueUpdateFor(
+    mapped: CsvTransferWithAttributes,
+    rowsByIndex: Map<Long, CsvRow>,
+    rewrittenRowIndexes: Set<Long>,
+    transactionRepository: TransactionReadRepository,
+): ReimportValueUpdate? {
+    if (mapped.passThrough != null || mapped.rowIndex in rewrittenRowIndexes) return null
+    val row = rowsByIndex[mapped.rowIndex] ?: return null
+    if (row.importStatus != ImportStatus.IMPORTED && row.importStatus != ImportStatus.UPDATED) return null
+    val transferId = row.transferId ?: return null
+    val existing = transactionRepository.getTransactionById(transferId.id).first() ?: return null
+    val changes =
+        buildList {
+            if (mapped.transfer.amount != existing.amount) {
+                add("amount ${existing.amount.display()} → ${mapped.transfer.amount.display()}")
+            }
+            if (mapped.transfer.timestamp != existing.timestamp) {
+                add("date ${existing.timestamp} → ${mapped.transfer.timestamp}")
+            }
+            if (mapped.transfer.description != existing.description) {
+                add("description '${existing.description}' → '${mapped.transfer.description}'")
+            }
+        }
+    if (changes.isEmpty()) return null
+    return ReimportValueUpdate(
+        rowIndex = mapped.rowIndex,
+        transferId = transferId,
+        description = mapped.transfer.description,
+        changes = changes,
+        newTimestamp = mapped.transfer.timestamp,
+        newDescription = mapped.transfer.description,
+        newAmount = mapped.transfer.amount,
+        sourceAccountId = existing.sourceAccountId,
+        targetAccountId = existing.targetAccountId,
+    )
 }
 
 private fun Money.display(): String = "${toDisplayValue()} ${currency.code}"
+
+/** Emits a throttled per-row [ImportProgress] (every [PLAN_PROGRESS_EVERY_ROWS] rows and at the end). */
+private suspend fun emitRowProgress(
+    onProgress: (suspend (ImportProgress) -> Unit)?,
+    detail: String,
+    index: Int,
+    total: Int,
+) {
+    if (onProgress == null) return
+    val processed = index + 1
+    if (processed % PLAN_PROGRESS_EVERY_ROWS == 0 || processed == total) {
+        onProgress(ImportProgress(detail, fraction = processed.toFloat() / total, processed = processed, total = total))
+    }
+}
 
 /**
  * Finds already-imported rows whose current preparation routes them through a pass-through conduit
@@ -355,12 +400,17 @@ internal suspend fun computeReimportRewrites(
     allRows: List<CsvRow>,
     mappedPrep: ImportPreparation,
     relationshipRepository: TransferRelationshipReadRepository,
+    onProgress: (suspend (ImportProgress) -> Unit)? = null,
     existingTransferLookup: suspend (TransferId) -> Transfer?,
 ): List<ReimportRewrite> {
     val rowsByIndex = allRows.associateBy { it.rowIndex }
-    return mappedPrep.validTransfers.mapNotNull { mapped ->
-        rewriteFor(mapped, rowsByIndex, relationshipRepository, existingTransferLookup)
+    val rewrites = mutableListOf<ReimportRewrite>()
+    val total = mappedPrep.validTransfers.size
+    mappedPrep.validTransfers.forEachIndexed { index, mapped ->
+        emitRowProgress(onProgress, "Checking pass-through rows", index, total)
+        rewriteFor(mapped, rowsByIndex, relationshipRepository, existingTransferLookup)?.let { rewrites += it }
     }
+    return rewrites
 }
 
 private suspend fun rewriteFor(
@@ -451,6 +501,9 @@ private suspend fun collectLinkedLegs(
  *    new mappings and route through the current pass-through chains;
  * 5. deletes import-created accounts left with no transfers (e.g. the raw "CRV*…" merchants);
  * 6. refreshes materialized views.
+ *
+ * [onProgress] reports each step (with counts where known) for a progress UI. [valueUpdateChunkSize]
+ * is exposed for tests to force multiple update chunks with a small fixture.
  */
 @Suppress("LongParameterList")
 suspend fun executeCsvReimport(
@@ -465,15 +518,25 @@ suspend fun executeCsvReimport(
     maintenance: Maintenance,
     importEngine: ImportEngine,
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
+    onProgress: (suspend (ImportProgress) -> Unit)? = null,
+    valueUpdateChunkSize: Int = REIMPORT_VALUE_UPDATE_CHUNK,
 ): CsvReimportResult {
     val merged = mutableListOf<ReimportMerge>()
     val skipped = plan.skipped.toMutableList()
 
-    val updatedRows = applyValueUpdates(plan.valueUpdates, csvImport, importEngine, skipped)
+    val updatedRows = applyValueUpdates(plan.valueUpdates, csvImport, importEngine, skipped, onProgress, valueUpdateChunkSize)
 
     // One batch per merge so a surprise failure (races past the read-only pre-checks) downgrades to a
     // per-account skip instead of aborting the remaining merges.
-    for (merge in plan.merges) {
+    for ((index, merge) in plan.merges.withIndex()) {
+        onProgress?.invoke(
+            ImportProgress(
+                "Merging accounts",
+                fraction = index.toFloat() / plan.merges.size,
+                processed = index,
+                total = plan.merges.size,
+            ),
+        )
         try {
             importEngine.import(
                 ImportBatch.manualEdits(
@@ -496,7 +559,15 @@ suspend fun executeCsvReimport(
     // One batch per rewrite so a failure downgrades to a per-row skip; the deletes and the row-status
     // reset ride in the same batch, so a row never loses its transfers without being queued for re-run.
     val rewritten = mutableListOf<ReimportRewrite>()
-    for (rewrite in plan.rewrites) {
+    for ((index, rewrite) in plan.rewrites.withIndex()) {
+        onProgress?.invoke(
+            ImportProgress(
+                "Rewriting pass-through rows",
+                fraction = index.toFloat() / plan.rewrites.size,
+                processed = index,
+                total = plan.rewrites.size,
+            ),
+        )
         try {
             importEngine.import(
                 ImportBatch(
@@ -538,10 +609,14 @@ suspend fun executeCsvReimport(
             importEngine = importEngine,
             refreshViews = false,
             passThroughAccounts = passThroughAccounts,
+            onProgress = onProgress,
+            engineBatchSize = REIMPORT_ENGINE_BATCH_SIZE,
         )
 
+    onProgress?.invoke(ImportProgress("Cleaning up empty accounts"))
     val deletedEmptyAccounts = deleteEmptyImportCreatedAccounts(csvImport, accountRepository, csvImportRepository, importEngine)
 
+    onProgress?.invoke(ImportProgress("Refreshing views"))
     maintenance.refreshMaterializedViews()
 
     return CsvReimportResult(
@@ -555,15 +630,21 @@ suspend fun executeCsvReimport(
 }
 
 /**
- * Applies the planned in-place transfer updates: one atomic batch (updates + row-status writeback to
- * UPDATED) with a per-row fallback so one bad row downgrades to a skip instead of blocking the rest.
- * Returns the updates that were applied; failures are appended to [skipped].
+ * Applies the planned in-place transfer updates in chunks of [chunkSize], each an engine batch of
+ * UPDATE intents plus the matching row-status writeback to UPDATED. Chunking exists for progress
+ * reporting and costs nothing in atomicity: the engine's UPDATE phase applies intents one repository
+ * call at a time (it never wraps them in a single transaction), so even a single big batch was never
+ * all-or-nothing. A failing chunk falls back to per-row updates so one bad row downgrades to a skip
+ * instead of blocking the rest. Returns the updates that were applied; failures are appended to
+ * [skipped].
  */
 private suspend fun applyValueUpdates(
     valueUpdates: List<ReimportValueUpdate>,
     csvImport: CsvImport,
     importEngine: ImportEngine,
     skipped: MutableList<ReimportSkippedAccount>,
+    onProgress: (suspend (ImportProgress) -> Unit)? = null,
+    chunkSize: Int = REIMPORT_VALUE_UPDATE_CHUNK,
 ): List<ReimportValueUpdate> {
     if (valueUpdates.isEmpty()) return emptyList()
 
@@ -593,28 +674,38 @@ private suspend fun applyValueUpdates(
                 ),
         )
 
-    try {
-        importEngine.import(batchFor(valueUpdates))
-        return valueUpdates
-    } catch (expected: Exception) {
-        logger.warn(expected) { "Bulk re-import value update failed, falling back to per-row updates" }
-    }
-
+    val total = valueUpdates.size
     val updated = mutableListOf<ReimportValueUpdate>()
-    for (update in valueUpdates) {
+    var done = 0
+    onProgress?.invoke(ImportProgress("Updating transactions", fraction = 0f, processed = 0, total = total))
+    for (chunk in valueUpdates.chunked(chunkSize.coerceAtLeast(1))) {
         try {
-            importEngine.import(batchFor(listOf(update)))
-            updated += update
+            importEngine.import(batchFor(chunk))
+            updated += chunk
         } catch (expected: Exception) {
-            logger.warn(expected) { "Re-import value update of row ${update.rowIndex} ('${update.description}') failed" }
-            skipped +=
-                ReimportSkippedAccount(
-                    accountId = null,
-                    accountName = update.description,
-                    reason = ReimportSkipReason.UPDATE_FAILED,
-                    detail = expected.message ?: "Update failed",
-                )
+            logger.warn(expected) { "Re-import value update chunk failed, falling back to per-row updates" }
+            for (update in chunk) {
+                try {
+                    importEngine.import(batchFor(listOf(update)))
+                    updated += update
+                } catch (expectedRowError: Exception) {
+                    logger.warn(expectedRowError) {
+                        "Re-import value update of row ${update.rowIndex} ('${update.description}') failed"
+                    }
+                    skipped +=
+                        ReimportSkippedAccount(
+                            accountId = null,
+                            accountName = update.description,
+                            reason = ReimportSkipReason.UPDATE_FAILED,
+                            detail = expectedRowError.message ?: "Update failed",
+                        )
+                }
+            }
         }
+        done += chunk.size
+        onProgress?.invoke(
+            ImportProgress("Updating transactions", fraction = done.toFloat() / total, processed = done, total = total),
+        )
     }
     return updated
 }

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvReimportDetectionTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvReimportDetectionTest.kt
@@ -31,6 +31,7 @@ import com.moneymanager.domain.model.passthrough.PassThroughAccount
 import com.moneymanager.domain.model.passthrough.PassThroughAccountId
 import com.moneymanager.domain.model.passthrough.PassThroughRule
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
+import com.moneymanager.importengineapi.ImportProgress
 import com.moneymanager.importengineapi.PassThroughDetector
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -523,6 +524,22 @@ class CsvReimportDetectionTest {
             assertEquals(listOf("Curve", "PayPal"), rewrite.conduitNames)
             // Both the funding transfer and its old spend leg are deleted before the re-run.
             assertEquals(listOf(TransferId(100), TransferId(101)), rewrite.transferIdsToDelete)
+        }
+
+    @Test
+    fun `row scans emit throttled monotonic progress ending at the total`() =
+        runTest {
+            // 30 plain rows (no pass-through): progress still ticks per row scanned.
+            val rows = (1L..30L).map { row(it, "Payee $it") }
+            val mappedPrep = prep(rows, emptyList(), emptyList())
+            val progress = mutableListOf<ImportProgress>()
+
+            computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(emptyMap()), { progress += it }) { null }
+
+            // Emissions every 25 rows plus the final one; monotonic and complete.
+            assertEquals(listOf(25, 30), progress.mapNotNull { it.processed })
+            assertTrue(progress.all { it.total == 30 })
+            assertTrue(progress.all { it.detail == "Checking pass-through rows" })
         }
 
     @Test

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvReimportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvReimportE2ETest.kt
@@ -31,6 +31,7 @@ import com.moneymanager.domain.model.csvstrategy.HardCodedAccountMapping
 import com.moneymanager.domain.model.csvstrategy.HardCodedCurrencyMapping
 import com.moneymanager.domain.model.csvstrategy.TransferField
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.ImportProgress
 import com.moneymanager.importengineapi.createAccountMapping
 import com.moneymanager.importer.ImportEngineImpl
 import com.moneymanager.test.database.createAccount
@@ -317,6 +318,7 @@ class CsvReimportE2ETest {
                             ),
                 )
 
+            val planProgress = mutableListOf<ImportProgress>()
             val plan =
                 planCsvReimport(
                     csvImport = fixture.csvImport,
@@ -328,12 +330,19 @@ class CsvReimportE2ETest {
                     csvImportRepository = dc.csvImportRepository,
                     transactionRepository = dc.transactionRepository,
                     relationshipRepository = dc.transferRelationshipRepository,
+                    onProgress = { planProgress += it },
                 )
             assertTrue(plan.merges.isEmpty())
             assertTrue(plan.skipped.isEmpty())
             assertEquals(2, plan.valueUpdates.size)
             assertTrue(plan.valueUpdates.all { it.changes.isNotEmpty() })
+            // The plan reports its phases, ending the value-change scan at 2 of 2.
+            assertTrue(planProgress.any { it.detail == "Analyzing rows (pass 1 of 2)" })
+            val valueScan = planProgress.filter { it.detail == "Checking rows for value changes" }
+            assertEquals(2, valueScan.last().processed)
+            assertEquals(2, valueScan.last().total)
 
+            val executeProgress = mutableListOf<ImportProgress>()
             val result =
                 executeCsvReimport(
                     plan = plan,
@@ -346,9 +355,17 @@ class CsvReimportE2ETest {
                     csvImportRepository = dc.csvImportRepository,
                     maintenance = DbMaintenance(dc.maintenanceService),
                     importEngine = fixture.importEngine,
+                    onProgress = { executeProgress += it },
+                    // Force one chunk per update so per-chunk progress is exercised with 2 rows.
+                    valueUpdateChunkSize = 1,
                 )
             assertEquals(2, result.updatedRows.size)
             assertTrue(result.skipped.isEmpty())
+            // Chunked updates report 0 → 1 → 2 of 2, and the run ends with the view refresh phase.
+            val updating = executeProgress.filter { it.detail == "Updating transactions" }
+            assertEquals(listOf(0, 1, 2), updating.mapNotNull { it.processed })
+            assertTrue(updating.all { it.total == 2 })
+            assertEquals("Refreshing views", executeProgress.last().detail)
             // All rows were already imported, so nothing was re-imported (no duplicates created).
             assertNull(result.importResult)
 

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -45,6 +46,7 @@ import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.ImportProgress
 import com.moneymanager.ui.components.AccountPicker
 import com.moneymanager.ui.components.LoadingTextButton
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
@@ -99,6 +101,8 @@ fun ReimportDialog(
     var plan by remember { mutableStateOf<ReimportPlan?>(null) }
     var isRunning by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
+    var planProgress by remember { mutableStateOf<ImportProgress?>(null) }
+    var executeProgress by remember { mutableStateOf<ImportProgress?>(null) }
 
     // Resolve the strategy that was last applied; fall back to column matching if it was deleted.
     LaunchedEffect(csvImport.id) {
@@ -136,6 +140,7 @@ fun ReimportDialog(
                     transactionRepository = transactionRepository,
                     relationshipRepository = transferRelationshipRepository,
                     passThroughAccounts = passThroughAccounts,
+                    onProgress = { planProgress = it },
                 )
             errorMessage = null
         } catch (expected: CancellationException) {
@@ -144,6 +149,8 @@ fun ReimportDialog(
             logger.error(expected) { "Re-import preview failed: ${expected.message}" }
             errorMessage = "Failed to prepare re-import: ${expected.message}"
             plan = null
+        } finally {
+            planProgress = null
         }
     }
 
@@ -186,8 +193,17 @@ fun ReimportDialog(
                         }
 
                         when (val currentPlan = plan) {
-                            null -> if (errorMessage == null) CircularProgressIndicator()
-                            else -> ReimportPlanPreview(currentPlan, hasUnimportedRows)
+                            null ->
+                                if (errorMessage == null) {
+                                    ReimportProgressIndicator(planProgress ?: ImportProgress("Preparing preview"))
+                                }
+                            else -> {
+                                if (isRunning) {
+                                    ReimportProgressIndicator(executeProgress ?: ImportProgress("Starting re-import"))
+                                    Spacer(modifier = Modifier.height(12.dp))
+                                }
+                                ReimportPlanPreview(currentPlan, hasUnimportedRows)
+                            }
                         }
                     }
                 }
@@ -224,6 +240,7 @@ fun ReimportDialog(
                                     maintenance = maintenance,
                                     importEngine = importEngine,
                                     passThroughAccounts = passThroughAccounts,
+                                    onProgress = { executeProgress = it },
                                 )
                             onComplete(result)
                         } catch (expected: CancellationException) {
@@ -232,6 +249,8 @@ fun ReimportDialog(
                             logger.error(expected) { "Re-import failed: ${expected.message}" }
                             errorMessage = "Re-import failed: ${expected.message}"
                             isRunning = false
+                        } finally {
+                            executeProgress = null
                         }
                     }
                 },
@@ -251,6 +270,33 @@ fun ReimportDialog(
             }
         },
     )
+}
+
+/**
+ * Phase label (plus "x of y" when counts are known) over a linear progress bar — determinate when
+ * the phase reports a fraction, indeterminate otherwise.
+ */
+@Composable
+private fun ReimportProgressIndicator(progress: ImportProgress) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        val counts =
+            progress.processed
+                ?.let { processed ->
+                    progress.total?.let { total -> " — $processed of $total" }
+                }.orEmpty()
+        Text(
+            text = "${progress.detail}$counts…",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        val fraction = progress.fraction
+        if (fraction != null) {
+            LinearProgressIndicator(progress = { fraction }, modifier = Modifier.fillMaxWidth())
+        } else {
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        }
+    }
 }
 
 @Composable


### PR DESCRIPTION
## What

The re-import dialog's two indeterminate spinners are replaced with real progress: a phase label, "x of y" counts, and a `LinearProgressIndicator` (determinate whenever a fraction is known) for both the preview build and the execution.

Follow-up to #629, whose per-row value-update detection made the plan phase noticeably slow on large imports (e.g. 1,728 rows).

## How

- `planCsvReimport` / `executeCsvReimport` take an optional `onProgress: (suspend (ImportProgress) -> Unit)` — reusing the engine's existing `ImportProgress(detail, fraction, processed, total)`, no new types. All new params are defaulted, so no other call site changes.
- Plan phase emits "Loading rows", "Analyzing rows (pass 1/2 of 2)", then per-row counts for "Checking pass-through rows" and "Checking rows for value changes" (throttled to every 25 rows), then "Checking duplicate accounts".
- Execute phase emits per-item counts for "Merging accounts" and "Rewriting pass-through rows"; "Updating transactions" is applied in chunks of 100 with per-chunk progress; the remaining-rows re-run threads `onProgress` + `batchSize = 250` through `applyStagedCsv`/`runCsvImport` so the engine reports its native write progress; then "Cleaning up empty accounts" and "Refreshing views".
- Chunking the value updates costs nothing in atomicity: the engine's UPDATE phase applies intents one repository call at a time (never one transaction), so the previous single batch was never all-or-nothing. The per-row failure fallback now re-runs only the failing chunk. Rationale recorded in the `applyValueUpdates` KDoc.
- `executeCsvReimport` exposes `valueUpdateChunkSize` so tests can force multiple chunks with a small fixture.

## Testing

- Unit (`CsvReimportDetectionTest`): the row scan emits throttled, monotonic progress ending at the total (30 rows → processed 25, 30).
- E2E (`CsvReimportE2ETest`): plan progress phases arrive with correct counts; chunked "Updating transactions" reports 0 → 1 → 2 of 2 (chunk size forced to 1); run ends with "Refreshing views"; results/statuses unchanged from #629 behavior.
- `./gradlew build buildHealth` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV re-import now shows live progress during preview generation and execution.
  * Progress includes phase details and, when available, processed/total counts for a clearer import status.
  * Larger CSV imports can now be processed in configurable batches, improving responsiveness during long-running updates.

* **Bug Fixes**
  * Progress updates are now reported consistently across scanning, update, rewrite, cleanup, and refresh steps.
  * Re-import value updates now retry smaller chunks if a batch fails, helping complete imports more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->