### PR TITLE
Crypto.com: single crypto account + treat any non-fiat ticker as crypto

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -20,6 +20,7 @@ import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.model.csv.ImportStatus
+import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
 import com.moneymanager.domain.model.csvstrategy.HardCodedAccountMapping
@@ -84,11 +85,36 @@ internal fun collapsePassThroughChain(
     return if (keptNodes.size < 2) null else keptNodes to keptDescriptions
 }
 
+/** Number of fractional digits in a raw CSV amount string (e.g. "0.79000000" → 8, "1,234.5" → 1). */
+private fun decimalPlaces(amount: String?): Int {
+    val cleaned = amount?.trim() ?: return 0
+    val dot = cleaned.indexOf('.')
+    if (dot < 0) return 0
+    var count = 0
+    for (i in dot + 1 until cleaned.length) {
+        if (cleaned[i].isDigit()) count++ else break
+    }
+    return count
+}
+
+/** `10^n` as a scale factor, bounded so it stays within a Long (crypto max precision is 18 decimals). */
+private fun scaleFactorForDecimals(decimals: Int): Long {
+    var factor = 1L
+    repeat(decimals.coerceIn(0, 18)) { factor *= 10 }
+    return factor
+}
+
 /**
- * Ensures a crypto asset exists for every registry-known ticker appearing in [strategy]'s currency
- * lookup column across [rows], creating any that are missing via the engine (upsert = idempotent), and
- * returns the full set of crypto assets to feed the mapper. Returns empty when no [cryptoRepository] is
- * supplied, the strategy's currency mapping isn't a column lookup, or the column carries only fiat.
+ * Ensures a crypto asset exists for every crypto ticker appearing in [strategy]'s currency-lookup
+ * columns across [rows], creating any missing ones via the engine (upsert = idempotent), and returns
+ * the full crypto-asset set to feed the mapper.
+ *
+ * A code is treated as crypto when it is registry-known, or — for a currency column whose
+ * [CurrencyLookupMapping.treatNonFiatAsCrypto] is set (the crypto.com strategies) — whenever it is not a
+ * known fiat currency. For an unknown code the scale factor is derived from the paired amount column's
+ * observed precision (CURRENCY↔AMOUNT, TO_CURRENCY↔TO_AMOUNT), so `Money.fromDisplayValue` (which throws
+ * on excess precision) always parses that asset's amounts exactly. Registry-known codes keep their
+ * registry scale. Returns empty when no [cryptoRepository] is supplied.
  */
 private suspend fun ensureCryptoAssets(
     strategy: CsvImportStrategy,
@@ -99,28 +125,51 @@ private suspend fun ensureCryptoAssets(
     cryptoRepository: CryptoReadRepository?,
 ): List<CryptoAsset> {
     if (cryptoRepository == null) return emptyList()
-    // Both the debited (CURRENCY) and credited (TO_CURRENCY) columns can carry a crypto ticker.
-    val currencyColumns =
-        listOf(TransferField.CURRENCY, TransferField.TO_CURRENCY)
-            .mapNotNull { strategy.fieldMappings[it] as? CurrencyLookupMapping }
-            .mapNotNull { m -> columns.firstOrNull { it.originalName == m.columnName }?.columnIndex }
-    if (currencyColumns.isNotEmpty()) {
-        val fiatCodes = currencies.mapTo(mutableSetOf()) { it.code.uppercase() }
-        val existingCrypto = cryptoRepository.getAllCryptoAssets().first().mapTo(mutableSetOf()) { it.code.uppercase() }
-        val newCryptoCodes =
-            rows
-                .asSequence()
-                .flatMap { row ->
-                    currencyColumns.asSequence().map {
-                        row.values
-                            .getOrNull(it)
-                            ?.trim()
-                            ?.uppercase()
-                    }
-                }.filterNotNull()
-                .filter { it.isNotEmpty() && it !in fiatCodes && it !in existingCrypto && CryptoRegistry.lookup(it) != null }
-                .toSet()
-        newCryptoCodes.forEach { importEngine.createCrypto(it) }
+
+    fun columnIndex(name: String): Int? = columns.firstOrNull { it.originalName == name }?.columnIndex
+
+    // Pair each currency-lookup column with its amount column (to derive an unknown asset's scale) and
+    // carry its treatNonFiatAsCrypto flag (whether non-fiat codes in that column become crypto assets).
+    val columnPairs =
+        listOf(
+            TransferField.CURRENCY to TransferField.AMOUNT,
+            TransferField.TO_CURRENCY to TransferField.TO_AMOUNT,
+        ).mapNotNull { (currencyField, amountField) ->
+            val currencyMapping = strategy.fieldMappings[currencyField] as? CurrencyLookupMapping ?: return@mapNotNull null
+            val currencyCol = columnIndex(currencyMapping.columnName) ?: return@mapNotNull null
+            val amountCol = (strategy.fieldMappings[amountField] as? AmountParsingMapping)?.amountColumnName?.let(::columnIndex)
+            Triple(currencyCol, amountCol, currencyMapping.treatNonFiatAsCrypto)
+        }
+    if (columnPairs.isEmpty()) return cryptoRepository.getAllCryptoAssets().first()
+
+    val fiatCodes = currencies.mapTo(mutableSetOf()) { it.code.uppercase() }
+    val existingCrypto = cryptoRepository.getAllCryptoAssets().first().mapTo(mutableSetOf()) { it.code.uppercase() }
+
+    // For each new crypto code, the max fractional digits seen in its paired amount column → its scale.
+    val maxDecimals = mutableMapOf<String, Int>()
+    for (row in rows) {
+        for ((currencyCol, amountCol, treatNonFiatAsCrypto) in columnPairs) {
+            val code =
+                row.values
+                    .getOrNull(currencyCol)
+                    ?.trim()
+                    ?.uppercase()
+            val isNewCrypto =
+                !code.isNullOrEmpty() &&
+                    code !in fiatCodes &&
+                    code !in existingCrypto &&
+                    (CryptoRegistry.lookup(code) != null || treatNonFiatAsCrypto)
+            if (isNewCrypto) {
+                val decimals = amountCol?.let { decimalPlaces(row.values.getOrNull(it)) } ?: 0
+                maxDecimals[code] = maxOf(maxDecimals[code] ?: 0, decimals)
+            }
+        }
+    }
+
+    for ((code, decimals) in maxDecimals) {
+        // Known codes keep their registry scale (scaleFactor = null → registry); unknown codes derive it.
+        val scaleFactor = if (CryptoRegistry.lookup(code) != null) null else scaleFactorForDecimals(decimals)
+        importEngine.createCrypto(code, scaleFactor = scaleFactor)
     }
     return cryptoRepository.getAllCryptoAssets().first()
 }

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoComCsvMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoComCsvMapperTest.kt
@@ -6,6 +6,8 @@ import com.moneymanager.bigdecimal.BigDecimal
 import com.moneymanager.builtin.BuiltInCsvStrategies
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.CryptoAsset
+import com.moneymanager.domain.model.CryptoId
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.Money
@@ -52,6 +54,10 @@ class CryptoComCsvMapperTest {
             "Transaction Hash",
         ).mapIndexed { index, name -> CsvColumn(CsvColumnId(Uuid.random()), index, name) }
 
+    // TGBP is a crypto asset (created on demand by ensureCryptoAssets in the real flow); provide it here
+    // so the mapper resolves it and the conversion rows map to cross-asset trades.
+    private val tgbp = CryptoAsset(id = CryptoId(100), code = "TGBP", name = "TGBP", scaleFactor = 100)
+
     private fun mapper(strategy: CsvImportStrategy): CsvTransferMapper =
         CsvTransferMapper(
             strategy = strategy,
@@ -59,6 +65,7 @@ class CryptoComCsvMapperTest {
             existingAccounts = mapOf(card.name to card, cash.name to cash),
             existingCurrencies = mapOf(gbp.id to gbp),
             existingCurrenciesByCode = mapOf(gbp.code to gbp),
+            existingCryptoByCode = mapOf(tgbp.code to tgbp),
         )
 
     @Suppress("LongParameterList")
@@ -127,22 +134,23 @@ class CryptoComCsvMapperTest {
     }
 
     @Test
-    fun `viban_purchase is Cash into the per-currency wallet`() {
+    fun `viban_purchase is a trade - Cash GBP into the single Crypto_com account as TGBP`() {
         val r = map(fiatStrategy, row("GBP -> TGBP", "GBP", "5000.0", "TGBP", "5000.0", "5000.0", "viban_purchase"))
+        // Debit GBP from Cash, credit TGBP into the single "Crypto.com" account (not a per-ticker wallet).
         assertEquals(cash.id, r.transfer.sourceAccountId)
-        assertEquals("Crypto.com TGBP", r.newAccountName())
-        // Amount stays in the Native (Cash-side) currency; no TGBP currency is needed.
+        assertEquals("Crypto.com", r.newAccountName())
         assertEquals(Money.fromDisplayValue(BigDecimal("5000.0"), gbp), r.transfer.amount)
+        assertEquals(Money.fromDisplayValue(BigDecimal("5000.0"), tgbp), r.tradeTo)
     }
 
     @Test
-    fun `crypto_viban is the per-currency wallet back into Cash`() {
+    fun `crypto_viban is a trade - TGBP out of the Crypto_com account into Cash as GBP`() {
         val r = map(fiatStrategy, row("TGBP -> GBP", "TGBP", "5009.86", "GBP", "5009.86", "5009.86", "crypto_viban"))
-        // The Currency<->To Currency swap resolves the wallet, and the positive amount flips it
-        // onto the source side.
+        // Debit TGBP from the "Crypto.com" account (source, after the positive-amount flip), credit GBP to Cash.
+        assertEquals("Crypto.com", r.newAccountName())
         assertEquals(cash.id, r.transfer.targetAccountId)
-        assertEquals("Crypto.com TGBP", r.newAccountName())
-        assertEquals(Money.fromDisplayValue(BigDecimal("5009.86"), gbp), r.transfer.amount)
+        assertEquals(Money.fromDisplayValue(BigDecimal("5009.86"), tgbp), r.transfer.amount)
+        assertEquals(Money.fromDisplayValue(BigDecimal("5009.86"), gbp), r.tradeTo)
     }
 
     @Test

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCryptoE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCryptoE2ETest.kt
@@ -129,7 +129,7 @@ class CryptoComCryptoE2ETest : DbTest() {
                 repositories.accountRepository
                     .getAllAccounts()
                     .first()
-                    .first { it.name == "Crypto.com CRO" }
+                    .first { it.name == "Crypto.com" }
             val balance =
                 repositories.transactionRepository
                     .getAccountBalances()
@@ -163,7 +163,7 @@ class CryptoComCryptoE2ETest : DbTest() {
             // The wallet holds a real crypto balance: 0.37 + 0.42 = 0.79 CRO.
             repositories.maintenanceService.refreshMaterializedViews()
             val accounts = repositories.accountRepository.getAllAccounts().first()
-            val wallet = accounts.first { it.name == "Crypto.com CRO" }
+            val wallet = accounts.first { it.name == "Crypto.com" }
             val balance =
                 repositories.transactionRepository
                     .getAccountBalances()

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCsvE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCsvE2ETest.kt
@@ -142,34 +142,55 @@ class CryptoComCsvE2ETest : DbTest() {
                 setOf(
                     "Crypto.com Card",
                     "Crypto.com Cash",
-                    "Crypto.com TGBP",
                     "GBP Deposit (via FPS)",
                     "GBP Withdrawal (via FPS)",
                     "Spotify P3 C6 Ef4945",
-                    // The crypto export's cashback rows: a real CRO wallet + the reward counterparty.
-                    "Crypto.com CRO",
+                    // The crypto reward counterparty, plus the single account that holds ALL crypto
+                    // (CRO cashback + TGBP conversions) as separate per-asset balances.
                     "Card Cashback",
+                    "Crypto.com",
                 ),
                 accountNames,
             )
 
-            // The CRO cashback lands as a real crypto balance (0.37 + 0.42 = 0.79 CRO), created on demand.
             repositories.maintenanceService.refreshMaterializedViews()
-            val croWalletId = accounts.first { it.name == "Crypto.com CRO" }.id
-            val croBalance =
+            val cryptoAccountId = accounts.first { it.name == "Crypto.com" }.id
+            val cashId = accounts.first { it.name == "Crypto.com Cash" }.id
+            val cardId = accounts.first { it.name == "Crypto.com Card" }.id
+            val depositId = accounts.first { it.name == "GBP Deposit (via FPS)" }.id
+            val withdrawalId = accounts.first { it.name == "GBP Withdrawal (via FPS)" }.id
+
+            // One "Crypto.com" account holds every crypto as a separate per-asset balance.
+            val cryptoBalances =
                 repositories.transactionRepository
                     .getAccountBalances()
                     .first()
-                    .first { it.accountId == croWalletId }
-                    .balance
-            assertEquals("CRO", croBalance.currency.code)
-            assertEquals("0.79", croBalance.toDisplayValue().toString())
+                    .filter { it.accountId == cryptoAccountId }
+                    .associate { it.balance.currency.code to it.balance.toDisplayValue().toString() }
+            assertEquals("0.79", cryptoBalances["CRO"], "CRO cashback 0.37 + 0.42, created on demand")
+            // TGBP is an unknown ticker created on demand as crypto; net of the two conversions.
+            assertEquals("-9.86", cryptoBalances["TGBP"], "TGBP bought 5000 - sold 5009.86")
 
-            val cashId = accounts.first { it.name == "Crypto.com Cash" }.id
-            val cardId = accounts.first { it.name == "Crypto.com Card" }.id
-            val walletId = accounts.first { it.name == "Crypto.com TGBP" }.id
-            val depositId = accounts.first { it.name == "GBP Deposit (via FPS)" }.id
-            val withdrawalId = accounts.first { it.name == "GBP Withdrawal (via FPS)" }.id
+            // The two viban conversions are cross-asset trades (not GBP wallet transfers), correctly directed.
+            val cryptoTrades = repositories.tradeRepository.getTradesByAccount(cryptoAccountId).first()
+            assertTrue(
+                cryptoTrades.any {
+                    it.fromAccountId == cashId &&
+                        it.from.currency.code == "GBP" &&
+                        it.toAccountId == cryptoAccountId &&
+                        it.to.currency.code == "TGBP"
+                },
+                "viban_purchase: Cash GBP -> Crypto.com TGBP",
+            )
+            assertTrue(
+                cryptoTrades.any {
+                    it.fromAccountId == cryptoAccountId &&
+                        it.from.currency.code == "TGBP" &&
+                        it.toAccountId == cashId &&
+                        it.to.currency.code == "GBP"
+                },
+                "crypto_viban: Crypto.com TGBP -> Cash GBP",
+            )
 
             // Amounts in GBP minor units (scale factor 100).
             fun Money.pence(): Long = amount.toLong()
@@ -183,18 +204,6 @@ class CryptoComCsvE2ETest : DbTest() {
             assertTrue(
                 cashTransfers.any { it.sourceAccountId == cashId && it.targetAccountId == withdrawalId },
                 "viban_withdrawal: Cash -> external",
-            )
-            assertTrue(
-                cashTransfers.any {
-                    it.sourceAccountId == cashId && it.targetAccountId == walletId && it.amount.pence() == 500_000L
-                },
-                "viban_purchase: Cash -> wallet despite the positive amount",
-            )
-            assertTrue(
-                cashTransfers.any {
-                    it.sourceAccountId == walletId && it.targetAccountId == cashId && it.amount.pence() == 500_986L
-                },
-                "crypto_viban: wallet -> Cash",
             )
 
             // The shared top-up: both records exist as Cash -> Card...
@@ -289,12 +298,13 @@ class CryptoComCsvE2ETest : DbTest() {
 
             val accounts = repositories.accountRepository.getAllAccounts().first()
             val cashId = accounts.first { it.name == "Crypto.com Cash" }.id
-            val btcWalletId = accounts.first { it.name == "Crypto.com BTC" }.id
+            // All crypto lands in the single "Crypto.com" account, not a per-ticker wallet.
+            val cryptoAccountId = accounts.first { it.name == "Crypto.com" }.id
 
-            // The conversion became a trade (GBP out of Cash, BTC into the wallet), not a GBP transfer.
+            // The conversion became a trade (GBP out of Cash, BTC into the crypto account), not a GBP transfer.
             val trade =
                 repositories.tradeRepository
-                    .getTradesByAccount(btcWalletId)
+                    .getTradesByAccount(cryptoAccountId)
                     .first()
                     .single()
             assertEquals(cashId, trade.fromAccountId)
@@ -307,7 +317,7 @@ class CryptoComCsvE2ETest : DbTest() {
             assertEquals(
                 "0.005",
                 balances
-                    .first { it.accountId == btcWalletId }
+                    .first { it.accountId == cryptoAccountId && it.balance.currency.code == "BTC" }
                     .balance
                     .toDisplayValue()
                     .toString(),

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
@@ -258,6 +258,13 @@ data class CurrencyLookupMapping(
     override val id: FieldMappingId,
     override val fieldType: TransferField,
     val columnName: String,
+    /**
+     * When true, a value in [columnName] that is not a known fiat currency is treated as a crypto asset
+     * and created on demand (scale derived from the paired amount column). Set on the crypto.com
+     * strategies, whose currency columns only ever carry fiat or crypto tickers. Default false keeps the
+     * safe registry-only behaviour for other banks (a stray/typo code stays fiat, not a bogus crypto).
+     */
+    val treatNonFiatAsCrypto: Boolean = false,
 ) : FieldMapping
 
 /**

--- a/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
+++ b/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
@@ -47,6 +47,9 @@ object BuiltInCsvStrategies {
     private const val CRYPTO_COM_CASH_ACCOUNT = "Crypto.com Cash"
     private const val CRYPTO_COM_WALLET_PREFIX = "Crypto.com "
 
+    /** Single account that holds every crypto.com crypto balance (one per-asset balance, not per account). */
+    private const val CRYPTO_COM_CRYPTO_ACCOUNT = "Crypto.com"
+
     /**
      * Cross-source reconciliation window for the crypto.com strategies. The same top-up appears in
      * both the card export ("GBP Deposit") and the fiat export (viban_card_top_up) with near-identical
@@ -104,8 +107,7 @@ object BuiltInCsvStrategies {
      * The column header shared by all three crypto.com exports (card_transactions_record_*,
      * fiat_transactions_record_* and crypto_transactions_record_*). Because the sets are identical,
      * the crypto.com strategies rely on [CsvImportStrategy.fileNamePattern] and content rules over
-     * the Transaction Kind column to tell the files apart; crypto_* files match neither built-in
-     * strategy and are skipped.
+     * the Transaction Kind column to tell the three files apart.
      */
     private val cryptoComIdentificationColumns =
         setOf(
@@ -248,13 +250,14 @@ object BuiltInCsvStrategies {
                             listOf(
                                 RowCondition("Currency", RowConditionOperator.NOT_EQUALS_COLUMN, otherColumnName = "To Currency"),
                             ),
-                        // Conversion rows target the per-currency wallet ("Crypto.com TGBP").
+                        // Conversion rows (GBP -> crypto/TGBP) credit the single "Crypto.com" account
+                        // (the To Currency asset), not a per-currency wallet.
                         whenTrue =
-                            TemplateAccountMapping(
+                            RegexAccountMapping(
                                 id = cryptoComFiatMappingId(3),
                                 fieldType = TransferField.TARGET_ACCOUNT,
-                                columnName = "To Currency",
-                                prefix = CRYPTO_COM_WALLET_PREFIX,
+                                columnName = "Transaction Description",
+                                rules = listOf(RegexRule(pattern = "^", accountName = CRYPTO_COM_CRYPTO_ACCOUNT)),
                             ),
                         whenFalse =
                             RegexAccountMapping(
@@ -299,6 +302,7 @@ object BuiltInCsvStrategies {
                         id = cryptoComFiatMappingId(8),
                         fieldType = TransferField.CURRENCY,
                         columnName = "Currency",
+                        treatNonFiatAsCrypto = true,
                     ),
                 // Credit leg of a conversion → the importer emits a trade when To Currency differs from
                 // Currency and resolves (e.g. a real crypto buy). The GBP-pegged TGBP token doesn't
@@ -315,6 +319,7 @@ object BuiltInCsvStrategies {
                         id = cryptoComFiatMappingId(10),
                         fieldType = TransferField.TO_CURRENCY,
                         columnName = "To Currency",
+                        treatNonFiatAsCrypto = true,
                     ),
                 TransferField.TIMEZONE to
                     HardCodedTimezoneMapping(
@@ -325,13 +330,10 @@ object BuiltInCsvStrategies {
             )
         val rowRules =
             listOf(
-                // crypto_viban rows are wallet → Cash ("TGBP -> GBP"): move the wallet code into
-                // To Currency so the conversion target mapping resolves the wallet account. The
-                // positive amount then flips it onto the source side.
-                RowPreprocessingRule(
-                    conditions = listOf(RowCondition("Transaction Kind", RowConditionOperator.EQUALS_VALUE, value = "crypto_viban")),
-                    columnSwaps = listOf(ColumnPairSwap("Currency", "To Currency")),
-                ),
+                // crypto_viban ("TGBP -> GBP", a crypto sale) is a cross-asset conversion → a trade.
+                // Its Currency/To Currency already name the sold/received assets, and the positive-amount
+                // flip puts the crypto (source) leg on the debit side, so the trade comes out correctly
+                // directed WITHOUT the old column swap (which was a single-asset-transfer artifact).
                 // Top-ups and purchases are positive but money LEAVES Cash: flipping source/target
                 // here cancels the positive-amount flip (the two flips are XORed), keeping Cash as
                 // the source.
@@ -386,13 +388,14 @@ object BuiltInCsvStrategies {
     fun buildCryptoComCryptoStrategy(now: Instant): CsvImportStrategy {
         val fieldMappings =
             mapOf(
-                // The wallet for this row's asset, e.g. "Crypto.com CRO"; created on demand if absent.
+                // All crypto lands in the single "Crypto.com" account (one balance per asset), not a
+                // separate wallet per ticker. The always-matching "^" rule routes every row there.
                 TransferField.SOURCE_ACCOUNT to
-                    TemplateAccountMapping(
+                    RegexAccountMapping(
                         id = cryptoComCryptoMappingId(1),
                         fieldType = TransferField.SOURCE_ACCOUNT,
-                        columnName = "Currency",
-                        prefix = CRYPTO_COM_WALLET_PREFIX,
+                        columnName = "Transaction Description",
+                        rules = listOf(RegexRule(pattern = "^", accountName = CRYPTO_COM_CRYPTO_ACCOUNT)),
                     ),
                 // Counterparty (reward source / merchant) looked up from the description.
                 TransferField.TARGET_ACCOUNT to
@@ -431,6 +434,7 @@ object BuiltInCsvStrategies {
                         id = cryptoComCryptoMappingId(6),
                         fieldType = TransferField.CURRENCY,
                         columnName = "Currency",
+                        treatNonFiatAsCrypto = true,
                     ),
                 TransferField.TIMEZONE to
                     HardCodedTimezoneMapping(

--- a/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
+++ b/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
@@ -45,7 +45,6 @@ object BuiltInCsvStrategies {
     /** Fixed account names shared by the crypto.com Card and Fiat strategies, so both files resolve the same accounts. */
     private const val CRYPTO_COM_CARD_ACCOUNT = "Crypto.com Card"
     private const val CRYPTO_COM_CASH_ACCOUNT = "Crypto.com Cash"
-    private const val CRYPTO_COM_WALLET_PREFIX = "Crypto.com "
 
     /** Single account that holds every crypto.com crypto balance (one per-asset balance, not per account). */
     private const val CRYPTO_COM_CRYPTO_ACCOUNT = "Crypto.com"
@@ -222,15 +221,15 @@ object BuiltInCsvStrategies {
      * - viban_withdrawal ("GBP Withdrawal (via FPS)", negative): Cash → external bank.
      * - viban_card_top_up ("Top Up Card", POSITIVE but money leaves Cash): Cash → Card. A row rule
      *   flips source/target to cancel the positive-amount flip.
-     * - viban_purchase ("GBP -> TGBP", positive, To Currency = wallet code): Cash → per-currency
-     *   wallet, same cancelled flip.
-     * - crypto_viban ("TGBP -> GBP", positive, Currency = wallet code): wallet → Cash. A column swap
-     *   moves the wallet code into To Currency so the conversion target mapping below sees it; the
-     *   positive-amount flip then puts the wallet on the source side.
+     * - viban_purchase ("GBP -> TGBP", a buy) and crypto_viban ("TGBP -> GBP", a sell) are cross-asset
+     *   conversions → cross-asset TRADES: the debited (Currency) and credited (To Currency) legs already
+     *   name the assets, and the positive-amount flip puts the debit leg on the source side, so both
+     *   directions come out correct with no column swap.
      *
-     * Amount/currency always read the Native columns (the Cash-side fiat value, present on every row
-     * including conversions), so no crypto-token currencies are required in the database.
-     * To Currency is populated on every row; conversions are detected by Currency != To Currency.
+     * Amount/currency read the real Currency/Amount columns; a To/From Currency that is not a fiat code
+     * (e.g. TGBP, or any crypto) is provisioned on demand as a crypto asset
+     * ([CurrencyLookupMapping.treatNonFiatAsCrypto]) and held in the single Crypto.com account. To
+     * Currency is populated on every row; conversions are detected by Currency != To Currency.
      */
     fun buildCryptoComFiatStrategy(now: Instant): CsvImportStrategy {
         val fieldMappings =
@@ -305,8 +304,8 @@ object BuiltInCsvStrategies {
                         treatNonFiatAsCrypto = true,
                     ),
                 // Credit leg of a conversion → the importer emits a trade when To Currency differs from
-                // Currency and resolves (e.g. a real crypto buy). The GBP-pegged TGBP token doesn't
-                // resolve, so those conversions stay ordinary transfers as before.
+                // Currency. Because the currency lookups set treatNonFiatAsCrypto, any non-fiat To/From
+                // Currency (TGBP and every real crypto) is created on demand and the conversion is a trade.
                 TransferField.TO_AMOUNT to
                     AmountParsingMapping(
                         id = cryptoComFiatMappingId(9),
@@ -376,14 +375,15 @@ object BuiltInCsvStrategies {
      * Built-in strategy for crypto.com's crypto_transactions_record_*.csv export — the crypto-native
      * ledger (card cashback, staking/earn rewards, swaps). Unlike the card/fiat strategies (which
      * denominate everything in the Native GBP columns and keep the crypto figure only as an
-     * attribute), this one denominates each row in its **real Currency/Amount**, so a wallet holds a
-     * genuine crypto balance (e.g. 0.37 CRO), and routes it to a per-asset "Crypto.com <CODE>" wallet.
-     * The crypto asset itself is created on demand during import (see CsvImportApplier.ensureCryptoAssets).
+     * attribute), this one denominates each row in its **real Currency/Amount**, so the account holds a
+     * genuine crypto balance (e.g. 0.37 CRO). Every row lands in the single [CRYPTO_COM_CRYPTO_ACCOUNT]
+     * account (one balance per asset), and the crypto asset itself is created on demand during import
+     * (see CsvImportApplier.ensureCryptoAssets; the currency lookup sets treatNonFiatAsCrypto).
      *
-     * The wallet is the SOURCE and the counterparty (from the description, e.g. "Card Cashback") the
-     * TARGET; [AmountParsingMapping.flipAccountsOnPositive] then makes a positive amount (rewards) flow
-     * INTO the wallet and a negative amount (a spend/swap out) flow OUT of it — mirroring the card
-     * strategy's sign convention.
+     * The Crypto.com account is the SOURCE and the counterparty (from the description, e.g. "Card
+     * Cashback") the TARGET; [AmountParsingMapping.flipAccountsOnPositive] then makes a positive amount
+     * (rewards) flow INTO the account and a negative amount (a spend/swap out) flow OUT of it —
+     * mirroring the card strategy's sign convention.
      */
     fun buildCryptoComCryptoStrategy(now: Instant): CsvImportStrategy {
         val fieldMappings =


### PR DESCRIPTION
Follow-up to #646 (crypto assets), from testing the crypto.com import on a real database. Two gaps:

1. **One account per asset.** The import created a separate account per ticker (`Crypto.com BNB`, `Crypto.com BOSON`, `Crypto.com MELANIA`, `Crypto.com TGBP`) instead of holding all crypto together.
2. **Unrecognized tickers dropped.** `ensureCryptoAssets` only created registry-known codes, so `TGBP`/`MELANIA` never became crypto assets (their rows fell back to GBP or failed).

## Changes

- **Single `Crypto.com` account.** The crypto export's source and the fiat export's conversion target now route to one fixed `Crypto.com` account. Balances are keyed `(account_id, asset_id)`, so that one account holds CRO / BNB / BOSON / TGBP / MELANIA as separate per-asset balances.
- **Any non-fiat ticker → crypto.** New per-mapping `CurrencyLookupMapping.treatNonFiatAsCrypto` flag (set on the crypto.com currency lookups) makes `ensureCryptoAssets` create *any* non-fiat code as crypto, not just registry-known ones. The flag lives in `field_mappings_json`, so it round-trips through the DB **with no schema change / no database recreation** (kept the existing `field-mappings` JSON, not a new strategy column, precisely to avoid wiping existing databases).
- **Data-derived precision.** Unknown tickers are created with a scale factor derived from the paired amount column's observed decimal places (CURRENCY↔AMOUNT, TO_CURRENCY↔TO_AMOUNT), so `Money.fromDisplayValue` (which throws on excess precision) always parses that asset's amounts exactly.
- **Correct trade directions.** Removed the fiat export's `crypto_viban` column-swap (a single-asset-transfer artifact). With TGBP now crypto, both `viban_purchase` (buy) and `crypto_viban` (sell) produce correctly-directed cross-asset trades.

## Testing

- `CryptoComCryptoE2ETest`, `CryptoComCsvE2ETest`: one `Crypto.com` account holds CRO + TGBP; the unknown ticker TGBP is created on demand; GBP↔TGBP conversions are correctly-directed trades.
- `CryptoComCsvMapperTest`: conversion rows map to trades into/out of the single account.
- Strategy install / export-round-trip / catalog lockstep tests still green (the flag serializes cleanly).
- Full `./gradlew build buildHealth` green locally.

## Note for existing databases

Existing databases still hold the old per-currency GBP wallets and no crypto assets — **re-import** (or re-import-all) the crypto.com CSVs to get the new behaviour; the old empty `Crypto.com <TICKER>` wallets are cleaned up by re-import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crypto.com imports now support a single crypto account with per-asset balances instead of separate wallet accounts.
  * Non-fiat currency values can now be treated as crypto assets during import, with amounts scaled from observed precision.

* **Bug Fixes**
  * Improved handling of crypto conversions and balance reconciliation for Crypto.com CSV imports.
  * Updated account matching so imported crypto activity maps to the correct wallet names and balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->