### PR TITLE
Android parity for import directories: SAF local folders + Google Drive

### DIFF
--- a/app/csvimporter/src/jvmTest/kotlin/com/moneymanager/csvimporter/ImportDirectoryDiscoveryTest.kt
+++ b/app/csvimporter/src/jvmTest/kotlin/com/moneymanager/csvimporter/ImportDirectoryDiscoveryTest.kt
@@ -52,4 +52,32 @@ class ImportDirectoryDiscoveryTest {
                 "only folders that directly contain .csv/.qif files are discovered (root and txt-only folder excluded)",
             )
         }
+
+    @Test
+    fun `refs are opaque - Android SAF document-tree URIs flow through discovery untouched`() =
+        runTest {
+            val root = "content://com.android.externalstorage.documents/tree/primary%3AStatements"
+            val child = "$root/document/primary%3AStatements%2F2024"
+            val tree =
+                mapOf(
+                    root to FakeNode(files = listOf("jan.csv"), subfolders = listOf(ImportSubfolder(child, "2024"))),
+                    child to FakeNode(files = listOf("feb.csv"), subfolders = emptyList()),
+                )
+
+            val discovered =
+                discoverImportableFolders(
+                    rootFolderRef = root,
+                    rootDisplayPath = "Statements",
+                    openFolder = { ref -> FakeTreeSource(tree.getValue(ref)) },
+                )
+
+            assertEquals(
+                listOf(
+                    root to "Statements",
+                    child to "Statements / 2024",
+                ),
+                discovered.map { it.folderRef to it.displayPath },
+                "URI-shaped refs must be passed through verbatim and display paths joined with ' / '",
+            )
+        }
 }

--- a/app/di/core/src/androidMain/kotlin/com/moneymanager/di/AppComponentParams.kt
+++ b/app/di/core/src/androidMain/kotlin/com/moneymanager/di/AppComponentParams.kt
@@ -11,4 +11,10 @@ actual data class AppComponentParams(
      * library module (no manifest/Activity). See `MainActivity`.
      */
     val googleTokenSource: GoogleAccessTokenSource,
+    /**
+     * A second token source scoped to `drive.readonly`, used only by import directories: files the
+     * user drops into a Drive folder aren't app-created, so [googleTokenSource]'s `drive.file` grant
+     * can't see them. Kept separate so browsing imports never widens (or re-prompts) the DB-sync grant.
+     */
+    val googleDriveImportTokenSource: GoogleAccessTokenSource,
 )

--- a/app/di/core/src/androidMain/kotlin/com/moneymanager/di/importfilesource/CreateDriveFolderBrowser.android.kt
+++ b/app/di/core/src/androidMain/kotlin/com/moneymanager/di/importfilesource/CreateDriveFolderBrowser.android.kt
@@ -1,10 +1,30 @@
 package com.moneymanager.di.importfilesource
 
+import com.moneymanager.di.AppComponentParams
 import com.moneymanager.importfilesource.DriveFolderBrowser
+import com.moneymanager.importfilesource.ImportFolder
 import com.moneymanager.localsettings.LocalSettings
+import com.moneymanager.remotestorage.googledrive.DriveImportFileSource
 
-// Drive folder browsing needs the drive.readonly scope via the native Android auth path, which is not
-// wired yet. Returning null makes the add-directory dialog hide the Google Drive option on Android
-// (configure Drive directories from desktop for now) instead of offering a picker that fails.
-@Suppress("ktlint:standard:function-naming")
-actual fun createDriveFolderBrowser(localSettings: LocalSettings): DriveFolderBrowser? = null
+@Suppress("ktlint:standard:function-naming", "UnusedParameter")
+actual fun createDriveFolderBrowser(
+    params: AppComponentParams,
+    localSettings: LocalSettings,
+): DriveFolderBrowser? =
+    object : DriveFolderBrowser {
+        override val rootFolderId: String = DriveImportFileSource.ROOT_FOLDER_ID
+        override val sharedWithMeFolderId: String = DriveImportFileSource.SHARED_WITH_ME_FOLDER_ID
+
+        // providerConfig (bring-your-own OAuth client) is a JVM concept and is deliberately ignored:
+        // Android auth is bound to the app's package + signing key via the GMS AuthorizationClient.
+        override suspend fun listChildFolders(
+            providerConfig: String?,
+            parentId: String,
+        ): List<ImportFolder> {
+            val tokenSource = params.googleDriveImportTokenSource
+            if (!tokenSource.isSignedInWithRequiredScopes()) tokenSource.signIn()
+            return DriveImportFileSource
+                .listChildFolders(tokenSource, parentId)
+                .map { ImportFolder(id = it.id, name = it.name) }
+        }
+    }

--- a/app/di/core/src/androidMain/kotlin/com/moneymanager/di/importfilesource/CreateImportFileSourceFactory.android.kt
+++ b/app/di/core/src/androidMain/kotlin/com/moneymanager/di/importfilesource/CreateImportFileSourceFactory.android.kt
@@ -1,23 +1,39 @@
 package com.moneymanager.di.importfilesource
 
+import com.moneymanager.di.AppComponentParams
 import com.moneymanager.domain.model.importdirectory.ImportDirectory
 import com.moneymanager.domain.model.importdirectory.ImportDirectoryProvider
 import com.moneymanager.importfilesource.ImportFileSource
 import com.moneymanager.importfilesource.ImportFileSourceFactory
 import com.moneymanager.importfilesource.localfolder.LocalFolderImportFileSource
+import com.moneymanager.importfilesource.localfolder.SafFolderImportFileSource
 import com.moneymanager.localsettings.LocalSettings
