### PR TITLE
Fix Crypto.com CSV re-import crashes and old-format file selection

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -50,6 +50,33 @@ import kotlin.time.Duration.Companion.seconds
 
 private val logger = logging()
 
+/**
+ * Collapses consecutive duplicate accounts out of a pass-through spend-leg chain ([nodes] = the conduit
+ * account ids followed by the merchant account id), keeping [spendDescriptions] aligned 1:1 with the
+ * surviving conduit legs by dropping the description of each removed leg.
+ *
+ * The engine builds one spend leg per adjacent node pair (`nodes[i] -> nodes[i+1]`). A node that equals
+ * its predecessor — e.g. a merchant that resolved to its feeding conduit, or a repeated conduit — would
+ * make that leg a zero-movement `source == target` transfer, which the `transfer` CHECK constraint
+ * rejects (aborting the whole file). Returns the collapsed (nodes, descriptions), or null when fewer
+ * than two distinct nodes remain (no real pass-through — the caller imports the plain funding transfer).
+ */
+internal fun collapsePassThroughChain(
+    nodes: List<AccountId>,
+    spendDescriptions: List<String>,
+): Pair<List<AccountId>, List<String>>? {
+    if (nodes.isEmpty()) return null
+    val keptNodes = mutableListOf(nodes.first())
+    val keptDescriptions = mutableListOf<String>()
+    for (legIndex in 0 until nodes.size - 1) {
+        if (nodes[legIndex + 1] != keptNodes.last()) {
+            keptNodes += nodes[legIndex + 1]
+            keptDescriptions += spendDescriptions.getOrElse(legIndex) { "" }
+        }
+    }
+    return if (keptNodes.size < 2) null else keptNodes to keptDescriptions
+}
+
 /** Summary of a bulk CSV import run across many files. */
 data class CsvBulkResult(
     override val filesImported: Int,
@@ -526,16 +553,17 @@ suspend fun runCsvImport(
                     if (merchantId == null || innerConduitIds.any { it == null }) {
                         null
                     } else {
-                        ImportPassThrough(
-                            conduits =
-                                (listOf(firstConduitId) + innerConduitIds.filterNotNull())
-                                    .map { AccountRef.Existing(it) },
-                            merchantTarget = AccountRef.Existing(merchantId),
-                            amount = row.transfer.amount,
-                            spendDescriptions = pt.spendDescriptions,
-                            relationshipTypeId = RelationshipTypeId(pt.relationshipTypeId),
-                            incoming = pt.incoming,
-                        )
+                        val nodes = listOf(firstConduitId) + innerConduitIds.filterNotNull() + merchantId
+                        collapsePassThroughChain(nodes, pt.spendDescriptions)?.let { (keptNodes, keptDescriptions) ->
+                            ImportPassThrough(
+                                conduits = keptNodes.dropLast(1).map { AccountRef.Existing(it) },
+                                merchantTarget = AccountRef.Existing(keptNodes.last()),
+                                amount = row.transfer.amount,
+                                spendDescriptions = keptDescriptions,
+                                relationshipTypeId = RelationshipTypeId(pt.relationshipTypeId),
+                                incoming = pt.incoming,
+                            )
+                        }
                     }
                 }
             ImportTransfer(

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -370,6 +370,22 @@ class CsvTransferMapper(
             // Parse accounts with potential flipping
             var sourceAccountId = resolvedSourceAccountId
             var targetAccountId = parseAccount(targetMapping, values)
+
+            // Both account fields can read the same column (e.g. Crypto.com's card strategy resolves both
+            // legs from "Transaction Description"), so a persisted counterparty mapping that matches the
+            // description can hijack the source leg too and collapse both onto one account. When the source
+            // came from the strategy's own SOURCE_ACCOUNT mapping (no UI override) and now collides with the
+            // target, re-resolve the source ignoring persisted mappings — its rule/historical name only —
+            // which restores the intended own-account (e.g. "Crypto.com Card").
+            if (sourceAccountOverride == null &&
+                sourceAccountId == targetAccountId &&
+                sourceAccountId != AccountId(-1)
+            ) {
+                strategy.fieldMappings[TransferField.SOURCE_ACCOUNT]?.let {
+                    sourceAccountId = parseAccount(it, values, applyPersistedMappings = false)
+                }
+            }
+
             if (flipAccounts) {
                 val temp = sourceAccountId
                 sourceAccountId = targetAccountId
@@ -425,6 +441,21 @@ class CsvTransferMapper(
                 if (conduitAccountId != null && flipAccounts) conduitAccountId else sourceAccountId
             val effectiveTargetAccountId =
                 if (conduitAccountId != null && !flipAccounts) conduitAccountId else targetAccountId
+
+            // A transfer must move between two distinct accounts (enforced by a DB CHECK). If both legs
+            // resolved to the same real account (e.g. an account mapping that matches this row on both
+            // sides), surface it as a per-row error instead of letting one bad row abort the whole file.
+            // AccountId(-1) is the "new account" placeholder; two not-yet-created accounts stay distinct.
+            if (effectiveSourceAccountId == effectiveTargetAccountId && effectiveSourceAccountId != AccountId(-1)) {
+                val accountName =
+                    existingAccounts.entries.firstOrNull { it.value.id == effectiveSourceAccountId }?.key
+                return MappingResult.Error(
+                    row.rowIndex,
+                    "Source and target resolved to the same account" +
+                        (accountName?.let { " (\"$it\")" } ?: "") +
+                        "; a transfer must move between two different accounts. Check your account mappings.",
+                )
+            }
 
             // Detect a personal counterparty (resolved from the target mapping regardless of any
             // account flip — the counterparty is the same account on whichever side it ends up). A
@@ -672,9 +703,17 @@ class CsvTransferMapper(
         csvValue: String,
     ): String = if (csvValue.isBlank()) "" else mapping.prefix + csvValue + mapping.suffix
 
+    /**
+     * Resolves a field mapping to an account id. Persisted account mappings (the user's "map this CSV
+     * value to that account" choices) are consulted first — they redirect a **counterparty** and handle
+     * renamed accounts. [applyPersistedMappings] can be set false to bypass them when re-resolving the
+     * **source** leg after a persisted counterparty mapping hijacked it into a self-transfer (both legs
+     * read the same column, so a merchant mapping can match the source too); see [mapRow].
+     */
     private fun parseAccount(
         mapping: FieldMapping,
         values: List<String>,
+        applyPersistedMappings: Boolean = true,
     ): AccountId {
         // For hardcoded accounts, return immediately
         if (mapping is HardCodedAccountMapping) {
@@ -686,23 +725,21 @@ class CsvTransferMapper(
                 val csvValue = getColumnValue(mapping.columnName, values).trim()
 
                 // Check persisted mappings FIRST - this handles renamed accounts
-                val persistedMatch = findPersistedMapping(csvValue)
-                if (persistedMatch != null) {
-                    return persistedMatch
+                if (applyPersistedMappings) {
+                    findPersistedMapping(csvValue)?.let { return it }
                 }
 
                 val name = templatedAccountName(mapping, csvValue)
                 resolveExistingAccountId(name)
                     ?: AccountId(-1) // Placeholder for new accounts
             }
-            is ConditionalAccountMapping -> parseAccount(resolveConditional(mapping, values), values)
+            is ConditionalAccountMapping -> parseAccount(resolveConditional(mapping, values), values, applyPersistedMappings)
             is AccountLookupMapping -> {
                 val csvValue = getColumnValue(mapping.columnName, values)
 
                 // Check persisted mappings FIRST - this handles renamed accounts
-                val persistedMatch = findPersistedMapping(csvValue)
-                if (persistedMatch != null) {
-                    return persistedMatch
+                if (applyPersistedMappings) {
+                    findPersistedMapping(csvValue)?.let { return it }
                 }
 
                 // Fall back to lookup by name (current, then historical for renamed accounts)
@@ -716,9 +753,8 @@ class CsvTransferMapper(
                 val result = getAccountNameFromRegexWithPattern(mapping, values)
 
                 // Check persisted mappings using the ACTUAL value that was resolved
-                val persistedMatch = findPersistedMapping(result.sourceColumnValue)
-                if (persistedMatch != null) {
-                    return persistedMatch
+                if (applyPersistedMappings) {
+                    findPersistedMapping(result.sourceColumnValue)?.let { return it }
                 }
 
                 // Fall back to lookup by name (current, then historical for renamed accounts)

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -377,12 +377,14 @@ class CsvTransferMapper(
             // came from the strategy's own SOURCE_ACCOUNT mapping (no UI override) and now collides with the
             // target, re-resolve the source ignoring persisted mappings — its rule/historical name only —
             // which restores the intended own-account (e.g. "Crypto.com Card").
+            var sourceUsedPersistedMappings = true
             if (sourceAccountOverride == null &&
                 sourceAccountId == targetAccountId &&
                 sourceAccountId != AccountId(-1)
             ) {
                 strategy.fieldMappings[TransferField.SOURCE_ACCOUNT]?.let {
                     sourceAccountId = parseAccount(it, values, applyPersistedMappings = false)
+                    sourceUsedPersistedMappings = false
                 }
             }
 
@@ -500,7 +502,13 @@ class CsvTransferMapper(
             val discoveries =
                 buildList {
                     if (sourceAccountOverride == null) {
-                        strategy.fieldMappings[TransferField.SOURCE_ACCOUNT]?.let { add(discoverNewAccount(it, values)) }
+                        // Discover the source under the same persisted-mapping rule its id was resolved with:
+                        // if the source leg was re-resolved without persisted mappings (collision above), a
+                        // genuinely new source account must still be discovered/created rather than suppressed
+                        // by a persisted mapping — otherwise it would dangle as AccountId(-1).
+                        strategy.fieldMappings[TransferField.SOURCE_ACCOUNT]?.let {
+                            add(discoverNewAccount(it, values, applyPersistedMappings = sourceUsedPersistedMappings))
+                        }
                     }
                     if (passThroughMatch == null) add(discoverNewAccount(targetMapping, values))
                 }
@@ -791,12 +799,13 @@ class CsvTransferMapper(
     private fun discoverNewAccount(
         mapping: FieldMapping,
         values: List<String>,
+        applyPersistedMappings: Boolean = true,
     ): Pair<NewAccount, DiscoveredAccountMapping>? =
         when (mapping) {
             is AccountLookupMapping -> {
                 val csvValue = getColumnValue(mapping.columnName, values)
                 // If a persisted mapping matched, don't create a new account
-                if (findPersistedMapping(csvValue) != null) {
+                if (applyPersistedMappings && findPersistedMapping(csvValue) != null) {
                     null
                 } else {
                     val name = getAccountName(mapping, values)
@@ -812,7 +821,7 @@ class CsvTransferMapper(
             is RegexAccountMapping -> {
                 val result = getAccountNameFromRegexWithPattern(mapping, values)
                 // If a persisted mapping matched, don't create a new account
-                if (findPersistedMapping(result.sourceColumnValue) != null) {
+                if (applyPersistedMappings && findPersistedMapping(result.sourceColumnValue) != null) {
                     null
                 } else if (result.accountName.isNotBlank() && !accountExists(result.accountName)) {
                     // For RegexAccountMapping, accountName differs from sourceColumnValue
@@ -830,7 +839,7 @@ class CsvTransferMapper(
             is TemplateAccountMapping -> {
                 val csvValue = getColumnValue(mapping.columnName, values).trim()
                 val name = templatedAccountName(mapping, csvValue)
-                if (findPersistedMapping(csvValue) != null ||
+                if ((applyPersistedMappings && findPersistedMapping(csvValue) != null) ||
                     name.isBlank() ||
                     accountExists(name)
                 ) {
@@ -840,7 +849,7 @@ class CsvTransferMapper(
                         DiscoveredAccountMapping(csvValue, name)
                 }
             }
-            is ConditionalAccountMapping -> discoverNewAccount(resolveConditional(mapping, values), values)
+            is ConditionalAccountMapping -> discoverNewAccount(resolveConditional(mapping, values), values, applyPersistedMappings)
             else -> null
         }
 

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/StrategySelector.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/StrategySelector.kt
@@ -60,7 +60,15 @@ fun List<CsvImportStrategy>.selectForCsv(
     rows: List<CsvRow>,
 ): CsvImportStrategy? {
     val headings = columns.map { it.originalName }.toSet()
-    val candidates = filter { it.matchesColumns(headings) }
+    // Exact column match first (the strict, unchanged behaviour). Only when nothing matches exactly,
+    // fall back to a tolerant match for a file that is missing optional columns a later export added
+    // (e.g. crypto.com's card/fiat exports gained a "Transaction Hash" column, so older files have one
+    // fewer): the file's columns must all still be known to the strategy (a subset of its identification
+    // columns). The filename/content ranking below then disambiguates as usual, so a genuinely different
+    // file (disjoint or extra columns) still resolves to null rather than being misrouted.
+    val candidates =
+        filter { it.matchesColumns(headings) }
+            .ifEmpty { if (headings.isEmpty()) emptyList() else filter { it.identificationColumns.containsAll(headings) } }
     if (candidates.isEmpty()) return null
 
     val indexByName = columns.associate { it.originalName to it.columnIndex }

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CollapsePassThroughChainTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CollapsePassThroughChainTest.kt
@@ -1,0 +1,53 @@
+package com.moneymanager.csvimporter
+
+import com.moneymanager.domain.model.AccountId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CollapsePassThroughChainTest {
+    private fun ids(vararg values: Long) = values.map { AccountId(it) }
+
+    @Test
+    fun `a chain with no duplicates is unchanged`() {
+        val (nodes, descriptions) = collapsePassThroughChain(ids(1, 2, 3), listOf("a", "b"))!!
+        assertEquals(ids(1, 2, 3), nodes)
+        assertEquals(listOf("a", "b"), descriptions)
+    }
+
+    @Test
+    fun `a single-conduit chain whose merchant equals the conduit is dropped`() {
+        // nodes = [C1, merchant(==C1)]: collapses to one node -> no real pass-through.
+        assertNull(collapsePassThroughChain(ids(1, 1), listOf("spend")))
+    }
+
+    @Test
+    fun `terminal duplicate drops the merchant leg and its description`() {
+        // C1 -> C2 -> merchant(==C2): the C2 -> C2 leg collapses.
+        val (nodes, descriptions) = collapsePassThroughChain(ids(1, 2, 2), listOf("leg1", "leg2"))!!
+        assertEquals(ids(1, 2), nodes)
+        assertEquals(listOf("leg1"), descriptions)
+    }
+
+    @Test
+    fun `a repeated middle conduit collapses that leg only`() {
+        // C1 -> C2 -> C2 -> C3(merchant): the middle C2 -> C2 leg collapses.
+        val (nodes, descriptions) = collapsePassThroughChain(ids(1, 2, 2, 3), listOf("a", "b", "c"))!!
+        assertEquals(ids(1, 2, 3), nodes)
+        assertEquals(listOf("a", "c"), descriptions)
+    }
+
+    @Test
+    fun `a chain that collapses to a single node is dropped`() {
+        // Only one distinct account across the whole chain: no real pass-through.
+        assertNull(collapsePassThroughChain(ids(5, 5, 5), listOf("x", "y")))
+    }
+
+    @Test
+    fun `a non-adjacent repeat is a real movement and is kept`() {
+        // C1 -> C2 -> C1: money genuinely moves back; not a zero-length hop.
+        val (nodes, descriptions) = collapsePassThroughChain(ids(1, 2, 1), listOf("out", "back"))!!
+        assertEquals(ids(1, 2, 1), nodes)
+        assertEquals(listOf("out", "back"), descriptions)
+    }
+}

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoComCsvMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoComCsvMapperTest.kt
@@ -206,4 +206,25 @@ class CryptoComCsvMapperTest {
         // crypto_* files (occasional viban rows, below the content threshold) match nothing.
         assertNull(strategies.selectForCsv("crypto_transactions_record_20251116_101217.csv", columns, cryptoRows))
     }
+
+    @Test
+    fun `older 10-column exports without Transaction Hash still route by filename`() {
+        val strategies = BuiltInCsvStrategies.builtInCsvStrategies(now)
+        // crypto.com added the "Transaction Hash" column later; 2021/2022 exports have one fewer column.
+        val legacyColumns =
+            columns.dropLast(1).mapIndexed { index, c -> CsvColumn(CsvColumnId(Uuid.random()), index, c.originalName) }
+
+        // The same rows minus the trailing Transaction Hash column (which older exports lacked).
+        fun legacy(full: CsvRow) = CsvRow(full.rowIndex, full.values.dropLast(1))
+        val legacyFiatRow = legacy(row("Top Up Card", "GBP", "200.0", "GBP", "200.0", "200.0", "viban_card_top_up"))
+        val legacyCardRow = legacy(row("Spotify", "GBP", "-12.99", "", "", "-12.99", ""))
+        assertEquals(
+            "Crypto.com Fiat",
+            strategies.selectForCsv("fiat_transactions_record_20210706_121420.csv", legacyColumns, listOf(legacyFiatRow))?.name,
+        )
+        assertEquals(
+            "Crypto.com Card",
+            strategies.selectForCsv("card_transactions_record_20210706_121443.csv", legacyColumns, listOf(legacyCardRow))?.name,
+        )
+    }
 }

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvAccountMappingTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvAccountMappingTest.kt
@@ -27,6 +27,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
@@ -752,6 +753,28 @@ class CsvAccountMappingTest {
         // The counterparty mapping applies to the target; the source falls back to its fixed "My Card".
         assertEquals(card.id, result.transfer.sourceAccountId)
         assertEquals(vendor.id, result.transfer.targetAccountId)
+    }
+
+    @Test
+    fun `a source re-resolved off a collision is still discovered as a new account`() {
+        // No "My Card" account exists yet: the re-resolved source is genuinely new. It must be discovered
+        // for creation despite the persisted counterparty mapping that hijacked (and still matches) the row.
+        val vendor = Account(id = AccountId(71), name = "Vendor", openingDate = Clock.System.now())
+        val mapper =
+            CsvTransferMapper(
+                strategy = createStrategySharingDescriptionColumn(),
+                columns = columnsWithType,
+                existingAccounts = mapOf("Vendor" to vendor),
+                existingCurrencies = mapOf(testCurrencyId to testCurrency),
+                existingCurrenciesByCode = mapOf(testCurrency.code.uppercase() to testCurrency),
+                accountMappings = listOf(createAccountMapping(1, "Amazon", vendor.id)),
+            )
+        val row = CsvRow(rowIndex = 1, values = listOf("15/12/2024", "Amazon purchase", "-10.00", "", ""))
+
+        val result = mapper.mapRow(row)
+        assertIs<MappingResult.Success>(result)
+        assertEquals(vendor.id, result.transfer.targetAccountId)
+        assertTrue(result.newAccounts.any { it.name == "My Card" }, "the re-resolved source account must be discovered")
     }
 
     @Test

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvAccountMappingTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvAccountMappingTest.kt
@@ -702,6 +702,78 @@ class CsvAccountMappingTest {
         assertEquals(specificAccountId, result.transfer.targetAccountId)
     }
 
+    // A strategy whose SOURCE and TARGET both read the same column, with the source assigned a fixed
+    // account by an always-match rule (like Crypto.com's card strategy: source = "My Card").
+    private fun createStrategySharingDescriptionColumn(): CsvImportStrategy {
+        val now = Clock.System.now()
+        val base = createStrategyWithRegex()
+        return base.copy(
+            fieldMappings =
+                base.fieldMappings +
+                    mapOf(
+                        TransferField.SOURCE_ACCOUNT to
+                            RegexAccountMapping(
+                                id = FieldMappingId(Uuid.random()),
+                                fieldType = TransferField.SOURCE_ACCOUNT,
+                                columnName = "Description",
+                                rules = listOf(RegexRule(pattern = "^", accountName = "My Card")),
+                            ),
+                        TransferField.TARGET_ACCOUNT to
+                            RegexAccountMapping(
+                                id = FieldMappingId(Uuid.random()),
+                                fieldType = TransferField.TARGET_ACCOUNT,
+                                columnName = "Description",
+                                rules = emptyList(),
+                            ),
+                    ),
+            updatedAt = now,
+        )
+    }
+
+    @Test
+    fun `persisted counterparty mapping does not hijack the fixed source leg into a self-transfer`() {
+        val card = Account(id = AccountId(70), name = "My Card", openingDate = Clock.System.now())
+        val vendor = Account(id = AccountId(71), name = "Vendor", openingDate = Clock.System.now())
+        // A persisted mapping the user created for the merchant "Amazon" — it matches the row's
+        // Description, which BOTH the source (always-match) and target legs read.
+        val mapper =
+            CsvTransferMapper(
+                strategy = createStrategySharingDescriptionColumn(),
+                columns = columnsWithType,
+                existingAccounts = mapOf("My Card" to card, "Vendor" to vendor),
+                existingCurrencies = mapOf(testCurrencyId to testCurrency),
+                existingCurrenciesByCode = mapOf(testCurrency.code.uppercase() to testCurrency),
+                accountMappings = listOf(createAccountMapping(1, "Amazon", vendor.id)),
+            )
+        val row = CsvRow(rowIndex = 1, values = listOf("15/12/2024", "Amazon purchase", "-10.00", "", ""))
+
+        val result = mapper.mapRow(row)
+        assertIs<MappingResult.Success>(result)
+        // The counterparty mapping applies to the target; the source falls back to its fixed "My Card".
+        assertEquals(card.id, result.transfer.sourceAccountId)
+        assertEquals(vendor.id, result.transfer.targetAccountId)
+    }
+
+    @Test
+    fun `a row that genuinely resolves to one account on both legs is an error row not a crash`() {
+        val card = Account(id = AccountId(70), name = "My Card", openingDate = Clock.System.now())
+        // The persisted mapping maps the merchant onto the card itself, so even after re-resolving the
+        // source there is no distinct counterparty — the row can't be a transfer and must error, not crash.
+        val mapper =
+            CsvTransferMapper(
+                strategy = createStrategySharingDescriptionColumn(),
+                columns = columnsWithType,
+                existingAccounts = mapOf("My Card" to card),
+                existingCurrencies = mapOf(testCurrencyId to testCurrency),
+                existingCurrenciesByCode = mapOf(testCurrency.code.uppercase() to testCurrency),
+                accountMappings = listOf(createAccountMapping(1, "Weird", card.id)),
+            )
+        val row = CsvRow(rowIndex = 1, values = listOf("15/12/2024", "Weird row", "-10.00", "", ""))
+
+        val result = mapper.mapRow(row)
+        assertIs<MappingResult.Error>(result)
+    }
+
     // ============= Column-Agnostic Mappings =============
 
     @Test

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/StrategySelectorTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/StrategySelectorTest.kt
@@ -86,6 +86,31 @@ class StrategySelectorTest {
     }
 
     @Test
+    fun `a file missing an optional column still matches by filename when nothing matches exactly`() {
+        // The strategy knows an extra "Transaction Hash" column a later export added; this older file
+        // has one fewer. No strategy matches the columns exactly, so the tolerant fallback + filename win.
+        val fiat = strategy("Fiat", identificationColumns = headings + "Transaction Hash", fileNamePattern = "^fiat_")
+        val selected = listOf(fiat).selectForCsv("fiat_transactions_record_2021.csv", columns, rows("viban_deposit"))
+        assertEquals("Fiat", selected?.name)
+    }
+
+    @Test
+    fun `an exact column match still wins over a tolerant candidate`() {
+        val exact = strategy("Exact", fileNamePattern = "^fiat_")
+        val superset = strategy("Superset", identificationColumns = headings + "Extra", fileNamePattern = "^fiat_")
+        val selected = listOf(superset, exact).selectForCsv("fiat_x.csv", columns, rows(""))
+        assertEquals("Exact", selected?.name)
+    }
+
+    @Test
+    fun `a file with an unknown extra column is not misrouted by the tolerant fallback`() {
+        // The strategy's identification columns are a strict subset of the file's, so the file carries a
+        // column the strategy doesn't know — it must not tolerantly match.
+        val s = strategy("A", identificationColumns = setOf("Date", "Amount"), fileNamePattern = "^fiat_")
+        assertNull(listOf(s).selectForCsv("fiat_transactions.csv", columns, rows("viban_deposit")))
+    }
+
+    @Test
     fun `filename match beats higher content score`() {
         val byName = strategy("Card", fileNamePattern = "^card_")
         val byContent = strategy("Fiat", contentMatchRules = listOf(kindRule))

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCsvE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCsvE2ETest.kt
@@ -221,6 +221,7 @@ class CryptoComCsvE2ETest : DbTest() {
             val fiatAgain = stage("fiat_transactions_record_20240101_000000.csv", fiatRows)
             val second = applyAll(listOf(cardAgain, fiatAgain))
 
+            assertEquals(0, second.filesFailed, "re-import must not fail")
             assertEquals(0, second.transfersCreated, "everything is a duplicate on re-import")
             assertEquals(transfersAfterFirst, allTransfers().size)
         }

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -6,6 +6,7 @@ import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.Category
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.RelationshipTypeId
 import com.moneymanager.domain.model.Source
@@ -28,6 +29,7 @@ import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.importengineapi.LocalCategoryKey
 import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.importengineapi.PersonMatchKey
+import com.moneymanager.importengineapi.getOrCreateAttributeType
 import com.moneymanager.importer.ImportEngineImpl
 import com.moneymanager.test.database.DbTest
 import com.moneymanager.test.database.createAccount
@@ -144,6 +146,67 @@ class ImportEngineDbTest : DbTest() {
                     .id
             val transfers = repositories.transactionRepository.getTransactionsByAccount(coffeeShopId).first()
             assertEquals(1, transfers.size)
+        }
+
+    private fun batchWithAttributes(
+        sourceId: AccountId,
+        currency: Currency,
+        source: Source,
+        attributes: List<NewAttribute>,
+        description: String = "Coffee",
+    ): ImportBatch =
+        batchWithCounterparty(sourceId, currency, description, source).let { base ->
+            base.copy(transfers = base.transfers.map { it.copy(attributes = attributes) })
+        }
+
+    /**
+     * Re-importing a row whose existing transfer already carries an attribute of the same type must not
+     * violate the UNIQUE(transaction_id, attribute_type_id) constraint: the update path upserts (updates a
+     * changed value, keeps an unchanged one, inserts a genuinely new type) instead of blindly inserting.
+     * Regression for a Crypto.com CSV re-import crash (existing transfer had an extra reconciliation
+     * attribute, so the re-import was classified UPDATED and re-supplied its already-present attributes).
+     */
+    @Test
+    fun reimportUpdatingAttributes_upsertsWithoutUniqueConstraintCrash() =
+        runTest {
+            val sourceId = createSourceAccount()
+            val currency = gbp()
+            val source = Source.SampleGenerator
+            val extId = engine().getOrCreateAttributeType("external-id")
+            val note = engine().getOrCreateAttributeType("note")
+
+            // First import creates the transfer with two attributes.
+            engine().import(
+                batchWithAttributes(
+                    sourceId,
+                    currency,
+                    source,
+                    listOf(NewAttribute(extId, "abc"), NewAttribute(note, "keep")),
+                ),
+            )
+            val transferId =
+                repositories.transactionRepository
+                    .getTransactionsByAccount(sourceId)
+                    .first()
+                    .single()
+                    .id
+
+            // Re-import the same row (same core fields) but drop one attribute and change the other's value.
+            // Core fields match, attributes differ -> UPDATED; the re-supplied external-id already exists.
+            val result =
+                engine().import(
+                    batchWithAttributes(sourceId, currency, source, listOf(NewAttribute(extId, "xyz"))),
+                )
+            assertEquals(0, result.transfersImported)
+            assertEquals(1, result.updated)
+
+            // external-id was updated in place; the untouched note attribute is preserved (nothing deleted).
+            val attrs =
+                repositories.transferAttributeRepository
+                    .getByTransaction(transferId)
+                    .first()
+                    .associate { it.attributeType.name to it.value }
+            assertEquals(mapOf("external-id" to "xyz", "note" to "keep"), attrs)
         }
 
     @Test

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionWriteRepositoryImpl.kt
@@ -195,14 +195,33 @@ class TransactionWriteRepositoryImpl(
                         id = updatedTransfer.id.id,
                     )
                     if (update.newAttributes.isNotEmpty()) {
+                        // The existing transfer may already carry some of these attribute types (e.g. a
+                        // cross-source reconciliation added one, so a re-import of an otherwise-unchanged
+                        // row is classified UPDATED). Upsert by (transaction_id, attribute_type_id) —
+                        // update a changed value, insert a genuinely new type — instead of blindly
+                        // inserting, which would violate the UNIQUE(transaction_id, attribute_type_id)
+                        // constraint on the types already present.
+                        val existingByType =
+                            transferAttributeSelectQueries
+                                .selectByTransaction(updatedTransfer.id.id) { rowId, _, typeId, value, _, _ ->
+                                    typeId to (rowId to value)
+                                }.executeAsList()
+                                .toMap()
                         database.beginCreationMode()
                         try {
                             update.newAttributes.forEach { attr ->
-                                transferAttributeWriteQueries.insert(
-                                    transaction_id = updatedTransfer.id.id,
-                                    attribute_type_id = attr.typeId.id,
-                                    attribute_value = attr.value,
-                                )
+                                val existing = existingByType[attr.typeId.id]
+                                when {
+                                    existing == null ->
+                                        transferAttributeWriteQueries.insert(
+                                            transaction_id = updatedTransfer.id.id,
+                                            attribute_type_id = attr.typeId.id,
+                                            attribute_value = attr.value,
+                                        )
+                                    existing.second != attr.value ->
+                                        transferAttributeWriteQueries.updateValue(attr.value, existing.first)
+                                    // Same value already present: nothing to do.
+                                }
                             }
                         } finally {
                             database.endCreationMode()

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionWriteRepositoryImpl.kt
@@ -209,13 +209,17 @@ class TransactionWriteRepositoryImpl(
                                 .toMap()
                         database.beginCreationMode()
                         try {
-                            update.newAttributes.forEach { attr ->
-                                val existing = existingByType[attr.typeId.id]
+                            // Deduplicate by type first: a transfer holds one value per attribute type, and
+                            // [existingByType] is a snapshot, so two incoming attributes of the same type would
+                            // both take the insert path and hit the UNIQUE(transaction_id, attribute_type_id)
+                            // constraint. Last value wins, matching how the attribute would be stored.
+                            update.newAttributes.associateBy { it.typeId.id }.forEach { (typeId, attr) ->
+                                val existing = existingByType[typeId]
                                 when {
                                     existing == null ->
                                         transferAttributeWriteQueries.insert(
                                             transaction_id = updatedTransfer.id.id,
-                                            attribute_type_id = attr.typeId.id,
+                                            attribute_type_id = typeId,
                                             attribute_value = attr.value,
                                         )
                                     existing.second != attr.value ->

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
@@ -94,6 +94,15 @@ class ImportDeduper(
 ) {
     private val existingList = existing
 
+    // The reconciliation exclusion attribute type (when the policy enables cross-source reconciliation),
+    // ignored in attribute comparison so a reconciled transfer still dedupes cleanly on re-import.
+    private val reconciledExclusionTypeId: AttributeTypeId? =
+        when (policy) {
+            is DedupePolicy.FuzzyAllFields -> policy.reconciledExclusionAttributeTypeId
+            is DedupePolicy.ApiMultiKey -> policy.reconciledExclusionAttributeTypeId
+            else -> null
+        }
+
     private val existingByUniqueKey: Map<Map<String, String>, ExistingTransferInfo> =
         existing.filter { it.uniqueKey.isNotEmpty() }.associateBy { it.uniqueKey }
 
@@ -305,8 +314,14 @@ class ImportDeduper(
         transfer: ImportTransfer,
         existing: ExistingTransferInfo,
     ): Boolean {
-        val newAttrs = transfer.attributes.associate { it.typeId to it.value }
-        return newAttrs == existing.attributes
+        // The cross-source reconciliation exclusion attribute is engine-added (never present in the
+        // source), so an existing transfer that was reconciled carries it while the re-imported row does
+        // not. Ignore it on both sides: a row that is otherwise unchanged is a DUPLICATE, not a perpetual
+        // UPDATED, so re-importing the same export is idempotent.
+        val ignore = reconciledExclusionTypeId
+        val newAttrs = transfer.attributes.filter { it.typeId != ignore }.associate { it.typeId to it.value }
+        val existingAttrs = if (ignore == null) existing.attributes else existing.attributes.filterKeys { it != ignore }
+        return newAttrs == existingAttrs
     }
 
     private fun isFuzzyDuplicate(

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -1044,13 +1044,21 @@ class ImportEngineImpl(
                 amount: Money,
                 legRowKey: ImportRowKey?,
             ) {
+                val sourceId = requireId(source)
+                val targetId = requireId(target)
+                // A transfer must move between two distinct accounts (enforced by a DB CHECK). The CSV path
+                // collapses degenerate pass-through chains upstream (collapsePassThroughChain); this guards
+                // the invariant for every producer with a clear error instead of an opaque SQLite failure.
+                require(sourceId != targetId) {
+                    "Refusing to create a self-transfer on account ${sourceId.id} for \"$description\""
+                }
                 transfersToCreate +=
                     Transfer(
                         id = tempId,
                         timestamp = requireNotNull(t.timestamp),
                         description = description,
-                        sourceAccountId = requireId(source),
-                        targetAccountId = requireId(target),
+                        sourceAccountId = sourceId,
+                        targetAccountId = targetId,
                         amount = amount,
                     )
                 orderedSources += t.source.forRow(legRowKey ?: rowKey)


### PR DESCRIPTION
## What

Re-importing a full Crypto.com history (card + fiat exports) hit a chain of hard failures — each aborting the whole file. This fixes all of them, with a regression test at each layer, and makes strategy selection tolerate older exports.

## Crashes fixed

**1. `transfer_attribute` UNIQUE constraint (re-import UPDATE)**
`TransactionWriteRepositoryImpl.importTransfers` blindly re-`INSERT`ed a transfer's attributes on the update path, colliding with attribute types already present. Now **upserts** (skip unchanged / `updateValue` changed / insert new). Reconciled transfers triggered this because the engine adds an `excluded=reconciled` attribute the CSV never contains.

**2. Reconcile re-import non-idempotency**
`ImportDeduper.attributesAreIdentical` now **ignores the cross-source reconciliation exclusion attribute** (engine-added, never in the source), so a reconciled transfer dedupes cleanly on re-import instead of being a perpetual `UPDATED`. Note: the old `CryptoComCsvE2ETest.reimportingBothFiles_producesOnlyDuplicates` was passing *coincidentally on the pre-fix crash* (file failed → 0 created); strengthened it with `filesFailed == 0`.

**3. `source == target` CHECK — persisted-mapping hijack**
The card strategy's always-match source regex reads the same column as the target, so a persisted **counterparty** mapping could hijack the *source* leg and collapse both legs onto one account. `CsvTransferMapper` now re-resolves the source **without** persisted mappings on collision (restoring "Crypto.com Card"), and turns any residual self-transfer into a **per-row error** instead of aborting the file.

**4. `source == target` CHECK — degenerate pass-through legs**
A Curve pass-through whose merchant resolves to one of its own conduits produced a zero-movement `Cn -> Cn` spend leg. `collapsePassThroughChain` (in `CsvImportApplier`, **before** classification so reversal-link indices stay aligned) removes consecutive-duplicate chain nodes. A defensive `require(source != target)` in `ImportEngineImpl.addLeg` turns any remaining self-transfer into a clear, account-naming error rather than an opaque SQLite failure.

## Selection fix

**5. Old 10-column exports skipped**
Crypto.com added a `Transaction Hash` column later, so 2021/2022 card/fiat files have 10 columns and failed the exact `matchesColumns` (`identificationColumns == csvHeadings`). `selectForCsv` now falls back to a **tolerant match** (file columns are a subset of the strategy's identification columns) **only when nothing matches exactly** — so old files route by filename, with **no schema change** and no change to stored strategies. Exact matches still win; files with extra/unknown columns still resolve to null.

`Transaction Hash` stays a plain attribute, **not** a unique identifier: it is blank for 100% of card/fiat rows (verified against the live DB), so using it for dedup would give empty keys (re-import duplicates) and disable cross-source reconciliation.

## Verification

- `./gradlew build buildHealth` green locally.
- New/updated regression tests: attribute upsert (`ImportEngineDbTest`), source-hijack + self-transfer guard (`CsvAccountMappingTest`), pass-through chain collapse (`CollapsePassThroughChainTest`), tolerant selection (`StrategySelectorTest`, `CryptoComCsvMapperTest`), reconcile idempotency (`CryptoComCsvE2ETest`).
- Confirmed on the real data: all previously-crashing card/fiat files now import; old 10-column files route correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV strategy selection now handles some exports with missing optional columns, improving import compatibility.
  * Re-imports now better preserve transfer attributes without creating duplicate records.

* **Bug Fixes**
  * Prevented accidental self-transfers when both sides resolve to the same account.
  * Improved pass-through transfer handling so duplicate account steps are collapsed correctly.
  * Re-imported reconciled transactions are now recognized as duplicates instead of changes.
  * Fixed CSV import behavior for legacy exports and duplicate-file reimports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->