### PR TITLE
Serializable NavKey routes, saved-state back stack, and transitions

### DIFF
--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ApiSession.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ApiSession.kt
@@ -3,6 +3,7 @@
 package com.moneymanager.domain.model
 
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
+import kotlinx.serialization.Serializable
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
@@ -63,6 +64,7 @@ data class ApiRequest(
     val headers: List<ApiRequestHeader>,
 )
 
+@Serializable
 @JvmInline
 value class ApiRequestId(
     val id: Long,
@@ -99,6 +101,7 @@ value class ApiResponseId(
     override fun toString() = id.toString()
 }
 
+@Serializable
 @JvmInline
 value class ApiSessionId(
     val id: Long,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Transfer.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Transfer.kt
@@ -2,6 +2,7 @@
 
 package com.moneymanager.domain.model
 
+import kotlinx.serialization.Serializable
 import kotlin.time.Instant
 
 data class Transfer(
@@ -15,6 +16,7 @@ data class Transfer(
     val attributes: List<TransferAttribute> = emptyList(),
 )
 
+@Serializable
 @JvmInline
 value class TransferId(
     override val id: Long,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiImportStrategyId.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiImportStrategyId.kt
@@ -2,9 +2,11 @@
 
 package com.moneymanager.domain.model.apistrategy
 
+import kotlinx.serialization.Serializable
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
+@Serializable
 @JvmInline
 value class ApiImportStrategyId(
     val id: Uuid,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csv/CsvImport.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csv/CsvImport.kt
@@ -4,12 +4,14 @@ package com.moneymanager.domain.model.csv
 
 import com.moneymanager.domain.model.DeviceInfo
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
+@Serializable
 @JvmInline
 value class CsvImportId
     @OptIn(ExperimentalUuidApi::class)

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategyId.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategyId.kt
@@ -2,8 +2,10 @@
 
 package com.moneymanager.domain.model.csvstrategy
 
+import kotlinx.serialization.Serializable
 import kotlin.uuid.Uuid
 
+@Serializable
 @JvmInline
 value class CsvImportStrategyId(
     val id: Uuid,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/importdirectory/ImportDirectoryId.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/importdirectory/ImportDirectoryId.kt
@@ -2,8 +2,10 @@
 
 package com.moneymanager.domain.model.importdirectory
 
+import kotlinx.serialization.Serializable
 import kotlin.uuid.Uuid
 
+@Serializable
 @JvmInline
 value class ImportDirectoryId(
     val id: Uuid,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/qif/QifImport.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/qif/QifImport.kt
@@ -4,12 +4,14 @@ package com.moneymanager.domain.model.qif
 
 import com.moneymanager.domain.model.DeviceInfo
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
+@Serializable
 @JvmInline
 value class QifImportId
     @OptIn(ExperimentalUuidApi::class)

--- a/app/ui/core/build.gradle.kts
+++ b/app/ui/core/build.gradle.kts
@@ -70,6 +70,7 @@ kotlin {
                 implementation(libs.androidx.compose.ui.graphics)
                 implementation(libs.androidx.compose.ui.text)
                 implementation(libs.androidx.navigation3.ui)
+                implementation(libs.androidx.savedstate)
                 implementation(libs.kotlinx.serialization.core)
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.http)
@@ -94,6 +95,7 @@ kotlin {
 
                 implementation(libs.androidx.compose.runtime.annotation)
                 implementation(libs.androidx.navigation3.runtime.desktop)
+                implementation(libs.androidx.savedstate.desktop)
                 implementation(libs.compose.animation.desktop)
                 implementation(libs.compose.foundation.desktop)
                 implementation(libs.compose.material3.desktop)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -2,9 +2,6 @@
 
 package com.moneymanager.ui
 
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -39,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
 import com.moneymanager.database.MoneyManagerDatabaseWrapper
 import com.moneymanager.domain.StrategyKind
@@ -65,6 +63,7 @@ import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.navigation.ImportTab
 import com.moneymanager.ui.navigation.NavigationHistory
 import com.moneymanager.ui.navigation.Screen
+import com.moneymanager.ui.navigation.ScreenSavedStateConfiguration
 import com.moneymanager.ui.navigation.mouseButtonNavigation
 import com.moneymanager.ui.screens.AccountAuditScreen
 import com.moneymanager.ui.screens.AccountsScreen
@@ -116,7 +115,8 @@ fun MoneyManagerApp(
     ProvideSchemaAwareScope {
         val scope = rememberSchemaAwareCoroutineScope()
         val backgroundTaskManager = rememberBackgroundTaskManager(scope)
-        val navigationHistory = remember { NavigationHistory(Screen.Accounts()) }
+        val backStack = rememberNavBackStack(ScreenSavedStateConfiguration, Screen.Accounts())
+        val navigationHistory = remember(backStack) { NavigationHistory(backStack) }
         val currentScreen = navigationHistory.currentScreen
         var showTransactionDialog by remember { mutableStateOf(false) }
         var preSelectedAccountId by remember { mutableStateOf<AccountId?>(null) }
@@ -318,11 +318,6 @@ fun MoneyManagerApp(
                             NavDisplay(
                                 backStack = navigationHistory.backStack,
                                 onBack = { navigationHistory.navigateBack() },
-                                // No-op transitions keep behavior identical to the previous switcher
-                                // and navigation deterministic for UI tests.
-                                transitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
-                                popTransitionSpec = { EnterTransition.None togetherWith ExitTransition.None },
-                                predictivePopTransitionSpec = { _ -> EnterTransition.None togetherWith ExitTransition.None },
                                 entryProvider =
                                     entryProvider {
                                         // Content keys deliberately ignore volatile params (scroll targets, tabs):

--- a/app/ui/foundation/build.gradle.kts
+++ b/app/ui/foundation/build.gradle.kts
@@ -1,14 +1,18 @@
 plugins {
     id("moneymanager.compose-ui-feature-convention")
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin {
     sourceSets {
         getByName("commonMain") {
             dependencies {
+                api(libs.androidx.navigation3.runtime)
+                api(libs.androidx.savedstate)
                 api(libs.kotlinx.coroutines.core)
                 api(libs.kotlinx.datetime)
+                api(libs.kotlinx.serialization.core)
                 api(projects.app.importengineapi)
                 api(projects.app.model.core)
                 api(projects.utils.bigdecimal)
@@ -25,6 +29,7 @@ kotlin {
         getByName("commonTest") {
             dependencies {
                 implementation(kotlin("test"))
+                implementation(libs.kotlinx.serialization.json)
                 implementation(projects.test.app.ui)
             }
         }
@@ -49,6 +54,8 @@ kotlin {
             dependsOn(jvmAndroidMain)
             dependencies {
                 api(libs.androidx.compose.runtime.desktop)
+                api(libs.androidx.navigation3.runtime.desktop)
+                api(libs.androidx.savedstate.desktop)
                 api(libs.compose.foundation.desktop)
                 api(libs.compose.ui.desktop)
                 api(projects.app.importengineapi)
@@ -70,6 +77,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(compose.desktop.currentOs)
+                implementation(libs.androidx.navigation3.runtime.desktop)
+                implementation(libs.androidx.savedstate.desktop)
                 implementation(libs.compose.ui.test.desktop)
             }
         }
@@ -77,6 +86,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(libs.androidx.compose.ui.test)
+                implementation(libs.kotlinx.serialization.json)
                 implementation(projects.test.app.ui)
             }
         }

--- a/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/navigation/NavigationHistory.kt
+++ b/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/navigation/NavigationHistory.kt
@@ -2,25 +2,30 @@ package com.moneymanager.ui.navigation
 
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.navigation3.runtime.NavKey
 
 /**
  * Manages navigation history with back/forward stack support.
  *
  * [backStack] always contains the current screen as its last element (it is never empty), so it
- * can be handed directly to Navigation 3's `NavDisplay`.
+ * can be handed directly to Navigation 3's `NavDisplay`. Pass a `rememberNavBackStack`-created
+ * stack to make the history survive process death; every element must be a [Screen].
  */
 @Stable
 class NavigationHistory(
-    initialScreen: Screen,
-) {
     /** The navigation back stack; the last element is the current screen. Never empty. */
-    val backStack: SnapshotStateList<Screen> = mutableStateListOf(initialScreen)
+    val backStack: MutableList<NavKey>,
+) {
+    constructor(initialScreen: Screen) : this(mutableStateListOf<NavKey>(initialScreen))
+
+    init {
+        require(backStack.isNotEmpty()) { "backStack must contain the initial screen" }
+    }
 
     private val forwardStack = mutableStateListOf<Screen>()
 
     val currentScreen: Screen
-        get() = backStack.last()
+        get() = backStack.last() as Screen
 
     val canGoBack: Boolean
         get() = backStack.size > 1
@@ -51,7 +56,7 @@ class NavigationHistory(
         // Move current screen to forward stack. removeAt instead of removeLast: on Android
         // compileSdk >= 35, removeLast() binds to the JDK 21 SequencedCollection method, which
         // crashes with NoSuchMethodError on devices below API 35.
-        forwardStack.add(backStack.removeAt(backStack.lastIndex))
+        forwardStack.add(backStack.removeAt(backStack.lastIndex) as Screen)
 
         return true
     }

--- a/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
+++ b/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
@@ -2,6 +2,7 @@
 
 package com.moneymanager.ui.navigation
 
+import androidx.navigation3.runtime.NavKey
 import com.moneymanager.domain.StrategyKind
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.ApiRequestId
@@ -14,119 +15,206 @@ import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
 import com.moneymanager.domain.model.importdirectory.ImportDirectoryId
 import com.moneymanager.domain.model.qif.QifImportId
+import kotlinx.serialization.Serializable
 
 enum class ImportTab { DIRECTORIES, CSV, QIF, API, MISC }
 
-sealed class Screen(
-    val title: String,
-) {
+/**
+ * Navigation destinations. Serializable [NavKey]s so the back stack survives process death via
+ * `rememberNavBackStack` (titles are computed properties, not serialized state).
+ */
+@Serializable
+sealed class Screen : NavKey {
+    abstract val title: String
+
+    @Serializable
     data class Accounts(
         val scrollToAccountId: AccountId? = null,
-    ) : Screen("Accounts")
+    ) : Screen() {
+        override val title: String get() = "Accounts"
+    }
 
-    data object Currencies : Screen("Currencies")
+    @Serializable
+    data object Currencies : Screen() {
+        override val title: String get() = "Currencies"
+    }
 
-    data object Categories : Screen("Categories")
+    @Serializable
+    data object Categories : Screen() {
+        override val title: String get() = "Categories"
+    }
 
-    data object People : Screen("People")
+    @Serializable
+    data object People : Screen() {
+        override val title: String get() = "People"
+    }
 
+    @Serializable
     data class PeopleScroll(
         val personId: PersonId,
-    ) : Screen("People")
+    ) : Screen() {
+        override val title: String get() = "People"
+    }
 
+    @Serializable
     data class Imports(
         val tab: ImportTab = ImportTab.DIRECTORIES,
-    ) : Screen("Imports")
+    ) : Screen() {
+        override val title: String get() = "Imports"
+    }
 
-    data object CsvStrategies : Screen("Import Strategies")
+    @Serializable
+    data object CsvStrategies : Screen() {
+        override val title: String get() = "Import Strategies"
+    }
 
+    @Serializable
     data class CsvStrategyEditor(
         val csvImportId: CsvImportId,
         val strategyId: CsvImportStrategyId? = null,
-    ) : Screen(if (strategyId == null) "Create Strategy" else "Edit Strategy")
+    ) : Screen() {
+        override val title: String get() = if (strategyId == null) "Create Strategy" else "Edit Strategy"
+    }
 
-    data object ApiStrategies : Screen("API Import Strategies")
+    @Serializable
+    data object ApiStrategies : Screen() {
+        override val title: String get() = "API Import Strategies"
+    }
 
+    @Serializable
     data class StrategyCatalog(
         val kindFilter: StrategyKind? = null,
-    ) : Screen("Strategy Catalog")
+    ) : Screen() {
+        override val title: String get() = "Strategy Catalog"
+    }
 
+    @Serializable
     data class ApiStrategyEditor(
         val strategyId: ApiImportStrategyId? = null,
-    ) : Screen(if (strategyId == null) "Create API Strategy" else "Edit API Strategy")
+    ) : Screen() {
+        override val title: String get() = if (strategyId == null) "Create API Strategy" else "Edit API Strategy"
+    }
 
-    data object Settings : Screen("Settings")
+    @Serializable
+    data object Settings : Screen() {
+        override val title: String get() = "Settings"
+    }
 
-    data object DatabaseSizeBreakdown : Screen("Database Size Breakdown")
+    @Serializable
+    data object DatabaseSizeBreakdown : Screen() {
+        override val title: String get() = "Database Size Breakdown"
+    }
 
+    @Serializable
     data class AccountTransactions(
         val accountId: AccountId,
         val accountName: String,
         val scrollToTransferId: TransferId? = null,
         val selectedCurrencyId: CurrencyId? = null,
-    ) : Screen(accountName)
+    ) : Screen() {
+        override val title: String get() = accountName
+    }
 
+    @Serializable
     data class CsvImportDetail(
         val importId: CsvImportId,
         val scrollToRowIndex: Long? = null,
-    ) : Screen("CSV Import")
+    ) : Screen() {
+        override val title: String get() = "CSV Import"
+    }
 
+    @Serializable
     data class QifImportDetail(
         val importId: QifImportId,
         val scrollToRecordIndex: Long? = null,
-    ) : Screen("QIF Import")
+    ) : Screen() {
+        override val title: String get() = "QIF Import"
+    }
 
+    @Serializable
     data class QifStrategyEditor(
         val qifImportId: QifImportId,
         val strategyId: CsvImportStrategyId? = null,
-    ) : Screen(if (strategyId == null) "Create Strategy" else "Edit Strategy")
+    ) : Screen() {
+        override val title: String get() = if (strategyId == null) "Create Strategy" else "Edit Strategy"
+    }
 
+    @Serializable
     data class AuditHistory(
         val transferId: TransferId,
-    ) : Screen("Audit History")
+    ) : Screen() {
+        override val title: String get() = "Audit History"
+    }
 
+    @Serializable
     data class AccountAuditHistory(
         val accountId: AccountId,
         val accountName: String,
-    ) : Screen("Account Audit: $accountName")
+    ) : Screen() {
+        override val title: String get() = "Account Audit: $accountName"
+    }
 
+    @Serializable
     data class PersonAuditHistory(
         val personId: PersonId,
         val personName: String,
-    ) : Screen("Person Audit: $personName")
+    ) : Screen() {
+        override val title: String get() = "Person Audit: $personName"
+    }
 
+    @Serializable
     data class CurrencyAuditHistory(
         val currencyId: CurrencyId,
         val currencyCode: String,
-    ) : Screen("Currency Audit: $currencyCode")
+    ) : Screen() {
+        override val title: String get() = "Currency Audit: $currencyCode"
+    }
 
+    @Serializable
     data class CategoryAuditHistory(
         val categoryId: Long,
         val categoryName: String,
-    ) : Screen("Category Audit: $categoryName")
+    ) : Screen() {
+        override val title: String get() = "Category Audit: $categoryName"
+    }
 
+    @Serializable
     data class ApiStrategyAuditHistory(
         val strategyId: ApiImportStrategyId,
         val strategyName: String,
-    ) : Screen("API Strategy Audit: $strategyName")
+    ) : Screen() {
+        override val title: String get() = "API Strategy Audit: $strategyName"
+    }
 
+    @Serializable
     data class CsvStrategyAuditHistory(
         val strategyId: CsvImportStrategyId,
         val strategyName: String,
-    ) : Screen("CSV Strategy Audit: $strategyName")
+    ) : Screen() {
+        override val title: String get() = "CSV Strategy Audit: $strategyName"
+    }
 
+    @Serializable
     data class ImportDirectoryAuditHistory(
         val directoryId: ImportDirectoryId,
         val directoryName: String,
-    ) : Screen("Import Directory Audit: $directoryName")
+    ) : Screen() {
+        override val title: String get() = "Import Directory Audit: $directoryName"
+    }
 
-    data object ConnectApi : Screen("Connect API Account")
+    @Serializable
+    data object ConnectApi : Screen() {
+        override val title: String get() = "Connect API Account"
+    }
 
+    @Serializable
     data class ApiSessionTraffic(
         val sessionId: ApiSessionId,
         /** When non-null the traffic screen should scroll to this request/response pair. */
         val highlightRequestId: ApiRequestId? = null,
         /** When non-null the traffic screen should expand and highlight this JSONPath. */
         val highlightJsonPath: String? = null,
-    ) : Screen("API Traffic")
+    ) : Screen() {
+        override val title: String get() = "API Traffic"
+    }
 }

