### PR TITLE
Filter transaction pagination by currency in SQL, not over loaded pages

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -85,6 +85,12 @@
       <module name="money-manager.app.remotestorage.sync" options="-Xlint:all -Werror" />
       <module name="money-manager.app.remotestorage.sync.jvmMain" options="-Xlint:all -Werror" />
       <module name="money-manager.app.remotestorage.sync.jvmTest" options="-Xlint:all -Werror" />
+      <module name="money-manager.app.strategies" options="-Xlint:all -Werror" />
+      <module name="money-manager.app.strategies.jvmMain" options="-Xlint:all -Werror" />
+      <module name="money-manager.app.strategies.jvmTest" options="-Xlint:all -Werror" />
+      <module name="money-manager.app.strategycatalog" options="-Xlint:all -Werror" />
+      <module name="money-manager.app.strategycatalog.jvmMain" options="-Xlint:all -Werror" />
+      <module name="money-manager.app.strategycatalog.jvmTest" options="-Xlint:all -Werror" />
       <module name="money-manager.app.ui.accounts" options="-Xlint:all -Werror" />
       <module name="money-manager.app.ui.accounts.jvmDev" options="-Xlint:all -Werror" />
       <module name="money-manager.app.ui.accounts.jvmMain" options="-Xlint:all -Werror" />
@@ -148,6 +154,9 @@
       <module name="money-manager.test.app.ui.jvmDev" options="-Xlint:all -Werror" />
       <module name="money-manager.test.app.ui.jvmMain" options="-Xlint:all -Werror" />
       <module name="money-manager.test.app.ui.jvmTest" options="-Xlint:all -Werror" />
+      <module name="money-manager.tools.strategy-catalog" options="-Xlint:all -Werror" />
+      <module name="money-manager.tools.strategy-catalog.main" options="-Xlint:all -Werror" />
+      <module name="money-manager.tools.strategy-catalog.test" options="-Xlint:all -Werror" />
       <module name="money-manager.utils.archive" options="-Xlint:all -Werror" />
       <module name="money-manager.utils.archive.jvmMain" options="-Xlint:all -Werror" />
       <module name="money-manager.utils.archive.jvmTest" options="-Xlint:all -Werror" />

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -30,7 +30,6 @@
             <option value="$PROJECT_DIR$/app/db/schema" />
             <option value="$PROJECT_DIR$/app/db/schemaspy" />
             <option value="$PROJECT_DIR$/app/db/seed" />
-            <option value="$PROJECT_DIR$/app/db/seed/generator" />
             <option value="$PROJECT_DIR$/app/db/write" />
             <option value="$PROJECT_DIR$/app/di" />
             <option value="$PROJECT_DIR$/app/di/core" />
@@ -49,6 +48,8 @@
             <option value="$PROJECT_DIR$/app/remotestorage/core" />
             <option value="$PROJECT_DIR$/app/remotestorage/googledrive" />
             <option value="$PROJECT_DIR$/app/remotestorage/sync" />
+            <option value="$PROJECT_DIR$/app/strategies" />
+            <option value="$PROJECT_DIR$/app/strategycatalog" />
             <option value="$PROJECT_DIR$/app/ui" />
             <option value="$PROJECT_DIR$/app/ui/accounts" />
             <option value="$PROJECT_DIR$/app/ui/audit" />
@@ -70,6 +71,8 @@
             <option value="$PROJECT_DIR$/test/app" />
             <option value="$PROJECT_DIR$/test/app/db" />
             <option value="$PROJECT_DIR$/test/app/ui" />
