### PR TITLE
Strategy-library Drive: reconnect on expired/revoked refresh token

### DIFF
--- a/app/remotestorage/core/src/commonMain/kotlin/com/moneymanager/remotestorage/RemoteStorageProviderFactory.kt
+++ b/app/remotestorage/core/src/commonMain/kotlin/com/moneymanager/remotestorage/RemoteStorageProviderFactory.kt
@@ -31,3 +31,19 @@ interface RemoteStorageProviderFactory {
         subfolder: String? = null,
     ): RemoteStorageProvider
 }
+
+/**
+ * Forces fresh interactive consent for [providerId]/[config], minting a new refresh token. Unlike a
+ * normal resolve (create-then-`signIn()`-only-if-not-`isSignedIn()`), this does NOT short-circuit on an
+ * existing stored token: a token the provider still reports as "signed in" can be expired or revoked
+ * (Google only rejects it with `invalid_grant` when it is actually used), so recovering from such a
+ * failure requires re-running consent unconditionally. Reusable by any remote-storage connection (DB
+ * archives, the strategy library, future backends).
+ *
+ * [subfolder] is irrelevant to the OAuth consent itself but accepted for a uniform call surface.
+ */
+suspend fun RemoteStorageProviderFactory.reconnect(
+    providerId: String,
+    config: String?,
+    subfolder: String? = null,
+) = create(providerId, config, subfolder).signIn()

--- a/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseController.kt
+++ b/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/RemoteDatabaseController.kt
@@ -6,6 +6,7 @@ import com.moneymanager.domain.model.dbLocationFromString
 import com.moneymanager.remotestorage.RemoteFile
 import com.moneymanager.remotestorage.RemoteStorageProvider
 import com.moneymanager.remotestorage.RemoteStorageProviderFactory
+import com.moneymanager.remotestorage.reconnect
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -184,7 +185,7 @@ class RemoteDatabaseController(
         providerId: String,
         config: String?,
     ) {
-        providerFactory.create(providerId, config).signIn()
+        providerFactory.reconnect(providerId, config)
     }
 
     /** Lists the archives stored by [providerId] (signing in if needed) for an open-from-remote picker. */

--- a/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/StrategySyncController.kt
+++ b/app/remotestorage/sync/src/commonMain/kotlin/com/moneymanager/remotestorage/sync/StrategySyncController.kt
@@ -12,6 +12,7 @@ import com.moneymanager.remotestorage.RemoteFile
 import com.moneymanager.remotestorage.RemoteStorageProvider
 import com.moneymanager.remotestorage.RemoteStorageProviderFactory
 import com.moneymanager.remotestorage.RemoteStorageType
+import com.moneymanager.remotestorage.reconnect
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -90,6 +91,17 @@ class StrategySyncController(
         resolveSignedIn(providerId, config)
         store.saveConnection(providerId, config)
         _state.value = _state.value.copy(connected = true)
+    }
+
+    /**
+     * Forces fresh interactive consent for the connected provider, minting a new refresh token. Recovers
+     * a revoked/expired refresh token (Google `invalid_grant`), which the normal [resolveSignedIn] path
+     * can't: its `isSignedIn()` check still reports a stored-but-revoked token as signed in and so never
+     * re-consents. Mirrors [RemoteDatabaseController.reconnect] via the shared [reconnect] helper.
+     */
+    suspend fun reconnect() {
+        val providerId = store.providerId() ?: error("Strategy library is not connected to remote storage")
+        providerFactory.reconnect(providerId, store.providerConfig(), SUBFOLDER)
     }
 
     /** Disconnects the library from remote storage (keeps local strategies and baselines). */

--- a/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/StrategySyncControllerTest.kt
+++ b/app/remotestorage/sync/src/commonTest/kotlin/com/moneymanager/remotestorage/sync/StrategySyncControllerTest.kt
@@ -254,6 +254,37 @@ class StrategySyncControllerTest {
         }
 
     @Test