--- a/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/navigation/ScreenSerialization.kt
+++ b/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/navigation/ScreenSerialization.kt
@@ -1,0 +1,24 @@
+package com.moneymanager.ui.navigation
+
+import androidx.navigation3.runtime.NavKey
+import androidx.savedstate.serialization.SavedStateConfiguration
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclassesOfSealed
+
+/**
+ * Saved-state serialization for the navigation back stack: `rememberNavBackStack` serializes the
+ * stack polymorphically through [NavKey], so every [Screen] subtype must be registered.
+ * `subclassesOfSealed` picks up new subtypes automatically.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+val ScreenSavedStateConfiguration: SavedStateConfiguration =
+    SavedStateConfiguration {
+        serializersModule =
+            SerializersModule {
+                polymorphic(NavKey::class) {
+                    subclassesOfSealed<Screen>()
+                }
+            }
+    }

--- a/app/ui/foundation/src/commonTest/kotlin/com/moneymanager/ui/navigation/ScreenSerializationTest.kt
+++ b/app/ui/foundation/src/commonTest/kotlin/com/moneymanager/ui/navigation/ScreenSerializationTest.kt
@@ -1,0 +1,74 @@
+@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.ui.navigation
+
+import androidx.navigation3.runtime.NavKey
+import com.moneymanager.domain.StrategyKind
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.ApiRequestId
+import com.moneymanager.domain.model.ApiSessionId
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.PersonId
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
+import com.moneymanager.domain.model.csv.CsvImportId
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.model.importdirectory.ImportDirectoryId
+import com.moneymanager.domain.model.qif.QifImportId
+import kotlinx.serialization.PolymorphicSerializer
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+/**
+ * Round-trips one instance of every [Screen] subtype through the polymorphic [NavKey] serializer
+ * that `rememberNavBackStack` uses, so an unserializable destination (e.g. a new id type missing
+ * `@Serializable`) fails here instead of at runtime when the back stack is saved.
+ */
+class ScreenSerializationTest {
+    private val json = Json { serializersModule = ScreenSavedStateConfiguration.serializersModule }
+
+    private val uuid = Uuid.parse("0b3a4e6e-8f5d-4c1a-9e2b-7d6c5b4a3f21")
+
+    private val screens: List<Screen> =
+        listOf(
+            Screen.Accounts(scrollToAccountId = AccountId(1)),
+            Screen.Currencies,
+            Screen.Categories,
+            Screen.People,
+            Screen.PeopleScroll(PersonId(2)),
+            Screen.Imports(ImportTab.QIF),
+            Screen.CsvStrategies,
+            Screen.CsvStrategyEditor(CsvImportId(uuid), CsvImportStrategyId(uuid)),
+            Screen.ApiStrategies,
+            Screen.StrategyCatalog(StrategyKind.PASS_THROUGH),
+            Screen.ApiStrategyEditor(ApiImportStrategyId(uuid)),
+            Screen.Settings,
+            Screen.DatabaseSizeBreakdown,
+            Screen.AccountTransactions(AccountId(3), "Checking", TransferId(4), CurrencyId(5)),
+            Screen.CsvImportDetail(CsvImportId(uuid), scrollToRowIndex = 7),
+            Screen.QifImportDetail(QifImportId(uuid), scrollToRecordIndex = 8),
+            Screen.QifStrategyEditor(QifImportId(uuid), CsvImportStrategyId(uuid)),
+            Screen.AuditHistory(TransferId(9)),
+            Screen.AccountAuditHistory(AccountId(10), "Savings"),
+            Screen.PersonAuditHistory(PersonId(11), "Ada"),
+            Screen.CurrencyAuditHistory(CurrencyId(12), "GBP"),
+            Screen.CategoryAuditHistory(13, "Groceries"),
+            Screen.ApiStrategyAuditHistory(ApiImportStrategyId(uuid), "Monzo"),
+            Screen.CsvStrategyAuditHistory(CsvImportStrategyId(uuid), "Wise"),
+            Screen.ImportDirectoryAuditHistory(ImportDirectoryId(uuid), "Downloads"),
+            Screen.ConnectApi,
+            Screen.ApiSessionTraffic(ApiSessionId(14), ApiRequestId(15), "$.items[0]"),
+        )
+
+    @Test
+    fun everyScreenSubtypeRoundTripsThroughTheNavKeySerializer() {
+        val serializer = PolymorphicSerializer(NavKey::class)
+        for (screen in screens) {
+            val encoded = json.encodeToString(serializer, screen)
+            val decoded = json.decodeFromString(serializer, encoded)
+            assertEquals(screen, decoded, "Round trip failed for ${screen::class.simpleName}")
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -111,6 +111,8 @@ androidx-compose-ui-test = { module = "androidx.compose.ui:ui-test", version.ref
 androidx-compose-ui-text = { module = "androidx.compose.ui:ui-text", version.ref = "androidx-compose" }
 androidx-compose-ui-unit = { module = "androidx.compose.ui:ui-unit", version.ref = "androidx-compose" }
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "androidx-navigation3" }
+androidx-savedstate = { module = "androidx.savedstate:savedstate", version.ref = "androidx-savedstate" }
+androidx-savedstate-desktop = { module = "androidx.savedstate:savedstate-desktop", version.ref = "androidx-savedstate" }
 androidx-navigation3-runtime-desktop = { module = "androidx.navigation3:navigation3-runtime-desktop", version.ref = "androidx-navigation3" }
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "androidx-navigation3" }
 jetbrains-navigation3-ui-desktop = { module = "org.jetbrains.androidx.navigation3:navigation3-ui-desktop", version.ref = "jetbrains-navigation3" }


### PR DESCRIPTION
Stacked on #632 (follow-ups promised there). Do not merge before #632; retarget to `main` after it lands.

## What

- **`Screen` is now a `@Serializable` sealed `NavKey` hierarchy.** Titles moved from a superclass constructor parameter to computed properties, so they are behavior, not serialized state.
- **The back stack survives process death on Android**: `MoneyManagerApp` builds it with `rememberNavBackStack` + a `SavedStateConfiguration` whose module registers `Screen` via `subclassesOfSealed` — new destinations are picked up automatically, no manual registration list to keep in sync. `NavigationHistory` now wraps the externally owned stack (same API, same semantics, same tests).
- **Route ids are serializable**: the Uuid-backed id value classes (`CsvImportId`, `QifImportId`, `CsvImportStrategyId`, `ApiImportStrategyId`, `ImportDirectoryId`) and the remaining Long-backed ones (`TransferId`, `ApiSessionId`, `ApiRequestId`) gained `@Serializable` (kotlinx-serialization ships a built-in `kotlin.uuid.Uuid` serializer).
- **`ScreenSerializationTest`** round-trips one instance of every `Screen` subtype through the polymorphic `NavKey` serializer, so an unserializable destination fails in unit tests rather than at runtime when the stack is first saved.
- **Default `NavDisplay` transitions are enabled** (the `EnterTransition.None` overrides from #632 are removed). The E2E suite stays deterministic — Compose UI tests auto-advance the animation clock; all 61 `:app:ui:core:jvmTest` E2Es pass with animations on.

## Not included (deliberately)

Deleting the `scrollToAccountId`/`replaceCurrentScreen` scroll-restore mechanism in favor of per-entry `rememberSaveable` state: that parameter also serves "scroll to newly created account", so untangling it deserves its own change.

## Verification

- `./gradlew build buildHealth` fully green on this branch.
- Foundation unit tests cover history semantics + serialization of all 27 destinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation state now persists more reliably, helping users return to the same screen after app restarts or configuration changes.
  * Several app entities now support saved state, improving continuity across Android and desktop.

* **Bug Fixes**
  * Updated screen navigation handling to better preserve in-app history and restore destinations consistently.

* **Tests**
  * Added coverage to verify navigation screens can be saved and restored without data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->