### PR TITLE
Fix Crypto.com Exchange trades/orders import (window params + fiat fee rounding)

### DIFF
--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ExchangeApiImportService.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ExchangeApiImportService.kt
@@ -461,7 +461,10 @@ suspend fun importApiSessionExchange(
         val feeAmount = t.feeAmount
         if (feeCode != null && feeAmount != null) {
             val feeAsset = asset(feeCode)
-            if (feeAsset != null) {
+            // Fiat fees carry more decimals than the currency's scale (e.g. "-0.525570" USD), so
+            // round like the quote leg; a fee that rounds to zero minor units is dropped.
+            val feeMoney = feeAsset?.let { moneyRounded(feeAmount, it) }
+            if (feeAsset != null && feeMoney != null && !feeMoney.isZero()) {
                 transferIntents +=
                     exchangeTransfer(
                         id = "${t.id}-fee",
@@ -469,7 +472,7 @@ suspend fun importApiSessionExchange(
                         description = "$description fee",
                         fromAccount = AccountRef.Existing(syntheticId),
                         toAccount = AccountRef.Existing(feeAccountId),
-                        money = Money.fromDisplayValue(feeAmount, feeAsset),
+                        money = feeMoney,
                         source = source,
                         requestId = t.requestId,
                         jsonPath = t.jsonPath,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/api/CryptoComExchangeApiE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/api/CryptoComExchangeApiE2ETest.kt
@@ -35,7 +35,9 @@ class CryptoComExchangeApiE2ETest : DbTest() {
         """
         {"code":0,"result":{"data":[
           {"instrument_name":"BTC_USD","side":"BUY","traded_quantity":"0.5","traded_price":"40000.55",
-           "fees":"0.001","fee_instrument_name":"BTC","create_time":1700000000000,"trade_id":"t1","order_id":"o1"}
+           "fees":"0.001","fee_instrument_name":"BTC","create_time":1700000000000,"trade_id":"t1","order_id":"o1"},
+          {"instrument_name":"BTC_USD","side":"SELL","traded_quantity":"0.1","traded_price":"41000.00",
+           "fees":"-0.525570","fee_instrument_name":"USD","create_time":1700000000100,"trade_id":"t2","order_id":"o2"}
         ]}}
         """.trimIndent()
 
@@ -106,10 +108,10 @@ class CryptoComExchangeApiE2ETest : DbTest() {
             assertNotNull(repositories.cryptoRepository.getCryptoAssetByCode("BTC").first(), "BTC created")
             assertNotNull(repositories.cryptoRepository.getCryptoAssetByCode("CRO").first(), "CRO created")
 
-            // One trade (BUY BTC/USD) on the exchange account.
+            // Two trades (BUY + SELL BTC/USD) on the exchange account.
             val trades = repositories.tradeRepository.getTradesByAccount(exchange.id).first()
-            assertEquals(1, trades.size, "one trade imported")
-            val trade = trades.single()
+            assertEquals(2, trades.size, "both trades imported")
+            val trade = trades.first { it.to.currency.code == "BTC" }
             // BUY: USD leaves, BTC arrives.
             assertEquals("USD", trade.from.currency.code)
             assertEquals("BTC", trade.to.currency.code)
@@ -119,6 +121,23 @@ class CryptoComExchangeApiE2ETest : DbTest() {
             assertEquals("20000.28", trade.from.toDisplayValue().toString())
             // Order type folded into the description as reference.
             assertTrue(trade.description.contains("LIMIT"), "order type recorded: ${trade.description}")
+
+            // The SELL's fiat fee ("-0.525570" USD, more decimals than USD's scale) books as its own
+            // movement to the Fees account, rounded half-up to 0.53 rather than crashing the import.
+            val feesAccount =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Crypto.com Exchange Fees" }
+            val feeTransfer =
+                repositories.transactionRepository
+                    .getTransactionsByDateRange(
+                        startDate = Instant.fromEpochMilliseconds(1_700_000_000_050L),
+                        endDate = Instant.fromEpochMilliseconds(1_700_000_000_150L),
+                    ).first()
+                    .first { it.targetAccountId == feesAccount.id }
+            assertEquals("USD", feeTransfer.amount.currency.code)
+            assertEquals("0.53", feeTransfer.amount.toDisplayValue().toString())
 
             // Provenance points at the real JSON node so the audit view can expand to it.
             val deposit =

--- a/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInApiStrategies.kt
+++ b/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInApiStrategies.kt
@@ -345,9 +345,16 @@ object BuiltInApiStrategies {
                 windowDays = 90,
                 lookbackDays = 365 * 6,
             )
-        // get-trades / get-order-history only serve a recent window (older trades come from the CSV
-        // import), so a short lookback avoids paging years of empty windows.
-        val recentWindow = historyWindow.copy(windowDays = 30, lookbackDays = 180)
+        // get-trades / get-order-history only serve the last 6 months (older trades come from the CSV
+        // import) and cap the window at 7 days; unlike the deposit/withdrawal endpoints they take
+        // start_time/end_time (start_ts/end_ts is silently ignored and defaults to the last 24h).
+        val recentWindow =
+            historyWindow.copy(
+                startParam = "start_time",
+                endParam = "end_time",
+                windowDays = 7,
+                lookbackDays = 180,
+            )
 
         fun signed(
             path: String,


### PR DESCRIPTION
## What

Fixes the Crypto.com Exchange API import returning zero trades and orders, and a crash once trades did arrive.

### 1. Wrong pagination params for trades/orders (`BuiltInApiStrategies.kt`)

The built-in strategy reused the deposit/withdrawal endpoints' `start_ts`/`end_ts` window params for `private/get-trades` and `private/get-order-history`, but those endpoints take **`start_time`/`end_time`** ([docs](https://exchange-developer.crypto.com/exchange/v1/docs/api/rest/private-get-order-history)). Crypto.com silently ignores unknown params and defaults each request to the last 24 hours, so every windowed request returned `code: 0` with empty `data` — no trades or orders were ever imported (deposits/withdrawals, which genuinely use `start_ts`/`end_ts`, worked fine). The docs also cap these two endpoints at a 7-day window, so `windowDays` drops from 30 to 7 (the 180-day lookback matches the API's documented 6-month history retention).

### 2. Fiat fee rounding crash (`ExchangeApiImportService.kt`)

With real data flowing, the import crashed with `ArithmeticException: Rounding necessary`: crypto.com reports trade fees to 6 decimal places even in fiat (e.g. `"fees": "-0.525570"` USD), and the fee leg used the exact `Money.fromDisplayValue`. The fee now rounds half-up to the asset's scale via the same `moneyRounded` helper as the quote leg, and a fee that rounds to zero minor units is dropped instead of booking a zero-value transfer. (Crypto-denominated fees were unaffected — crypto assets are auto-sized to the precision seen in the data.)

## Testing

- `CryptoComExchangeApiE2ETest` extended with a SELL trade carrying a `-0.525570` USD fee, asserting it books to the "Crypto.com Exchange Fees" account as `0.53`.
- Verified against a live Crypto.com Exchange connection: with the old params all 14 trade/order requests returned empty; with the fix the API returns real trades (which then exposed and reproduced the fee crash).
- `./gradlew build buildHealth` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exchange trade imports so fee amounts are rounded correctly and zero-value fee entries are no longer created.
  * Crypto.com trade imports now handle fiat fees more accurately, including booking them as separate fee movements when applicable.

* **Tests**
  * Updated end-to-end coverage for Crypto.com imports to reflect multiple trades and verify fee handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->