+    fun `reconnect forces a fresh sign-in even when already signed in`() =
+        runTest {
+            // A stored-but-revoked refresh token still reports isSignedIn() == true, so recovery must
+            // re-run consent unconditionally (unlike the normal resolve path, which would short-circuit).
+            val base = InMemoryStorageProvider()
+            var signInCount = 0
+            val provider =
+                object : RemoteStorageProvider by base {
+                    override suspend fun signIn() {
+                        signInCount++
+                        base.signIn()
+                    }
+                }
+            val store = StrategyRemoteConnectionStore(InMemoryLocalSettings())
+            val controller = StrategySyncController(SingleProviderFactory(provider), store)
+            controller.connect(provider.id, null)
+            // connect resolves via isSignedIn() (true here), so it must not have re-consented.
+            assertEquals(0, signInCount)
+
+            controller.reconnect()
+            assertEquals(1, signInCount, "reconnect must re-consent even when isSignedIn() is true")
+        }
+
+    @Test
+    fun `reconnect fails when the library is not connected`() =
+        runTest {
+            val controller = controllerWith(InMemoryStorageProvider())
+            assertFailsWith<IllegalStateException> { controller.reconnect() }
+        }
+
+    @Test
     fun `identical content on both sides with no baseline is IN_SYNC not conflict`() =
         runTest {
             val provider = InMemoryStorageProvider()

--- a/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/StrategyCloudCard.kt
+++ b/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/StrategyCloudCard.kt
@@ -38,6 +38,7 @@ import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
+import com.moneymanager.remotestorage.RemoteAuthException
 import com.moneymanager.remotestorage.sync.StrategyItem
 import com.moneymanager.remotestorage.sync.StrategyItemStatus
 import com.moneymanager.remotestorage.sync.StrategySyncController
@@ -80,6 +81,9 @@ fun StrategyCloudCard(
     val state by controller.state.collectAsState()
     var connected by remember { mutableStateOf(controller.isConnected()) }
     var message by remember { mutableStateOf<String?>(null) }
+    // Set when a failure was an expired/revoked Drive connection (Google `invalid_grant`), so the card
+    // offers a "Reconnect" button (re-consent) instead of a dead error — mirrors the main-database flow.
+    var needsReconnect by remember { mutableStateOf(false) }
     // Remote artifacts the user has ticked to pull (REMOTE_AHEAD / AVAILABLE).
     val selectedToPull = remember { mutableStateListOf<StrategyKey>() }
     // Per-conflict direction chosen by the user; a conflict without a choice is left untouched.
@@ -90,6 +94,16 @@ fun StrategyCloudCard(
     var syncProgress by remember { mutableStateOf<SyncProgress?>(null) }
     val actionsEnabled = !state.busy && !busyLocal
 
+    // Records a failure message and, when the cause is an expired/revoked Drive connection, flags the
+    // reconnect affordance so the user can re-consent (rather than being stuck on a dead error).
+    fun fail(
+        prefix: String,
+        cause: Throwable,
+    ) {
+        message = "$prefix ${cause.message}"
+        needsReconnect = cause is RemoteAuthException
+    }
+
     // Runs the two-way sync (auto-upload + the given pulls/forced uploads) with collected resolutions.
     fun performSync(
         pull: Set<StrategyKey>,
@@ -97,6 +111,7 @@ fun StrategyCloudCard(
         resolutions: Map<StrategyKey, Map<CsvUnresolvedReference, CsvResolution>>,
     ) {
         message = null
+        needsReconnect = false
         busyLocal = true
         scope.launch {
             runCatching {
@@ -112,7 +127,7 @@ fun StrategyCloudCard(
                 selectedToPull.clear()
                 conflictChoices.clear()
                 message = "Synced: ${summary.uploaded} uploaded, ${summary.pulled} imported."
-            }.onFailure { message = "Sync failed: ${it.message}" }
+            }.onFailure { fail("Sync failed:", it) }
             syncProgress = null
             busyLocal = false
         }
@@ -122,7 +137,7 @@ fun StrategyCloudCard(
     LaunchedEffect(connected) {
         if (connected) {
             runCatching { controller.refresh(library, appVersion) }
-                .onFailure { message = "Could not read the remote strategy library: ${it.message}" }
+                .onFailure { fail("Could not read the remote strategy library:", it) }
         }
     }
 
@@ -144,13 +159,14 @@ fun StrategyCloudCard(
                     OutlinedButton(
                         onClick = {
                             message = null
+                            needsReconnect = false
                             controller.beginBusy()
                             scope.launch {
                                 runCatching {
                                     controller.connect(type.id, config = null)
                                     connected = true
                                     controller.refresh(library, appVersion)
-                                }.onFailure { message = "Could not connect: ${it.message}" }
+                                }.onFailure { fail("Could not connect:", it) }
                             }
                         },
                         enabled = actionsEnabled,
@@ -177,10 +193,11 @@ fun StrategyCloudCard(
                     OutlinedButton(
                         onClick = {
                             message = null
+                            needsReconnect = false
                             controller.beginBusy()
                             scope.launch {
                                 runCatching { controller.refresh(library, appVersion) }
-                                    .onFailure { message = "Check failed: ${it.message}" }
+                                    .onFailure { fail("Check failed:", it) }
                             }
                         },
                         enabled = actionsEnabled,
@@ -191,6 +208,7 @@ fun StrategyCloudCard(
                     OutlinedButton(
                         onClick = {
                             message = null
+                            needsReconnect = false
                             // Only choices for keys that are still conflicts apply (state may have moved on).
                             val conflicts =
                                 state.items
@@ -217,7 +235,7 @@ fun StrategyCloudCard(
                                         pendingSync = PendingSync(pull, force, unresolved)
                                     }
                                 }.onFailure {
-                                    message = "Sync failed: ${it.message}"
+                                    fail("Sync failed:", it)
                                     syncProgress = null
                                     busyLocal = false
                                 }
@@ -233,10 +251,34 @@ fun StrategyCloudCard(
                 TextButton(onClick = {
                     controller.disconnect()
                     connected = false
+                    needsReconnect = false
                     selectedToPull.clear()
                     conflictChoices.clear()
                 }) {
                     Text("Disconnect")
+                }
+            }
+
+            // A dead Drive connection (expired/revoked refresh token) can't be refreshed silently — the
+            // user must re-consent. Offer that here (only while connected), then re-read the library.
+            if (needsReconnect && connected) {
+                OutlinedButton(
+                    onClick = {
+                        message = null
+                        busyLocal = true
+                        scope.launch {
+                            runCatching {
+                                controller.reconnect()
+                                needsReconnect = false
+                                controller.refresh(library, appVersion)
+                            }.onFailure { fail("Reconnect failed:", it) }
+                            busyLocal = false
+                        }
+                    },
+                    enabled = actionsEnabled,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text("Reconnect to Google Drive")
                 }
             }
 


### PR DESCRIPTION
## What

Gives the shared **strategy library** the same expired-connection recovery the main-database Drive path already has, and extracts the shared core into a **generic reusable function** any Google Drive connection can use.

## Why

A Google Drive-backed **database** recovers gracefully when its OAuth **refresh token** expires or is revoked: the restore flow catches `RemoteAuthException` and offers a **"Reconnect to Google Drive"** button that re-runs consent to mint a fresh refresh token.

The **strategy-library** Drive sync had no such recovery — a dead refresh token (Google `invalid_grant`) just rendered as a dead error string (`Sync failed: Google token request failed (400): {"error":"invalid_grant"}`) and left the user stuck. Disconnect/Connect didn't reliably re-consent, because `isSignedIn()` still reports a stored-but-revoked token as signed in, so the normal resolve path never re-consents.

This is routine, not rare: the app is **bring-your-own OAuth credentials**, and OAuth apps in Google's "Testing" publishing status expire refresh tokens every **7 days**.

### Root cause (narrows the fix)

The ordinary **access-token** refresh (short-lived token expired, refresh token still valid) *already worked* for strategies — both the DB and strategy paths share the same refresh-capable Ktor Bearer client. The only gap was recovery from a dead **refresh token**, which requires interactive re-consent (a browser round-trip).

## Changes

- **Generic function** (`app/remotestorage/core`): new `RemoteStorageProviderFactory.reconnect(providerId, config, subfolder)` suspend extension that forces fresh consent **unconditionally** (`create(...).signIn()`), instead of short-circuiting on a stored-but-revoked token. Reusable by any remote-storage connection.
- **DB controller**: `RemoteDatabaseController.reconnect` now delegates to the extension (no behaviour change; proves it's shared).
- **Strategy controller**: `StrategySyncController.reconnect()` added, using the same helper for the connected provider.
- **Strategy UI** (`StrategyCloudCard`): distinguishes `RemoteAuthException` from other failures and shows a **"Reconnect to Google Drive"** button that re-consents and refreshes the library view.
- **Tests**: `reconnect()` forces a fresh `signIn()` even when `isSignedIn()` is `true`, and fails cleanly when the library is not connected.

## UX note

Re-consent needs a browser, so recovery is **button-triggered** (matching the main database), not fully silent — a dead connection shows the button rather than auto-launching consent.

## Verification

- `./gradlew build buildHealth` green locally (new tests, detekt, ktlint, `verifyNoWriteRepositoryUsage`).
- End-to-end manual check (revoke app access in Google account → Sync now → Reconnect button appears and recovers) requires real Google credentials and is left for manual QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reconnect flow for remote storage connections to request fresh sign-in consent.
  * Added a “Reconnect to Google Drive” action in settings when authorization has expired or been revoked.

* **Bug Fixes**
  * Improved handling of authentication failures so they can be recovered from instead of leaving a dead-end error state.
  * Reconnect now works even if a previous session still appears signed in, and it properly errors when no remote connection exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->