### PR TITLE
Model crypto.com asset conversions as linked transfers (config-driven)

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -31,6 +31,7 @@ import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CryptoReadRepository
 import com.moneymanager.domain.repository.CsvImportReadRepository
 import com.moneymanager.importengineapi.AccountRef
+import com.moneymanager.importengineapi.BatchRelationship
 import com.moneymanager.importengineapi.CsvImportMutation
 import com.moneymanager.importengineapi.DedupePolicy
 import com.moneymanager.importengineapi.ExistingUniqueKeyExtractor
@@ -778,6 +779,35 @@ suspend fun runCsvImport(
             )
         }
 
+    // Asset-conversion linking: pair each debit leg to a credit leg (same pairing key, nearest
+    // timestamp within the configured window) so the engine links them with the conversion
+    // relationship. Handles both 1:1 swaps and N-debits -> 1-credit dust events (many debits share the
+    // one credit). Debits with no in-window credit are left unlinked (still valid, balance-correct).
+    val conversionConfig = strategy.conversionConfig
+    val conversionLinkByRow: Map<Long, BatchRelationship> =
+        if (conversionConfig == null) {
+            emptyMap()
+        } else {
+            val window = conversionConfig.pairingWindowSeconds.seconds
+            val credits = finalPrep.validTransfers.filter { it.conversionLeg?.side == ConversionSide.CREDIT }
+            finalPrep.validTransfers
+                .filter { it.conversionLeg?.side == ConversionSide.DEBIT }
+                .mapNotNull { debit ->
+                    val key = debit.conversionLeg!!.pairingKey
+                    val match =
+                        credits
+                            .filter { it.conversionLeg!!.pairingKey == key }
+                            .minByOrNull { (it.transfer.timestamp - debit.transfer.timestamp).absoluteValue }
+                            ?.takeIf { (it.transfer.timestamp - debit.transfer.timestamp).absoluteValue <= window }
+                            ?: return@mapNotNull null
+                    debit.rowIndex to
+                        BatchRelationship(
+                            relatedRowKey = ImportRowKey.CsvRow(match.rowIndex),
+                            typeName = conversionConfig.relationshipTypeName,
+                        )
+                }.toMap()
+        }
+
     val importTransfers =
         finalPrep.validTransfers.filter { it.tradeTo == null }.map { row ->
             val uniqueKey =
@@ -836,6 +866,7 @@ suspend fun runCsvImport(
                 uniqueKey = uniqueKey,
                 fee = fee,
                 passThrough = passThrough,
+                batchRelationships = listOfNotNull(conversionLinkByRow[row.rowIndex]),
             )
         }
 

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -27,6 +27,7 @@ import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
 import com.moneymanager.domain.model.csvstrategy.ColumnExtraction
 import com.moneymanager.domain.model.csvstrategy.ColumnPairSwap
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
+import com.moneymanager.domain.model.csvstrategy.ConversionAccountRule
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
 import com.moneymanager.domain.model.csvstrategy.DateTimeParsingMapping
@@ -93,6 +94,8 @@ sealed interface MappingResult {
          * Null for ordinary rows.
          */
         val passThrough: CsvPassThrough? = null,
+        /** Set when the row is one leg of an asset conversion (see [ConversionConfig]); null otherwise. */
+        val conversionLeg: ConversionLegInfo? = null,
     ) : MappingResult {
         /** Convenience for flows where only the target side can discover a new account. */
         val newAccountName: String? get() = newAccounts.firstOrNull()?.name
@@ -142,6 +145,22 @@ data class CsvPassThrough(
     val conduitName: String get() = conduitNames.first()
 }
 
+/** Which side of an asset conversion a row represents (see [ConversionConfig]). */
+enum class ConversionSide { DEBIT, CREDIT }
+
+/**
+ * Marks a mapped row as one leg of an asset conversion (see [ConversionConfig]). The applier pairs
+ * each [ConversionSide.DEBIT] leg to a [ConversionSide.CREDIT] leg with the same [pairingKey] within
+ * the config's time window and links them with the conversion relationship.
+ *
+ * @property side Whether this leg is the debit (asset leaving) or credit (asset received).
+ * @property pairingKey Value that must match between a debit and credit leg of the same event.
+ */
+data class ConversionLegInfo(
+    val side: ConversionSide,
+    val pairingKey: String,
+)
+
 /**
  * A transfer with its associated attributes extracted from CSV.
  * Uses attribute type names (not IDs) since types may need to be created.
@@ -168,6 +187,8 @@ data class CsvTransferWithAttributes(
     val personalCounterpartyName: String? = null,
     /** Pass-through (conduit) routing for the row (e.g. Curve); null for ordinary rows. */
     val passThrough: CsvPassThrough? = null,
+    /** Set when the row is one leg of an asset conversion (see [ConversionConfig]); null otherwise. */
+    val conversionLeg: ConversionLegInfo? = null,
 )
 
 /**
@@ -216,6 +237,9 @@ data class DiscoveredAccountMapping(
     val matchedPattern: String? = null,
 )
 
+/** Separator joining the parts of a conversion pairing key; a control char that won't appear in data. */
+private const val PAIRING_KEY_SEPARATOR = "\u0000"
+
 /**
  * Maps CSV rows to Transfer objects using an import strategy.
  */
@@ -242,6 +266,20 @@ class CsvTransferMapper(
 ) {
     private val columnIndexByName: Map<String, Int> =
         columns.associate { it.originalName to it.columnIndex }
+
+    // Precompiled conversion detection (null when the strategy declares no conversionConfig). Regexes
+    // are case-insensitive, matching the file's existing account/content-rule matching convention.
+    private val conversionDebitRegex: Regex? =
+        strategy.conversionConfig?.let { Regex(it.debitPattern, RegexOption.IGNORE_CASE) }
+    private val conversionCreditRegex: Regex? =
+        strategy.conversionConfig?.let { Regex(it.creditPattern, RegexOption.IGNORE_CASE) }
+    private val conversionPairingKeyRegex: Regex? =
+        strategy.conversionConfig?.pairingKeyPattern?.let { Regex(it, RegexOption.IGNORE_CASE) }
+    private val conversionAccountRuleRegexes: List<Pair<Regex, ConversionAccountRule>> =
+        strategy.conversionConfig
+            ?.conversionAccountRules
+            .orEmpty()
+            .map { Regex(it.pattern, RegexOption.IGNORE_CASE) to it }
 
     // Extract unique identifier column names from strategy
     private val uniqueIdentifierColumns: List<String> =
@@ -292,6 +330,7 @@ class CsvTransferMapper(
                             tradeTo = result.tradeTo,
                             personalCounterpartyName = result.personalCounterpartyName,
                             passThrough = result.passThrough,
+                            conversionLeg = result.conversionLeg,
                         ),
                     )
                     // Count by status