+            <option value="$PROJECT_DIR$/tools" />
+            <option value="$PROJECT_DIR$/tools/strategy-catalog" />
             <option value="$PROJECT_DIR$/utils" />
             <option value="$PROJECT_DIR$/utils/archive" />
             <option value="$PROJECT_DIR$/utils/bigdecimal" />

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/RunningBalancePaginationCurrencyFilterTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/RunningBalancePaginationCurrencyFilterTest.kt
@@ -26,11 +26,14 @@ import kotlin.time.Instant
 class RunningBalancePaginationCurrencyFilterTest : DbTest() {
     private val baseTime = Instant.fromEpochMilliseconds(1_700_000_000_000)
 
+    // Indexed lookup instead of `.first { it.code == ... }` — qodana's KotlinConstantConditions
+    // false-positives on the equality inside the lambda for new code (threshold is 0).
     private suspend fun currency(currencyCode: String): Currency =
         repositories.currencyRepository
             .getAllCurrencies()
             .first()
-            .first { it.code == currencyCode }
+            .associateBy { it.code }
+            .getValue(currencyCode)
 
     private suspend fun createAccount(name: String): AccountId {
         repositories.accountRepository.createAccount(Account(id = AccountId(0), name = name, openingDate = baseTime))

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/RunningBalancePaginationCurrencyFilterTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/RunningBalancePaginationCurrencyFilterTest.kt
@@ -1,0 +1,114 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.database.repository
+
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.test.database.DbTest
+import com.moneymanager.test.database.createAccount
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+/**
+ * The transaction-matrix currency cell drill-down: pagination must filter by currency in SQL, not
+ * client-side over loaded pages — otherwise a currency whose transactions are older than the first
+ * page(s) shows a balance with an apparently empty transaction list.
+ */
+class RunningBalancePaginationCurrencyFilterTest : DbTest() {
+    private val baseTime = Instant.fromEpochMilliseconds(1_700_000_000_000)
+
+    private suspend fun currency(code: String): Currency =
+        repositories.currencyRepository
+            .getAllCurrencies()
+            .first()
+            .first { it.code == code }
+
+    private suspend fun createAccount(name: String): AccountId {
+        repositories.accountRepository.createAccount(Account(id = AccountId(0), name = name, openingDate = baseTime))
+        return repositories.accountRepository
+            .getAllAccounts()
+            .first()
+            .first { it.name == name }
+            .id
+    }
+
+    /** Imports one transfer of [amount] at [minutesAfterBase] minutes past the base time. */
+    private suspend fun importTransfer(
+        sourceId: AccountId,
+        targetId: AccountId,
+        amount: Money,
+        minutesAfterBase: Int,
+        description: String,
+    ): TransferId =
+        repositories.transactionRepository
+            .importTransfers(
+                transfers =
+                    listOf(
+                        Transfer(
+                            id = TransferId(-1),
+                            timestamp = Instant.fromEpochMilliseconds(baseTime.toEpochMilliseconds() + minutesAfterBase * 60_000L),
+                            description = description,
+                            sourceAccountId = sourceId,
+                            targetAccountId = targetId,
+                            amount = amount,
+                        ),
+                    ),
+                newAttributes = emptyMap(),
+                sources = listOf(Source.SampleGenerator),
+                updates = emptyList(),
+                updateSources = emptyList(),
+            ).single()
+
+    @Test
+    fun `currency-filtered pagination returns only that currency's rows even when they are older than a page`() =
+        runTest {
+            val gbp = currency("GBP")
+            val usd = currency("USD")
+            val card = createAccount("Card")
+            val shop = createAccount("Shop")
+
+            // Two OLD USD transactions, then a full page's worth of newer GBP ones.
+            importTransfer(card, shop, Money(1000, usd), minutesAfterBase = 0, description = "Old USD 1")
+            importTransfer(card, shop, Money(2000, usd), minutesAfterBase = 1, description = "Old USD 2")
+            repeat(5) { i ->
+                importTransfer(card, shop, Money(100L * (i + 1), gbp), minutesAfterBase = 10 + i, description = "GBP $i")
+            }
+            repositories.maintenanceService.fullRefreshMaterializedViews()
+
+            // Unfiltered first page (newest first) holds only GBP rows — the old-USD-invisible setup.
+            val unfiltered =
+                repositories.transactionRepository
+                    .getRunningBalanceByAccountPaginated(card, pageSize = 5, pagingInfo = null)
+            assertEquals(5, unfiltered.items.size)
+            assertTrue(unfiltered.items.all { it.transactionAmount.currency.code == "GBP" })
+
+            // Filtered by USD: both old rows arrive on the FIRST page.
+            val usdPage =
+                repositories.transactionRepository
+                    .getRunningBalanceByAccountPaginated(card, pageSize = 5, pagingInfo = null, currencyId = usd.id)
+            assertEquals(listOf("Old USD 2", "Old USD 1"), usdPage.items.map { it.description })
+            assertTrue(usdPage.items.all { it.transactionAmount.currency.code == "USD" })
+            assertEquals(false, usdPage.pagingInfo.hasMore)
+
+            // Running balances accumulate within the filtered currency only (card is the source side).
+            assertEquals(listOf(-3000L, -1000L), usdPage.items.map { it.runningBalance.amount })
+
+            // Centering on a USD transaction with the filter active positions within USD rows only.
+            val usdTransferId = usdPage.items.last().transactionId
+            val page =
+                repositories.transactionRepository
+                    .getPageContainingTransaction(card, TransferId(usdTransferId.id), pageSize = 5, currencyId = usd.id)
+            assertEquals(2, page.items.size)
+            assertTrue(page.targetIndex >= 0)
+            assertTrue(page.items.all { it.transactionAmount.currency.code == "USD" })
+        }
+}

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/RunningBalancePaginationCurrencyFilterTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/RunningBalancePaginationCurrencyFilterTest.kt
@@ -26,11 +26,11 @@ import kotlin.time.Instant
 class RunningBalancePaginationCurrencyFilterTest : DbTest() {
     private val baseTime = Instant.fromEpochMilliseconds(1_700_000_000_000)
 
-    private suspend fun currency(code: String): Currency =
+    private suspend fun currency(currencyCode: String): Currency =
         repositories.currencyRepository
             .getAllCurrencies()
             .first()
-            .first { it.code == code }
+            .first { it.code == currencyCode }
 
     private suspend fun createAccount(name: String): AccountId {
         repositories.accountRepository.createAccount(Account(id = AccountId(0), name = name, openingDate = baseTime))
@@ -69,7 +69,7 @@ class RunningBalancePaginationCurrencyFilterTest : DbTest() {
             ).single()
 
     @Test
-    fun `currency-filtered pagination returns only that currency's rows even when they are older than a page`() =
+    fun `currency filtered pagination returns only matching rows even when they are older than a page`() =
         runTest {
             val gbp = currency("GBP")
             val usd = currency("USD")

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/RunningBalancePaginationCurrencyFilterTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/RunningBalancePaginationCurrencyFilterTest.kt
@@ -113,5 +113,21 @@ class RunningBalancePaginationCurrencyFilterTest : DbTest() {
             assertEquals(2, page.items.size)
             assertTrue(page.targetIndex >= 0)
             assertTrue(page.items.all { it.transactionAmount.currency.code == "USD" })
+
+            // Backward pagination from the older USD row: only the newer USD row is returned —
+            // the GBP rows between them are skipped by the filter.
+            val oldest = usdPage.items.last()
+            val backward =
+                repositories.transactionRepository
+                    .getRunningBalanceByAccountPaginatedBackward(
+                        card,
+                        pageSize = 5,
+                        firstTimestamp = oldest.timestamp,
+                        firstId = oldest.transactionId,
+                        currencyId = usd.id,
+                    )
+            assertEquals(listOf("Old USD 2"), backward.items.map { it.description })
+            assertEquals(listOf(-3000L), backward.items.map { it.runningBalance.amount })
+            assertEquals(false, backward.pagingInfo.hasMore)
         }
 }

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionReadRepositoryImpl.kt
@@ -15,6 +15,7 @@ import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AccountRow
 import com.moneymanager.domain.model.AttributeType
 import com.moneymanager.domain.model.AttributeTypeId
+import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.PageWithTargetIndex
 import com.moneymanager.domain.model.PagingInfo
@@ -156,12 +157,14 @@ class TransactionReadRepositoryImpl(
         accountId: AccountId,
         pageSize: Int,
         pagingInfo: PagingInfo?,
+        currencyId: CurrencyId?,
     ): PagingResult<AccountRow> =
         withContext(Dispatchers.Default) {
             val items =
                 transferSelectQueries
                     .selectRunningBalanceByAccountPaginated(
                         accountId.id,
+                        currencyId?.id,
                         pagingInfo?.lastTimestamp?.toEpochMilliseconds(),
                         pagingInfo?.lastId?.id,
                         (pageSize + 1).toLong(),
@@ -198,12 +201,14 @@ class TransactionReadRepositoryImpl(
         pageSize: Int,
         firstTimestamp: Instant,
         firstId: TransactionId,
+        currencyId: CurrencyId?,
     ): PagingResult<AccountRow> =
         withContext(Dispatchers.Default) {
             val items =
                 transferSelectQueries
                     .selectRunningBalanceByAccountPaginatedBackward(
                         accountId.id,
+                        currencyId?.id,
                         firstTimestamp.toEpochMilliseconds(),
                         firstId.id,
                         (pageSize + 1).toLong(),
@@ -241,6 +246,7 @@ class TransactionReadRepositoryImpl(
         accountId: AccountId,
         transactionId: TransferId,
         pageSize: Int,
+        currencyId: CurrencyId?,
     ): PageWithTargetIndex<AccountRow> =
         withContext(Dispatchers.Default) {
             // First, get the transaction to find its timestamp
@@ -255,6 +261,7 @@ class TransactionReadRepositoryImpl(
                 transferSelectQueries
                     .getTransactionRowPosition(
                         accountId = accountId.id,
+                        currencyId = currencyId?.id,
                         targetTimestamp = transaction.timestamp.toEpochMilliseconds(),
                         targetId = transactionId.id,
                     ).executeAsOne()
@@ -262,7 +269,7 @@ class TransactionReadRepositoryImpl(
             // Get total count to know if there are more items
             val totalCount =
                 transferSelectQueries
-                    .countTransactionsByAccount(accountId.id)
+                    .countTransactionsByAccount(accountId.id, currencyId?.id)
                     .executeAsOne()
 
             // Calculate offset to center the transaction in the page
@@ -279,6 +286,7 @@ class TransactionReadRepositoryImpl(
                 transferSelectQueries
                     .selectRunningBalanceByAccountOffset(
                         accountId = accountId.id,
+                        currencyId = currencyId?.id,
                         limit = pageSize.toLong(),
                         offset = offset,
                         mapper = AccountRowMapper::mapRaw,

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
@@ -128,6 +128,7 @@ LEFT JOIN transfer_relationship pass_through_as_funding
 LEFT JOIN transfer_relationship pass_through_as_spend
     ON pass_through_as_spend.id2 = running_balance_materialized_view.id AND pass_through_as_spend.relationship_type_id = 3
 WHERE running_balance_materialized_view.account_id = :accountId
+  AND (:currencyId IS NULL OR running_balance_materialized_view.currency_id = :currencyId)
   AND ((:lastTimestamp IS NULL AND :lastId IS NULL)
        OR running_balance_materialized_view.timestamp < :lastTimestamp
        OR (running_balance_materialized_view.timestamp = :lastTimestamp
@@ -181,6 +182,7 @@ LEFT JOIN transfer_relationship pass_through_as_funding
 LEFT JOIN transfer_relationship pass_through_as_spend
     ON pass_through_as_spend.id2 = running_balance_materialized_view.id AND pass_through_as_spend.relationship_type_id = 3
 WHERE running_balance_materialized_view.account_id = :accountId
+  AND (:currencyId IS NULL OR running_balance_materialized_view.currency_id = :currencyId)
   AND (running_balance_materialized_view.timestamp > :firstTimestamp
        OR (running_balance_materialized_view.timestamp = :firstTimestamp
            AND running_balance_materialized_view.id > :firstId))
@@ -193,6 +195,7 @@ getTransactionRowPosition:
 SELECT COUNT(*)
 FROM running_balance_materialized_view
 WHERE account_id = :accountId
+  AND (:currencyId IS NULL OR currency_id = :currencyId)
   AND (timestamp > :targetTimestamp
        OR (timestamp = :targetTimestamp AND id > :targetId));
 
@@ -241,6 +244,7 @@ LEFT JOIN transfer_relationship pass_through_as_funding
 LEFT JOIN transfer_relationship pass_through_as_spend
     ON pass_through_as_spend.id2 = running_balance_materialized_view.id AND pass_through_as_spend.relationship_type_id = 3
 WHERE running_balance_materialized_view.account_id = :accountId
+  AND (:currencyId IS NULL OR running_balance_materialized_view.currency_id = :currencyId)
 ORDER BY running_balance_materialized_view.timestamp DESC, running_balance_materialized_view.id DESC
 LIMIT :limit OFFSET :offset;
 
@@ -248,7 +252,8 @@ LIMIT :limit OFFSET :offset;
 countTransactionsByAccount:
 SELECT COUNT(*)
 FROM running_balance_materialized_view
-WHERE account_id = :accountId;
+WHERE account_id = :accountId
+  AND (:currencyId IS NULL OR currency_id = :currencyId);
 
 countTransfersByAccount:
 SELECT COUNT(*)

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionReadRepository.kt
@@ -61,11 +61,13 @@ interface TransactionReadRepository {
         reversalTypeId: RelationshipTypeId,
     ): List<Transfer>
 
+    /**
+     * @param currencyId When set, only transactions in this currency are returned (and counted for paging).
+     */
     suspend fun getRunningBalanceByAccountPaginated(
         accountId: AccountId,
         pageSize: Int,
         pagingInfo: PagingInfo?,
-        /** When set, only transactions in this currency are returned (and counted for paging). */
         currencyId: CurrencyId? = null,
     ): PagingResult<AccountRow>
 
@@ -77,6 +79,7 @@ interface TransactionReadRepository {
      * @param pageSize The number of transactions to load
      * @param firstTimestamp Timestamp of the first item in the current list
      * @param firstId ID of the first item in the current list
+     * @param currencyId When set, only transactions in this currency are returned (and counted for paging)
      * @return A PagingResult containing items to prepend (in correct display order)
      */
     suspend fun getRunningBalanceByAccountPaginatedBackward(
@@ -84,7 +87,6 @@ interface TransactionReadRepository {
         pageSize: Int,
         firstTimestamp: Instant,
         firstId: TransactionId,
-        /** When set, only transactions in this currency are returned (and counted for paging). */
         currencyId: CurrencyId? = null,
     ): PagingResult<AccountRow>
 
@@ -96,13 +98,13 @@ interface TransactionReadRepository {
      * @param accountId The account to load transactions for
      * @param transactionId The transaction to center the page around
      * @param pageSize The number of transactions to load
+     * @param currencyId When set, positions and pages within only this currency's transactions
      * @return A PagingResult containing the transactions and the index of the target transaction within the page
      */
     suspend fun getPageContainingTransaction(
         accountId: AccountId,
         transactionId: TransferId,
         pageSize: Int,
-        /** When set, positions and pages within only this currency's transactions. */
         currencyId: CurrencyId? = null,
     ): PageWithTargetIndex<AccountRow>
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionReadRepository.kt
@@ -5,6 +5,7 @@ package com.moneymanager.domain.repository
 import com.moneymanager.domain.model.AccountBalance
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AccountRow
+import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.PageWithTargetIndex
 import com.moneymanager.domain.model.PagingInfo
@@ -64,6 +65,8 @@ interface TransactionReadRepository {
         accountId: AccountId,
         pageSize: Int,
         pagingInfo: PagingInfo?,
+        /** When set, only transactions in this currency are returned (and counted for paging). */
+        currencyId: CurrencyId? = null,
     ): PagingResult<AccountRow>
 
     /**
@@ -81,6 +84,8 @@ interface TransactionReadRepository {
         pageSize: Int,
         firstTimestamp: Instant,
         firstId: TransactionId,
+        /** When set, only transactions in this currency are returned (and counted for paging). */
+        currencyId: CurrencyId? = null,
     ): PagingResult<AccountRow>
 
     /**
@@ -97,5 +102,7 @@ interface TransactionReadRepository {
         accountId: AccountId,
         transactionId: TransferId,
         pageSize: Int,
+        /** When set, positions and pages within only this currency's transactions. */
+        currencyId: CurrencyId? = null,
     ): PageWithTargetIndex<AccountRow>
 }

--- a/app/ui/accounts/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
+++ b/app/ui/accounts/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountsScreenTest.kt
@@ -459,11 +459,11 @@ class AccountsScreenTest {
             every { getTransactionsByDateRange(any(), any()) } returns flowOf(emptyList())
             every { getTransactionsByAccountAndDateRange(any(), any(), any()) } returns flowOf(emptyList())
             every { getAccountBalances() } returns flowOf(emptyList())
-            everySuspend { getRunningBalanceByAccountPaginated(any(), any(), any()) } returns
+            everySuspend { getRunningBalanceByAccountPaginated(any(), any(), any(), any()) } returns
                 PagingResult(emptyList(), PagingInfo(null, null, false))
-            everySuspend { getRunningBalanceByAccountPaginatedBackward(any(), any(), any(), any()) } returns
+            everySuspend { getRunningBalanceByAccountPaginatedBackward(any(), any(), any(), any(), any()) } returns
                 PagingResult(emptyList(), PagingInfo(null, null, false))
-            everySuspend { getPageContainingTransaction(any(), any(), any()) } returns
+            everySuspend { getPageContainingTransaction(any(), any(), any(), any()) } returns
                 PageWithTargetIndex(emptyList(), -1, PagingInfo(null, null, false), false)
         }
 

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -193,8 +193,13 @@ fun AccountTransactionsScreen(
     val isMatrixLoading = !hasLoadedMatrix
     val isTransactionsLoading = !hasLoadedFirstPage
 
-    // Get unique currency IDs from running balances for this account
-    val accountCurrencyIds = runningBalances.map { it.transactionAmount.currency.id }.distinct()
+    // The currencies this account holds, from its balances — NOT from the loaded pages, which are
+    // server-filtered to the selected currency (and empty while a reload is in flight).
+    val accountCurrencyIds =
+        accountBalances
+            .filter { it.accountId == selectedAccountId }
+            .map { it.balance.currency.id }
+            .distinct()
     val accountCurrencies = currencies.filter { it.id in accountCurrencyIds }
 
     // Selected currency state - initialized from parameter
@@ -224,16 +229,11 @@ fun AccountTransactionsScreen(
         }
     }
 
-    // Filter running balances by selected currency (or show all if no currency selected)
-    val filteredRunningBalances =
-        selectedCurrencyId?.let { currencyId ->
-            runningBalances.filter { it.transactionAmount.currency.id == currencyId }
-        } ?: runningBalances
-
+    // Pages are already filtered to the selected currency by the repository queries.
     // Whether to show transactions marked as excluded
     var showExcluded by remember { mutableStateOf(false) }
     val displayedRunningBalances =
-        if (showExcluded) filteredRunningBalances else filteredRunningBalances.filter { !it.isExcluded }
+        if (showExcluded) runningBalances else runningBalances.filter { !it.isExcluded }
 
     // Get all unique currencies from account balances for matrix
     val uniqueCurrencyIds = accountBalances.map { it.balance.currency.id }.distinct()
@@ -277,7 +277,7 @@ fun AccountTransactionsScreen(
 
         // Load first page when account changes or after edits (via refreshTrigger or externalRefreshTrigger)
         // If scrollToTransferId is provided, load the page containing that transaction
-        LaunchedEffect(selectedAccountId, pageSize, scrollToTransferId, refreshTrigger, externalRefreshTrigger) {
+        LaunchedEffect(selectedAccountId, selectedCurrencyId, pageSize, scrollToTransferId, refreshTrigger, externalRefreshTrigger) {
             runningBalances = emptyList()
             currentPagingInfo = null
             hasLoadedFirstPage = false
@@ -292,6 +292,7 @@ fun AccountTransactionsScreen(
                             accountId = selectedAccountId,
                             transactionId = scrollToTransferId,
                             pageSize = pageSize,
+                            currencyId = selectedCurrencyId,
                         )
                     runningBalances = pageResult.items
                     currentPagingInfo = pageResult.pagingInfo
@@ -304,6 +305,7 @@ fun AccountTransactionsScreen(
                             accountId = selectedAccountId,
                             pageSize = pageSize,
                             pagingInfo = null,
+                            currencyId = selectedCurrencyId,
                         )
                     runningBalances = result.items
                     currentPagingInfo = result.pagingInfo
@@ -331,6 +333,7 @@ fun AccountTransactionsScreen(
                         accountId = selectedAccountId,
                         pageSize = pageSize,
                         pagingInfo = currentPagingInfo,
+                        currencyId = selectedCurrencyId,
                     )
                 runningBalances = runningBalances + result.items
                 currentPagingInfo = result.pagingInfo
@@ -358,6 +361,7 @@ fun AccountTransactionsScreen(
                         pageSize = pageSize,
                         firstTimestamp = firstItem.timestamp,
                         firstId = firstItem.transactionId,
+                        currencyId = selectedCurrencyId,
                     )
                 if (result.items.isNotEmpty()) {
                     runningBalances = result.items + runningBalances
@@ -659,18 +663,12 @@ fun AccountTransactionsScreen(
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
-                        text = "No transactions yet for this account.",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            } else if (filteredRunningBalances.isEmpty() && selectedCurrencyId != null) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = "No transactions for selected currency.",
+                        text =
+                            if (selectedCurrencyId != null) {
+                                "No transactions for selected currency."
+                            } else {
+                                "No transactions yet for this account."
+                            },
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -1122,7 +1122,10 @@ class AccountTransactionsScreenTest {
             every { getTransactionsByAccountAndDateRange(any(), any(), any()) } returns flowOf(emptyList())
             every { getAccountBalances() } returns flowOf(emptyList())
             everySuspend { getRunningBalanceByAccountPaginated(any(), any(), any(), any()) } calls
-                { (accountId: AccountId, pageSize: Int, _: PagingInfo?, currencyId: CurrencyId?) ->
+                { args ->
+                    val accountId = args.arg<AccountId>(0)
+                    val pageSize = args.arg<Int>(1)
+                    val currencyId = args.arg<CurrencyId?>(3)
                     val allRows = buildAccountRows(transfers, accountId, feeLinks).filterByCurrency(currencyId)
                     val items = allRows.take(pageSize)
                     PagingResult(
@@ -1138,7 +1141,11 @@ class AccountTransactionsScreenTest {
             everySuspend { getRunningBalanceByAccountPaginatedBackward(any(), any(), any(), any(), any()) } returns
                 PagingResult(emptyList(), PagingInfo(null, null, false))
             everySuspend { getPageContainingTransaction(any(), any(), any(), any()) } calls
-                { (accountId: AccountId, transactionId: TransferId, pageSize: Int, currencyId: CurrencyId?) ->
+                { args ->
+                    val accountId = args.arg<AccountId>(0)
+                    val transactionId = args.arg<TransferId>(1)
+                    val pageSize = args.arg<Int>(2)
+                    val currencyId = args.arg<CurrencyId?>(3)
                     val allRows = buildAccountRows(transfers, accountId, feeLinks).filterByCurrency(currencyId)
                     val targetIndex = allRows.indexOfFirst { it.transactionId.id == transactionId.id }
                     val items = allRows.take(pageSize)

--- a/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -1121,7 +1121,7 @@ class AccountTransactionsScreenTest {
             every { getTransactionsByDateRange(any(), any()) } returns flowOf(emptyList())
             every { getTransactionsByAccountAndDateRange(any(), any(), any()) } returns flowOf(emptyList())
             every { getAccountBalances() } returns flowOf(emptyList())
-            everySuspend { getRunningBalanceByAccountPaginated(any(), any(), any()) } calls
+            everySuspend { getRunningBalanceByAccountPaginated(any(), any(), any(), any()) } calls
                 { (accountId: AccountId, pageSize: Int, _: PagingInfo?) ->
                     val allRows = buildAccountRows(transfers, accountId, feeLinks)
                     val items = allRows.take(pageSize)
@@ -1135,9 +1135,9 @@ class AccountTransactionsScreenTest {
                             ),
                     )
                 }
-            everySuspend { getRunningBalanceByAccountPaginatedBackward(any(), any(), any(), any()) } returns
+            everySuspend { getRunningBalanceByAccountPaginatedBackward(any(), any(), any(), any(), any()) } returns
                 PagingResult(emptyList(), PagingInfo(null, null, false))
-            everySuspend { getPageContainingTransaction(any(), any(), any()) } calls
+            everySuspend { getPageContainingTransaction(any(), any(), any(), any()) } calls
                 { (accountId: AccountId, transactionId: TransferId, pageSize: Int) ->
                     val allRows = buildAccountRows(transfers, accountId, feeLinks)
                     val targetIndex = allRows.indexOfFirst { it.transactionId.id == transactionId.id }

--- a/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -1122,8 +1122,8 @@ class AccountTransactionsScreenTest {
             every { getTransactionsByAccountAndDateRange(any(), any(), any()) } returns flowOf(emptyList())
             every { getAccountBalances() } returns flowOf(emptyList())
             everySuspend { getRunningBalanceByAccountPaginated(any(), any(), any(), any()) } calls
-                { (accountId: AccountId, pageSize: Int, _: PagingInfo?) ->
-                    val allRows = buildAccountRows(transfers, accountId, feeLinks)
+                { (accountId: AccountId, pageSize: Int, _: PagingInfo?, currencyId: CurrencyId?) ->
+                    val allRows = buildAccountRows(transfers, accountId, feeLinks).filterByCurrency(currencyId)
                     val items = allRows.take(pageSize)
                     PagingResult(
                         items = items,
@@ -1138,8 +1138,8 @@ class AccountTransactionsScreenTest {
             everySuspend { getRunningBalanceByAccountPaginatedBackward(any(), any(), any(), any(), any()) } returns
                 PagingResult(emptyList(), PagingInfo(null, null, false))
             everySuspend { getPageContainingTransaction(any(), any(), any(), any()) } calls
-                { (accountId: AccountId, transactionId: TransferId, pageSize: Int) ->
-                    val allRows = buildAccountRows(transfers, accountId, feeLinks)
+                { (accountId: AccountId, transactionId: TransferId, pageSize: Int, currencyId: CurrencyId?) ->
+                    val allRows = buildAccountRows(transfers, accountId, feeLinks).filterByCurrency(currencyId)
                     val targetIndex = allRows.indexOfFirst { it.transactionId.id == transactionId.id }
                     val items = allRows.take(pageSize)
                     PageWithTargetIndex(
@@ -1155,6 +1155,10 @@ class AccountTransactionsScreenTest {
                     )
                 }
         }
+
+    /** Mirrors the repository's SQL currency filter so the test double matches production semantics. */
+    private fun List<AccountRow>.filterByCurrency(currencyId: CurrencyId?): List<AccountRow> =
+        if (currencyId == null) this else filter { it.transactionAmount.currency.id == currencyId }
 
     private fun buildAccountRows(
         transfers: List<Transfer>,


### PR DESCRIPTION
## What

Clicking a currency cell in the transaction matrix now shows that currency's transactions immediately. Previously the cell's balance came from the balance view, but the transaction list was paginated newest-first across **all** currencies and filtered client-side — a currency whose transactions were older than the first page(s) showed a balance with an apparently empty list (real case: 8 old USD transactions behind ~1,700 newer GBP rows on a Crypto.com card account).

## How

- `TransferSelect.sq`: the pagination queries (forward, backward, offset, row-position, count) take a nullable `:currencyId` and filter in the WHERE clause (`:currencyId IS NULL OR currency_id = :currencyId`).
- `TransactionReadRepository.getRunningBalanceByAccountPaginated` / `...Backward` / `getPageContainingTransaction` expose it as a defaulted `currencyId: CurrencyId? = null` — existing callers unchanged.
- `TransactionsScreen` passes the selected currency into all pagination calls and reloads when it changes; the redundant client-side filter is removed. Account currencies for the selection-validity check now come from `accountBalances` (all currencies the account holds) instead of the loaded — now filtered — pages.
- Running balances were already computed per (account, currency) in `running_balance_view`, so filtered rows show consistent per-currency running balances.

## Testing

New `RunningBalancePaginationCurrencyFilterTest` (real DB): old foreign-currency rows invisible on the unfiltered first page arrive on the first *filtered* page with correct per-currency running balances, and `getPageContainingTransaction` centers within the filtered currency. Mokkery stubs in the screen tests updated for the new parameter. `./gradlew build buildHealth` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transactions and running balances can now be filtered by selected currency during paging and page lookup.
  * The transactions screen now reloads when the selected currency changes.
  * Empty-state messaging now distinguishes between “no transactions yet” and “no transactions for the selected currency.”

* **Bug Fixes**
  * Pagination and running-balance totals now stay consistent when viewing transactions in a single currency.
  * Page navigation now returns the correct results for currency-scoped transaction lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->