+import com.moneymanager.remotestorage.googledrive.driveImportFileSource
 
-@Suppress("ktlint:standard:function-naming")
-actual fun createImportFileSourceFactory(localSettings: LocalSettings): ImportFileSourceFactory =
+@Suppress("ktlint:standard:function-naming", "UnusedParameter")
+actual fun createImportFileSourceFactory(
+    params: AppComponentParams,
+    localSettings: LocalSettings,
+): ImportFileSourceFactory =
     object : ImportFileSourceFactory {
-        // Android reads local folders only; Drive needs the drive.readonly native auth path (not wired
-        // yet), so the UI disables download for synced GDRIVE directories rather than failing on click.
-        override fun supportsProvider(provider: ImportDirectoryProvider): Boolean = provider == ImportDirectoryProvider.LOCAL
+        override fun supportsProvider(provider: ImportDirectoryProvider): Boolean = true
 
         override suspend fun create(directory: ImportDirectory): ImportFileSource =
             when (directory.provider) {
-                ImportDirectoryProvider.LOCAL -> LocalFolderImportFileSource(directory.folderRef)
-                ImportDirectoryProvider.GDRIVE ->
-                    throw UnsupportedOperationException("Google Drive import directories are not yet supported on Android.")
+                ImportDirectoryProvider.LOCAL ->
+                    // SAF-picked folders carry a content:// tree/document URI; plain paths (rows created
+                    // before SAF support, or app-readable paths) still go through java.io.
+                    if (SafFolderImportFileSource.isDocumentTreeRef(directory.folderRef)) {
+                        SafFolderImportFileSource(params.context.contentResolver, directory.folderRef)
+                    } else {
+                        LocalFolderImportFileSource(directory.folderRef)
+                    }
+                ImportDirectoryProvider.GDRIVE -> {
+                    // directory.providerConfig (bring-your-own OAuth client) is a JVM concept and is
+                    // deliberately ignored: Android auth is bound to the app's package + signing key.
+                    val tokenSource = params.googleDriveImportTokenSource
+                    if (!tokenSource.isSignedInWithRequiredScopes()) tokenSource.signIn()
+                    driveImportFileSource(tokenSource, directory.folderRef)
+                }
             }
     }

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/importfilesource/CreateDriveFolderBrowser.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/importfilesource/CreateDriveFolderBrowser.kt
@@ -1,12 +1,17 @@
 package com.moneymanager.di.importfilesource
 
+import com.moneymanager.di.AppComponentParams
 import com.moneymanager.importfilesource.DriveFolderBrowser
 import com.moneymanager.localsettings.LocalSettings
 
 /**
  * Builds the platform's [DriveFolderBrowser] for the add-directory folder picker, or null when this
  * platform can't browse Google Drive (the UI then hides the Drive option). [localSettings] supplies
- * the Google Drive credentials/token store.
+ * the Google Drive credentials/token store on JVM; [params] supplies the natively-authorized Drive
+ * token source on Android.
  */
 @Suppress("ktlint:standard:function-naming")
-expect fun createDriveFolderBrowser(localSettings: LocalSettings): DriveFolderBrowser?
+expect fun createDriveFolderBrowser(
+    params: AppComponentParams,
+    localSettings: LocalSettings,
+): DriveFolderBrowser?

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/importfilesource/CreateImportFileSourceFactory.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/importfilesource/CreateImportFileSourceFactory.kt
@@ -1,12 +1,17 @@
 package com.moneymanager.di.importfilesource
 
+import com.moneymanager.di.AppComponentParams
 import com.moneymanager.importfilesource.ImportFileSourceFactory
 import com.moneymanager.localsettings.LocalSettings
 
 /**
  * Builds the platform's [ImportFileSourceFactory], which resolves a read-only file source for a
  * configured import directory (local folder or Google Drive folder). [localSettings] supplies the
- * Google Drive credentials/token store for Drive directories.
+ * Google Drive credentials/token store on JVM; [params] supplies the Android `Context` (SAF folder
+ * access) and the natively-authorized Drive token source.
  */
 @Suppress("ktlint:standard:function-naming")
-expect fun createImportFileSourceFactory(localSettings: LocalSettings): ImportFileSourceFactory
+expect fun createImportFileSourceFactory(
+    params: AppComponentParams,
+    localSettings: LocalSettings,
+): ImportFileSourceFactory

--- a/app/di/core/src/jvmMain/kotlin/com/moneymanager/di/importfilesource/CreateDriveFolderBrowser.jvm.kt
+++ b/app/di/core/src/jvmMain/kotlin/com/moneymanager/di/importfilesource/CreateDriveFolderBrowser.jvm.kt
@@ -17,7 +17,7 @@ private fun googleDriveDefaultConfig(): String? =
         null
     }
 
-@Suppress("ktlint:standard:function-naming", "UnusedParameter")
+@Suppress("ktlint:standard:function-naming")
 actual fun createDriveFolderBrowser(
     params: AppComponentParams,
     localSettings: LocalSettings,

--- a/app/di/core/src/jvmMain/kotlin/com/moneymanager/di/importfilesource/CreateDriveFolderBrowser.jvm.kt
+++ b/app/di/core/src/jvmMain/kotlin/com/moneymanager/di/importfilesource/CreateDriveFolderBrowser.jvm.kt
@@ -1,5 +1,6 @@
 package com.moneymanager.di.importfilesource
 
+import com.moneymanager.di.AppComponentParams
 import com.moneymanager.importfilesource.DriveFolderBrowser
 import com.moneymanager.importfilesource.ImportFolder
 import com.moneymanager.localsettings.LocalSettings
@@ -16,8 +17,11 @@ private fun googleDriveDefaultConfig(): String? =
         null
     }
 