@@ -384,6 +423,15 @@ class CsvTransferMapper(
             var sourceAccountId = resolvedSourceAccountId
             var targetAccountId = parseAccount(targetMapping, values)
 
+            // Asset-conversion leg: route the counterparty side to the shared conversion account so both
+            // the debit and credit legs parse as valid single-asset transfers (owner account <-> conversion
+            // account). The amount-sign flip below then places the owner on the correct side (owner is the
+            // source of a debit, the target of a credit). The applier pairs and links the legs afterwards.
+            val conversionDetection = detectConversionLeg(values)
+            if (conversionDetection != null) {
+                targetAccountId = resolveExistingAccountId(conversionDetection.accountName) ?: AccountId(-1)
+            }
+
             // Both account fields can read the same column (e.g. Crypto.com's card strategy resolves both
             // legs from "Transaction Description"), so a persisted counterparty mapping that matches the
             // description can hijack the source leg too and collapse both onto one account. When the source
@@ -474,9 +522,13 @@ class CsvTransferMapper(
 
             // Detect a personal counterparty (resolved from the target mapping regardless of any
             // account flip — the counterparty is the same account on whichever side it ends up). A
-            // pass-through merchant is never a person, so skip it there.
+            // pass-through merchant / conversion counterparty is never a person, so skip it there.
             val personalCounterpartyName =
-                if (passThroughMatch != null) null else resolvePersonalCounterparty(targetMapping, values)
+                if (passThroughMatch != null || conversionDetection != null) {
+                    null
+                } else {
+                    resolvePersonalCounterparty(targetMapping, values)
+                }
 
             // Create Money with absolute value (direction is indicated by source/target)
             val amount = Money.fromDisplayValue(rawAmount.abs(), currency)
@@ -538,7 +590,9 @@ class CsvTransferMapper(
                             add(discoverNewAccount(it, values, applyPersistedMappings = sourceUsedPersistedMappings))
                         }
                     }
-                    if (passThroughMatch == null) add(discoverNewAccount(targetMapping, values))
+                    // A conversion leg's counterparty is the shared conversion account (added below), not
+                    // the description-derived account the target mapping would discover, so skip it here.
+                    if (passThroughMatch == null && conversionDetection == null) add(discoverNewAccount(targetMapping, values))
                 }
             val targetCategoryId =
                 when (targetMapping) {
@@ -550,6 +604,10 @@ class CsvTransferMapper(
             val newAccounts =
                 buildList {
                     addAll(discoveries.mapNotNull { it?.first })
+                    // Create the shared conversion counterparty account on demand.
+                    if (conversionDetection != null && !accountExists(conversionDetection.accountName)) {
+                        add(NewAccount(conversionDetection.accountName, Category.UNCATEGORIZED_ID))
+                    }
                     if (passThrough != null) {
                         passThrough.conduitNames
                             .filterNot { accountExists(it) }
@@ -570,6 +628,8 @@ class CsvTransferMapper(
                 tradeTo = tradeTo,
                 personalCounterpartyName = personalCounterpartyName,
                 passThrough = passThrough,
+                conversionLeg =
+                    conversionDetection?.let { ConversionLegInfo(side = it.side, pairingKey = it.pairingKey) },
             )
         } catch (expected: Exception) {
             MappingResult.Error(row.rowIndex, expected.message ?: "Unknown error")
@@ -606,6 +666,46 @@ class CsvTransferMapper(
     ): String? {
         val index = columnIndexByName[columnName] ?: return null
         return values.getOrNull(index)
+    }
+
+    /** A detected conversion leg: which side, the counterparty account name, and the pairing key. */
+    private data class ConversionDetection(
+        val side: ConversionSide,
+        val accountName: String,
+        val pairingKey: String,
+    )
+
+    /**
+     * Detects whether [values] is a leg of an asset conversion per [CsvImportStrategy.conversionConfig].
+     * Returns null when the strategy has no conversion config, the signal column doesn't match a
+     * debit/credit pattern, or no counterparty account can be resolved.
+     */
+    private fun detectConversionLeg(values: List<String>): ConversionDetection? {
+        val config = strategy.conversionConfig ?: return null
+        val signal = getColumnValueOrNull(config.signalColumn, values)?.trim().orEmpty()
+        if (signal.isEmpty()) return null
+        val side =
+            when {
+                conversionDebitRegex?.containsMatchIn(signal) == true -> ConversionSide.DEBIT
+                conversionCreditRegex?.containsMatchIn(signal) == true -> ConversionSide.CREDIT
+                else -> return null
+            }
+        val accountName =
+            conversionAccountRuleRegexes
+                .firstOrNull { (regex, rule) ->
+                    getColumnValueOrNull(rule.column, values)?.let { regex.containsMatchIn(it) } == true
+                }?.second
+                ?.accountName
+                ?: config.conversionAccountName
+                ?: return null
+        val base =
+            conversionPairingKeyRegex
+                ?.find(signal)
+                ?.groupValues
+                ?.getOrNull(1)
+                .orEmpty()
+        val extra = config.pairingKeyColumns.joinToString(PAIRING_KEY_SEPARATOR) { getColumnValueOrNull(it, values)?.trim().orEmpty() }
+        return ConversionDetection(side, accountName, "$base$PAIRING_KEY_SEPARATOR$extra")
     }
 
     private fun parseAmount(

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/ConversionConfigMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/ConversionConfigMapperTest.kt
@@ -1,0 +1,145 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.csvimporter
+
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.csv.CsvColumn
+import com.moneymanager.domain.model.csv.CsvColumnId
+import com.moneymanager.domain.model.csv.CsvRow
+import com.moneymanager.domain.model.csvstrategy.AmountMode
+import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
+import com.moneymanager.domain.model.csvstrategy.ConversionConfig
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
+import com.moneymanager.domain.model.csvstrategy.DateTimeParsingMapping
+import com.moneymanager.domain.model.csvstrategy.DirectColumnMapping
+import com.moneymanager.domain.model.csvstrategy.FieldMappingId
+import com.moneymanager.domain.model.csvstrategy.RegexAccountMapping
+import com.moneymanager.domain.model.csvstrategy.RegexRule
+import com.moneymanager.domain.model.csvstrategy.TransferField
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+/**
+ * Proves [ConversionConfig] is a generic, source-agnostic mechanism — nothing crypto.com-specific.
+ * A synthetic strategy with its own column names, signal patterns, and counterparty account routes
+ * both legs of a two-row conversion through the configured account and marks each leg's side.
+ */
+class ConversionConfigMapperTest {
+    private val now = Clock.System.now()
+
+    private val usd = Currency(id = CurrencyId(1), code = "USD", name = "US Dollar")
+    private val eur = Currency(id = CurrencyId(2), code = "EUR", name = "Euro")
+    private val wallet = Account(id = AccountId(1), name = "Wallet", openingDate = now)
+
+    private val columns =
+        listOf("Kind", "Amount", "Asset", "Date", "Memo")
+            .mapIndexed { index, name -> CsvColumn(CsvColumnId(Uuid.random()), index, name) }
+
+    private fun fieldId() = FieldMappingId(Uuid.random())
+
+    private val strategy =
+        CsvImportStrategy(
+            id = CsvImportStrategyId(Uuid.random()),
+            name = "Synthetic",
+            identificationColumns = setOf("Kind", "Amount", "Asset", "Date", "Memo"),
+            fieldMappings =
+                mapOf(
+                    TransferField.SOURCE_ACCOUNT to
+                        RegexAccountMapping(fieldId(), TransferField.SOURCE_ACCOUNT, "Memo", listOf(RegexRule("^", "Wallet"))),
+                    TransferField.TARGET_ACCOUNT to
+                        RegexAccountMapping(fieldId(), TransferField.TARGET_ACCOUNT, "Memo", listOf(RegexRule("^", "Counterparty"))),
+                    TransferField.AMOUNT to
+                        AmountParsingMapping(
+                            fieldId(),
+                            TransferField.AMOUNT,
+                            mode = AmountMode.SINGLE_COLUMN,
+                            amountColumnName = "Amount",
+                            flipAccountsOnPositive = true,
+                        ),
+                    TransferField.CURRENCY to CurrencyLookupMapping(fieldId(), TransferField.CURRENCY, "Asset"),
+                    TransferField.TIMESTAMP to
+                        DateTimeParsingMapping(
+                            fieldId(),
+                            TransferField.TIMESTAMP,
+                            dateColumnName = "Date",
+                            dateFormat = "yyyy-MM-dd",
+                            dateTimeFormat = "yyyy-MM-dd HH:mm:ss",
+                        ),
+                    TransferField.DESCRIPTION to DirectColumnMapping(fieldId(), TransferField.DESCRIPTION, "Memo"),
+                ),
+            conversionConfig =
+                ConversionConfig(
+                    signalColumn = "Kind",
+                    debitPattern = "^swap_out$",
+                    creditPattern = "^swap_in$",
+                    conversionAccountName = "Conversions",
+                    pairingKeyPattern = "^(swap)_",
+                    pairingWindowSeconds = 5,
+                    relationshipTypeName = "conversion",
+                ),
+            createdAt = now,
+            updatedAt = now,
+        )
+
+    private fun mapper() =
+        CsvTransferMapper(
+            strategy = strategy,
+            columns = columns,
+            existingAccounts = mapOf(wallet.name to wallet),
+            existingCurrencies = mapOf(usd.id to usd, eur.id to eur),
+            existingCurrenciesByCode = mapOf(usd.code to usd, eur.code to eur),
+        )
+
+    private fun row(
+        kind: String,
+        amount: String,
+        asset: String,
+    ): CsvRow = CsvRow(rowIndex = 1, values = listOf(kind, amount, asset, "2024-01-01 10:00:00", "Swap"))
+
+    private fun map(row: CsvRow) = assertIs<MappingResult.Success>(mapper().mapRow(row), "mapping failed")
+
+    @Test
+    fun debitLeg_routesCounterpartyToConversionsAccountAndMarksSide() {
+        val r = map(row("swap_out", "-5", "USD"))
+        // Negative amount -> no flip: Wallet is the source, the shared Conversions account the target.
+        assertEquals(wallet.id, r.transfer.sourceAccountId)
+        assertEquals(AccountId(-1), r.transfer.targetAccountId, "Conversions is a new account (placeholder id)")
+        assertTrue(r.newAccounts.any { it.name == "Conversions" }, "the Conversions account is created on demand")
+        assertTrue(r.newAccounts.none { it.name == "Counterparty" }, "the description-derived counterparty is not used")
+        val leg = assertIs<ConversionLegInfo>(r.conversionLeg)
+        assertEquals(ConversionSide.DEBIT, leg.side)
+    }
+
+    @Test
+    fun creditLeg_flipsSoWalletReceivesAndMarksSide() {
+        val r = map(row("swap_in", "5", "EUR"))
+        // Positive amount flips: the Conversions account is the source, Wallet receives the asset.
+        assertEquals(AccountId(-1), r.transfer.sourceAccountId, "Conversions is a new account (placeholder id)")
+        assertEquals(wallet.id, r.transfer.targetAccountId)
+        val leg = assertIs<ConversionLegInfo>(r.conversionLeg)
+        assertEquals(ConversionSide.CREDIT, leg.side)
+    }
+
+    @Test
+    fun debitAndCreditLegs_shareAPairingKey() {
+        val debit = map(row("swap_out", "-5", "USD")).conversionLeg
+        val credit = map(row("swap_in", "5", "EUR")).conversionLeg
+        assertEquals(debit?.pairingKey, credit?.pairingKey, "both legs of the family pair on the same key")
+    }
+
+    @Test
+    fun nonConversionRow_hasNoConversionLeg() {
+        val r = map(row("reward", "5", "USD"))
+        assertNull(r.conversionLeg)
+    }
+}

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
@@ -414,6 +414,7 @@ class CsvStrategyExportService(
                 contentMatchRules = export.contentMatchRules,
                 fileNamePattern = export.fileNamePattern,
                 crossSourceReconcileWindowSeconds = export.crossSourceReconcileWindowSeconds,
+                conversionConfig = export.conversionConfig,
                 createdAt = now,
                 updatedAt = now,
             )

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCryptoE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCryptoE2ETest.kt
@@ -173,4 +173,103 @@ class CryptoComCryptoE2ETest : DbTest() {
             assertEquals("CRO", balance.currency.code)
             assertEquals("0.79", balance.toDisplayValue().toString())
         }
+
+    @Test
+    fun dustConversion_manyDebitsOneCredit_linkedThroughConversionsAccount() =
+        runTest {
+            // A "Convert Dust" event: three tiny tokens converted into one aggregate CRO credit, all at
+            // the same timestamp (crypto.com reports the credit as a separate *_credited row with only
+            // Currency/Amount — no To Currency). Previously the credit leg errored and the debits imported
+            // one-sided; now every leg imports through the shared Conversions account and each debit links
+            // to the credit.
+            val file =
+                stage(
+                    "crypto_transactions_record_dust.csv",
+                    listOf(
+                        row("2022-06-22 22:38:22", "Convert Dust", "CRO", "0.53", "0.06", "dust_conversion_credited"),
+                        row("2022-06-22 22:38:22", "Convert Dust", "LUNA2", "-0.016", "0.03", "dust_conversion_debited"),
+                        row("2022-06-22 22:38:22", "Convert Dust", "DOT", "-0.0002", "0.0002", "dust_conversion_debited"),
+                        row("2022-06-22 22:38:23", "Convert Dust", "ALI", "-1.35", "0.026", "dust_conversion_debited"),
+                    ),
+                )
+            applyAll(listOf(file))
+
+            val accounts = repositories.accountRepository.getAllAccounts().first()
+            val wallet = accounts.first { it.name == "Crypto.com" }
+            val conversions = accounts.first { it.name == "Crypto.com Conversions" }
+
+            // All four legs imported (the credited leg is no longer an ERROR): the Conversions account
+            // touches every leg — 3 debits in + 1 credit out.
+            val conversionLegs = repositories.transactionRepository.getTransactionsByAccount(conversions.id).first()
+            assertEquals(4, conversionLegs.size)
+            val credit = conversionLegs.single { it.sourceAccountId == conversions.id }
+            val debits = conversionLegs.filter { it.targetAccountId == conversions.id }
+            assertEquals(wallet.id, credit.targetAccountId)
+            assertEquals("CRO", credit.amount.currency.code)
+            assertEquals(3, debits.size)
+            assertEquals(setOf("LUNA2", "DOT", "ALI"), debits.map { it.amount.currency.code }.toSet())
+
+            // Each debit links to the credit with a `conversion` relationship (credit is id2).
+            val links = repositories.transferRelationshipRepository.getByTransfer(credit.id).first()
+            assertEquals(3, links.size)
+            assertEquals(setOf("conversion"), links.map { it.relationshipType.name }.toSet())
+            assertEquals(setOf(credit.id), links.map { it.id2 }.toSet())
+            assertEquals(debits.map { it.id }.toSet(), links.map { it.id1 }.toSet())
+
+            // The wallet gained the credited CRO; balances stay exact.
+            repositories.maintenanceService.refreshMaterializedViews()
+            val cro =
+                repositories.transactionRepository
+                    .getAccountBalances()
+                    .first()
+                    .first { it.accountId == wallet.id && it.balance.currency.code == "CRO" }
+                    .balance
+            assertEquals("0.53", cro.toDisplayValue().toString())
+        }
+
+    @Test
+    fun walletSwap_oneToOne_linkedThroughConversionsAccount() =
+        runTest {
+            // A 1:1 "Balance Conversion" (crypto_wallet_swap): LUNA -> LUNC.
+            val file =
+                stage(
+                    "crypto_transactions_record_swap.csv",
+                    listOf(
+                        row("2022-05-13 07:00:00", "Balance Conversion", "LUNC", "0.054", "0.00", "crypto_wallet_swap_credited"),
+                        row("2022-05-13 07:00:00", "Balance Conversion", "LUNA", "-0.054", "0.00", "crypto_wallet_swap_debited"),
+                    ),
+                )
+            applyAll(listOf(file))
+
+            val accounts = repositories.accountRepository.getAllAccounts().first()
+            val wallet = accounts.first { it.name == "Crypto.com" }
+            val conversions = accounts.first { it.name == "Crypto.com Conversions" }
+
+            val legs = repositories.transactionRepository.getTransactionsByAccount(conversions.id).first()
+            assertEquals(2, legs.size)
+            val credit = legs.single { it.sourceAccountId == conversions.id }
+            val debit = legs.single { it.targetAccountId == conversions.id }
+            assertEquals(wallet.id, credit.targetAccountId)
+            assertEquals(wallet.id, debit.sourceAccountId)
+
+            val links = repositories.transferRelationshipRepository.getByTransfer(credit.id).first()
+            assertEquals(1, links.size)
+            assertEquals("conversion", links.single().relationshipType.name)
+            assertEquals(debit.id, links.single().id1)
+            assertEquals(credit.id, links.single().id2)
+
+            // Re-import is idempotent: still exactly two legs and one link (re-import may recreate the
+            // transfers, so re-fetch the credit leg rather than reuse the stale id).
+            reimportAll(repositories.csvImportRepository.getAllImports().first())
+            val legsAfter = repositories.transactionRepository.getTransactionsByAccount(conversions.id).first()
+            assertEquals(2, legsAfter.size)
+            val creditAfter = legsAfter.single { it.sourceAccountId == conversions.id }
+            assertEquals(
+                1,
+                repositories.transferRelationshipRepository
+                    .getByTransfer(creditAfter.id)
+                    .first()
+                    .size,
+            )
+        }
 }

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/json/FieldMappingJsonCodec.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/json/FieldMappingJsonCodec.kt
@@ -3,6 +3,7 @@ package com.moneymanager.database.json
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.ContentMatchRule
+import com.moneymanager.domain.model.csvstrategy.ConversionConfig
 import com.moneymanager.domain.model.csvstrategy.FieldMapping
 import com.moneymanager.domain.model.csvstrategy.RowPreprocessingRule
 import com.moneymanager.domain.model.csvstrategy.TransferField
@@ -79,4 +80,14 @@ object FieldMappingJsonCodec {
      * Decodes content match rules from JSON array string.
      */
     fun decodeContentRules(jsonString: String): List<ContentMatchRule> = json.decodeFromString(jsonString)
+
+    /**
+     * Encodes an optional conversion config to a JSON string, or null when absent.
+     */
+    fun encodeConversionConfig(config: ConversionConfig?): String? = config?.let { json.encodeToString(it) }
+
+    /**
+     * Decodes an optional conversion config from a JSON string (null when the column is null).
+     */
+    fun decodeConversionConfig(jsonString: String?): ConversionConfig? = jsonString?.let { json.decodeFromString(it) }
 }

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyReadRepositoryImpl.kt
@@ -56,6 +56,7 @@ class CsvImportStrategyReadRepositoryImpl(
             contentMatchRules = FieldMappingJsonCodec.decodeContentRules(entity.content_match_rules_json),
             fileNamePattern = entity.file_name_pattern,
             crossSourceReconcileWindowSeconds = entity.cross_source_reconcile_window_seconds,
+            conversionConfig = FieldMappingJsonCodec.decodeConversionConfig(entity.conversion_config_json),
             createdAt = Instant.fromEpochMilliseconds(entity.created_at),
             updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
         )

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategy.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategy.sq
@@ -11,6 +11,7 @@ CREATE TABLE csv_import_strategy (
     content_match_rules_json TEXT NOT NULL DEFAULT '[]',
     file_name_pattern TEXT,
     cross_source_reconcile_window_seconds INTEGER,
+    conversion_config_json TEXT,
     created_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000),
     updated_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000)
 );

--- a/app/db/seed/src/commonMain/sqldelight/com/moneymanager/database/sql/seed/StaticSeed.sq
+++ b/app/db/seed/src/commonMain/sqldelight/com/moneymanager/database/sql/seed/StaticSeed.sq
@@ -43,6 +43,7 @@ INSERT INTO relationship_type (id, name) VALUES (1, 'reconciled');
 INSERT INTO relationship_type (id, name) VALUES (2, 'fee');
 INSERT INTO relationship_type (id, name) VALUES (3, 'pass-through');
 INSERT INTO relationship_type (id, name) VALUES (4, 'reversal');
+INSERT INTO relationship_type (id, name) VALUES (5, 'conversion');
 
 -- Pass-through (conduit) definitions are NOT seeded: the built-in Curve/PayPal definitions live in
 -- the strategy-library/ catalog and are installed on demand from the UI.

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/CsvImportStrategyInsert.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/CsvImportStrategyInsert.kt
@@ -23,5 +23,6 @@ fun CsvImportStrategyWriteQueries.insertStrategy(strategy: CsvImportStrategy) {
         content_match_rules_json = FieldMappingJsonCodec.encodeContentRules(strategy.contentMatchRules),
         file_name_pattern = strategy.fileNamePattern,
         cross_source_reconcile_window_seconds = strategy.crossSourceReconcileWindowSeconds,
+        conversion_config_json = FieldMappingJsonCodec.encodeConversionConfig(strategy.conversionConfig),
     )
 }

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyWriteRepositoryImpl.kt
@@ -63,6 +63,7 @@ class CsvImportStrategyWriteRepositoryImpl(
                     content_match_rules_json = FieldMappingJsonCodec.encodeContentRules(strategy.contentMatchRules),
                     file_name_pattern = strategy.fileNamePattern,
                     cross_source_reconcile_window_seconds = strategy.crossSourceReconcileWindowSeconds,
+                    conversion_config_json = FieldMappingJsonCodec.encodeConversionConfig(strategy.conversionConfig),
                     updated_at = now.toEpochMilliseconds(),
                     id = strategy.id.id.toString(),
                 )

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategyWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategyWrite.sq
@@ -1,12 +1,12 @@
 -- Insert a new strategy. created_at/updated_at are filled by their column DEFAULTs (current time).
 insert:
-INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json, file_name_pattern, cross_source_reconcile_window_seconds)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json, file_name_pattern, cross_source_reconcile_window_seconds, conversion_config_json)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- Update an existing strategy
 update:
 UPDATE csv_import_strategy
