### PR TITLE
Fix Account Matrix rendering crypto assets as "?"

### DIFF
--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -236,8 +236,8 @@ fun AccountTransactionsScreen(
     val displayedRunningBalances =
         if (showExcluded) runningBalances else runningBalances.filter { !it.isExcluded }
 
-    // Get all unique currencies from account balances for matrix
-    val uniqueCurrencyIds = accountBalances.map { CurrencyId(it.balance.currency.id.id) }.distinct()
+    // Get all unique assets (fiat or crypto) from account balances for matrix, deduped by id
+    val uniqueAssets = accountBalances.map { it.balance.currency }.distinctBy { it.id.id }
 
     // Calculate column widths for each account based on account name and balance amounts
     val accountColumnWidths: Map<AccountId, Dp> =
@@ -511,8 +511,8 @@ fun AccountTransactionsScreen(
                                             .verticalScroll(verticalScrollState),
                                     verticalArrangement = Arrangement.spacedBy(4.dp),
                                 ) {
-                                    uniqueCurrencyIds.forEach { currencyId ->
-                                        val isCurrencySelected = selectedCurrencyId == currencyId
+                                    uniqueAssets.forEach { asset ->
+                                        val isCurrencySelected = selectedCurrencyId?.id == asset.id.id
                                         Box(
                                             modifier =
                                                 Modifier
@@ -526,7 +526,7 @@ fun AccountTransactionsScreen(
                                                     ).padding(vertical = 4.dp),
                                         ) {
                                             Text(
-                                                text = "${currencies.find { it.id == currencyId }?.code ?: "?"}:",
+                                                text = "${asset.code}:",
                                                 style = MaterialTheme.typography.bodySmall,
                                                 color =
                                                     if (isCurrencySelected) {
@@ -550,7 +550,7 @@ fun AccountTransactionsScreen(
                                     verticalArrangement = Arrangement.spacedBy(4.dp),
                                 ) {
                                     // Row for each currency
-                                    uniqueCurrencyIds.forEach { currencyId ->
+                                    uniqueAssets.forEach { asset ->
                                         Row(
                                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                                             verticalAlignment = Alignment.CenterVertically,
@@ -559,9 +559,10 @@ fun AccountTransactionsScreen(
                                             allAccounts.forEach { account ->
                                                 val balance =
                                                     accountBalances.find {
-                                                        it.accountId == account.id && it.balance.currency.id == currencyId
+                                                        it.accountId == account.id && it.balance.currency.id.id == asset.id.id
                                                     }
-                                                val isSelectedCell = selectedAccountId == account.id && selectedCurrencyId == currencyId
+                                                val isSelectedCell =
+                                                    selectedAccountId == account.id && selectedCurrencyId?.id == asset.id.id
                                                 val isColumnSelected = selectedAccountId == account.id && selectedCurrencyId == null
                                                 val columnWidth = accountColumnWidths[account.id] ?: ACCOUNT_COLUMN_MIN_WIDTH
 
@@ -578,9 +579,10 @@ fun AccountTransactionsScreen(
                                                             .width(columnWidth)
                                                             .background(backgroundColor)
                                                             .clickable(enabled = balance != null) {
+                                                                val assetCurrencyId = CurrencyId(asset.id.id)
                                                                 selectedAccountId = account.id
-                                                                selectedCurrencyId = currencyId
-                                                                onAccountClick(account.id, account.name, currencyId, null)
+                                                                selectedCurrencyId = assetCurrencyId
+                                                                onAccountClick(account.id, account.name, assetCurrencyId, null)
                                                             }.padding(vertical = 4.dp),
                                                     contentAlignment = Alignment.Center,
                                                 ) {
@@ -790,8 +792,8 @@ fun AccountTransactionsScreen(
                             // Scroll matrix to show the account and currency
                             val accountIndex = allAccounts.indexOfFirst { it.id == accountId }
                             val currencyIndex =
-                                uniqueCurrencyIds.indexOfFirst {
-                                    it == transaction.transactionAmount.currency.id
+                                uniqueAssets.indexOfFirst {
+                                    it.id.id == transaction.transactionAmount.currency.id.id
                                 }
 
                             if (accountIndex >= 0 && currencyIndex >= 0) {
@@ -920,8 +922,8 @@ fun AccountTransactionsScreen(
                                                 )
                                             // Calculate vertical scroll position for the currency
                                             val currencyIndex =
-                                                uniqueCurrencyIds.indexOfFirst {
-                                                    it == runningBalance.transactionAmount.currency.id
+                                                uniqueAssets.indexOfFirst {
+                                                    it.id.id == runningBalance.transactionAmount.currency.id.id
                                                 }
                                             if (currencyIndex >= 0) {
                                                 // Each currency row: text + padding + spacing ≈ 28.dp

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -46,6 +46,7 @@ import com.moneymanager.compose.scrollbar.VerticalScrollbarForScrollState
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Asset
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.TransactionId
@@ -236,8 +237,12 @@ fun AccountTransactionsScreen(
     val displayedRunningBalances =
         if (showExcluded) runningBalances else runningBalances.filter { !it.isExcluded }
 
-    // Get all unique assets (fiat or crypto) from account balances for matrix, deduped by id
-    val uniqueAssets = accountBalances.map { it.balance.currency }.distinctBy { it.id.id }
+    // Get all unique assets (fiat or crypto) from account balances for matrix, deduped by id.
+    // Sorted by code for a deterministic row order independent of balance emission order.
+    val uniqueAssets =
+        remember(accountBalances) {
+            accountBalances.map { it.balance.currency }.distinctBy { it.id.id }.sortedBy { it.code }
+        }
 
     // Calculate column widths for each account based on account name and balance amounts
     val accountColumnWidths: Map<AccountId, Dp> =
@@ -791,10 +796,7 @@ fun AccountTransactionsScreen(
 
                             // Scroll matrix to show the account and currency
                             val accountIndex = allAccounts.indexOfFirst { it.id == accountId }
-                            val currencyIndex =
-                                uniqueAssets.indexOfFirst {
-                                    it.id.id == transaction.transactionAmount.currency.id.id
-                                }
+                            val currencyIndex = uniqueAssets.indexOfAsset(transaction.transactionAmount.currency.id.id)
 
                             if (accountIndex >= 0 && currencyIndex >= 0) {
                                 val targetScrollX =
@@ -922,9 +924,7 @@ fun AccountTransactionsScreen(
                                                 )
                                             // Calculate vertical scroll position for the currency
                                             val currencyIndex =
-                                                uniqueAssets.indexOfFirst {
-                                                    it.id.id == runningBalance.transactionAmount.currency.id.id
-                                                }
+                                                uniqueAssets.indexOfAsset(runningBalance.transactionAmount.currency.id.id)
                                             if (currencyIndex >= 0) {
                                                 // Each currency row: text + padding + spacing ≈ 28.dp
                                                 val targetScrollY =
@@ -1009,3 +1009,6 @@ fun AccountTransactionsScreen(
         )
     }
 }
+
+/** Index of the matrix row for the asset with the given id, or -1 if absent. */
+private fun List<Asset>.indexOfAsset(assetId: Long): Int = indexOfFirst { it.id.id == assetId }


### PR DESCRIPTION
## What

The Account Matrix (accounts × currencies grid on the Transactions screen) rendered crypto rows with a `?:` label instead of the ticker (e.g. `BTC:`), and — from the same root cause — left the crypto **balance cells empty**.

## Why

The matrix keyed its rows on the fiat `CurrencyId`, laundering every balance's asset id into one and resolving row labels from the fiat-only currency list (`getAllCurrencies()`):

- Crypto assets live in a separate `CryptoAsset` type with a `CryptoId`, so a crypto id was never in the fiat list → label fell back to `"?:"`.
- The cell lookup compared `balance.currency.id == currencyId`. For crypto that's `CryptoId == CurrencyId`; Kotlin value classes of different types are never equal, so `find` returned null and the cell rendered empty.
- The two "scroll matrix to selected transaction" `indexOfFirst` lookups had the same mismatch and silently no-op'd for crypto rows.

The transaction list/filtering already worked for crypto because the repository binds the raw `Long` asset id (`currencyId?.id`) into its SQL — so the laundering was harmless for queries; the breakage was confined to the matrix's in-memory comparisons and its fiat-only label lookup.

## How

Key the matrix off each balance's own `Asset` (the supertype of both `Currency` and `CryptoAsset`):

- Row set derives from the distinct assets (`distinctBy { it.id.id }`) instead of re-wrapped `CurrencyId`s.
- Row label renders `asset.code` directly (no fiat lookup, no `?`).
- Cell match, selection highlight, and scroll-to-selected all compare by the underlying `Long` asset id.
- Cell clicks still feed the query layer via `CurrencyId(asset.id.id)`, so transaction filtering keeps working unchanged.

Public `selectedCurrencyId: CurrencyId?` state and the `onAccountClick`/`onCurrencyIdChange` signatures are unchanged.

## Testing

- `./gradlew build` passes locally.
- Manual: with a crypto-holding DB, the matrix shows e.g. `BTC:` with its balance in the cell, and clicking a crypto cell filters the transaction list to that asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the transactions account matrix so balances and labels now group by asset instead of by currency ID.
  * Fixed cell highlighting and selection to stay in sync when viewing accounts.
  * Clicking a balance cell now opens the correct account more reliably.
  * Scrolling to a selected transfer or account now lands on the right row in the matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->