### PR TITLE
Fix UI slowness on large databases (flow re-subscription + matrix virtualization)

### DIFF
--- a/app/ui/accounts/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
+++ b/app/ui/accounts/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
@@ -42,6 +42,7 @@ import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.CreateAccountDialog
 import com.moneymanager.ui.components.EditAccountDialog
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.util.formatAmount
 import kotlinx.coroutines.launch
@@ -63,22 +64,23 @@ fun AccountsScreen(
     onAccountClick: (Account) -> Unit,
     onAuditClick: (Account) -> Unit = {},
 ) {
-    // Use schema-error-aware collection for flows that may fail on old databases
-    val accounts by accountRepository
-        .getAllAccounts()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val balances by transactionRepository
-        .getAccountBalances()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val categories by categoryRepository
-        .getAllCategories()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val people by personRepository
-        .getAllPeople()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val ownerships by personAccountOwnershipRepository
-        .getAllOwnerships()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    // Use schema-error-aware collection for flows that may fail on old databases.
+    // Flows are remembered so they subscribe once instead of re-querying on every recomposition.
+    val accounts by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        accountRepository.getAllAccounts()
+    }
+    val balances by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        transactionRepository.getAccountBalances()
+    }
+    val categories by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        categoryRepository.getAllCategories()
+    }
+    val people by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        personRepository.getAllPeople()
+    }
+    val ownerships by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        personAccountOwnershipRepository.getAllOwnerships()
+    }
     var showCreateDialog by remember { mutableStateOf(false) }
     var accountToEdit by remember { mutableStateOf<Account?>(null) }
     var selectedOwnerIds by remember { mutableStateOf<Set<Long>>(emptySet()) }
@@ -90,15 +92,30 @@ fun AccountsScreen(
     }
 
     val ownerIdsByAccount: Map<AccountId, Set<Long>> =
-        ownerships.groupBy({ it.accountId }, { it.personId.id }).mapValues { it.value.toSet() }
+        remember(ownerships) {
+            ownerships.groupBy({ it.accountId }, { it.personId.id }).mapValues { it.value.toSet() }
+        }
     val displayedAccounts =