-@Suppress("ktlint:standard:function-naming")
-actual fun createDriveFolderBrowser(localSettings: LocalSettings): DriveFolderBrowser? =
+@Suppress("ktlint:standard:function-naming", "UnusedParameter")
+actual fun createDriveFolderBrowser(
+    params: AppComponentParams,
+    localSettings: LocalSettings,
+): DriveFolderBrowser? =
     object : DriveFolderBrowser {
         override val rootFolderId: String = DriveImportFileSource.ROOT_FOLDER_ID
         override val sharedWithMeFolderId: String = DriveImportFileSource.SHARED_WITH_ME_FOLDER_ID

--- a/app/di/core/src/jvmMain/kotlin/com/moneymanager/di/importfilesource/CreateImportFileSourceFactory.jvm.kt
+++ b/app/di/core/src/jvmMain/kotlin/com/moneymanager/di/importfilesource/CreateImportFileSourceFactory.jvm.kt
@@ -1,5 +1,6 @@
 package com.moneymanager.di.importfilesource
 
+import com.moneymanager.di.AppComponentParams
 import com.moneymanager.domain.model.importdirectory.ImportDirectory
 import com.moneymanager.domain.model.importdirectory.ImportDirectoryProvider
 import com.moneymanager.importfilesource.ImportFileSource
@@ -21,8 +22,11 @@ private fun googleDriveDefaultConfig(): String? =
         null
     }
 
-@Suppress("ktlint:standard:function-naming")
-actual fun createImportFileSourceFactory(localSettings: LocalSettings): ImportFileSourceFactory =
+@Suppress("ktlint:standard:function-naming", "UnusedParameter")
+actual fun createImportFileSourceFactory(
+    params: AppComponentParams,
+    localSettings: LocalSettings,
+): ImportFileSourceFactory =
     object : ImportFileSourceFactory {
         // Desktop reads both local folders and Google Drive.
         override fun supportsProvider(provider: ImportDirectoryProvider): Boolean = true

--- a/app/di/core/src/jvmMain/kotlin/com/moneymanager/di/importfilesource/CreateImportFileSourceFactory.jvm.kt
+++ b/app/di/core/src/jvmMain/kotlin/com/moneymanager/di/importfilesource/CreateImportFileSourceFactory.jvm.kt
@@ -22,7 +22,7 @@ private fun googleDriveDefaultConfig(): String? =
         null
     }
 