-SET revision_id = revision_id + 1, name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, content_match_rules_json = ?, file_name_pattern = ?, cross_source_reconcile_window_seconds = ?, updated_at = ?
+SET revision_id = revision_id + 1, name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, content_match_rules_json = ?, file_name_pattern = ?, cross_source_reconcile_window_seconds = ?, conversion_config_json = ?, updated_at = ?
 WHERE id = ?;
 
 -- Delete a strategy by ID

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/transferRelationship/TransferRelationshipWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/transferRelationship/TransferRelationshipWrite.sq
@@ -1,5 +1,5 @@
 insert:
-INSERT INTO transfer_relationship (id1, id2, relationship_type_id)
+INSERT OR IGNORE INTO transfer_relationship (id1, id2, relationship_type_id)
 VALUES (?, ?, ?);
 
 delete:

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
@@ -370,13 +370,16 @@ data class ImportPassThrough(
 }
 
 /**
- * A relationship from the owning [ImportTransfer] (id1) to another transfer created in the SAME batch,
- * referenced by its [ImportRowKey] rather than a persisted id. Unlike [NewRelationship] (whose
- * `relatedTransferId` must already exist), this lets a producer link two co-created transfers before
- * either has an id; the engine resolves [relatedRowKey] to the related transfer's real id (created in
- * this batch, in an earlier chunk, or the existing transfer it was deduped to) and resolves
- * [typeName] get-or-create. If [relatedRowKey] cannot be resolved (e.g. the related row errored and
- * produced no transfer), the link is silently skipped.
+ * A relationship from the owning [ImportTransfer] (id1) to another transfer **created in the SAME
+ * batch**, referenced by its [ImportRowKey] rather than a persisted id. Unlike [NewRelationship]
+ * (whose `relatedTransferId` must already exist), this lets a producer link two co-created transfers
+ * before either has an id; the engine resolves [relatedRowKey] to the related transfer's real id
+ * (created in this chunk, or in an earlier chunk of this batch) and resolves [typeName] get-or-create.
+ *
+ * The link is silently skipped when [relatedRowKey] resolves to no newly-created transfer — i.e. the
+ * related row was deduped to an existing transfer (DUPLICATE/UPDATED) or errored. This is deliberate:
+ * such a link is already redundant. On re-import the owning row and its target dedupe together, so the
+ * relationship persisted by the first import still stands; nothing needs re-linking.
  */
 data class BatchRelationship(
     val relatedRowKey: ImportRowKey,
@@ -395,9 +398,10 @@ data class BatchRelationship(
  * @property attributes Transfer attributes with type ids already resolved by the builder.
  * @property relationships Relationships to existing transfers, created once this transfer's id exists.
  * @property batchRelationships Relationships to OTHER transfers created in the same batch, referenced
- *   by their [ImportRowKey]; the engine resolves each related row key to its id (created in this batch,
- *   an earlier chunk, or an existing transfer it deduped to) and the type name get-or-create. This
- *   transfer becomes id1, the related transfer id2.
+ *   by their [ImportRowKey]; the engine resolves each related row key to its newly-created id (in this
+ *   chunk or an earlier chunk of this batch) and the type name get-or-create. This transfer becomes
+ *   id1, the related transfer id2. A link whose target was not newly created (deduped/errored) is
+ *   skipped — see [BatchRelationship].
  * @property uniqueKey Unique-identifier dedupe key (attribute name -> value), or null for fuzzy dedupe.
  * @property fee An optional fee charged on this transaction, expanded by the engine into a linked transfer.
  */

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
@@ -370,6 +370,20 @@ data class ImportPassThrough(
 }
 
 /**
+ * A relationship from the owning [ImportTransfer] (id1) to another transfer created in the SAME batch,
+ * referenced by its [ImportRowKey] rather than a persisted id. Unlike [NewRelationship] (whose
+ * `relatedTransferId` must already exist), this lets a producer link two co-created transfers before
+ * either has an id; the engine resolves [relatedRowKey] to the related transfer's real id (created in
+ * this batch, in an earlier chunk, or the existing transfer it was deduped to) and resolves
+ * [typeName] get-or-create. If [relatedRowKey] cannot be resolved (e.g. the related row errored and
+ * produced no transfer), the link is silently skipped.
+ */
+data class BatchRelationship(
+    val relatedRowKey: ImportRowKey,
+    val typeName: String,
+)
+
+/**
  * A transfer to import. Account references may be [AccountRef.Existing] (resolved by the builder) or
  * [AccountRef.Local] (resolved by the engine from [ImportBatch.accountsToCreate]).
  *
@@ -380,6 +394,10 @@ data class ImportPassThrough(
  *   per-row detail from [rowKey] via `Source.forRow`.
  * @property attributes Transfer attributes with type ids already resolved by the builder.
  * @property relationships Relationships to existing transfers, created once this transfer's id exists.
+ * @property batchRelationships Relationships to OTHER transfers created in the same batch, referenced
+ *   by their [ImportRowKey]; the engine resolves each related row key to its id (created in this batch,
+ *   an earlier chunk, or an existing transfer it deduped to) and the type name get-or-create. This
+ *   transfer becomes id1, the related transfer id2.
  * @property uniqueKey Unique-identifier dedupe key (attribute name -> value), or null for fuzzy dedupe.
  * @property fee An optional fee charged on this transaction, expanded by the engine into a linked transfer.
  */
@@ -393,6 +411,7 @@ data class ImportTransfer(
     val amount: Money? = null,
     val attributes: List<NewAttribute> = emptyList(),
     val relationships: List<NewRelationship> = emptyList(),
+    val batchRelationships: List<BatchRelationship> = emptyList(),
     val uniqueKey: Map<String, String>? = null,
     // API transaction id, for DedupePolicy.ApiMultiKey.
     val apiId: String? = null,

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -18,6 +18,7 @@ import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.NewRelationship
 import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.PersonId
+import com.moneymanager.domain.model.RelationshipTypeId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.TradeId
 import com.moneymanager.domain.model.Transfer
@@ -970,14 +971,33 @@ class ImportEngineImpl(
             return emptyList()
         }
 
+        // Resolve (get-or-create) every relationship type named by a batch relationship once, so
+        // buildCreatePayload (not suspend) can look ids up synchronously.
+        val batchRelTypeIds: Map<String, RelationshipTypeId> =
+            toImport
+                .flatMap { it.transfer.batchRelationships }
+                .map { it.typeName }
+                .distinct()
+                .associateWith { relationshipTypeRepository.getOrCreate(it) }
+
         val total = toImport.size
         val createdIds = mutableListOf<TransferId>()
         // Spend-leg real ids from already-written chunks, keyed by (to-import index, leg index), so
         // later chunks can resolve reversal targets that point across a chunk boundary.
         val resolvedSpendLegIds = mutableMapOf<LegKey, TransferId>()
+        // Main-transfer real ids from already-written chunks, keyed by row key, so a batch relationship
+        // whose target landed in an earlier chunk (its temp id is no longer resolvable) still links.
+        val priorMainIdsByRowKey = mutableMapOf<ImportRowKey, TransferId>()
         var written = 0
         chunks.forEachIndexed { index, chunk ->
-            val payload = buildCreatePayload(chunk, chunkStartIndex = index * effectiveBatchSize, resolvedSpendLegIds)
+            val payload =
+                buildCreatePayload(
+                    chunk,
+                    chunkStartIndex = index * effectiveBatchSize,
+                    resolvedSpendLegIds,
+                    priorMainIdsByRowKey,
+                    batchRelTypeIds,
+                )
             // Updates ride with the final create chunk (one transaction in the common single-chunk case).
             val (updates, updateSources) =
                 if (index == chunks.lastIndex) buildUpdates(toUpdate) else emptyList<TransferUpdate>() to emptyList()
@@ -991,7 +1011,12 @@ class ImportEngineImpl(
                     updateSources = updateSources,
                 )
             // Keep only the main transfers' ids (fee transfers are interleaved), aligned to [toImport].
-            createdIds += payload.mainResultIndices.map { allCreatedIds[it] }
+            val chunkMainIds = payload.mainResultIndices.map { allCreatedIds[it] }
+            createdIds += chunkMainIds
+            // Record this chunk's main ids by row key so later chunks can resolve cross-chunk batch links.
+            chunk.forEachIndexed { i, classified ->
+                classified.transfer.rowKey?.let { priorMainIdsByRowKey[it] = chunkMainIds[i] }
+            }
             payload.spendResultIndices.forEach { (legKey, resultIndex) ->
                 resolvedSpendLegIds[legKey] = allCreatedIds[resultIndex]
             }
@@ -1030,6 +1055,11 @@ class ImportEngineImpl(
         // reversal target that landed in a previous chunk (its temp id is no longer resolvable) still
         // links by real id.
         priorSpendLegIds: Map<LegKey, TransferId>,
+        // Real main-transfer ids created by earlier chunks, keyed by row key, so a batch relationship
+        // whose target landed in a previous chunk still links by real id.
+        priorMainIdsByRowKey: Map<ImportRowKey, TransferId>,
+        // Resolved relationship-type ids for every type named by a batch relationship in this batch.
+        batchRelTypeIds: Map<String, RelationshipTypeId>,
     ): CreatePayload {
         // Assign negative temp ids so newAttributes/newRelationships can be keyed before real ids exist.
         // A main transfer carrying a fee expands into two transfers (main + fee) created in this same
@@ -1046,9 +1076,15 @@ class ImportEngineImpl(
         val spendTempIdByLeg = mutableMapOf<LegKey, TransferId>()
         val spendResultIndices = mutableMapOf<LegKey, Int>()
         var tempCounter = 0
+        // Pre-assign a temp id for every main transfer up front, so a batch relationship can reference
+        // another row's main transfer regardless of their relative order in this chunk (a debit leg may
+        // appear before or after the credit leg it links to).
+        val mainTempIds = chunk.map { TransferId(-(++tempCounter).toLong()) }
+        val mainTempIdByRowKey: Map<ImportRowKey, TransferId> =
+            chunk.mapIndexedNotNull { i, c -> c.transfer.rowKey?.let { it to mainTempIds[i] } }.toMap()
         chunk.forEachIndexed { chunkIndex, classified ->
             val t = classified.transfer
-            val mainTempId = TransferId(-(++tempCounter).toLong())
+            val mainTempId = mainTempIds[chunkIndex]
             val fee = t.fee
             val feeTempId = if (fee != null) TransferId(-(++tempCounter).toLong()) else null
             val passThrough = t.passThrough
@@ -1062,6 +1098,16 @@ class ImportEngineImpl(
                     }
                     if (passThrough != null && spendTempIds != null) {
                         add(NewRelationship(relatedTransferId = spendTempIds.first(), typeId = passThrough.relationshipTypeId))
+                    }
+                    // Link to sibling transfers created in this batch (this chunk's temp id, or an
+                    // earlier chunk's real id). Targets that weren't created (deduped/errored) resolve
+                    // to null and are skipped.
+                    for (br in t.batchRelationships) {
+                        val targetId = mainTempIdByRowKey[br.relatedRowKey] ?: priorMainIdsByRowKey[br.relatedRowKey]
+                        val typeId = batchRelTypeIds[br.typeName]
+                        if (targetId != null && typeId != null) {
+                            add(NewRelationship(relatedTransferId = targetId, typeId = typeId))
+                        }
                     }
                 }
             val rowKey = requireNotNull(t.rowKey)

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/ConversionConfig.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/ConversionConfig.kt
@@ -53,7 +53,13 @@ data class ConversionConfig(
     val pairingKeyColumns: List<String> = emptyList(),
     val pairingWindowSeconds: Long,
     val relationshipTypeName: String,
-)
+) {
+    init {
+        require(conversionAccountName != null || conversionAccountRules.isNotEmpty()) {
+            "ConversionConfig needs a conversionAccountName or at least one conversionAccountRule to route legs through"
+        }
+    }
+}
 
 /**
  * A single per-value routing rule for [ConversionConfig.conversionAccountRules]: when the value in

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/ConversionConfig.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/ConversionConfig.kt
@@ -1,0 +1,69 @@
+package com.moneymanager.domain.model.csvstrategy
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Declares how a CSV source expresses an **asset conversion** that arrives as two (or more) separate
+ * rows — a *debit* leg (an asset leaving the owner account) plus a *credit* leg (the asset received) —
+ * rather than as a single cross-asset row. Such conversions cannot be modelled as one [transfer] (a
+ * transfer is single-asset) nor reliably as a [trade] (the source often reports only the aggregate
+ * credited amount for a many-assets-in / one-asset-out event, e.g. crypto.com "Convert Dust").
+ *
+ * When set on a [CsvImportStrategy], the importer:
+ * 1. routes every detected leg through a shared **conversion counterparty account** (so both legs
+ *    parse as valid single-asset transfers with distinct accounts — the owner account on one side and
+ *    the conversion account on the other), and
+ * 2. pairs each debit leg to its credit leg and links them with a [relationshipTypeName] relationship,
+ *    so the legs read as one conversion event while keeping every owner-account balance exact.
+ *
+ * This is intentionally source-agnostic: crypto.com is only the first consumer; any exchange export
+ * that reports conversions as debited/credited row pairs can supply its own config.
+ *
+ * @property signalColumn Column examined to classify a row as a conversion leg (e.g. "Transaction Kind").
+ * @property debitPattern Regex matched (case-insensitively) against [signalColumn] identifying the
+ *                        DEBIT leg — the asset leaving the owner account.
+ * @property creditPattern Regex matched (case-insensitively) against [signalColumn] identifying the
+ *                         CREDIT leg — the asset received into the owner account.
+ * @property conversionAccountName Name of the shared counterparty account the legs route through. Used
+ *                                 when a single account fits every conversion. Created on demand.
+ * @property conversionAccountRules Optional per-value routing when more than one counterparty account
+ *                                  is needed; the first matching rule wins, otherwise
+ *                                  [conversionAccountName] is used. At least one of
+ *                                  [conversionAccountName]/[conversionAccountRules] must resolve.
+ * @property pairingKeyPattern Optional regex whose first capture group on [signalColumn] yields the
+ *                             pairing key, so `<base>_debited`/`<base>_credited` collapse to a shared
+ *                             `<base>` and only pair within the same family.
+ * @property pairingKeyColumns Extra columns whose values must also match for a debit and a credit leg
+ *                             to be paired (e.g. a shared reference id). Combined with
+ *                             [pairingKeyPattern] to form the full pairing key.
+ * @property pairingWindowSeconds Maximum seconds between a debit leg and its credit leg for the two to
+ *                                be paired. Tolerates small intra-event timestamp jitter while keeping
+ *                                distinct events (typically far apart in time) separate.
+ * @property relationshipTypeName Relationship type name linking each debit leg to its credit leg
+ *                                (resolved get-or-create, so already-populated databases self-heal).
+ */
+@Serializable
+data class ConversionConfig(
+    val signalColumn: String,
+    val debitPattern: String,
+    val creditPattern: String,
+    val conversionAccountName: String? = null,
+    val conversionAccountRules: List<ConversionAccountRule> = emptyList(),
+    val pairingKeyPattern: String? = null,
+    val pairingKeyColumns: List<String> = emptyList(),
+    val pairingWindowSeconds: Long,
+    val relationshipTypeName: String,
+)
+
+/**
+ * A single per-value routing rule for [ConversionConfig.conversionAccountRules]: when the value in
+ * [column] matches [pattern] (case-insensitively), the leg routes through the account named
+ * [accountName]. Lets one strategy send different conversion families to different counterparty
+ * accounts.
+ */
+@Serializable
+data class ConversionAccountRule(
+    val column: String,
+    val pattern: String,
+    val accountName: String,
+)

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategy.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategy.kt
@@ -42,6 +42,10 @@ data class ContentMatchRule(
  *                                             amount, timestamps within this window) is imported
  *                                             but tagged excluded and linked as reconciled instead
  *                                             of counting twice. Null disables reconciliation.
+ * @property conversionConfig When set, describes how this source expresses asset conversions as
+ *                            separate debited/credited rows; the importer routes the legs through a
+ *                            shared counterparty account and links each debit to its credit (see
+ *                            [ConversionConfig]). Null when the source has no such conversions.
  * @property createdAt Timestamp when this strategy was created
  * @property updatedAt Timestamp when this strategy was last modified
  */
@@ -56,6 +60,7 @@ data class CsvImportStrategy(
     val contentMatchRules: List<ContentMatchRule> = emptyList(),
     val fileNamePattern: String? = null,
     val crossSourceReconcileWindowSeconds: Long? = null,
+    val conversionConfig: ConversionConfig? = null,
     val createdAt: Instant,
     val updatedAt: Instant,
 ) {

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExport.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExport.kt
@@ -6,6 +6,7 @@ import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
 import com.moneymanager.domain.model.csvstrategy.ColumnExtraction
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.ContentMatchRule
+import com.moneymanager.domain.model.csvstrategy.ConversionConfig
 import com.moneymanager.domain.model.csvstrategy.RegexRule
 import com.moneymanager.domain.model.csvstrategy.RowCondition
 import com.moneymanager.domain.model.csvstrategy.RowPreprocessingRule
@@ -29,6 +30,8 @@ import kotlinx.serialization.Serializable
  * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.fileNamePattern])
  * @property crossSourceReconcileWindowSeconds Cross-source reconciliation window
  * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.crossSourceReconcileWindowSeconds])
+ * @property conversionConfig Asset-conversion configuration (already portable, no IDs)
+ * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.conversionConfig])
  */
 @Serializable
 data class CsvStrategyExport(
@@ -43,6 +46,7 @@ data class CsvStrategyExport(
     val accountMappings: List<AccountMappingExport> = emptyList(),
     val fileNamePattern: String? = null,
     val crossSourceReconcileWindowSeconds: Long? = null,
+    val conversionConfig: ConversionConfig? = null,
 )
 
 /**

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExportMapper.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExportMapper.kt
@@ -48,6 +48,7 @@ object CsvStrategyExportMapper {
             accountMappings = accountMappings,
             fileNamePattern = strategy.fileNamePattern,
             crossSourceReconcileWindowSeconds = strategy.crossSourceReconcileWindowSeconds,
+            conversionConfig = strategy.conversionConfig,
         )
 
     private fun FieldMapping.toExport(

--- a/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
+++ b/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
@@ -12,6 +12,7 @@ import com.moneymanager.domain.model.csvstrategy.ColumnPairSwap
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
 import com.moneymanager.domain.model.csvstrategy.ContentMatchRule
+import com.moneymanager.domain.model.csvstrategy.ConversionConfig
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
 import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
@@ -58,11 +59,26 @@ object BuiltInCsvStrategies {
     private const val CRYPTO_COM_EXCHANGE_ACCOUNT = "Crypto.com Exchange"
 
     /**
+     * Counterparty account for crypto.com asset conversions that arrive as separate debited/credited
+     * rows (dust conversions, wallet swaps). The dusted assets flow Crypto.com -> here and the received
+     * asset flows here -> Crypto.com, so the Crypto.com balances stay exact and the (economically
+     * meaningless) mixed-asset residual is isolated in this one account. See [ConversionConfig].
+     */
+    private const val CRYPTO_COM_CONVERSIONS_ACCOUNT = "Crypto.com Conversions"
+
+    /**
      * Cross-source reconciliation window for the crypto.com strategies. The same top-up appears in
      * both the card export ("GBP Deposit") and the fiat export (viban_card_top_up) with near-identical
      * timestamps, but statement exports are less precise than API feeds, so allow up to an hour.
      */
     private const val CRYPTO_COM_RECONCILE_WINDOW_SECONDS = 3600L
+
+    /**
+     * Window for pairing a conversion's debit leg to its credit leg. Crypto.com stamps the two legs of
+     * one event within ~1s of each other (occasionally straddling a second boundary), while distinct
+     * conversion events are minutes-to-days apart, so a few seconds cleanly separates events.
+     */
+    private const val CRYPTO_COM_CONVERSION_PAIRING_WINDOW_SECONDS = 5L
 
     /** Account name prefix shared with the Wise API import strategy ("Wise: " + currency code). */
     private const val WISE_ACCOUNT_PREFIX = "Wise: "
@@ -467,6 +483,24 @@ object BuiltInCsvStrategies {
             attributeMappings = attributeMappings,
             fileNamePattern = "^crypto_transactions_record_",
             crossSourceReconcileWindowSeconds = CRYPTO_COM_RECONCILE_WINDOW_SECONDS,
+            // Dust conversions ("Convert Dust") and wallet swaps ("Balance Conversion") arrive as
+            // separate *_debited/*_credited rows (only Currency/Amount populated, no To Currency). Route
+            // both legs through the Conversions account and link each debit to its credit. The signal
+            // patterns match ONLY these two families — one-sided *_credited kinds (supercharger/rewards/
+            // admin income) are deliberately excluded. Debit rows are negative and credit rows positive,
+            // so the AMOUNT flip-on-positive already places the Crypto.com wallet on the correct side.
+            conversionConfig =
+                ConversionConfig(
+                    signalColumn = "Transaction Kind",
+                    debitPattern = "^(dust_conversion|crypto_wallet_swap)_debited$",
+                    creditPattern = "^(dust_conversion|crypto_wallet_swap)_credited$",
+                    conversionAccountName = CRYPTO_COM_CONVERSIONS_ACCOUNT,
+                    // Group 1 (dust_conversion | crypto_wallet_swap) keeps the two families from pairing
+                    // across each other; the time window then separates individual events within a family.
+                    pairingKeyPattern = "^(dust_conversion|crypto_wallet_swap)_",
+                    pairingWindowSeconds = CRYPTO_COM_CONVERSION_PAIRING_WINDOW_SECONDS,
+                    relationshipTypeName = "conversion",
+                ),
             createdAt = now,
             updatedAt = now,
         )


### PR DESCRIPTION
## What

Adds a generic, source-agnostic **`ConversionConfig`** to CSV import strategies for asset conversions that arrive as **separate debited/credited rows** (crypto.com dust conversions and wallet swaps), plus a reusable **`BatchRelationship`** engine primitive.

## Why

Crypto.com's App export (`crypto_transactions_record_*.csv`) reports a conversion as two rows — a `*_debited` leg and a `*_credited` leg — each carrying only `Currency`/`Amount` (blank `To Currency`). The crypto strategy mapped no `To Currency`, so the **credited leg imported as ERROR (the received crypto was silently lost)** and the debit imported one-sided. Dust events are frequently **N debited tokens → 1 aggregate CRO credit**, which can't be a single trade (crypto.com gives no per-token split).

## Approach

Represent each event with its **true legs** — N debit transfers + 1 credit transfer — all routed through **one shared counterparty account** (crypto.com: "Crypto.com Conversions"), with each debit **linked to the credit** by a new `conversion` relationship type. Owner-account balances stay exact; the meaningless mixed-asset residual is isolated in the counterparty account.

The mechanism is config-driven (reusable for Binance/Kraken/etc.); crypto.com is just the first consumer, wired via a `conversionConfig` block. Single-row `crypto_exchange`/`crypto_purchase` are left unchanged.

### Key pieces
- **`ConversionConfig`** (+ `ConversionAccountRule`) model; nullable field on `CsvImportStrategy`, persisted as a `conversion_config_json` column and carried through the strategy export round-trip.
- **Mapper** (`CsvTransferMapper`) detects legs, routes the counterparty to the conversion account, and tags rows with `ConversionLegInfo(side, pairingKey)`.
- **Applier** (`CsvImportApplier`) pairs each debit to its nearest credit (same pairing key, within a time window; handles N:1) and attaches the link.
- **`BatchRelationship`**: reusable engine primitive linking two co-created transfers by `ImportRowKey` + relationship-type name (get-or-create, self-healing), resolved in `ImportEngineImpl` across chunks; `transfer_relationship` insert made idempotent.
- Seed `relationship_type` id 5 `conversion`; add `conversionConfig` to `buildCryptoComCryptoStrategy`.

## Testing
- New E2E tests in `CryptoComCryptoE2ETest`: dust **N:1** (LUNA2/DOT/ALI → CRO) and **1:1** wallet swap — assert the credited leg imports, both legs route through the Conversions account, each debit links to the credit via a `conversion` relationship, balances are exact, and **re-import is idempotent**.
- Source-agnostic `ConversionConfigMapperTest` proves genericity with a synthetic (non-crypto.com) strategy.
- `./gradlew build buildHealth` passes.

> Note: this changes the SQLite schema (new column + seeded type). Per the BETA no-migrations policy, the DB is recreated from scratch on schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV imports can now recognize paired asset conversion rows and link related debit/credit legs together.
  * Crypto.com CSV strategy now supports dust conversions and wallet swaps through a shared conversion account.

* **Bug Fixes**
  * Conversion relationships are now preserved when saving, loading, and exporting import strategies.
  * Imported conversion legs are matched more reliably, even across related rows and time windows.

* **Tests**
  * Added coverage for conversion pairing, account routing, and end-to-end crypto import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->