-        if (selectedOwnerIds.isEmpty()) {
-            accounts
-        } else {
-            accounts.filter { account ->
-                ownerIdsByAccount[account.id].orEmpty().any { it in selectedOwnerIds }
+        remember(accounts, selectedOwnerIds, ownerIdsByAccount) {
+            if (selectedOwnerIds.isEmpty()) {
+                accounts
+            } else {
+                accounts.filter { account ->
+                    ownerIdsByAccount[account.id].orEmpty().any { it in selectedOwnerIds }
+                }
             }
         }
+
+    // Precompute per-account lookups once so each card avoids O(accounts)/O(balances) scans.
+    val ownersByAccount: Map<AccountId, List<Person>> =
+        remember(ownerships, people) {
+            val peopleById = people.associateBy { it.id }
+            ownerships
+                .groupBy { it.accountId }
+                .mapValues { (_, os) -> os.mapNotNull { peopleById[it.personId] } }
+        }
+    val balancesByAccount = remember(balances) { balances.groupBy { it.accountId } }
+    val categoriesById = remember(categories) { categories.associateBy { it.id } }
 
     Column(
         modifier =
@@ -174,15 +191,12 @@ fun AccountsScreen(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     items(displayedAccounts, key = { it.id.id }) { account ->
-                        val accountBalances = balances.filter { it.accountId == account.id }
-                        val category = categories.find { it.id == account.categoryId }
                         AccountCard(
                             account = account,
-                            category = category,
-                            balances = accountBalances,
+                            category = categoriesById[account.categoryId],
+                            balances = balancesByAccount[account.id].orEmpty(),
+                            owners = ownersByAccount[account.id].orEmpty(),
                             accountRepository = accountRepository,
-                            personRepository = personRepository,
-                            personAccountOwnershipRepository = personAccountOwnershipRepository,
                             maintenance = maintenance,
                             onClick = { onAccountClick(account) },
                             onEditClick = { accountToEdit = account },
@@ -303,26 +317,14 @@ fun AccountCard(
     account: Account,
     category: Category?,
     balances: List<AccountBalance>,
+    owners: List<Person>,
     accountRepository: AccountReadRepository,
-    personRepository: PersonReadRepository,
-    personAccountOwnershipRepository: PersonAccountOwnershipReadRepository,
     maintenance: Maintenance,
     onClick: () -> Unit,
     onEditClick: () -> Unit,
     onAuditClick: () -> Unit = {},
 ) {
     var showDeleteDialog by remember { mutableStateOf(false) }
-
-    val ownerships by personAccountOwnershipRepository
-        .getOwnershipsByAccount(account.id)
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val allPeople by personRepository
-        .getAllPeople()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val owners =
-        ownerships.mapNotNull { ownership ->
-            allPeople.find { it.id == ownership.personId }
-        }
 
     Card(
         modifier =

--- a/app/ui/categories/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
+++ b/app/ui/categories/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
@@ -77,7 +77,7 @@ import com.moneymanager.importengineapi.LocalCategoryKey
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.ErrorMessageText
 import com.moneymanager.ui.components.LoadingTextButton
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.navigation.linuxHorizontalScrollWheel
 import com.moneymanager.ui.util.CategoryNode
@@ -100,15 +100,15 @@ fun CategoriesScreen(
     currencyRepository: CurrencyReadRepository,
     onAuditClick: (Category) -> Unit = {},
 ) {
-    val categories by categoryRepository
-        .getAllCategories()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val categoryBalances by categoryRepository
-        .getCategoryBalances()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val currencies by currencyRepository
-        .getAllCurrencies()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val categories by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        categoryRepository.getAllCategories()
+    }
+    val categoryBalances by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        categoryRepository.getCategoryBalances()
+    }
+    val currencies by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        currencyRepository.getAllCurrencies()
+    }
 
     var expandedIds by remember { mutableStateOf(emptySet<Long>()) }
     var showCreateDialog by remember { mutableStateOf(false) }

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/AccountPicker.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/AccountPicker.kt
@@ -22,7 +22,7 @@ import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.util.onEnterKeyDown
 
 /**
@@ -58,9 +58,9 @@ fun AccountPicker(
     focusRequester: FocusRequester? = null,
     onSubmit: (() -> Unit)? = null,
 ) {
-    val accounts by accountRepository
-        .getAllAccounts()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val accounts by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        accountRepository.getAllAccounts()
+    }
 
     var expanded by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/AssetPicker.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/AssetPicker.kt
@@ -26,7 +26,7 @@ import com.moneymanager.domain.model.CryptoAsset
 import com.moneymanager.domain.model.CryptoId
 import com.moneymanager.domain.repository.CryptoReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.util.onEnterKeyDown
 
 /**
@@ -48,12 +48,12 @@ fun AssetPicker(
     focusRequester: FocusRequester? = null,
     onSubmit: (() -> Unit)? = null,
 ) {
-    val currencies by currencyRepository
-        .getAllCurrencies()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val cryptos by cryptoRepository
-        .getAllCryptoAssets()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val currencies by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        currencyRepository.getAllCurrencies()
+    }
+    val cryptos by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        cryptoRepository.getAllCryptoAssets()
+    }
 
     val assets: List<Asset> = remember(currencies, cryptos) { currencies + cryptos }
 

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/CreateAccountDialog.kt
@@ -38,7 +38,7 @@ import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportOwnershipIntent
 import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.ui.LocalImportEngine
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.CreateCategoryDialog
 import com.moneymanager.ui.util.onEnterKeyDown
@@ -67,12 +67,12 @@ fun CreateAccountDialog(
     var selectedOwnerIdForAddition by remember { mutableStateOf<Long?>(null) }
     var ownerDropdownExpanded by remember { mutableStateOf(false) }
 
-    val categories by categoryRepository
-        .getAllCategories()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val people by personRepository
-        .getAllPeople()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val categories by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        categoryRepository.getAllCategories()
+    }
+    val people by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        personRepository.getAllPeople()
+    }
     val scope = rememberSchemaAwareCoroutineScope()
     val importEngine = LocalImportEngine.current
 

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/CurrencyPicker.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/CurrencyPicker.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.repository.CurrencyReadRepository
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.util.onEnterKeyDown
 
 /**
@@ -53,9 +53,9 @@ fun CurrencyPicker(
     focusRequester: FocusRequester? = null,
     onSubmit: (() -> Unit)? = null,
 ) {
-    val currencies by currencyRepository
-        .getAllCurrencies()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val currencies by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        currencyRepository.getAllCurrencies()
+    }
 
     var expanded by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
@@ -42,7 +42,7 @@ import com.moneymanager.importengineapi.ImportOwnershipIntent
 import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.importengineapi.getOrCreateAttributeType
 import com.moneymanager.ui.LocalImportEngine
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.CreateCategoryDialog
 import com.moneymanager.ui.screens.transactions.EditableAttributesSection
@@ -68,15 +68,15 @@ fun EditAccountDialog(
 ) {
     val accountState = rememberAccountDialogState(initialName = account.name, initialCategoryId = account.categoryId)
 
-    val categories by categoryRepository
-        .getAllCategories()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val people by personRepository
-        .getAllPeople()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val existingOwnerships by personAccountOwnershipRepository
-        .getOwnershipsByAccount(account.id)
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val categories by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        categoryRepository.getAllCategories()
+    }
+    val people by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        personRepository.getAllPeople()
+    }
+    val existingOwnerships by rememberFlowAsStateWithSchemaErrorHandling(account.id, initial = emptyList()) {
+        personAccountOwnershipRepository.getOwnershipsByAccount(account.id)
+    }
 
     var selectedOwnerIds by remember(existingOwnerships) {
         mutableStateOf(existingOwnerships.map { it.personId.id }.toSet())

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/screens/CreateCategoryDialog.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/screens/CreateCategoryDialog.kt
@@ -39,7 +39,7 @@ import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportCategoryIntent
 import com.moneymanager.importengineapi.LocalCategoryKey
 import com.moneymanager.ui.LocalImportEngine
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.util.onEnterKeyDown
 import kotlinx.coroutines.launch
@@ -61,9 +61,9 @@ fun CreateCategoryDialog(
     val source = Source.Manual
     val importEngine = LocalImportEngine.current
 
-    val categories by categoryRepository
-        .getAllCategories()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val categories by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        categoryRepository.getAllCategories()
+    }
     val scope = rememberSchemaAwareCoroutineScope()
 
     val nameFocusRequester = remember { FocusRequester() }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PassThroughAccountsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/PassThroughAccountsScreen.kt
@@ -40,7 +40,7 @@ import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.createPassThroughAccount
 import com.moneymanager.importengineapi.deletePassThroughAccount
 import com.moneymanager.importengineapi.updatePassThroughAccount
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.launch
 
@@ -57,7 +57,9 @@ fun PassThroughAccountsScreen(
     onBrowseCatalog: () -> Unit = {},
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
-    val accounts by passThroughAccountRepository.getAll().collectAsStateWithSchemaErrorHandling(emptyList())
+    val accounts by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        passThroughAccountRepository.getAll()
+    }
     var editing by remember { mutableStateOf<PassThroughAccount?>(null) }
     var showEditor by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }

--- a/app/ui/currencies/src/commonMain/kotlin/com/moneymanager/ui/screens/AssetsScreen.kt
+++ b/app/ui/currencies/src/commonMain/kotlin/com/moneymanager/ui/screens/AssetsScreen.kt
@@ -40,7 +40,7 @@ import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.importengineapi.deleteCrypto
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.CreateCryptoDialog
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.launch
 import org.lighthousegames.logging.logging
@@ -83,9 +83,9 @@ fun AssetsScreen(
 
 @Composable
 private fun CryptoAssetsTab(cryptoRepository: CryptoReadRepository) {
-    val cryptoAssets by cryptoRepository
-        .getAllCryptoAssets()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val cryptoAssets by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        cryptoRepository.getAllCryptoAssets()
+    }
     var showCreateDialog by remember { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {

--- a/app/ui/currencies/src/commonMain/kotlin/com/moneymanager/ui/screens/CurrenciesScreen.kt
+++ b/app/ui/currencies/src/commonMain/kotlin/com/moneymanager/ui/screens/CurrenciesScreen.kt
@@ -17,7 +17,7 @@ import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.importengineapi.deleteCurrency
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.CreateCurrencyDialog
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.launch
 import org.lighthousegames.logging.logging
@@ -29,9 +29,9 @@ fun CurrenciesScreen(
     currencyRepository: CurrencyReadRepository,
     onAuditClick: (Currency) -> Unit = {},
 ) {
-    val currencies by currencyRepository
-        .getAllCurrencies()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val currencies by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        currencyRepository.getAllCurrencies()
+    }
     var showCreateDialog by remember { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {

--- a/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/error/SchemaErrorAwareFlow.kt
+++ b/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/error/SchemaErrorAwareFlow.kt
@@ -3,6 +3,7 @@ package com.moneymanager.ui.error
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import org.lighthousegames.logging.logging
@@ -32,3 +33,27 @@ fun <T> Flow<T>.collectAsStateWithSchemaErrorHandling(
             }
         }.collect { value = it }
     }
+
+/**
+ * Remembers a repository [Flow] and collects it as Compose State (via
+ * [collectAsStateWithSchemaErrorHandling]). Repository query builders return a **new** Flow instance
+ * on every call; passing that straight into [collectAsStateWithSchemaErrorHandling] re-keys the
+ * underlying `produceState` on each recomposition, cancelling and relaunching the collector — which
+ * re-runs the SQL query and its Kotlin-side mapping every recomposition. Wrapping the flow in
+ * [remember] here keeps the instance (and thus the subscription) stable; the flow still re-emits
+ * reactively when its tables change.
+ *
+ * Pass any values the [flow] closes over as [keys] so the flow is rebuilt when they change (e.g. an
+ * account id for a per-account query). Param-less flows need no keys.
+ *
+ * @param keys inputs the flow depends on; changing any rebuilds and re-subscribes the flow
+ * @param initial value used before the first emission and if a schema error occurs
+ * @param flow factory that builds the repository flow
+ */
+@Composable
+fun <T> rememberFlowAsStateWithSchemaErrorHandling(
+    vararg keys: Any?,
+    initial: T,
+    databaseLocation: String = "default",
+    flow: () -> Flow<T>,
+): State<T> = remember(*keys) { flow() }.collectAsStateWithSchemaErrorHandling(initial, databaseLocation)

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -96,7 +96,7 @@ import com.moneymanager.ui.api.sca.generateScaKeyPair
 import com.moneymanager.ui.api.sca.signScaChallenge
 import com.moneymanager.ui.background.LocalBackgroundTaskManager
 import com.moneymanager.ui.background.formatElapsedTime
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.util.ContentCopyIcon
 import com.moneymanager.ui.util.currentCountryCode
@@ -137,7 +137,9 @@ fun ApiSessionsScreen(
     val scope = rememberSchemaAwareCoroutineScope()
     val backgroundTasks = LocalBackgroundTaskManager.current
     val clipboard = LocalClipboard.current
-    val passThroughAccounts by passThroughAccountRepository.getAll().collectAsStateWithSchemaErrorHandling(emptyList())
+    val passThroughAccounts by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        passThroughAccountRepository.getAll()
+    }
 
     var credentials by remember { mutableStateOf<List<MonzoCredential>>(emptyList()) }
     var sessionsByCredential by remember { mutableStateOf<Map<MonzoCredentialId, List<ApiSession>>>(emptyMap()) }

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategiesScreen.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategiesScreen.kt
@@ -44,7 +44,7 @@ import com.moneymanager.domain.repository.ApiImportStrategyReadRepository
 import com.moneymanager.importengineapi.createApiStrategy
 import com.moneymanager.importengineapi.deleteApiStrategy
 import com.moneymanager.ui.LocalImportEngine
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
@@ -59,9 +59,9 @@ fun ApiStrategiesScreen(
     onAuditHistoryClick: ((ApiImportStrategy) -> Unit)? = null,
 ) {
     val importEngine = LocalImportEngine.current
-    val strategies by apiImportStrategyRepository
-        .getAllStrategies()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val strategies by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        apiImportStrategyRepository.getAllStrategies()
+    }
 
     var strategyPendingDelete by remember { mutableStateOf<ApiImportStrategy?>(null) }
     var importError by remember { mutableStateOf<String?>(null) }

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
@@ -50,7 +50,7 @@ import com.moneymanager.domain.repository.TransferSourceReadRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.deleteCsvImport
 import com.moneymanager.ui.components.csv.CsvPreviewTable
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.csv.ApplyStrategyDialog
 import com.moneymanager.ui.screens.csv.ReimportDialog
@@ -82,9 +82,9 @@ fun CsvImportDetailScreen(
     onTransferClick: ((TransferId, Boolean) -> Unit)? = null,
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
-    val import by csvImportRepository
-        .getImport(importId)
-        .collectAsStateWithSchemaErrorHandling(initial = null)
+    val import by rememberFlowAsStateWithSchemaErrorHandling(importId, initial = null) {
+        csvImportRepository.getImport(importId)
+    }
     var rows by remember { mutableStateOf<List<CsvRow>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
     var showDeleteDialog by remember { mutableStateOf(false) }
@@ -98,9 +98,9 @@ fun CsvImportDetailScreen(
     var hasMatchingStrategy by remember { mutableStateOf(false) }
 
     // Observe strategies to re-check when new ones are added
-    val strategies by csvImportStrategyRepository
-        .getAllStrategies()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val strategies by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        csvImportStrategyRepository.getAllStrategies()
+    }
 
     // Check if there's a matching strategy for this import (filename/content-aware selection).
     // Re-runs when the import, the strategies list, or the loaded rows change.

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
@@ -53,7 +53,7 @@ import com.moneymanager.domain.repository.TransferSourceReadRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.createCsvImport
 import com.moneymanager.importengineapi.setCsvImportIgnored
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.csv.CsvImportAllDialog
 import com.moneymanager.ui.screens.csv.CsvReimportAllDialog
@@ -84,9 +84,9 @@ fun CsvImportsScreen(
     onStrategiesClick: () -> Unit = {},
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
-    val imports by csvImportRepository
-        .getAllImports()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val imports by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        csvImportRepository.getAllImports()
+    }
     var isImporting by remember { mutableStateOf(false) }
     var importMessage by remember { mutableStateOf<String?>(null) }
     var importMessageIsError by remember { mutableStateOf(false) }

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/accountmapping/AccountMappingsScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/accountmapping/AccountMappingsScreen.kt
@@ -55,7 +55,7 @@ import com.moneymanager.domain.repository.CategoryReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.importengineapi.deleteAccountMapping
 import com.moneymanager.ui.LocalImportEngine
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import kotlinx.coroutines.launch
 
@@ -78,10 +78,14 @@ fun AccountMappingsScreen(
     val importEngine = LocalImportEngine.current
     val scope = rememberSchemaAwareCoroutineScope()
 
-    val allMappings by accountMappingRepository.getAllMappings().collectAsStateWithSchemaErrorHandling(emptyList())
+    val allMappings by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        accountMappingRepository.getAllMappings()
+    }
     // This screen manages only global mappings; strategy-scoped ones are edited in the strategy editor.
     val mappings = remember(allMappings) { allMappings.filter { it.strategyId == null } }
-    val accounts by accountRepository.getAllAccounts().collectAsStateWithSchemaErrorHandling(emptyList())
+    val accounts by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        accountRepository.getAllAccounts()
+    }
     val accountsById = remember(accounts) { accounts.associateBy { it.id } }
 
     var editingMapping by remember { mutableStateOf<AccountMapping?>(null) }

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
@@ -59,7 +59,7 @@ import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.domain.repository.QifImportReadRepository
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import kotlinx.coroutines.launch
 import nl.jacobras.humanreadable.HumanReadable
 
@@ -81,9 +81,9 @@ fun CsvStrategiesScreen(
     onEditQifStrategy: (CsvImportStrategyId, QifImportId) -> Unit = { _, _ -> },
     onAuditHistoryClick: (CsvImportStrategy) -> Unit = {},
 ) {
-    val strategies by csvImportStrategyRepository
-        .getAllStrategies()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val strategies by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        csvImportStrategyRepository.getAllStrategies()
+    }
 
     // Edit flow state: pick a sample file to edit the strategy against, then navigate to the editor.
     // QIF strategies (columns are the fixed QIF fields) need a QIF file as sample data, not a CSV one.

--- a/app/ui/imports/importDirectory/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportDirectoriesScreen.kt
+++ b/app/ui/imports/importDirectory/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportDirectoriesScreen.kt
@@ -49,7 +49,7 @@ import com.moneymanager.importengineapi.updateImportDirectory
 import com.moneymanager.importfilesource.DriveFolderBrowser
 import com.moneymanager.importfilesource.ImportFileSourceFactory
 import com.moneymanager.ui.LocalImportEngine
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.navigation.ImportTab
 import kotlinx.coroutines.launch
@@ -77,12 +77,16 @@ fun ImportDirectoriesScreen(
     val importEngine = LocalImportEngine.current
     val scope = rememberSchemaAwareCoroutineScope()
 
-    val directories by importDirectoryRepository
-        .getAllDirectories()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val directories by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        importDirectoryRepository.getAllDirectories()
+    }
     // All staged imports, used to tell whether a directory's downloaded files are still un-imported.
-    val csvImports by csvImportRepository.getAllImports().collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val qifImports by qifImportRepository.getAllImports().collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val csvImports by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        csvImportRepository.getAllImports()
+    }
+    val qifImports by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        qifImportRepository.getAllImports()
+    }
 
     var showAddDialog by remember { mutableStateOf(false) }
     var statusMessage by remember { mutableStateOf<String?>(null) }
@@ -344,9 +348,9 @@ private fun ImportDirectoryRow(
     onAudit: () -> Unit,
     onDelete: () -> Unit,
 ) {
-    val trackedFiles by importDirectoryRepository
-        .getTrackedFiles(directory.id)
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val trackedFiles by rememberFlowAsStateWithSchemaErrorHandling(directory.id, initial = emptyList()) {
+        importDirectoryRepository.getTrackedFiles(directory.id)
+    }
 
     val csvCount = trackedFiles.count { it.csvImportId != null }
     val qifCount = trackedFiles.count { it.qifImportId != null }

--- a/app/ui/imports/qif/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportDetailScreen.kt
+++ b/app/ui/imports/qif/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportDetailScreen.kt
@@ -41,7 +41,7 @@ import com.moneymanager.domain.repository.TransferSourceReadRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.deleteQifImport
 import com.moneymanager.ui.components.qif.QifRecordList
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.qif.QifApplyStrategyDialog
 import com.moneymanager.ui.screens.qif.QifReimportDialog
@@ -70,7 +70,9 @@ fun QifImportDetailScreen(
     onTransferClick: (TransferId, Boolean) -> Unit,
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
-    val import by qifImportRepository.getImport(importId).collectAsStateWithSchemaErrorHandling(initial = null)
+    val import by rememberFlowAsStateWithSchemaErrorHandling(importId, initial = null) {
+        qifImportRepository.getImport(importId)
+    }
 
     var records by remember { mutableStateOf<List<QifImportRecord>>(emptyList()) }
     var refreshTrigger by remember { mutableStateOf(0) }

--- a/app/ui/imports/qif/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportsScreen.kt
+++ b/app/ui/imports/qif/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportsScreen.kt
@@ -50,7 +50,7 @@ import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.createQifImport
 import com.moneymanager.importengineapi.setQifImportIgnored
 import com.moneymanager.qif.QifParser
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.qif.QifImportAllDialog
 import com.moneymanager.ui.screens.qif.QifReimportAllDialog
@@ -81,9 +81,9 @@ fun QifImportsScreen(
     onStrategiesClick: () -> Unit = {},
 ) {
     val scope = rememberSchemaAwareCoroutineScope()
-    val imports by qifImportRepository
-        .getAllImports()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val imports by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        qifImportRepository.getAllImports()
+    }
     var isImporting by remember { mutableStateOf(false) }
     var importMessage by remember { mutableStateOf<String?>(null) }
     var importMessageIsError by remember { mutableStateOf(false) }

--- a/app/ui/people/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
+++ b/app/ui/people/src/commonMain/kotlin/com/moneymanager/ui/screens/PeopleScreen.kt
@@ -46,7 +46,7 @@ import com.moneymanager.domain.repository.PersonAttributeReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.ui.components.DeletePersonConfirmationDialog
 import com.moneymanager.ui.components.EditPersonDialog
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 
 @Composable
 fun PeopleScreen(
@@ -57,9 +57,9 @@ fun PeopleScreen(
     scrollToPersonId: PersonId? = null,
     onAuditClick: (Person) -> Unit = {},
 ) {
-    val people by personRepository
-        .getAllPeople()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val people by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        personRepository.getAllPeople()
+    }
     var showCreateDialog by remember { mutableStateOf(false) }
     var personToEdit by remember { mutableStateOf<Person?>(null) }
     var personToDelete by remember { mutableStateOf<Person?>(null) }
@@ -110,9 +110,12 @@ fun PeopleScreen(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     items(people) { person ->
-                        val ownerships by personAccountOwnershipRepository
-                            .getOwnershipsByPerson(person.id)
-                            .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+                        val ownerships by rememberFlowAsStateWithSchemaErrorHandling(
+                            person.id,
+                            initial = emptyList(),
+                        ) {
+                            personAccountOwnershipRepository.getOwnershipsByPerson(person.id)
+                        }
                         PersonCard(
                             person = person,
                             ownerships = ownerships,
@@ -151,9 +154,12 @@ fun PeopleScreen(
 
     val currentPersonToDelete = personToDelete
     if (currentPersonToDelete != null) {
-        val ownerships by personAccountOwnershipRepository
-            .getOwnershipsByPerson(currentPersonToDelete.id)
-            .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+        val ownerships by rememberFlowAsStateWithSchemaErrorHandling(
+            currentPersonToDelete.id,
+            initial = emptyList(),
+        ) {
+            personAccountOwnershipRepository.getOwnershipsByPerson(currentPersonToDelete.id)
+        }
         DeletePersonConfirmationDialog(
             person = currentPersonToDelete,
             accountCount = ownerships.size,

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,6 +37,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
@@ -61,7 +63,7 @@ import com.moneymanager.domain.repository.PersonAccountOwnershipReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.ui.components.EditAccountDialog
-import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.navigation.linuxHorizontalScrollWheel
 import com.moneymanager.ui.util.ScreenSizeClass
@@ -107,6 +109,48 @@ private fun verticalMatrixScrollTarget(
         (rowCenterPx - (viewportHeightPx / 2)).coerceAtLeast(0f).toInt()
     }
 
+/** A precomputed matrix cell: formatted balance text and whether it is negative (for color). */
+private class MatrixCell(
+    val text: String,
+    val isNegative: Boolean,
+)
+
+/**
+ * Per-column horizontal geometry (in px) for the account matrix. Precomputing the cumulative column
+ * offsets lets the matrix virtualize its columns — only the ones intersecting the viewport are
+ * composed instead of all ~1000+, which otherwise materializes tens of thousands of cells on open.
+ */
+private class MatrixColumns(
+    val starts: FloatArray,
+    val widths: FloatArray,
+    val totalPx: Float,
+    val spacingPx: Float,
+)
+
+/** The inclusive range of account-column indices intersecting the viewport, with a small overscan. */
+private fun visibleColumnRange(
+    columns: MatrixColumns,
+    scrollPx: Float,
+    viewportPx: Float,
+    count: Int,
+): IntRange {
+    if (count == 0) return IntRange.EMPTY
+    val viewStart = scrollPx
+    val viewEnd = scrollPx + viewportPx
+    var first = 0
+    while (first < count && columns.starts[first] + columns.widths[first] < viewStart) {
+        first++
+    }
+    var last = first
+    while (last < count && columns.starts[last] <= viewEnd) {
+        last++
+    }
+    last--
+    if (last < first) return IntRange.EMPTY
+    val overscan = 3
+    return (first - overscan).coerceAtLeast(0)..(last + overscan).coerceAtMost(count - 1)
+}
+
 @Composable
 fun AccountTransactionsScreen(
     accountId: AccountId,
@@ -128,15 +172,15 @@ fun AccountTransactionsScreen(
     initialCurrencyId: CurrencyId? = null,
     externalRefreshTrigger: Int = 0,
 ) {
-    val allAccounts by accountRepository
-        .getAllAccounts()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val currencies by currencyRepository
-        .getAllCurrencies()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val accountBalances by transactionRepository
-        .getAccountBalances()
-        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val allAccounts by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        accountRepository.getAllAccounts()
+    }
+    val currencies by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        currencyRepository.getAllCurrencies()
+    }
+    val accountBalances by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        transactionRepository.getAccountBalances()
+    }
 
     // Selected account state - synced with parent's accountId parameter
     var selectedAccountId by remember { mutableStateOf(accountId) }
@@ -237,6 +281,21 @@ fun AccountTransactionsScreen(
     val displayedRunningBalances =
         if (showExcluded) runningBalances else runningBalances.filter { !it.isExcluded }
 
+    // Precompute per-(account, asset) formatted balances once, keyed accountId -> assetId -> cell, so
+    // matrix cells are O(1) lookups with no per-cell find/formatAmount (formatAmount builds a
+    // CurrencyFormatter per call). With ~1000 accounts this is the difference between one pass and a
+    // find over every balance for each of tens of thousands of cells.
+    val cellsByAccount: Map<Long, Map<Long, MatrixCell>> =
+        remember(accountBalances) {
+            accountBalances
+                .groupBy { it.accountId.id }
+                .mapValues { (_, list) ->
+                    list.associate { ab ->
+                        ab.balance.currency.id.id to MatrixCell(formatAmount(ab.balance), ab.balance.isNegative())
+                    }
+                }
+        }
+
     // Get all unique assets (fiat or crypto) from account balances for matrix, deduped by id.
     // Sorted by code for a deterministic row order independent of balance emission order.
     val uniqueAssets =
@@ -244,18 +303,19 @@ fun AccountTransactionsScreen(
             accountBalances.map { it.balance.currency }.distinctBy { it.id.id }.sortedBy { it.code }
         }
 
-    // Calculate column widths for each account based on account name and balance amounts
+    // Calculate column widths for each account based on account name and balance amounts,
+    // reusing the precomputed formatted strings above.
     val accountColumnWidths: Map<AccountId, Dp> =
-        remember(allAccounts, accountBalances) {
+        remember(allAccounts, cellsByAccount) {
             allAccounts.associate { account ->
                 // Calculate width needed for account name header
                 val nameWidth = (account.name.length * 8 + 16).dp
 
                 // Calculate max balance width for this account
                 val maxBalanceWidth =
-                    accountBalances
-                        .filter { it.accountId == account.id }
-                        .maxOfOrNull { formatAmount(it.balance).length }
+                    cellsByAccount[account.id.id]
+                        ?.values
+                        ?.maxOfOrNull { it.text.length }
                         ?.let { (it * 8 + 16).dp }
                         ?: 0.dp
 
@@ -385,11 +445,45 @@ fun AccountTransactionsScreen(
         val screenSizeClass = ScreenSizeClass.fromWidth(maxWidth)
 
         // Get density for dp to pixel conversion
-        val density = androidx.compose.ui.platform.LocalDensity.current
+        val density = LocalDensity.current
 
         // Capture container dimensions for centering calculations
         val containerWidthDp = maxWidth
         val containerHeightDp = maxHeight
+
+        // Precompute cumulative column x-offsets (px) so the matrix can virtualize its columns.
+        val matrixColumns =
+            remember(allAccounts, accountColumnWidths, density) {
+                with(density) {
+                    val spacingPx = 8.dp.toPx()
+                    val starts = FloatArray(allAccounts.size)
+                    val widths = FloatArray(allAccounts.size)
+                    var offsetPx = 0f
+                    for (i in allAccounts.indices) {
+                        val widthPx = (accountColumnWidths[allAccounts[i].id] ?: ACCOUNT_COLUMN_MIN_WIDTH).toPx()
+                        starts[i] = offsetPx
+                        widths[i] = widthPx
+                        offsetPx += widthPx + spacingPx
+                    }
+                    MatrixColumns(starts, widths, totalPx = offsetPx, spacingPx = spacingPx)
+                }
+            }
+
+        // Width of the scrollable balance grid: the container minus the fixed 60dp label column.
+        val gridViewportPx = with(density) { (containerWidthDp - 60.dp).toPx() }
+
+        // Only the account columns intersecting the viewport (plus overscan) are composed. Recomputes
+        // (via derivedStateOf) only when the visible index range actually changes, not every scroll px.
+        val visibleColumns by remember(matrixColumns, gridViewportPx) {
+            derivedStateOf {
+                visibleColumnRange(
+                    matrixColumns,
+                    horizontalScrollState.value.toFloat(),
+                    gridViewportPx,
+                    allAccounts.size,
+                )
+            }
+        }
 
         // Auto-scroll matrix horizontally when account changes (including on initial load)
         LaunchedEffect(selectedAccountId, allAccounts) {
@@ -432,6 +526,28 @@ fun AccountTransactionsScreen(
                         )
                     }
                 } else if (allAccounts.isNotEmpty()) {
+                    // Horizontal virtualization: only the account columns intersecting the viewport
+                    // (plus overscan) are composed. The rest of the scrollable width is filled by
+                    // leading/trailing spacers so the ScrollState range (and the scrollbar / auto-scroll
+                    // pixel math) stay identical to a fully-materialized grid.
+                    val range = visibleColumns
+                    val leadingWidth =
+                        with(density) {
+                            (if (range.isEmpty()) matrixColumns.totalPx else matrixColumns.starts[range.first]).toDp()
+                        }
+                    val trailingWidth =
+                        with(density) {
+                            val end =
+                                if (range.isEmpty()) {
+                                    matrixColumns.totalPx
+                                } else {
+                                    matrixColumns.starts[range.last] +
+                                        matrixColumns.widths[range.last] +
+                                        matrixColumns.spacingPx
+                                }
+                            (matrixColumns.totalPx - end).coerceAtLeast(0f).toDp()
+                        }
+
                     // Account Picker - Buttons with balances underneath in table format
                     Column(
                         modifier = Modifier.fillMaxSize(),
@@ -441,16 +557,17 @@ fun AccountTransactionsScreen(
                             // Empty corner space for currency label column
                             Spacer(modifier = Modifier.width(60.dp))
 
-                            // Account names row (horizontally scrollable)
+                            // Account names row (horizontally scrollable, virtualized)
                             Row(
                                 modifier =
                                     Modifier
                                         .weight(1f)
                                         .linuxHorizontalScrollWheel(horizontalScrollState)
                                         .horizontalScroll(horizontalScrollState),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
-                                allAccounts.forEach { account ->
+                                Spacer(modifier = Modifier.width(leadingWidth))
+                                for (columnIndex in range) {
+                                    val account = allAccounts[columnIndex]
                                     val isSelectedColumn = selectedAccountId == account.id
                                     val isColumnSelected = isSelectedColumn && selectedCurrencyId == null
                                     val isCellSelected = isSelectedColumn && selectedCurrencyId != null
@@ -499,7 +616,9 @@ fun AccountTransactionsScreen(
                                             }
                                         }
                                     }
+                                    Spacer(modifier = Modifier.width(8.dp))
                                 }
+                                Spacer(modifier = Modifier.width(trailingWidth))
                             }
                         }
 
@@ -544,7 +663,7 @@ fun AccountTransactionsScreen(
                                     }
                                 }
 
-                                // Right side: Balance grid (scrolls both vertically and horizontally)
+                                // Right side: Balance grid (scrolls both vertically and horizontally, virtualized)
                                 Column(
                                     modifier =
                                         Modifier
@@ -557,15 +676,13 @@ fun AccountTransactionsScreen(
                                     // Row for each currency
                                     uniqueAssets.forEach { asset ->
                                         Row(
-                                            horizontalArrangement = Arrangement.spacedBy(8.dp),
                                             verticalAlignment = Alignment.CenterVertically,
                                         ) {
-                                            // Balance for each account
-                                            allAccounts.forEach { account ->
-                                                val balance =
-                                                    accountBalances.find {
-                                                        it.accountId == account.id && it.balance.currency.id.id == asset.id.id
-                                                    }
+                                            Spacer(modifier = Modifier.width(leadingWidth))
+                                            // Balance for each visible account
+                                            for (columnIndex in range) {
+                                                val account = allAccounts[columnIndex]
+                                                val cell = cellsByAccount[account.id.id]?.get(asset.id.id)
                                                 val isSelectedCell =
                                                     selectedAccountId == account.id && selectedCurrencyId?.id == asset.id.id
                                                 val isColumnSelected = selectedAccountId == account.id && selectedCurrencyId == null
@@ -583,7 +700,7 @@ fun AccountTransactionsScreen(
                                                         Modifier
                                                             .width(columnWidth)
                                                             .background(backgroundColor)
-                                                            .clickable(enabled = balance != null) {
+                                                            .clickable(enabled = cell != null) {
                                                                 val assetCurrencyId = CurrencyId(asset.id.id)
                                                                 selectedAccountId = account.id
                                                                 selectedCurrencyId = assetCurrencyId
@@ -591,12 +708,12 @@ fun AccountTransactionsScreen(
                                                             }.padding(vertical = 4.dp),
                                                     contentAlignment = Alignment.Center,
                                                 ) {
-                                                    if (balance != null) {
+                                                    if (cell != null) {
                                                         Text(
-                                                            text = formatAmount(balance.balance),
+                                                            text = cell.text,
                                                             style = MaterialTheme.typography.bodySmall,
                                                             color =
-                                                                if (!balance.balance.isNegative()) {
+                                                                if (!cell.isNegative) {
                                                                     MaterialTheme.colorScheme.primary
                                                                 } else {
                                                                     MaterialTheme.colorScheme.error
@@ -612,7 +729,9 @@ fun AccountTransactionsScreen(
                                                         )
                                                     }
                                                 }
+                                                Spacer(modifier = Modifier.width(8.dp))
                                             }
+                                            Spacer(modifier = Modifier.width(trailingWidth))
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Problem

Navigating the app became sluggish on a large database (the default DB has ~1256 accounts, ~1244 materialized balances, ~38k running-balance rows, many crypto assets). The original hypothesis — *crypto isn't materialized and is computed on the fly* — turned out to be **wrong**: crypto balances are fully materialized in `account_balance_materialized_view` and are never converted to a base currency anywhere. DB queries return in ~18ms. The cost was entirely in the **Compose layer**.

## Fixes (navigation-only; the edit/import `recompute()` full-rebuild is intentionally out of scope)

### 1. Flow re-subscription storm
`collectAsStateWithSchemaErrorHandling` did `produceState(initial, this)` keyed on the **Flow instance**, but repository query builders return a **new** `Flow` on every call. So every recomposition cancelled and relaunched the collector — re-running the SQL query *and* its Kotlin `BigInteger` mapping.

- Added `rememberFlowAsStateWithSchemaErrorHandling(vararg keys, initial) { flow }` which remembers the flow so it subscribes **once** (still reactive to table changes). Parameterized flows pass their id as a key.
- Swept ~33 call sites across the UI screens/pickers to use it.
- `AccountsScreen`: hoisted per-account maps (`ownersByAccount` / `balancesByAccount` / `categoriesById`) computed once instead of per-card O(N) scans, and removed `AccountCard`'s per-card `getAllPeople()` + ownership subscriptions (it now takes `owners: List<Person>`).

### 2. Account matrix (TransactionsScreen) slow launch
The account × asset matrix was a **non-lazy** grid (`horizontalScroll`/`verticalScroll`) that composed `uniqueAssets × allAccounts` cells (≈ 24 × 1256 ≈ **30k cells**) on every open, each running an O(1244) `accountBalances.find`.

- Precompute `cellsByAccount` (`accountId → assetId → formatted cell`) once, so cells are O(1) with no per-cell `formatAmount`.
- **Virtualize the account columns** while keeping the existing `ScrollState`: only the columns intersecting the viewport (plus overscan) are composed, with leading/trailing spacers preserving the scroll range. Kept `ScrollState` (not `LazyRow`) because there's no `HorizontalScrollbarForLazyList` and `linuxHorizontalScrollWheel` only accepts a `ScrollState`; the scrollbar and auto-scroll pixel math are unchanged.

## Verification
- `./gradlew build` passes (ktlint + tests + dependency health).
- Existing `AccountTransactionsScreen` UI tests (matrix headers + cell clicks) pass.
- App launches cleanly against the real default DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved loading and responsiveness across accounts, people, categories, currencies, imports, and pickers, with smoother updates and less UI reprocessing.
  * Optimized the transactions matrix so wide account views scroll more efficiently and render faster.

* **Bug Fixes**
  * Made account, ownership, balance, and category information display more reliably in the accounts view.
  * Kept selection and filtering behavior consistent while improving overall screen stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->