### PR TITLE
Fix crypto import "Rounding necessary" errors: fixed 18-decimal scale for all crypto assets

### DIFF
--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ExchangeApiImportService.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ExchangeApiImportService.kt
@@ -3,7 +3,7 @@
 package com.moneymanager.apiimporter
 
 import com.moneymanager.bigdecimal.BigDecimal
-import com.moneymanager.bigdecimal.BigInteger
+import com.moneymanager.bigdecimal.toBigIntegerTruncated
 import com.moneymanager.domain.model.ApiRequestId
 import com.moneymanager.domain.model.ApiSessionId
 import com.moneymanager.domain.model.Asset
@@ -349,33 +349,21 @@ suspend fun importApiSessionExchange(
     // Resolve assets: any code that isn't a known fiat currency is treated as a crypto asset and
     // auto-created (the same rule as the CSV importer), sized to the precision the data actually uses.
     val fiatByCode = currencyRepository.getAllCurrencies().first().associateBy { it.code.uppercase() }
-    val cryptoDecimals = mutableMapOf<String, Int>()
+    val cryptoCodes = mutableSetOf<String>()
 
-    fun noteCrypto(
-        code: String?,
-        amount: BigDecimal?,
-    ) {
+    fun noteCrypto(code: String?) {
         if (code == null || code.uppercase() in fiatByCode) return
-        val digits = amount?.let { fractionDigits(it.toString()) } ?: 0
-        cryptoDecimals[code.uppercase()] = maxOf(cryptoDecimals[code.uppercase()] ?: 0, digits)
+        cryptoCodes += code.uppercase()
     }
     for (t in trades) {
-        noteCrypto(t.baseCode, t.baseQuantity)
-        // Size the quote asset to its own precision too, so a crypto that only ever appears as the quote
-        // leg isn't created with zero decimals and then rounded away by moneyRounded().
-        noteCrypto(t.quoteCode, t.quoteAmount)
-        noteCrypto(t.feeCode, t.feeAmount)
+        noteCrypto(t.baseCode)
+        noteCrypto(t.quoteCode)
+        noteCrypto(t.feeCode)
     }
-    for (tx in transfers) noteCrypto(tx.currencyCode, tx.amount)
+    for (tx in transfers) noteCrypto(tx.currencyCode)
 
-    for ((code, decimals) in cryptoDecimals) {
-        val explicit = CryptoRegistry.explicitDecimalsFor(code) ?: 0
-        importEngine.createCrypto(
-            code,
-            name = CryptoRegistry.nameFor(code),
-            scaleFactor = scaleFactorForDecimals(maxOf(explicit, decimals)),
-            source = source,
-        )
+    for (code in cryptoCodes) {
+        importEngine.createCrypto(code, name = CryptoRegistry.nameFor(code), source = source)
     }
 
     val cryptoByCode = cryptoRepository.getAllCryptoAssets().first().associateBy { it.code.uppercase() }
@@ -710,26 +698,17 @@ private fun parseExchangeTransfer(
 }
 
 /** Rounds a positive display value to its asset's minor units (half-up), avoiding fromDisplayValue's
- * exact-precision requirement for a computed leg (quote = quantity × price). */
+ * exact-precision requirement for a computed leg (quote = quantity × price). Truncation via
+ * BigInteger — never Long — because 18-decimal crypto minor units easily exceed a Long. */
 private fun moneyRounded(
     displayValue: BigDecimal,
     asset: Asset,
 ): Money {
     val scaled = displayValue.abs() * BigDecimal(asset.scaleFactor)
-    val minor = (scaled + HALF).toLong()
-    return Money(BigInteger(minor), asset)
+    return Money((scaled + HALF).toBigIntegerTruncated(), asset)
 }
 
 private val HALF = BigDecimal("0.5")
-
-/** Significant fractional digits of a decimal string (trailing zeros ignored). */
-private fun fractionDigits(value: String): Int = value.substringAfter('.', "").trimEnd('0').length
-
-private fun scaleFactorForDecimals(decimals: Int): Long {
-    var factor = 1L
-    repeat(decimals.coerceIn(0, 18)) { factor *= 10 }
-    return factor
-}
 
 private fun JsonObject.str(path: String): String? =
     (resolveJsonPathElement(path) as? kotlinx.serialization.json.JsonPrimitive)?.let { it.contentOrNullCompat() }

--- a/app/cryptodata/src/commonMain/kotlin/com/moneymanager/cryptodata/CryptoDataset.kt
+++ b/app/cryptodata/src/commonMain/kotlin/com/moneymanager/cryptodata/CryptoDataset.kt
@@ -2,15 +2,11 @@ package com.moneymanager.cryptodata
 
 import com.moneymanager.domain.model.CryptoRegistry
 
-/** Highest crypto precision we encode (ETH/ERC-20 use 18); bounded so `10^decimals` fits a Long. */
-private const val MAX_DECIMALS = 18
-
 /**
- * Parses the bundled/refreshed TSV catalog (`SYMBOL\tNAME\tDECIMALS`, one entry per line, DECIMALS
- * optional) into a ticker→[CryptoRegistry.Entry] map keyed by uppercased symbol. Blank lines and rows
- * with a blank symbol or name are skipped; the first occurrence of a symbol wins (the generator already
- * de-duplicates, so this is just defensive). A missing/blank/invalid decimals field yields a null scale
- * factor ("name known, decimals unknown").
+ * Parses the bundled/refreshed TSV catalog (`SYMBOL\tNAME`, one entry per line; any extra columns
+ * are ignored for compatibility with older stored catalogs) into a ticker→[CryptoRegistry.Entry]
+ * map keyed by uppercased symbol. Blank lines and rows with a blank symbol or name are skipped; the
+ * first occurrence of a symbol wins (the generator already de-duplicates, so this is just defensive).
  */
 fun parseCryptoDataset(text: String): Map<String, CryptoRegistry.Entry> {
     val result = LinkedHashMap<String, CryptoRegistry.Entry>()
@@ -24,13 +20,7 @@ fun parseCryptoDataset(text: String): Map<String, CryptoRegistry.Entry> {
                 .orEmpty()
         val name = fields.getOrNull(1)?.trim().orEmpty()
         if (symbol.isNotEmpty() && name.isNotEmpty() && symbol !in result) {
-            val decimals =
-                fields
-                    .getOrNull(2)
-                    ?.trim()
-                    ?.toIntOrNull()
-                    ?.takeIf { it in 0..MAX_DECIMALS }
-            result[symbol] = CryptoRegistry.Entry(name, decimals?.let { scaleFactorForDecimals(it) })
+            result[symbol] = CryptoRegistry.Entry(name)
         }
     }
     return result
@@ -52,11 +42,5 @@ fun renderCryptoDataset(entries: List<CryptoDatasetEntry>): String {
     }
     return deduped.values
         .sortedBy { it.symbol }
-        .joinToString("\n", postfix = "\n") { "${it.symbol}\t${it.name}\t${it.decimals ?: ""}" }
-}
-
-private fun scaleFactorForDecimals(decimals: Int): Long {
-    var factor = 1L
-    repeat(decimals.coerceIn(0, MAX_DECIMALS)) { factor *= 10 }
-    return factor
+        .joinToString("\n", postfix = "\n") { "${it.symbol}\t${it.name}" }
 }

--- a/app/cryptodata/src/commonMain/kotlin/com/moneymanager/cryptodata/CryptoDatasetEntry.kt
+++ b/app/cryptodata/src/commonMain/kotlin/com/moneymanager/cryptodata/CryptoDatasetEntry.kt
@@ -1,12 +1,10 @@
 package com.moneymanager.cryptodata
 
 /**
- * One row of the crypto catalog dataset: a ticker [symbol], a human-readable [name], and an optional
- * [decimals] precision. CoinGecko's coin list carries no decimals, so [decimals] is normally null and
- * the importer derives an asset's precision from the observed data instead.
+ * One row of the crypto catalog dataset: a ticker [symbol] and a human-readable [name]. Precision is
+ * not part of the catalog — every crypto asset uses the fixed 18-decimal scale factor.
  */
 data class CryptoDatasetEntry(
     val symbol: String,
     val name: String,
-    val decimals: Int? = null,
 )

--- a/app/cryptodata/src/commonTest/kotlin/com/moneymanager/cryptodata/CryptoDatasetTest.kt
+++ b/app/cryptodata/src/commonTest/kotlin/com/moneymanager/cryptodata/CryptoDatasetTest.kt
@@ -2,18 +2,15 @@ package com.moneymanager.cryptodata
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class CryptoDatasetTest {
     @Test
-    fun parsesTickerNameAndOptionalDecimals() {
+    fun parsesTickerAndNameIgnoringLegacyDecimalsColumn() {
+        // Older stored catalogs carried a third DECIMALS column; it is ignored.
         val map = parseCryptoDataset("BTC\tBitcoin\t8\nSOL\tSolana\t\n\n")
         assertEquals("Bitcoin", map["BTC"]?.name)
-        assertEquals(100_000_000L, map["BTC"]?.scaleFactor)
         assertEquals("Solana", map["SOL"]?.name)
-        // Blank decimals -> null scale factor ("name known, decimals unknown").
-        assertNull(map["SOL"]?.scaleFactor)
     }
 
     @Test
@@ -30,13 +27,13 @@ class CryptoDatasetTest {
             renderCryptoDataset(
                 listOf(
                     CryptoDatasetEntry("sol", "Solana"),
-                    CryptoDatasetEntry("BTC", "Bitcoin", decimals = 8),
+                    CryptoDatasetEntry("BTC", "Bitcoin"),
                     CryptoDatasetEntry("SOL", "Duplicate wins-first"),
                 ),
             )
         val map = parseCryptoDataset(tsv)
         assertEquals(2, map.size)
         assertEquals("Solana", map["SOL"]?.name)
-        assertEquals(100_000_000L, map["BTC"]?.scaleFactor)
+        assertEquals("Bitcoin", map["BTC"]?.name)
     }
 }

--- a/app/cryptodata/src/jvmTest/kotlin/com/moneymanager/cryptodata/BundledCryptoCatalogTest.kt
+++ b/app/cryptodata/src/jvmTest/kotlin/com/moneymanager/cryptodata/BundledCryptoCatalogTest.kt
@@ -22,17 +22,14 @@ class BundledCryptoCatalogTest {
         CryptoRegistry.install(BundledCryptoCatalog)
         // Long-tail ticker resolves from the bundled catalog.
         assertEquals("Solana", CryptoRegistry.nameFor("SOL"))
-        // Curated default still wins over the catalog and keeps its explicit precision.
+        // Curated default still wins over the catalog.
         assertEquals("Bitcoin", CryptoRegistry.nameFor("BTC"))
-        assertEquals(8, CryptoRegistry.explicitDecimalsFor("BTC"))
-        // A name-only catalog entry has no explicit precision.
-        assertEquals(null, CryptoRegistry.explicitDecimalsFor("SOL"))
     }
 
     @Test
     fun overridesWinOverInstalledCatalog() {
         CryptoRegistry.install(BundledCryptoCatalog)
-        CryptoRegistry.installOverrides(mapOf("SOL" to CryptoRegistry.Entry("Solana (refreshed)", null)))
+        CryptoRegistry.installOverrides(mapOf("SOL" to CryptoRegistry.Entry("Solana (refreshed)")))
         assertEquals("Solana (refreshed)", CryptoRegistry.nameFor("SOL"))
     }
 }

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -20,7 +20,6 @@ import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.model.csv.ImportStatus
-import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
 import com.moneymanager.domain.model.csvstrategy.HardCodedAccountMapping
@@ -86,25 +85,6 @@ internal fun collapsePassThroughChain(
     return if (keptNodes.size < 2) null else keptNodes to keptDescriptions
 }
 
-/** Number of fractional digits in a raw CSV amount string (e.g. "0.79000000" → 8, "1,234.5" → 1). */
-private fun decimalPlaces(amount: String?): Int {
-    val cleaned = amount?.trim() ?: return 0
-    val dot = cleaned.indexOf('.')
-    if (dot < 0) return 0
-    var count = 0
-    for (i in dot + 1 until cleaned.length) {
-        if (cleaned[i].isDigit()) count++ else break
-    }
-    return count
-}
-
-/** `10^n` as a scale factor, bounded so it stays within a Long (crypto max precision is 18 decimals). */
-private fun scaleFactorForDecimals(decimals: Int): Long {
-    var factor = 1L
-    repeat(decimals.coerceIn(0, 18)) { factor *= 10 }
-    return factor
-}
-
 /**
  * Ensures a crypto asset exists for every crypto ticker appearing in [strategy]'s currency-lookup
  * columns across [rows], creating any missing ones via the engine (upsert = idempotent), and returns
@@ -114,11 +94,9 @@ private fun scaleFactorForDecimals(decimals: Int): Long {
  * **Any** value in a currency-lookup column that is not a known fiat currency is treated as a crypto
  * asset and auto-created, using the catalog's display name (or the ticker itself when unknown), so a
  * crypto ticker resolves instead of failing with "Currency not found". This is unconditional — it does
- * not depend on any per-strategy flag, so it holds even for strategies stored before crypto support. The
- * scale factor is `max(catalog decimals, observed precision)`: the bundled catalog carries no decimals,
- * so this is normally the paired amount column's observed precision (CURRENCY↔AMOUNT, TO_CURRENCY↔
- * TO_AMOUNT), ensuring `Money.fromDisplayValue` (which throws on excess precision) parses every amount
- * exactly; the curated defaults (BTC/ETH) contribute their real scale when higher. Returns empty when no
+ * not depend on any per-strategy flag, so it holds even for strategies stored before crypto support.
+ * Every asset is created at the fixed 18-decimal crypto scale, so any observed precision parses
+ * exactly via `Money.fromDisplayValue` (which throws on excess precision). Returns empty when no
  * [cryptoRepository] is supplied.
  */
 suspend fun ensureCryptoAssets(
@@ -132,19 +110,16 @@ suspend fun ensureCryptoAssets(
     if (cryptoRepository == null) return emptyList()
     val fiatCodes = currencies.mapTo(mutableSetOf()) { it.code.uppercase() }
     val existingCrypto = cryptoRepository.getAllCryptoAssets().first().mapTo(mutableSetOf()) { it.code.uppercase() }
-    val needs = collectCryptoScaleNeeds(strategy, columns, rows, fiatCodes, existingCrypto)
-    createCryptoAssets(needs, importEngine)
+    createCryptoAssets(collectCryptoCodes(strategy, columns, rows, fiatCodes, existingCrypto), importEngine)
     return cryptoRepository.getAllCryptoAssets().first()
 }
 
 /**
  * Pre-creates every crypto asset needed across a whole batch of [imports] **before** any file is
- * imported, sizing each asset's scale factor to the maximum precision seen for that ticker across the
- * entire batch. This is what the per-file [ensureCryptoAssets] cannot do: a ticker that first appears
- * with few decimals in one file and with many in another would otherwise be created too small and the
- * high-precision rows fail with "Rounding necessary"; and a fiat file processed before the crypto file
- * that introduces a ticker would fail with "Currency not found". Creating everything up front, at the
- * batch-wide precision, removes both. Returns the full crypto-asset set. No-op without [cryptoRepository].
+ * imported. This is what the per-file [ensureCryptoAssets] cannot do: a fiat file processed before
+ * the crypto file that introduces a ticker would fail with "Currency not found". Creating everything
+ * up front removes that ordering dependency. Returns the full crypto-asset set. No-op without
+ * [cryptoRepository].
  */
 suspend fun ensureCryptoAssetsForImports(
     imports: List<CsvImport>,
@@ -158,91 +133,76 @@ suspend fun ensureCryptoAssetsForImports(
     val fiatCodes = currencies.mapTo(mutableSetOf()) { it.code.uppercase() }
     val existingCrypto = cryptoRepository.getAllCryptoAssets().first().mapTo(mutableSetOf()) { it.code.uppercase() }
 
-    val globalNeeds = mutableMapOf<String, Int>()
+    val codes = mutableSetOf<String>()
     for (listedImport in imports) {
-        cryptoScaleNeedsForImport(listedImport, strategies, csvImportRepository, fiatCodes, existingCrypto).forEach { (code, dec) ->
-            globalNeeds[code] = maxOf(globalNeeds[code] ?: 0, dec)
-        }
+        codes += cryptoCodesForImport(listedImport, strategies, csvImportRepository, fiatCodes, existingCrypto)
     }
-    createCryptoAssets(globalNeeds, importEngine)
+    createCryptoAssets(codes, importEngine)
     return cryptoRepository.getAllCryptoAssets().first()
 }
 
-/** Per-import crypto scale needs for the batch pre-pass: matches the strategy and scans importable rows. */
-private suspend fun cryptoScaleNeedsForImport(
+/** Per-import crypto codes for the batch pre-pass: matches the strategy and scans importable rows. */
+private suspend fun cryptoCodesForImport(
     listedImport: CsvImport,
     strategies: List<CsvImportStrategy>,
     csvImportRepository: CsvImportReadRepository,
     fiatCodes: Set<String>,
     existingCrypto: Set<String>,
-): Map<String, Int> {
-    val csvImport = csvImportRepository.getImport(listedImport.id).first() ?: return emptyMap()
+): Set<String> {
+    val csvImport = csvImportRepository.getImport(listedImport.id).first() ?: return emptySet()
     val sampleRows = csvImportRepository.getImportRows(csvImport.id, limit = STRATEGY_CONTENT_SAMPLE_SIZE, offset = 0)
     val strategy =
         csvImport.lastAppliedStrategyId?.let { id -> strategies.find { it.id == id } }
             ?: strategies.selectForCsv(csvImport.originalFileName, csvImport.columns, sampleRows)
-            ?: return emptyMap()
+            ?: return emptySet()
     val allRows = csvImportRepository.getImportRows(csvImport.id, limit = csvImport.rowCount.coerceAtLeast(1), offset = 0)
     val rows = allRows.filter { it.importStatus == null || it.importStatus == ImportStatus.ERROR }
-    return collectCryptoScaleNeeds(strategy, csvImport.columns, rows, fiatCodes, existingCrypto)
+    return collectCryptoCodes(strategy, csvImport.columns, rows, fiatCodes, existingCrypto)
 }
 
 /**
- * Scans [rows] of [strategy]'s currency-lookup columns and returns, for each non-fiat ticker not already
- * an [existingCryptoCodes] asset, the maximum fractional-digit count observed in its paired amount column.
- * Any non-fiat code qualifies (unconditional — no per-strategy flag). Pure; does not create anything.
+ * Scans [rows] of [strategy]'s currency-lookup columns and returns every non-fiat ticker not already
+ * an [existingCryptoCodes] asset. Any non-fiat code qualifies (unconditional — no per-strategy flag).
+ * Pure; does not create anything.
  */
-private fun collectCryptoScaleNeeds(
+private fun collectCryptoCodes(
     strategy: CsvImportStrategy,
     columns: List<CsvColumn>,
     rows: List<CsvRow>,
     fiatCodes: Set<String>,
     existingCryptoCodes: Set<String>,
-): Map<String, Int> {
+): Set<String> {
     fun columnIndex(name: String): Int? = columns.firstOrNull { it.originalName == name }?.columnIndex
 
-    // Pair each currency-lookup column with its amount column (to derive an unknown asset's scale).
-    val columnPairs =
-        listOf(
-            TransferField.CURRENCY to TransferField.AMOUNT,
-            TransferField.TO_CURRENCY to TransferField.TO_AMOUNT,
-        ).mapNotNull { (currencyField, amountField) ->
-            val currencyMapping = strategy.fieldMappings[currencyField] as? CurrencyLookupMapping ?: return@mapNotNull null
-            val currencyCol = columnIndex(currencyMapping.columnName) ?: return@mapNotNull null
-            val amountCol = (strategy.fieldMappings[amountField] as? AmountParsingMapping)?.amountColumnName?.let(::columnIndex)
-            currencyCol to amountCol
+    val currencyColumns =
+        listOf(TransferField.CURRENCY, TransferField.TO_CURRENCY).mapNotNull { field ->
+            (strategy.fieldMappings[field] as? CurrencyLookupMapping)?.columnName?.let(::columnIndex)
         }
-    if (columnPairs.isEmpty()) return emptyMap()
+    if (currencyColumns.isEmpty()) return emptySet()
 
-    val maxDecimals = mutableMapOf<String, Int>()
+    val codes = mutableSetOf<String>()
     for (row in rows) {
-        for ((currencyCol, amountCol) in columnPairs) {
+        for (currencyCol in currencyColumns) {
             val code =
                 row.values
                     .getOrNull(currencyCol)
                     ?.trim()
                     ?.uppercase()
             if (!code.isNullOrEmpty() && code !in fiatCodes && code !in existingCryptoCodes) {
-                val decimals = amountCol?.let { decimalPlaces(row.values.getOrNull(it)) } ?: 0
-                maxDecimals[code] = maxOf(maxDecimals[code] ?: 0, decimals)
+                codes += code
             }
         }
     }
-    return maxDecimals
+    return codes
 }
 
-/** Creates a crypto asset for each ([code] → observed decimals) need, sized to hold that precision. */
+/** Creates a crypto asset for each of [codes] (fixed 18-decimal scale; display name from the catalog). */
 private suspend fun createCryptoAssets(
-    needs: Map<String, Int>,
+    codes: Set<String>,
     importEngine: ImportEngine,
 ) {
-    for ((code, observedDecimals) in needs) {
-        // Prefer the catalog's explicit precision when it has one, but never below the precision the data
-        // actually uses — otherwise Money.fromDisplayValue throws on a higher-precision amount and the row
-        // fails all over again. The catalog (CoinGecko) has no decimals, so this is normally the observed
-        // precision; the curated defaults (BTC/ETH) contribute their real scale when it is higher.
-        val decimals = maxOf(CryptoRegistry.explicitDecimalsFor(code) ?: 0, observedDecimals)
-        importEngine.createCrypto(code, name = CryptoRegistry.nameFor(code), scaleFactor = scaleFactorForDecimals(decimals))
+    for (code in codes) {
+        importEngine.createCrypto(code, name = CryptoRegistry.nameFor(code))
     }
 }
 

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoAssetCsvResolutionTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoAssetCsvResolutionTest.kt
@@ -38,7 +38,7 @@ class CryptoAssetCsvResolutionTest {
     private val now = Clock.System.now()
     private val external = Account(id = AccountId(1), name = "External", openingDate = now)
     private val wallet = Account(id = AccountId(2), name = "Crypto.com CRO", openingDate = now)
-    private val cro = CryptoAsset(id = CryptoId(50), code = "CRO", name = "Cronos", scaleFactor = 100_000_000L)
+    private val cro = CryptoAsset(id = CryptoId(50), code = "CRO", name = "Cronos")
 
     private val columns =
         listOf("Date", "Amount", "Currency")
@@ -86,5 +86,26 @@ class CryptoAssetCsvResolutionTest {
         assertTrue(success.transfer.amount.currency is CryptoAsset, "denominated in a crypto asset")
         assertEquals("CRO", success.transfer.amount.currency.code)
         assertEquals(Money.fromDisplayValue("48.78055303", cro), success.transfer.amount)
+    }
+
+    @Test
+    fun eighteenDecimalDustAmountParsesExactly() {
+        // Regression: crypto.com "Convert Dust" rows carry 18 fractional digits. With the fixed
+        // 18-decimal crypto scale they must map instead of failing with "Rounding necessary".
+        val mapper =
+            buildCsvMapper(
+                strategy = strategy,
+                columns = columns,
+                accounts = listOf(external, wallet),
+                currencies = emptyList(),
+                accountMappings = emptyList(),
+                sourceAccountOverride = null,
+                cryptoAssets = listOf(cro),
+            )
+
+        val result = mapper.mapRow(CsvRow(rowIndex = 1, values = listOf("2023-11-01", "0.011548987600813619", "CRO")))
+        val success = assertIs<MappingResult.Success>(result, "dust row should map: ${(result as? MappingResult.Error)?.errorMessage}")
+
+        assertEquals(Money.fromDisplayValue("0.011548987600813619", cro), success.transfer.amount)
     }
 }

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/crypto/Crypto.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/crypto/Crypto.sq
@@ -1,10 +1,11 @@
 -- crypto: a crypto asset (BTC, ETH, CRO, …) — a subtype of `asset`, sibling to `currency`.
 -- Its id is drawn from the shared `asset` id space. Crypto assets are created on demand (not
--- seeded from the platform ISO list) and use a larger scale factor than fiat for higher precision.
+-- seeded from the platform ISO list) and all use the fixed 18-decimal scale factor, so any
+-- observed precision parses exactly regardless of which import introduced the ticker first.
 CREATE TABLE crypto (
     id INTEGER PRIMARY KEY NOT NULL REFERENCES asset(id) ON DELETE CASCADE,
     revision_id INTEGER NOT NULL DEFAULT 1,
     code TEXT NOT NULL UNIQUE CHECK(length(trim(code)) > 0),
     name TEXT NOT NULL CHECK(length(trim(name)) > 0),
-    scale_factor INTEGER NOT NULL DEFAULT 100000000
+    scale_factor INTEGER NOT NULL DEFAULT 1000000000000000000
 );

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/CryptoWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/CryptoWriteRepositoryImpl.kt
@@ -26,7 +26,6 @@ class CryptoWriteRepositoryImpl(
     override suspend fun upsertCryptoByCode(
         code: String,
         name: String?,
-        scaleFactor: Long?,
         source: Source,
     ): CryptoId =
         withContext(Dispatchers.Default) {
@@ -34,12 +33,11 @@ class CryptoWriteRepositoryImpl(
                 val existing = selectQueries.selectByCode(code).executeAsOneOrNull()
                 existing?.let { CryptoId(it.id) }
                     ?: run {
-                        val scaleFactor = scaleFactor ?: CryptoRegistry.scaleFactorFor(code)
                         val displayName = name ?: CryptoRegistry.nameFor(code)
                         // Allocate an id from the shared `asset` id space, then insert the crypto with it.
                         assetWriteQueries.insert()
                         val newId = assetWriteQueries.lastInsertedId().executeAsOne()
-                        writeQueries.insert(newId, code, displayName, scaleFactor)
+                        writeQueries.insert(newId, code, displayName, CryptoAsset.CRYPTO_SCALE_FACTOR)
                         database.recordSource(deviceId, EntityType.CRYPTO, newId, 1L, source)
                         CryptoId(newId)
                     }

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
@@ -249,8 +249,8 @@ value class LocalCryptoKey(
 )
 
 /**
- * A crypto asset to create/update/delete. CREATE upserts by [code] (ticker); scale factor and
- * default name come from the crypto registry. The resulting id is read back from
+ * A crypto asset to create/update/delete. CREATE upserts by [code] (ticker) at the fixed 18-decimal
+ * crypto scale; the default name comes from the crypto registry. The resulting id is read back from
  * [ImportResult.createdCryptoIds] via [key]. [existingId]/[crypto] target the row for UPDATE;
  * [existingId] for DELETE.
  */
@@ -259,8 +259,6 @@ data class ImportCryptoIntent(
     override val source: Source,
     val code: String? = null,
     val name: String? = null,
-    /** CREATE: overrides the scale factor (minor-unit divisor); null falls back to the CryptoRegistry. */
-    val scaleFactor: Long? = null,
     override val operation: ImportOperation = ImportOperation.CREATE,
     val existingId: CryptoId? = null,
     /** UPDATE: the new crypto row, passed straight to the repository. */

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineActions.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineActions.kt
@@ -35,11 +35,10 @@ suspend fun ImportEngine.createCurrency(
     return requireNotNull(result.createdCurrencyIds[key]) { "Currency $code was not created" }
 }
 
-/** Upserts a crypto asset by ticker [code] and returns its id (scale/name from the crypto registry). */
+/** Upserts a crypto asset by ticker [code] and returns its id (fixed 18-decimal scale; name from the registry). */
 suspend fun ImportEngine.createCrypto(
     code: String,
     name: String? = null,
-    scaleFactor: Long? = null,
     source: Source = Source.Manual,
 ): CryptoId {
     val key = LocalCryptoKey(code)
@@ -47,7 +46,7 @@ suspend fun ImportEngine.createCrypto(
         import(
             ImportBatch(
                 cryptoAssets =
-                    listOf(ImportCryptoIntent(key = key, source = source, code = code, name = name, scaleFactor = scaleFactor)),
+                    listOf(ImportCryptoIntent(key = key, source = source, code = code, name = name)),
             ),
         )
     return requireNotNull(result.createdCryptoIds[key]) { "Crypto asset $code was not created" }

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -150,7 +150,7 @@ class ImportEngineImpl(
         val createdCryptoIds = mutableMapOf<LocalCryptoKey, CryptoId>()
         for (intent in batch.cryptoAssets.creates()) {
             createdCryptoIds[intent.key] =
-                cryptoRepository.upsertCryptoByCode(requireNotNull(intent.code), intent.name, intent.scaleFactor, intent.source)
+                cryptoRepository.upsertCryptoByCode(requireNotNull(intent.code), intent.name, intent.source)
         }
         val createdTradeIds = mutableMapOf<LocalTradeKey, TradeId>()
         for (intent in batch.trades) {

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Asset.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Asset.kt
@@ -15,7 +15,19 @@ sealed interface Asset {
 
     /**
      * Stored amount = display amount × [scaleFactor]. 100 for 2-decimal fiat, 1 for 0-decimal
-     * fiat (JPY), up to very large values for high-precision crypto (e.g. 1e18 for ETH).
+     * fiat (JPY), 1e18 for crypto. Always a power of ten.
      */
     val scaleFactor: Long
 }
+
+/** Number of decimal places implied by [Asset.scaleFactor] (e.g. 100 → 2, 1e18 → 18). */
+val Asset.decimalPlaces: Int
+    get() {
+        var factor = scaleFactor
+        var places = 0
+        while (factor > 1) {
+            factor /= 10
+            places++
+        }
+        return places
+    }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/CryptoAsset.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/CryptoAsset.kt
@@ -6,24 +6,26 @@ import kotlinx.serialization.Serializable
  * Represents a crypto asset (e.g. BTC, ETH, CRO, BNB) — one [Asset] class, sibling to [Currency].
  *
  * Crypto assets are not part of the platform ISO-4217 list; they are created on demand (e.g. by
- * the crypto.com importer) rather than seeded. They use a larger [scaleFactor] than fiat to carry
- * their higher precision; amounts are stored as arbitrary-precision integers (see [Money]).
+ * the crypto.com importer) rather than seeded. Every crypto asset uses the fixed 18-decimal
+ * [CRYPTO_SCALE_FACTOR] (the highest precision in practice — ETH/ERC-20 wei), so any observed
+ * amount parses exactly regardless of which file or API introduced the ticker first; amounts are
+ * stored as arbitrary-precision integers (see [Money]), so the large scale cannot overflow.
  *
  * @property id Unique identifier, drawn from the shared `asset` id space
  * @property code Ticker symbol (e.g. "BTC", "ETH")
  * @property name Human-readable name (e.g. "Bitcoin")
- * @property scaleFactor Stored amount = display amount × scaleFactor (e.g. 1e8 for 8 decimals)
+ * @property scaleFactor Stored amount = display amount × scaleFactor
  */
 data class CryptoAsset(
     override val id: CryptoId,
     val revisionId: Long = 1,
     override val code: String,
     override val name: String,
-    override val scaleFactor: Long = DEFAULT_CRYPTO_SCALE_FACTOR,
+    override val scaleFactor: Long = CRYPTO_SCALE_FACTOR,
 ) : Asset {
     companion object {
-        /** 8 decimal places (satoshi-style) — the default when a crypto's precision is unknown. */
-        const val DEFAULT_CRYPTO_SCALE_FACTOR = 100_000_000L
+        /** 18 decimal places (ETH/ERC-20 wei) — the fixed precision of every crypto asset. */
+        const val CRYPTO_SCALE_FACTOR = 1_000_000_000_000_000_000L
     }
 }
 

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/CryptoRegistry.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/CryptoRegistry.kt
@@ -1,7 +1,7 @@
 package com.moneymanager.domain.model
 
 /**
- * A source of crypto-asset definitions (ticker → display name + optional scale factor).
+ * A source of crypto-asset definitions (ticker → display name).
  *
  * Implemented by the bundled offline catalog (see `app/cryptodata`) and installed into
  * [CryptoRegistry] at app startup. Kept intentionally tiny and synchronous so the registry's callers
@@ -13,48 +13,36 @@ interface CryptoCatalog {
 }
 
 /**
- * Registry of known crypto assets (ticker → display name + scale factor).
+ * Registry of known crypto assets (ticker → display name).
  *
  * Crypto assets are not part of the platform ISO-4217 list, so they cannot be seeded from it. Instead
- * they are created on demand during import, using this registry to resolve a human-readable name and,
- * when known, the asset's precision.
+ * they are created on demand during import, using this registry to resolve a human-readable name.
+ * Precision is not looked up: every crypto asset is created with the fixed 18-decimal
+ * [CryptoAsset.CRYPTO_SCALE_FACTOR].
  *
  * Resolution order for a ticker is: **built-in default entries → refreshed overrides → installed
- * catalog**. The hand-curated defaults win because they carry correct names *and* decimals for the
- * few coins that matter, whereas the large offline catalog (installed via [install]) is a noisy
- * ~17k-ticker dump with no decimals and arbitrary names for colliding tickers. A user-triggered
- * network refresh ([installOverrides]) layers newer long-tail names above the shipped catalog but
- * still below the curated defaults. The defaults always resolve even before a catalog is installed
- * (tests, early startup).
- *
- * An [Entry.scaleFactor] of `null` means "name known, decimals unknown" — the bundled catalog knows
- * names but not decimals, so callers must derive the precision from the data (observed CSV precision)
- * rather than assuming a fixed scale. [scaleFactorFor] falls back to the 8-decimal default for such
- * entries and for unknown tickers.
- *
- * Scale factors are [Long] (not [Int]) because high-precision tokens such as ETH use 18 decimal
- * places (scale factor 1e18), which overflows an [Int].
+ * catalog**. The hand-curated defaults win because they carry correct names for the few coins that
+ * matter, whereas the large offline catalog (installed via [install]) is a noisy ~17k-ticker dump
+ * with arbitrary names for colliding tickers. A user-triggered network refresh ([installOverrides])
+ * layers newer long-tail names above the shipped catalog but still below the curated defaults. The
+ * defaults always resolve even before a catalog is installed (tests, early startup).
  */
 object CryptoRegistry {
-    /** A known crypto asset's display name and (optionally known) scale factor. */
+    /** A known crypto asset's display name. */
     data class Entry(
         val name: String,
-        val scaleFactor: Long?,
     )
-
-    private const val SCALE_8 = 100_000_000L // 8 decimals (satoshi-style)
-    private const val SCALE_18 = 1_000_000_000_000_000_000L // 18 decimals (ETH/ERC-20 wei)
 
     /** Built-in fallback entries — always available even with no catalog installed. */
     private val defaultEntries =
         mapOf(
-            "BTC" to Entry("Bitcoin", SCALE_8),
-            "ETH" to Entry("Ethereum", SCALE_18),
-            "BNB" to Entry("BNB", SCALE_8),
-            "CRO" to Entry("Cronos", SCALE_8),
-            "BOSON" to Entry("Boson Protocol", SCALE_8),
-            "USDC" to Entry("USD Coin", SCALE_8),
-            "USDT" to Entry("Tether", SCALE_8),
+            "BTC" to Entry("Bitcoin"),
+            "ETH" to Entry("Ethereum"),
+            "BNB" to Entry("BNB"),
+            "CRO" to Entry("Cronos"),
+            "BOSON" to Entry("Boson Protocol"),
+            "USDC" to Entry("USD Coin"),
+            "USDT" to Entry("Tether"),
         )
 
     @Volatile
@@ -88,27 +76,6 @@ object CryptoRegistry {
         return defaultEntries[upper] ?: overrides[upper] ?: installedCatalog?.lookup(upper)
     }
 
-    /** Returns the scale factor for [code], defaulting to 8 decimals for unknown/decimal-less tickers. */
-    fun scaleFactorFor(code: String): Long = lookup(code)?.scaleFactor ?: CryptoAsset.DEFAULT_CRYPTO_SCALE_FACTOR
-
-    /**
-     * Returns the *explicitly known* decimal count for [code], or null when the ticker is unknown or its
-     * entry carries no scale factor. Callers use this to prefer a known precision while still deriving an
-     * unknown asset's scale from the data — never forcing the 8-decimal default onto a name-only entry.
-     */
-    fun explicitDecimalsFor(code: String): Int? = lookup(code)?.scaleFactor?.let(::decimalsForScaleFactor)
-
     /** Returns the display name for [code], defaulting to the ticker itself for unknown tickers. */
     fun nameFor(code: String): String = lookup(code)?.name ?: code.uppercase()
-
-    /** Number of decimal places encoded by a power-of-ten [scaleFactor] (e.g. 1e8 → 8). */
-    private fun decimalsForScaleFactor(scaleFactor: Long): Int {
-        var decimals = 0
-        var value = scaleFactor
-        while (value > 1) {
-            value /= 10
-            decimals++
-        }
-        return decimals
-    }
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Money.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Money.kt
@@ -18,7 +18,7 @@ import com.moneymanager.bigdecimal.toBigIntegerExact
  * For example:
  * - £123.45 is stored as amount=12345 with GBP (scaleFactor=100)
  * - ¥1000 is stored as amount=1000 with JPY (scaleFactor=1)
- * - 0.5 BTC is stored as amount=50000000 with BTC (scaleFactor=100000000)
+ * - 0.5 BTC is stored as amount=5·10^17 with BTC (scaleFactor=10^18)
  *
  * @property amount The amount in the asset's smallest unit (pence, satoshis, wei, …)
  * @property currency The asset this monetary amount is denominated in
@@ -36,9 +36,12 @@ data class Money(
     /**
      * Converts the stored amount to a display value using BigDecimal for precision.
      *
+     * Exact: shifts the decimal point by the asset's decimal count instead of dividing, because
+     * [BigDecimal.div] rounds to a fixed scale and would corrupt high-precision crypto amounts.
+     *
      * @return The display value as BigDecimal (e.g., 12345 with scaleFactor=100 becomes 123.45)
      */
-    fun toDisplayValue(): BigDecimal = amount.toBigDecimal() / BigDecimal(currency.scaleFactor)
+    fun toDisplayValue(): BigDecimal = amount.toBigDecimal().movePointLeft(currency.decimalPlaces)
 
     /**
      * Adds another Money amount to this one.

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/CryptoWriteRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/CryptoWriteRepository.kt
@@ -7,7 +7,8 @@ import com.moneymanager.domain.model.Source
 interface CryptoWriteRepository : CryptoReadRepository {
     /**
      * Creates a crypto asset, or returns the existing one if a crypto asset with the same code
-     * exists. The scale factor and (when [name] is null) display name are resolved from
+     * exists. Every crypto asset is created with the fixed 18-decimal
+     * [CryptoAsset.CRYPTO_SCALE_FACTOR]; the display name (when [name] is null) is resolved from
      * [com.moneymanager.domain.model.CryptoRegistry].
      *
      * @param code The ticker symbol (e.g. "BTC", "ETH")
@@ -17,7 +18,6 @@ interface CryptoWriteRepository : CryptoReadRepository {
     suspend fun upsertCryptoByCode(
         code: String,
         name: String? = null,
-        scaleFactor: Long? = null,
         source: Source,
     ): CryptoId
 

--- a/app/model/core/src/commonTest/kotlin/com/moneymanager/domain/model/MoneyTest.kt
+++ b/app/model/core/src/commonTest/kotlin/com/moneymanager/domain/model/MoneyTest.kt
@@ -307,9 +307,24 @@ class MoneyTest {
 
     @Test
     fun fromDisplayValue_throwsOnExcessPrecision() {
-        // 9 decimals for an 8-decimal asset cannot be represented exactly — must throw, not truncate.
+        // 19 decimals for an 18-decimal asset cannot be represented exactly — must throw, not truncate.
         assertFailsWith<ArithmeticException> {
-            Money.fromDisplayValue("0.123456789", btc)
+            Money.fromDisplayValue("0.1234567890123456789", eth)
         }
+    }
+
+    @Test
+    fun crypto_roundTrip_fullEighteenDecimalPrecision() {
+        // All 18 fractional digits must survive the display round-trip: a division-based
+        // toDisplayValue that rounds at a fixed scale would corrupt this value.
+        val original = "0.123456789012345678"
+        val money = Money.fromDisplayValue(original, eth)
+        assertEquals(original, money.toDisplayValue().toString())
+    }
+
+    @Test
+    fun crypto_oneWei_displaysExactly() {
+        val money = Money(BigInteger(1L), eth)
+        assertEquals("0.000000000000000001", money.toDisplayValue().toString())
     }
 }

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/CreateCryptoDialog.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/CreateCryptoDialog.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.CryptoId
 import com.moneymanager.domain.model.CryptoRegistry
@@ -36,29 +35,10 @@ import org.lighthousegames.logging.logging
 
 private val cryptoDialogLogger = logging()
 
-/** Highest decimal precision a crypto asset can have (ETH/ERC-20 use 18); bounded so `10^decimals` fits a Long. */
-private const val MAX_CRYPTO_DECIMALS = 18
-
-private fun scaleFactorForDecimals(decimals: Int): Long {
-    var factor = 1L
-    repeat(decimals) { factor *= 10 }
-    return factor
-}
-
-private fun decimalsForScaleFactor(scaleFactor: Long): Int {
-    var decimals = 0
-    var value = scaleFactor
-    while (value > 1) {
-        value /= 10
-        decimals++
-    }
-    return decimals
-}
-
 /**
  * A dialog for manually creating a crypto asset. The ticker drives a [CryptoRegistry] lookup that
- * pre-fills the name and decimals for known coins (BTC, ETH, …); both stay editable so unknown/custom
- * assets can be added with any precision.
+ * pre-fills the name for known coins (BTC, ETH, …); it stays editable so unknown/custom assets can
+ * be added. Every crypto asset is created at the fixed 18-decimal precision.
  *
  * @param onCryptoCreated Callback invoked with the new crypto id once created.
  * @param onDismiss Callback invoked when the dialog is dismissed.
@@ -72,41 +52,34 @@ fun CreateCryptoDialog(
     var code by remember { mutableStateOf("") }
     var name by remember { mutableStateOf("") }
     var nameEdited by remember { mutableStateOf(false) }
-    var decimals by remember { mutableStateOf("8") }
     val saveState = rememberDialogSaveState()
     val scope = rememberSchemaAwareCoroutineScope()
 
     val codeFocusRequester = remember { FocusRequester() }
     var codeError by remember { mutableStateOf(false) }
-    var decimalsError by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) { runCatching { codeFocusRequester.requestFocus() } }
 
     val submit: () -> Unit = submit@{
         if (saveState.isSaving) return@submit
-        val decimalsValue = decimals.toIntOrNull()
         codeError = code.isBlank()
-        decimalsError = decimalsValue == null || decimalsValue !in 0..MAX_CRYPTO_DECIMALS
-        when {
-            codeError -> saveState.errorMessage = "Ticker is required"
-            decimalsError -> saveState.errorMessage = "Decimals must be between 0 and $MAX_CRYPTO_DECIMALS"
-            else -> {
-                saveState.isSaving = true
-                saveState.errorMessage = null
-                scope.launch {
-                    try {
-                        val cryptoId =
-                            importEngine.createCrypto(
-                                code = code.trim(),
-                                name = name.trim().ifBlank { null },
-                                scaleFactor = scaleFactorForDecimals(decimalsValue!!),
-                            )
-                        onCryptoCreated(cryptoId)
-                    } catch (expected: Exception) {
-                        cryptoDialogLogger.error(expected) { "Failed to create crypto asset: ${expected.message}" }
-                        saveState.errorMessage = "Failed to create crypto asset: ${expected.message}"
-                        saveState.isSaving = false
-                    }
+        if (codeError) {
+            saveState.errorMessage = "Ticker is required"
+        } else {
+            saveState.isSaving = true
+            saveState.errorMessage = null
+            scope.launch {
+                try {
+                    val cryptoId =
+                        importEngine.createCrypto(
+                            code = code.trim(),
+                            name = name.trim().ifBlank { null },
+                        )
+                    onCryptoCreated(cryptoId)
+                } catch (expected: Exception) {
+                    cryptoDialogLogger.error(expected) { "Failed to create crypto asset: ${expected.message}" }
+                    saveState.errorMessage = "Failed to create crypto asset: ${expected.message}"
+                    saveState.isSaving = false
                 }
             }
         }
@@ -129,12 +102,9 @@ fun CreateCryptoDialog(
                     onValueChange = {
                         code = it.uppercase().take(10)
                         codeError = false
-                        // Pre-fill name/decimals from the registry for a known ticker (unless the user typed a name).
+                        // Pre-fill the name from the registry for a known ticker (unless the user typed a name).
                         CryptoRegistry.lookup(code)?.let { entry ->
                             if (!nameEdited) name = entry.name
-                            // Catalog entries may carry no scale factor (name known, decimals unknown);
-                            // leave the field's default in that case rather than forcing 8.
-                            entry.scaleFactor?.let { decimals = decimalsForScaleFactor(it).toString() }
                         }
                     },
                     label = { Text("Ticker (e.g., BTC)") },
@@ -154,20 +124,7 @@ fun CreateCryptoDialog(
                     modifier = Modifier.fillMaxWidth().onEnterKeyDown(submit),
                     singleLine = true,
                     enabled = !saveState.isSaving,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
-                )
-                OutlinedTextField(
-                    value = decimals,
-                    onValueChange = {
-                        decimals = it.filter { ch -> ch.isDigit() }.take(2)
-                        decimalsError = false
-                    },
-                    label = { Text("Decimals (e.g., 8 for BTC, 18 for ETH)") },
-                    modifier = Modifier.fillMaxWidth().onEnterKeyDown(submit),
-                    singleLine = true,
-                    enabled = !saveState.isSaving,
-                    isError = decimalsError,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Done),
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = { submit() }),
                 )
                 saveState.errorMessage?.let { error -> ErrorMessageText(error) }

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/CreateCryptoDialog.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/CreateCryptoDialog.kt
@@ -30,6 +30,7 @@ import com.moneymanager.importengineapi.createCrypto
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.util.onEnterKeyDown
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import org.lighthousegames.logging.logging
 
@@ -76,6 +77,8 @@ fun CreateCryptoDialog(
                             name = name.trim().ifBlank { null },
                         )
                     onCryptoCreated(cryptoId)
+                } catch (expected: CancellationException) {
+                    throw expected
                 } catch (expected: Exception) {
                     cryptoDialogLogger.error(expected) { "Failed to create crypto asset: ${expected.message}" }
                     saveState.errorMessage = "Failed to create crypto asset: ${expected.message}"

--- a/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/util/CurrencyFormatting.kt
+++ b/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/util/CurrencyFormatting.kt
@@ -11,7 +11,8 @@ import com.moneymanager.currency.Currency as CurrencyFormatter
  *
  * Fiat assets are formatted with the locale currency symbol via [CurrencyFormatter] (ISO 4217).
  * Crypto assets are not ISO 4217 (java.util.Currency throws on them), so they are formatted as a
- * plain decimal padded to the asset's precision with the ticker appended, e.g. "5.00000000 BNB".
+ * plain decimal with trailing zeros trimmed and the ticker appended, e.g. "5 BNB", "0.5 BTC" —
+ * every crypto asset carries 18 decimals, so padding to full precision would be unreadable.
  *
  * @param amount The amount to format
  * @param asset The asset the amount is denominated in
@@ -21,7 +22,8 @@ fun formatAmount(
     asset: Asset,
 ): String =
     if (asset is CryptoAsset) {
-        "${amount.toPlainStringWithDecimals(decimalPlacesOf(asset.scaleFactor))} ${asset.code}"
+        // BigDecimal.toString() already strips trailing zeros and never uses scientific notation.
+        "$amount ${asset.code}"
     } else {
         try {
             CurrencyFormatter(asset.code).format(amount)
@@ -35,31 +37,6 @@ fun formatAmount(
  * Formats a Money value using the embedded asset.
  *
  * @param money The Money value to format
- * @return Formatted string (e.g., "$1,234.56" for USD, "5.00000000 BNB" for a crypto asset)
+ * @return Formatted string (e.g., "$1,234.56" for USD, "0.5 BTC" for a crypto asset)
  */
 fun formatAmount(money: Money): String = formatAmount(money.toDisplayValue(), money.currency)
-
-/** Number of decimal places implied by a scale factor (e.g. 100 -> 2, 1e8 -> 8). */
-private fun decimalPlacesOf(scaleFactor: Long): Int {
-    var factor = scaleFactor
-    var places = 0
-    while (factor > 1) {
-        factor /= 10
-        places++
-    }
-    return places
-}
-
-/** Formats [this] with exactly [decimals] fractional digits (zero-padded). */
-private fun BigDecimal.toPlainStringWithDecimals(decimals: Int): String {
-    val s = toString()
-    if (decimals == 0) return s.substringBefore('.')
-    val dot = s.indexOf('.')
-    if (dot < 0) return s + "." + "0".repeat(decimals)
-    val frac = s.length - dot - 1
-    return when {
-        frac == decimals -> s
-        frac < decimals -> s + "0".repeat(decimals - frac)
-        else -> s.substring(0, dot + 1 + decimals)
-    }
-}

--- a/utils/bigdecimal/src/commonMain/kotlin/com/moneymanager/bigdecimal/BigDecimal.kt
+++ b/utils/bigdecimal/src/commonMain/kotlin/com/moneymanager/bigdecimal/BigDecimal.kt
@@ -51,6 +51,12 @@ expect class BigDecimal : Comparable<BigDecimal> {
     operator fun div(divisor: BigDecimal): BigDecimal
 
     /**
+     * Returns a BigDecimal whose value is this × 10^-n. Exact — unlike [div], which rounds to a
+     * fixed scale — so it is the right way to convert integer minor units to a display value.
+     */
+    fun movePointLeft(n: Int): BigDecimal
+
+    /**
      * Returns a BigDecimal whose value is -this.
      */
     operator fun unaryMinus(): BigDecimal

--- a/utils/bigdecimal/src/commonMain/kotlin/com/moneymanager/bigdecimal/BigInteger.kt
+++ b/utils/bigdecimal/src/commonMain/kotlin/com/moneymanager/bigdecimal/BigInteger.kt
@@ -85,3 +85,9 @@ expect class BigInteger : Comparable<BigInteger> {
  * Used when turning a scaled display value into integer minor units without silent truncation.
  */
 expect fun BigDecimal.toBigIntegerExact(): BigInteger
+
+/**
+ * Converts this [BigDecimal] to a [BigInteger], discarding any fractional part (truncation toward
+ * zero). Used after explicit rounding arithmetic, where the fraction is meant to be dropped.
+ */
+expect fun BigDecimal.toBigIntegerTruncated(): BigInteger

--- a/utils/bigdecimal/src/commonTest/kotlin/com/moneymanager/bigdecimal/BigDecimalTest.kt
+++ b/utils/bigdecimal/src/commonTest/kotlin/com/moneymanager/bigdecimal/BigDecimalTest.kt
@@ -111,4 +111,28 @@ class BigDecimalTest {
         val pence = pounds * scaleFactor
         assertEquals(12345L, pence.toLong())
     }
+
+    @Test
+    fun movePointLeft_isExactAtEighteenDecimals() {
+        // div rounds to a fixed scale of 10, so it cannot convert 18-decimal minor units; movePointLeft can.
+        val wei = BigDecimal("123456789012345678901")
+        assertEquals("123.456789012345678901", wei.movePointLeft(18).toString())
+        assertEquals("0.000000000000000001", BigDecimal(1).movePointLeft(18).toString())
+    }
+
+    @Test
+    fun movePointLeft_zeroPlacesIsIdentity() {
+        assertEquals("123.45", BigDecimal("123.45").movePointLeft(0).toString())
+    }
+
+    @Test
+    fun toBigIntegerTruncated_dropsFraction() {
+        assertEquals("123", BigDecimal("123.999").toBigIntegerTruncated().toString())
+        assertEquals("0", BigDecimal("0.5").toBigIntegerTruncated().toString())
+        // Values far beyond Long.MAX must not overflow.
+        assertEquals(
+            "123456789012345678901",
+            BigDecimal("123456789012345678901.75").toBigIntegerTruncated().toString(),
+        )
+    }
 }

--- a/utils/bigdecimal/src/jvmAndroidMain/kotlin/com/moneymanager/bigdecimal/BigDecimal.kt
+++ b/utils/bigdecimal/src/jvmAndroidMain/kotlin/com/moneymanager/bigdecimal/BigDecimal.kt
@@ -38,6 +38,8 @@ actual class BigDecimal : Comparable<BigDecimal> {
 
     actual operator fun div(divisor: BigDecimal): BigDecimal = BigDecimal(value.divide(divisor.value, 10, RoundingMode.HALF_UP))
 
+    actual fun movePointLeft(n: Int): BigDecimal = BigDecimal(value.movePointLeft(n))
+
     actual operator fun unaryMinus(): BigDecimal = BigDecimal(value.negate())
 
     actual fun abs(): BigDecimal = BigDecimal(value.abs())

--- a/utils/bigdecimal/src/jvmAndroidMain/kotlin/com/moneymanager/bigdecimal/BigInteger.kt
+++ b/utils/bigdecimal/src/jvmAndroidMain/kotlin/com/moneymanager/bigdecimal/BigInteger.kt
@@ -58,3 +58,9 @@ actual class BigInteger : Comparable<BigInteger> {
  * fractional part. Reconstructs the java value from the plain string so no internal access is needed.
  */
 actual fun BigDecimal.toBigIntegerExact(): BigInteger = BigInteger(java.math.BigDecimal(toString()).toBigIntegerExact())
+
+/**
+ * Converts this [BigDecimal] to a [BigInteger], discarding any fractional part (truncation toward
+ * zero). Reconstructs the java value from the plain string so no internal access is needed.
+ */
+actual fun BigDecimal.toBigIntegerTruncated(): BigInteger = BigInteger(java.math.BigDecimal(toString()).toBigInteger())


### PR DESCRIPTION
## Problem

A crypto asset's scale factor was sized from the **first** data that introduced the ticker, and nothing ever upsized it afterwards — both the CSV pre-pass (`collectCryptoScaleNeeds`) and the Exchange API importer skipped tickers that already existed. In practice CRO got created at 10^8, after which every crypto.com "Convert Dust" row (18 fractional digits) failed `Money.fromDisplayValue` with `ArithmeticException: Rounding necessary`: 156 CSV error rows, plus a whole Exchange API session import crashing on the same exception.

## Fix

**Every crypto asset is created at a fixed 18-decimal scale** (`CryptoAsset.CRYPTO_SCALE_FACTOR = 10^18`, the highest precision in practice — ETH/ERC-20 wei). Stored amounts are arbitrary-precision integers (TEXT), so the large scale cannot overflow. Enforced at the single write seam:

- `CryptoWriteRepositoryImpl.upsertCryptoByCode` always inserts at 10^18; the `scaleFactor` parameter is removed from `ImportCryptoIntent`, the `createCrypto` helper, and the repository interface, so no caller can undersize an asset.
- The CSV pre-pass now only *discovers* unknown tickers (the batch-wide pass still exists — it protects against "Currency not found" file-ordering, no longer against precision).
- The Exchange API importer likewise just collects codes.
- `CryptoRegistry` + the bundled catalog are name-only (no decimals); `CreateCryptoDialog` lost its decimals field; `Crypto.sq` default is 10^18.

## Latent precision bugs fixed alongside (required for 18 decimals to work)

- `Money.toDisplayValue()` divided via the common `BigDecimal.div`, which rounds at **scale 10 HALF_UP** — it silently corrupted any amount with more than 10 significant decimals (ETH was already exposed). Now exact via a new `BigDecimal.movePointLeft` + `Asset.decimalPlaces`.
- `ExchangeApiImportService.moneyRounded` rounded through `.toLong()`, which overflows for 18-decimal minor units (1000 CRO = 10^21). Now via a new truncating `BigDecimal.toBigIntegerTruncated()`.
- Crypto display formatting padded to the asset's full precision; it now trims trailing zeros ("0.5 BTC", "5 BNB").

## Notes

- Schema change (`crypto.scale_factor` default) ⇒ existing databases are recreated per the BETA no-migrations policy; assets created undersized by the old code are healed by re-importing.
- New regression tests: the exact 18-decimal dust row from the failing files (csvimporter), full-precision display round-trip + 1-wei display (MoneyTest), and `movePointLeft`/`toBigIntegerTruncated` (bigdecimal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cryptocurrency assets now use consistent 18-decimal precision.
  * Crypto creation no longer requires users to enter decimal-place settings.
  * Crypto catalogs now focus on ticker symbols and display names.

* **Bug Fixes**
  * Improved accuracy when importing and displaying high-precision crypto amounts.
  * Fixed handling of very small crypto values, including 18-decimal “dust” amounts.
  * Crypto amount formatting now avoids unnecessary trailing zeros.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->