-@Suppress("ktlint:standard:function-naming", "UnusedParameter")
+@Suppress("ktlint:standard:function-naming")
 actual fun createImportFileSourceFactory(
     params: AppComponentParams,
     localSettings: LocalSettings,

--- a/app/importfilesource/localfolder/build.gradle.kts
+++ b/app/importfilesource/localfolder/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 // Local-folder backend for ImportFileSource: lists + reads files from a filesystem folder via
 // java.io.File. JVM and Android share one jvmAndroidMain source set (java.io is available on both for
-// real filesystem paths). Database-free.
+// real filesystem paths); androidMain adds the SAF document-tree variant on top. Database-free.
 kotlin {
     sourceSets {
         val jvmAndroidMain =

--- a/app/importfilesource/localfolder/src/androidMain/kotlin/com/moneymanager/importfilesource/localfolder/SafFolderImportFileSource.kt
+++ b/app/importfilesource/localfolder/src/androidMain/kotlin/com/moneymanager/importfilesource/localfolder/SafFolderImportFileSource.kt
@@ -1,0 +1,128 @@
+package com.moneymanager.importfilesource.localfolder
+
+import android.content.ContentResolver
+import android.database.Cursor
+import android.net.Uri
+import android.provider.DocumentsContract
+import com.moneymanager.importfilesource.ImportFileEntry
+import com.moneymanager.importfilesource.ImportFileSource
+import com.moneymanager.importfilesource.ImportSubfolder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.FileNotFoundException
+import java.io.IOException
+
+/**
+ * Lists and reads files from a Storage Access Framework document tree. [folderUri] is either the
+ * tree URI returned by OpenDocumentTree (a top-level import directory) or a document-in-tree URI
+ * produced by [listSubfolders] (a discovered subfolder) — both carry the persisted tree grant, so
+ * subfolders need no permission of their own.
+ *
+ * The file ref is the child's document id (stable while the file keeps its name/location — the same
+ * semantics as the filename refs used by [LocalFolderImportFileSource] on the JVM); the subfolder
+ * ref is a full document-in-tree URI so it can be reopened through the factory on its own.
+ */
+class SafFolderImportFileSource(
+    private val contentResolver: ContentResolver,
+    folderUri: String,
+) : ImportFileSource {
+    private val uri: Uri = Uri.parse(folderUri)
+
+    // A tree URI has no document segment, so getDocumentId throws; fall back to the tree's own root.
+    private val folderDocumentId: String =
+        runCatching { DocumentsContract.getDocumentId(uri) }
+            .getOrElse { DocumentsContract.getTreeDocumentId(uri) }
+
+    override suspend fun list(): List<ImportFileEntry> =
+        withContext(Dispatchers.IO) {
+            queryChildren()
+                .filter { !it.isDirectory }
+                .map { child ->
+                    ImportFileEntry(
+                        ref = child.documentId,
+                        name = child.displayName,
+                        lastModifiedEpochMs = child.lastModifiedEpochMs,
+                        sizeBytes = child.sizeBytes,
+                    )
+                }.sortedBy { it.name }
+        }
+
+    override suspend fun listSubfolders(): List<ImportSubfolder> =
+        withContext(Dispatchers.IO) {
+            queryChildren()
+                .filter { it.isDirectory }
+                .map { child ->
+                    ImportSubfolder(
+                        ref = DocumentsContract.buildDocumentUriUsingTree(uri, child.documentId).toString(),
+                        name = child.displayName,
+                    )
+                }.sortedBy { it.name }
+        }
+
+    override suspend fun download(fileRef: String): ByteArray =
+        withContext(Dispatchers.IO) {
+            val fileUri = DocumentsContract.buildDocumentUriUsingTree(uri, fileRef)
+            translateRevokedGrant {
+                contentResolver.openInputStream(fileUri)?.use { it.readBytes() }
+                    ?: throw FileNotFoundException("Cannot open file in import directory: $fileUri")
+            }
+        }
+
+    private data class ChildDocument(
+        val documentId: String,
+        val displayName: String,
+        val isDirectory: Boolean,
+        val lastModifiedEpochMs: Long?,
+        val sizeBytes: Long?,
+    )
+
+    // Child queries ignore selection args on most providers, so file/folder filtering is client-side.
+    private fun queryChildren(): List<ChildDocument> {
+        val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(uri, folderDocumentId)
+        val projection =
+            arrayOf(
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                DocumentsContract.Document.COLUMN_MIME_TYPE,
+                DocumentsContract.Document.COLUMN_LAST_MODIFIED,
+                DocumentsContract.Document.COLUMN_SIZE,
+            )
+        val cursor =
+            translateRevokedGrant { contentResolver.query(childrenUri, projection, null, null, null) }
+                ?: throw FileNotFoundException("Import directory does not exist (or its provider is gone): $uri")
+        return cursor.use { c ->
+            buildList {
+                while (c.moveToNext()) {
+                    add(
+                        ChildDocument(
+                            documentId = c.getString(0),
+                            displayName = c.getString(1) ?: c.getString(0),
+                            isDirectory = c.getString(2) == DocumentsContract.Document.MIME_TYPE_DIR,
+                            lastModifiedEpochMs = c.getLongOrNullAt(3)?.takeIf { it > 0 },
+                            sizeBytes = c.getLongOrNullAt(4)?.takeIf { it >= 0 },
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    // A revoked (or never-granted) persisted permission surfaces as SecurityException; rethrow with a
+    // message the scan-failure UI can show, telling the user how to recover.
+    private inline fun <T> translateRevokedGrant(block: () -> T): T =
+        try {
+            block()
+        } catch (e: SecurityException) {
+            throw IOException(
+                "Access to this folder was revoked — delete the import directory and pick the folder again.",
+                e,
+            )
+        }
+
+    companion object {
+        /** True when [ref] is a SAF document/tree URI rather than a plain filesystem path. */
+        fun isDocumentTreeRef(ref: String): Boolean = ref.startsWith("content://")
+    }
+}
+
+private fun Cursor.getLongOrNullAt(index: Int): Long? = if (isNull(index)) null else getLong(index)

--- a/app/main/android/src/main/kotlin/com/moneymanager/android/MainActivity.kt
+++ b/app/main/android/src/main/kotlin/com/moneymanager/android/MainActivity.kt
@@ -17,6 +17,8 @@ import com.moneymanager.di.importfilesource.createDriveFolderBrowser
 import com.moneymanager.di.importfilesource.createImportFileSourceFactory
 import com.moneymanager.di.initializeVersionReader
 import com.moneymanager.importengineapi.EditingLockedException
+import com.moneymanager.remotestorage.googledrive.DRIVE_FILE_SCOPE
+import com.moneymanager.remotestorage.googledrive.DRIVE_READONLY_SCOPE
 import com.moneymanager.remotestorage.sync.RemoteDatabaseController
 import com.moneymanager.remotestorage.sync.SyncResult
 import com.moneymanager.ui.AppStartupHost
@@ -98,12 +100,18 @@ class MainActivity : ComponentActivity() {
             AppComponentParams(
                 context = applicationContext,
                 googleTokenSource = AndroidGoogleAccessTokenSource(applicationContext, googleAuthConsentLauncher),
+                googleDriveImportTokenSource =
+                    AndroidGoogleAccessTokenSource(
+                        applicationContext,
+                        googleAuthConsentLauncher,
+                        scopes = listOf(DRIVE_FILE_SCOPE, DRIVE_READONLY_SCOPE),
+                    ),
             )
         val component: AppComponent = AppComponent.create(params)
         val controller = component.remoteDatabaseController
         remoteController = controller
-        val importFileSourceFactory = createImportFileSourceFactory(component.localSettings)
-        val driveFolderBrowser = createDriveFolderBrowser(component.localSettings)
+        val importFileSourceFactory = createImportFileSourceFactory(params, component.localSettings)
+        val driveFolderBrowser = createDriveFolderBrowser(params, component.localSettings)
 
         setContent {
             AppStartupHost(

--- a/app/main/android/src/main/kotlin/com/moneymanager/android/auth/AndroidGoogleAccessTokenSource.kt
+++ b/app/main/android/src/main/kotlin/com/moneymanager/android/auth/AndroidGoogleAccessTokenSource.kt
@@ -18,7 +18,9 @@ import kotlin.coroutines.resumeWithException
 /**
  * Android [GoogleAccessTokenSource] backed by Google Identity Services' `AuthorizationClient`. Sign-in
  * shows a native account/consent sheet (no browser, no loopback) and GMS re-issues short-lived access
- * tokens silently once the `drive.file` scope is granted — so there is no refresh token and no backend.
+ * tokens silently once the requested [scopes] are granted — so there is no refresh token and no backend.
+ * DB sync uses the default `drive.file`; import directories need an instance with `drive.readonly` on
+ * top (user-dropped files are invisible to `drive.file`).
  *
  * Requires Google Play Services and an Android-type OAuth client registered for this app's package +
  * signing SHA-1 in the Cloud Console (no client id is passed in code; GMS matches by package/signature).
@@ -26,6 +28,7 @@ import kotlin.coroutines.resumeWithException
 class AndroidGoogleAccessTokenSource(
     context: Context,
     private val consentLauncher: GoogleAuthConsentLauncher,
+    private val scopes: List<String> = listOf(DRIVE_FILE_SCOPE),
 ) : GoogleAccessTokenSource {
     private val authorizationClient = Identity.getAuthorizationClient(context)
 
@@ -43,6 +46,11 @@ class AndroidGoogleAccessTokenSource(
         )
 
     override suspend fun isSignedIn(): Boolean = runCatching { authorizeSilently() != null }.getOrDefault(false)
+
+    // authorize() carries this instance's scopes, so a silent grant covering them all means no consent
+    // sheet is needed; anything else (no grant, or a narrower earlier grant) must go through signIn().
+    override suspend fun isSignedInWithRequiredScopes(): Boolean =
+        runCatching { authorizeSilently()?.grantedScopes?.containsAll(scopes) == true }.getOrDefault(false)
 
     override suspend fun signIn() {
         cachedToken =
@@ -64,7 +72,7 @@ class AndroidGoogleAccessTokenSource(
     private fun request(): AuthorizationRequest =
         AuthorizationRequest
             .builder()
-            .setRequestedScopes(listOf(Scope(DRIVE_FILE_SCOPE)))
+            .setRequestedScopes(scopes.map(::Scope))
             .build()
 
     /** Returns a result only when a token is available without UI; null when consent would be required. */

--- a/app/main/jvm/src/main/kotlin/com/moneymanager/Main.kt
+++ b/app/main/jvm/src/main/kotlin/com/moneymanager/Main.kt
@@ -140,9 +140,10 @@ fun main() {
 @Suppress("FunctionName")
 private fun MainWindow(onExit: () -> Unit) {
     // Initialize DI component once
+    val params = remember { AppComponentParams() }
     val component =
         remember {
-            AppComponent.create(AppComponentParams()).also {
+            AppComponent.create(params).also {
                 logger.info { "DI component created successfully" }
             }
         }
@@ -151,8 +152,8 @@ private fun MainWindow(onExit: () -> Unit) {
     val appVersion = component.appVersion
     val localSettings = component.localSettings
     val remoteController = component.remoteDatabaseController
-    val importFileSourceFactory = createImportFileSourceFactory(localSettings)
-    val driveFolderBrowser = createDriveFolderBrowser(localSettings)
+    val importFileSourceFactory = createImportFileSourceFactory(params, localSettings)
+    val driveFolderBrowser = createDriveFolderBrowser(params, localSettings)
     // The currently open database, tracked so we can push it and clean up on app close.
     val openDatabase = remember { arrayOfNulls<MoneyManagerDatabaseWrapper>(1) }
     val scope = rememberCoroutineScope()

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/importdirectory/ImportDirectory.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/importdirectory/ImportDirectory.kt
@@ -28,11 +28,10 @@ enum class ImportDirectoryProvider(
  * lists the folder and stages new/changed importable files (.csv/.qif) into the Imports tabs, tracked
  * per file via [ImportDirectoryFile].
  *
- * @property folderRef Local absolute filesystem path, or Drive folder id (used to access it). LOCAL
- *   directories are filesystem paths only — Android Storage Access Framework tree URIs are not
- *   supported (the local backend reads via java.io.File).
+ * @property folderRef Whatever the platform backend needs to open the folder: a local absolute
+ *   filesystem path (JVM), an Android Storage Access Framework tree/document URI, or a Drive folder id.
  * @property displayPath Human-readable full path shown in the UI (e.g. "My Drive / Statements"); null
- *   falls back to [folderRef] (e.g. local folders, whose ref is already readable).
+ *   falls back to [folderRef] (e.g. JVM local folders, whose path ref is already readable).
  * @property providerConfig Provider-specific config (e.g. Drive OAuth client JSON); null for LOCAL.
  * @property deviceId Set for LOCAL directories (scanned only on that device); null for shared GDRIVE.
  * @property topLevel True for a user-picked folder (download discovers + creates child directories);

--- a/app/ui/imports/importDirectory/src/commonMain/kotlin/com/moneymanager/ui/screens/AddImportDirectoryDialog.kt
+++ b/app/ui/imports/importDirectory/src/commonMain/kotlin/com/moneymanager/ui/screens/AddImportDirectoryDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.compose.filepicker.manualFolderEntrySupported
 import com.moneymanager.compose.filepicker.rememberFolderPicker
 import com.moneymanager.domain.model.importdirectory.ImportDirectoryProvider
 import com.moneymanager.importfilesource.DriveFolderBrowser
@@ -39,14 +40,18 @@ fun AddImportDirectoryDialog(
     var name by remember { mutableStateOf("") }
     var provider by remember { mutableStateOf(ImportDirectoryProvider.LOCAL) }
     var folderRef by remember { mutableStateOf("") }
+    var localFolderName by remember { mutableStateOf<String?>(null) }
     var driveFolderName by remember { mutableStateOf<String?>(null) }
     var showDrivePicker by remember { mutableStateOf(false) }
 
     val folderPicker =
-        rememberFolderPicker { path ->
-            if (path != null) {
-                folderRef = path
+        rememberFolderPicker { picked ->
+            if (picked != null) {
+                folderRef = picked.ref
+                localFolderName = picked.displayName
                 driveFolderName = null
+                // Pre-fill the directory name with the folder name (only if the user hasn't typed one).
+                if (name.isBlank()) name = picked.displayName
             }
         }
 
@@ -89,6 +94,7 @@ fun AddImportDirectoryDialog(
                         onClick = {
                             provider = ImportDirectoryProvider.LOCAL
                             folderRef = ""
+                            localFolderName = null
                             driveFolderName = null
                         },
                         label = { Text("Local folder") },
@@ -98,6 +104,7 @@ fun AddImportDirectoryDialog(
                         onClick = {
                             provider = ImportDirectoryProvider.GDRIVE
                             folderRef = ""
+                            localFolderName = null
                         },
                         enabled = driveFolderBrowser != null,
                         label = { Text("Google Drive") },
@@ -105,14 +112,27 @@ fun AddImportDirectoryDialog(
                 }
 
                 if (provider == ImportDirectoryProvider.LOCAL) {
-                    OutlinedTextField(
-                        value = folderRef,
-                        onValueChange = { folderRef = it },
-                        label = { Text("Folder path") },
-                        singleLine = true,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    OutlinedButton(onClick = { folderPicker.launch() }) { Text("Browse…") }
+                    if (manualFolderEntrySupported) {
+                        OutlinedTextField(
+                            value = folderRef,
+                            onValueChange = {
+                                folderRef = it
+                                // A hand-typed path is its own display; drop any stale picked name.
+                                localFolderName = null
+                            },
+                            label = { Text("Folder path") },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        OutlinedButton(onClick = { folderPicker.launch() }) { Text("Browse…") }
+                    } else {
+                        // SAF-only platforms: the folder ref is an opaque content:// URI, so never show
+                        // or edit it — mirror the Drive branch and show the picked folder's name instead.
+                        OutlinedButton(onClick = { folderPicker.launch() }) {
+                            Text(if (localFolderName == null) "Choose folder…" else "Change folder")
+                        }
+                        localFolderName?.let { Text("Selected: $it", style = MaterialTheme.typography.bodyMedium) }
+                    }
                 } else {
                     OutlinedButton(
                         enabled = driveFolderBrowser != null,
@@ -125,8 +145,17 @@ fun AddImportDirectoryDialog(
         confirmButton = {
             TextButton(
                 enabled = canCreate,
-                // driveFolderName holds the full Drive path; null for local (folderRef is already readable).
-                onClick = { onCreate(name.trim(), provider, folderRef.trim(), driveFolderName) },
+                onClick = {
+                    // Drive: the full Drive path. Local: the picked folder's name when the ref is an
+                    // opaque URI; null when the ref is a readable path (typed, or JVM picker where
+                    // displayName == ref).
+                    val displayPath =
+                        when (provider) {
+                            ImportDirectoryProvider.GDRIVE -> driveFolderName
+                            ImportDirectoryProvider.LOCAL -> localFolderName?.takeIf { it != folderRef }
+                        }
+                    onCreate(name.trim(), provider, folderRef.trim(), displayPath)
+                },
             ) { Text("Add") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },

--- a/app/ui/imports/importDirectory/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportDirectoriesScreen.kt
+++ b/app/ui/imports/importDirectory/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportDirectoriesScreen.kt
@@ -1,12 +1,14 @@
 @file:OptIn(
     kotlin.time.ExperimentalTime::class,
     kotlin.uuid.ExperimentalUuidApi::class,
+    androidx.compose.foundation.layout.ExperimentalLayoutApi::class,
 )
 
 package com.moneymanager.ui.screens
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -218,12 +220,18 @@ fun ImportDirectoriesScreen(
                 .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Row(
+        // FlowRow so the buttons wrap below the title on narrow (phone) screens instead of being
+        // pushed off the right edge.
+        FlowRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Text("Import Directories", style = MaterialTheme.typography.headlineMedium)
+            Text(
+                "Import Directories",
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.align(Alignment.CenterVertically),
+            )
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
                     enabled = scanningId == null && directories.any(::scannable),
@@ -394,7 +402,8 @@ private fun ImportDirectoryRow(
                     LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
                 }
             }
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            // FlowRow: the download button plus four links don't fit one line on phones.
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(
                     enabled = canDownload && !onWrongDevice && !directory.excluded,
                     onClick = onDownload,

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -266,11 +266,12 @@ exclude:
     paths:
       - app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/ImportDirectoryScanner.kt
       - app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/QifStagingConversion.kt
-  # Per-platform capability stubs intentionally return a constant: JVM supports every provider, and
-  # Android can't browse Drive yet (returns null so the UI hides it). Not a simplifiable code smell.
+  # Per-platform capability methods intentionally return a constant: both platforms now support every
+  # import-directory provider, so supportsProvider() is always true. Not a simplifiable code smell.
   - name: SameReturnValue
     paths:
       - app/di/core/src/jvmMain/kotlin/com/moneymanager/di/importfilesource/CreateImportFileSourceFactory.jvm.kt
+      - app/di/core/src/androidMain/kotlin/com/moneymanager/di/importfilesource/CreateImportFileSourceFactory.android.kt
       - app/di/core/src/androidMain/kotlin/com/moneymanager/di/importfilesource/CreateDriveFolderBrowser.android.kt
   - name: unused
     paths:

--- a/utils/compose/filePicker/src/androidDeviceTest/kotlin/com/moneymanager/compose/filepicker/FolderPickerAndroidTest.kt
+++ b/utils/compose/filePicker/src/androidDeviceTest/kotlin/com/moneymanager/compose/filepicker/FolderPickerAndroidTest.kt
@@ -1,0 +1,21 @@
+package com.moneymanager.compose.filepicker
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FolderPickerAndroidTest {
+    @Test
+    fun displayNameFromDocumentId_usesLastPathSegment() {
+        assertEquals("2024", displayNameFromDocumentId("primary:Statements/2024"))
+    }
+
+    @Test
+    fun displayNameFromDocumentId_handlesRootOfVolume() {
+        assertEquals("Statements", displayNameFromDocumentId("primary:Statements"))
+    }
+
+    @Test
+    fun displayNameFromDocumentId_fallsBackToWholeIdWhenEmpty() {
+        assertEquals("primary:", displayNameFromDocumentId("primary:"))
+    }
+}

--- a/utils/compose/filePicker/src/androidMain/kotlin/com/moneymanager/compose/filepicker/FolderPickerLauncher.kt
+++ b/utils/compose/filePicker/src/androidMain/kotlin/com/moneymanager/compose/filepicker/FolderPickerLauncher.kt
@@ -1,20 +1,74 @@
 package com.moneymanager.compose.filepicker
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 
 /**
- * Android folder picking via the Storage Access Framework yields a content-tree URI, which the
- * filesystem-based local import backend cannot read. Until tree-URI support is added, the launcher is a
- * no-op (returns null) and the UI falls back to manual path entry.
+ * Android folder picking via the Storage Access Framework: OpenDocumentTree yields a content-tree
+ * URI whose read permission is persisted so the import scanner can re-open the folder across app
+ * restarts. The URI itself is unreadable to humans, so the picked folder's display name is resolved
+ * up front and returned alongside it.
  */
 @Composable
-actual fun rememberFolderPicker(onResult: (String?) -> Unit): FolderPickerLauncher = remember(onResult) { FolderPickerLauncher(onResult) }
+actual fun rememberFolderPicker(onResult: (PickedFolder?) -> Unit): FolderPickerLauncher {
+    val context = LocalContext.current
+    val launcher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.OpenDocumentTree(),
+        ) { uri: Uri? ->
+            onResult(uri?.let { pickedFolderFromTreeUri(context, it) })
+        }
+    return remember(launcher) { FolderPickerLauncher { launcher.launch(null) } }
+}
+
+actual val manualFolderEntrySupported: Boolean = false
 
 actual class FolderPickerLauncher(
-    private val onResult: (String?) -> Unit,
+    private val launcher: () -> Unit,
 ) {
     actual fun launch() {
-        onResult(null)
+        launcher()
     }
 }
+
+private fun pickedFolderFromTreeUri(
+    context: Context,
+    treeUri: Uri,
+): PickedFolder {
+    context.contentResolver.takePersistableUriPermission(treeUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    val treeDocId = DocumentsContract.getTreeDocumentId(treeUri)
+    val documentUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, treeDocId)
+    val displayName = queryDisplayName(context, documentUri) ?: displayNameFromDocumentId(treeDocId)
+    return PickedFolder(ref = treeUri.toString(), displayName = displayName)
+}
+
+private fun queryDisplayName(
+    context: Context,
+    documentUri: Uri,
+): String? =
+    try {
+        context.contentResolver
+            .query(documentUri, arrayOf(DocumentsContract.Document.COLUMN_DISPLAY_NAME), null, null, null)
+            ?.use { cursor -> if (cursor.moveToFirst()) cursor.getString(0) else null }
+            ?.takeIf { it.isNotBlank() }
+    } catch (_: Exception) {
+        null
+    }
+
+/**
+ * Fallback when the provider won't answer a display-name query: document ids like
+ * "primary:Statements/2024" end with the folder's relative path, so the last path segment is the
+ * closest thing to a name.
+ */
+internal fun displayNameFromDocumentId(documentId: String): String =
+    documentId
+        .substringAfterLast(':')
+        .substringAfterLast('/')
+        .ifBlank { documentId }

--- a/utils/compose/filePicker/src/androidMain/kotlin/com/moneymanager/compose/filepicker/FolderPickerLauncher.kt
+++ b/utils/compose/filePicker/src/androidMain/kotlin/com/moneymanager/compose/filepicker/FolderPickerLauncher.kt
@@ -42,7 +42,14 @@ private fun pickedFolderFromTreeUri(
     context: Context,
     treeUri: Uri,
 ): PickedFolder {
-    context.contentResolver.takePersistableUriPermission(treeUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    // Persist the grant so the import scanner can re-open the folder after process death. A provider
+    // that doesn't offer persistable grants throws SecurityException; don't crash the picker over it —
+    // the transient activity-result grant still covers this session, and a later scan surfaces the
+    // revoked-access error with a re-pick hint.
+    try {
+        context.contentResolver.takePersistableUriPermission(treeUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    } catch (_: SecurityException) {
+    }
     val treeDocId = DocumentsContract.getTreeDocumentId(treeUri)
     val documentUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, treeDocId)
     val displayName = queryDisplayName(context, documentUri) ?: displayNameFromDocumentId(treeDocId)

--- a/utils/compose/filePicker/src/commonMain/kotlin/com/moneymanager/compose/filepicker/FolderPickerLauncher.kt
+++ b/utils/compose/filePicker/src/commonMain/kotlin/com/moneymanager/compose/filepicker/FolderPickerLauncher.kt
@@ -3,11 +3,26 @@ package com.moneymanager.compose.filepicker
 import androidx.compose.runtime.Composable
 
 /**
- * Creates and remembers a folder (directory) picker launcher. [onResult] receives the chosen folder's
- * absolute path, or null if cancelled. Used to configure a local import directory.
+ * A picked folder. [ref] is what the platform backend can open later (a JVM absolute path, or an
+ * Android document-tree URI), [displayName] is human-readable (on JVM it is the path itself).
+ */
+data class PickedFolder(
+    val ref: String,
+    val displayName: String,
+)
+
+/**
+ * Creates and remembers a folder (directory) picker launcher. [onResult] receives the chosen folder,
+ * or null if cancelled. Used to configure a local import directory.
  */
 @Composable
-expect fun rememberFolderPicker(onResult: (String?) -> Unit): FolderPickerLauncher
+expect fun rememberFolderPicker(onResult: (PickedFolder?) -> Unit): FolderPickerLauncher
+
+/**
+ * Whether the platform can also accept a hand-typed folder path. True on JVM (any readable path
+ * works); false on Android, where folders are only reachable through a SAF document-tree grant.
+ */
+expect val manualFolderEntrySupported: Boolean
 
 expect class FolderPickerLauncher {
     fun launch()

--- a/utils/compose/filePicker/src/jvmMain/kotlin/com/moneymanager/compose/filepicker/FolderPickerLauncher.kt
+++ b/utils/compose/filePicker/src/jvmMain/kotlin/com/moneymanager/compose/filepicker/FolderPickerLauncher.kt
@@ -8,15 +8,17 @@ import kotlinx.coroutines.launch
 import javax.swing.JFileChooser
 
 @Composable
-actual fun rememberFolderPicker(onResult: (String?) -> Unit): FolderPickerLauncher {
+actual fun rememberFolderPicker(onResult: (PickedFolder?) -> Unit): FolderPickerLauncher {
     val scope = rememberCoroutineScope()
     return remember(onResult) {
-        FolderPickerLauncher(onResult = { path -> scope.launch { onResult(path) } })
+        FolderPickerLauncher(onResult = { picked -> scope.launch { onResult(picked) } })
     }
 }
 
+actual val manualFolderEntrySupported: Boolean = true
+
 actual class FolderPickerLauncher(
-    private val onResult: (String?) -> Unit,
+    private val onResult: (PickedFolder?) -> Unit,
 ) {
     actual fun launch() {
         val chooser =
@@ -32,6 +34,6 @@ actual class FolderPickerLauncher(
                 null
             }
         chosen?.let { localSettings.putString(KEY_LAST_DIRECTORY, it) }
-        onResult(chosen)
+        onResult(chosen?.let { PickedFolder(ref = it, displayName = it) })
     }
 }


### PR DESCRIPTION
## What

Makes the import-directories feature (Imports → Directories) fully functional on Android. It shipped desktop-only in #602: the Android folder picker was a no-op, Google Drive directories were disabled (`supportsProvider` = LOCAL only, `createDriveFolderBrowser` = null), and — it turns out — the Add directory button was rendered off-screen on phone widths anyway.

## How

**Local folders via Storage Access Framework**
- `rememberFolderPicker` now returns `PickedFolder(ref, displayName)`; the Android actual launches `OpenDocumentTree`, takes a persistable read grant, and resolves the folder's display name. New `manualFolderEntrySupported` expect (JVM true / Android false) drives the dialog UX.
- New `SafFolderImportFileSource` (localfolder `androidMain`, raw `DocumentsContract` — no new dependencies): file refs are child document ids, subfolder refs are document-in-tree URIs (they inherit the persisted tree grant and reopen through the factory on their own). A revoked grant fails loudly with a "pick the folder again" message in the existing scan-failure UI. Plain-path refs still route to the `java.io.File` source.
- Discovery/scanner are untouched — refs are opaque to them; added a discovery test with `content://`-shaped refs.

**Google Drive on Android**
- `AndroidGoogleAccessTokenSource` gains a `scopes` parameter and implements `isSignedInWithRequiredScopes()` via `grantedScopes`. `MainActivity` supplies a second, `drive.readonly`-scoped instance as `AppComponentParams.googleDriveImportTokenSource`, so import consent never widens (or re-prompts) the DB-sync `drive.file` grant.
- The Android `createDriveFolderBrowser` / `createImportFileSourceFactory` actuals are now real implementations reusing the already-multiplatform `DriveImportFileSource`; both expect functions now take `AppComponentParams` (mirroring `createRemoteStorageProviderFactory`). `providerConfig` is deliberately ignored on Android — GMS auth is package/signature-bound.

**UI**
- Add-directory dialog: on SAF-only platforms the local branch shows a Choose-folder button plus the folder name (never the raw `content://` URI); picked local folders store a `displayPath`. JVM keeps the editable path field.
- `ImportDirectoriesScreen`: header and per-card action rows now wrap (`FlowRow`) — previously the Add directory button was pushed off the right edge on phones.

## Testing

- `./gradlew build buildHealth` green locally (includes new discovery + display-name-fallback tests).
- Manually installed on a device: Directories tab now shows Add directory, SAF picker opens and persists the grant.
- Not yet exercised live: Drive-on-Android end-to-end (needs the `drive.readonly` scope enabled on the user's own Cloud Console consent screen; first browse shows the consent sheet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android folder selection via the system picker, including saved access to selected folders.
  * Enabled Google Drive folder imports alongside local folder imports.
  * Folder selections now include a readable name plus the underlying reference for better consistency.

* **Bug Fixes**
  * Improved handling of Android document-tree folders so they import correctly.
  * Made import directory labels and paths display more reliably across local, SAF, and Drive sources.

* **UI Improvements**
  * Updated import screens to wrap actions on smaller displays, preventing controls from being cut off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->