### PR TITLE
Mark zero-row CSV files as imported on "Import all"

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -186,7 +186,18 @@ suspend fun applyStagedCsv(
 ): CsvImportResult? {
     val allRows = csvImportRepository.getImportRows(csvImport.id, limit = csvImport.rowCount.coerceAtLeast(1), offset = 0)
     val rows = allRows.filter { it.importStatus == null || it.importStatus == ImportStatus.ERROR }
-    if (rows.isEmpty()) return null
+    if (rows.isEmpty()) {
+        // A file with no data rows is nonetheless "done". Leaving it without an application record keeps
+        // it in the Unimported tab, so it reappears on every "Import all". Record the strategy application
+        // to mark it imported — but only when the file is genuinely empty (allRows empty). When allRows is
+        // non-empty, every row was already imported on an earlier run (its application is already recorded),
+        // so return null and leave it untouched.
+        if (allRows.isEmpty()) {
+            recordCsvApplication(importEngine, csvImport.id, strategy)
+            return CsvImportResult(successCount = 0, failedRows = emptyList())
+        }
+        return null
+    }
 
     // The shared override only applies to strategies that need a user-chosen source. A hard-coded
     // mapping resolves its own account; a per-row mapping decides per row.
@@ -227,6 +238,32 @@ suspend fun applyStagedCsv(
         onProgress = onProgress,
         engineBatchSize = engineBatchSize,
     )
+}
+
+/**
+ * Records that [strategy] was applied to [csvImportId], moving the file into the "Imported" tab
+ * (`last_applied_at` becomes non-null). Failures are logged, not thrown — the transfers are already
+ * committed, so a missing history row must not fail the import.
+ */
+private suspend fun recordCsvApplication(
+    importEngine: ImportEngine,
+    csvImportId: CsvImportId,
+    strategy: CsvImportStrategy,
+) {
+    runCatching {
+        importEngine.applyCsvImportMutations(
+            listOf(
+                CsvImportMutation.RecordApplication(
+                    id = csvImportId,
+                    strategyId = strategy.id,
+                    strategyName = strategy.name,
+                    appliedAt = Clock.System.now(),
+                ),
+            ),
+        )
+    }.onFailure { error ->
+        logger.warn { "Import application history could not be recorded for import $csvImportId: ${error.message}" }
+    }
 }
 
 /**
@@ -656,22 +693,7 @@ suspend fun runCsvImport(
     }
 
     if ((successCount + duplicateCount) > 0) {
-        runCatching {
-            importEngine.applyCsvImportMutations(
-                listOf(
-                    CsvImportMutation.RecordApplication(
-                        id = csvImport.id,
-                        strategyId = strategy.id,
-                        strategyName = strategy.name,
-                        appliedAt = Clock.System.now(),
-                    ),
-                ),
-            )
-        }.onFailure { error ->
-            logger.warn {
-                "Import application history could not be recorded for import ${csvImport.id}: ${error.message}"
-            }
-        }
+        recordCsvApplication(importEngine, csvImport.id, strategy)
     }
 
     logger.info { "Import completed successfully" }

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -187,12 +187,12 @@ suspend fun applyStagedCsv(
     val allRows = csvImportRepository.getImportRows(csvImport.id, limit = csvImport.rowCount.coerceAtLeast(1), offset = 0)
     val rows = allRows.filter { it.importStatus == null || it.importStatus == ImportStatus.ERROR }
     if (rows.isEmpty()) {
-        // A file with no data rows is nonetheless "done". Leaving it without an application record keeps
-        // it in the Unimported tab, so it reappears on every "Import all". Record the strategy application
-        // to mark it imported — but only when the file is genuinely empty (allRows empty). When allRows is
-        // non-empty, every row was already imported on an earlier run (its application is already recorded),
-        // so return null and leave it untouched.
-        if (allRows.isEmpty()) {
+        // A genuinely empty file (a header-only export with no data rows) has nothing to import, but
+        // must still be marked applied or it reappears in the Unimported tab on every "Import all".
+        // Record the strategy application once (the lastAppliedAt guard keeps repeated runs a no-op).
+        // Scoped to allRows.isEmpty() so it never fires on re-import, which always has rows and whose
+        // "nothing new to import" outcome must stay a null result.
+        if (allRows.isEmpty() && csvImport.lastAppliedAt == null) {
             recordCsvApplication(importEngine, csvImport.id, strategy)
             return CsvImportResult(successCount = 0, failedRows = emptyList())
         }

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCsvE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCsvE2ETest.kt
@@ -246,10 +246,16 @@ class CryptoComCsvE2ETest : DbTest() {
                 "the empty file has an application record (out of the Unimported tab)",
             )
 
-            // Idempotent: a second "Import all" keeps it imported and imports nothing new.
+            // Idempotent: once applied, a second "Import all" is a no-op — it neither re-records nor
+            // re-imports, and the file stays imported.
             val second = applyAll(listOf(applied))
-            assertEquals(1, second.filesImported)
+            assertEquals(0, second.filesImported, "already-applied empty file is not re-recorded")
             assertEquals(0, second.transfersCreated)
             assertEquals(0, second.filesFailed)
+            val stillApplied = repositories.csvImportRepository.getImport(emptyFiat.id).first()!!
+            assertTrue(
+                stillApplied.lastAppliedAt != null,
+                "the empty file stays imported after a second run",
+            )
         }
 }

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCsvE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCsvE2ETest.kt
@@ -225,4 +225,31 @@ class CryptoComCsvE2ETest : DbTest() {
             assertEquals(0, second.transfersCreated, "everything is a duplicate on re-import")
             assertEquals(transfersAfterFirst, allTransfers().size)
         }
+
+    @Test
+    fun importAll_marksHeaderOnlyFileAsImported() =
+        runTest {
+            // A header-only export (no transactions in that period) still matches its strategy by
+            // filename. It has nothing to import, but must be marked imported so it leaves the
+            // Unimported tab instead of reappearing on every "Import all".
+            val emptyFiat = stage("fiat_transactions_record_20231120_085814.csv", emptyList())
+
+            val result = applyAll(listOf(emptyFiat))
+
+            assertEquals(1, result.filesImported, "the empty file is counted as imported")
+            assertEquals(0, result.transfersCreated, "nothing to import")
+            assertEquals(0, result.filesSkippedNoStrategy)
+            assertEquals(0, result.filesFailed)
+            val applied = repositories.csvImportRepository.getImport(emptyFiat.id).first()!!
+            assertTrue(
+                applied.lastAppliedAt != null,
+                "the empty file has an application record (out of the Unimported tab)",
+            )
+
+            // Idempotent: a second "Import all" keeps it imported and imports nothing new.
+            val second = applyAll(listOf(applied))
+            assertEquals(1, second.filesImported)
+            assertEquals(0, second.transfersCreated)
+            assertEquals(0, second.filesFailed)
+        }
 }


### PR DESCRIPTION
## What

A header-only CSV export (columns present, zero data rows — e.g. a bank/exchange export from a period with no transactions) is now marked **imported** by "Import all" instead of perpetually reappearing in the **Unimported** tab.

## Why

A file's imported/unimported status is driven purely by whether a `csv_import_application` row exists (`last_applied_at != null`). For a zero-row file, `applyStagedCsv` returned `null` before recording anything, so `bulkApplyCsv` silently skipped it — the file had nothing to import yet never got marked done, so it came back on every "Import all". (Observed with a real `fiat_transactions_record_*.csv` Crypto.com export that had 11 columns and 0 rows.)

## How

- `applyStagedCsv` (`app/csvimporter/.../CsvImportApplier.kt`): when the file is genuinely empty (`allRows.isEmpty()`), record the strategy application and return a zero-count result instead of `null`. The "all rows already imported on a prior run" case still returns `null` (that file already has its application record).
- Extracted the `RecordApplication` emission into a shared `recordCsvApplication(...)` helper, reused by the existing `runCsvImport` success path (removes duplication).
- Also covers single-file and bulk **re-import** of empty files, which route through the same seam.

## Scope / non-goals

A truly blank file with **no header row at all** matches no strategy (`selectForCsv` returns null → counted `filesSkippedNoStrategy`) and never reaches `applyStagedCsv`; not handled, as it would need a nullable-strategy application row.

## Test

Adds `importAll_marksHeaderOnlyFileAsImported` to `CryptoComCsvE2ETest`: stages a header-only file, runs `bulkApplyCsv` against a real `ImportEngine`, and asserts it is counted imported with `lastAppliedAt != null` and zero transfers created — idempotent on a second run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Header-only CSV imports are now handled correctly and marked as imported, even when there are no data rows.
  * Re-running the same import no longer creates duplicate entries and remains idempotent.
  * Import history is now recorded consistently for empty files, with non-fatal handling if recording fails.

* **Tests**
  * Added end-to-end coverage for header-only CSV imports and repeat import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->