### PR TITLE
Fail exchange imports loudly on precision loss instead of rounding

### DIFF
--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ExchangeApiImportService.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ExchangeApiImportService.kt
@@ -3,7 +3,6 @@
 package com.moneymanager.apiimporter
 
 import com.moneymanager.bigdecimal.BigDecimal
-import com.moneymanager.bigdecimal.toBigIntegerTruncated
 import com.moneymanager.domain.model.ApiRequestId
 import com.moneymanager.domain.model.ApiSessionId
 import com.moneymanager.domain.model.Asset
@@ -427,7 +426,7 @@ suspend fun importApiSessionExchange(
         val quoteAsset = asset(t.quoteCode)
         if (baseAsset == null || quoteAsset == null) return@forEachTrade
         val baseMoney = Money.fromDisplayValue(t.baseQuantity, baseAsset)
-        val quoteMoney = moneyRounded(t.quoteAmount, quoteAsset)
+        val quoteMoney = moneyExact(t.quoteAmount, quoteAsset, "Trade ${t.id} quote leg")
         val orderInfo = t.orderId?.let { orderMeta[it] }
         val description = tradeDescription(t, orderInfo)
         // BUY: quote leaves, base arrives. SELL: base leaves, quote arrives. Both on the one account.
@@ -449,9 +448,9 @@ suspend fun importApiSessionExchange(
         val feeAmount = t.feeAmount
         if (feeCode != null && feeAmount != null) {
             val feeAsset = asset(feeCode)
-            // Fiat fees carry more decimals than the currency's scale (e.g. "-0.525570" USD), so
-            // round like the quote leg; a fee that rounds to zero minor units is dropped.
-            val feeMoney = feeAsset?.let { moneyRounded(feeAmount, it) }
+            // A fee whose precision exceeds the asset's scale fails the import (no silent rounding);
+            // a genuinely zero fee is dropped.
+            val feeMoney = feeAsset?.let { moneyExact(feeAmount, it, "Trade ${t.id} fee") }
             if (feeAsset != null && feeMoney != null && !feeMoney.isZero()) {
                 transferIntents +=
                     exchangeTransfer(
@@ -697,18 +696,21 @@ private fun parseExchangeTransfer(
     )
 }
 
-/** Rounds a positive display value to its asset's minor units (half-up), avoiding fromDisplayValue's
- * exact-precision requirement for a computed leg (quote = quantity × price). Truncation via
- * BigInteger — never Long — because 18-decimal crypto minor units easily exceed a Long. */
-private fun moneyRounded(
+/** Converts an exchange-reported display value exactly; throws if the asset's scale can't
+ * represent it, so precision is never silently lost. */
+private fun moneyExact(
     displayValue: BigDecimal,
     asset: Asset,
-): Money {
-    val scaled = displayValue.abs() * BigDecimal(asset.scaleFactor)
-    return Money((scaled + HALF).toBigIntegerTruncated(), asset)
-}
-
-private val HALF = BigDecimal("0.5")
+    context: String,
+): Money =
+    try {
+        Money.fromDisplayValue(displayValue.abs(), asset)
+    } catch (e: ArithmeticException) {
+        throw IllegalArgumentException(
+            "$context: $displayValue ${asset.code} cannot be represented exactly at scale ${asset.scaleFactor}",
+            e,
+        )
+    }
 
 private fun JsonObject.str(path: String): String? =
     (resolveJsonPathElement(path) as? kotlinx.serialization.json.JsonPrimitive)?.let { it.contentOrNullCompat() }

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/api/CryptoComExchangeApiE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/api/CryptoComExchangeApiE2ETest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Instant
@@ -34,10 +35,10 @@ class CryptoComExchangeApiE2ETest : DbTest() {
     private val tradesJson =
         """
         {"code":0,"result":{"data":[
-          {"instrument_name":"BTC_USD","side":"BUY","traded_quantity":"0.5","traded_price":"40000.55",
+          {"instrument_name":"BTC_USD","side":"BUY","traded_quantity":"0.5","traded_price":"40000.54",
            "fees":"0.001","fee_instrument_name":"BTC","create_time":1700000000000,"trade_id":"t1","order_id":"o1"},
           {"instrument_name":"BTC_USD","side":"SELL","traded_quantity":"0.1","traded_price":"41000.00",
-           "fees":"-0.525570","fee_instrument_name":"USD","create_time":1700000000100,"trade_id":"t2","order_id":"o2"}
+           "fees":"-0.52","fee_instrument_name":"USD","create_time":1700000000100,"trade_id":"t2","order_id":"o2"}
         ]}}
         """.trimIndent()
 
@@ -57,7 +58,10 @@ class CryptoComExchangeApiE2ETest : DbTest() {
         ]}}
         """.trimIndent()
 
-    private suspend fun stageSessionAndImport(deposits: String = depositsJson): Int {
+    private suspend fun stageSessionAndImport(
+        deposits: String = depositsJson,
+        trades: String = tradesJson,
+    ): Int {
         val strategy = repositories.apiImportStrategyRepository.getStrategyByName("Crypto.com Exchange").first()
         assertNotNull(strategy, "built-in Crypto.com Exchange strategy should be installed")
         val deviceId = repositories.deviceRepository.getOrCreateDevice(DeviceInfo.Jvm("test-os", "test-machine"))
@@ -76,7 +80,7 @@ class CryptoComExchangeApiE2ETest : DbTest() {
                 )
             repositories.apiSessionRepository.insertResponse(requestId, sessionId, json)
         }
-        stage("private/get-trades", tradesJson)
+        stage("private/get-trades", trades)
         stage("private/get-order-history", ordersJson)
         stage("private/get-deposit-history", deposits)
 
@@ -117,13 +121,12 @@ class CryptoComExchangeApiE2ETest : DbTest() {
             assertEquals("BTC", trade.to.currency.code)
             // 0.5 BTC in.
             assertEquals("0.5", trade.to.toDisplayValue().toString())
-            // quote = 0.5 * 40000.55 = 20000.275 -> rounded to 2 dp = 20000.28.
-            assertEquals("20000.28", trade.from.toDisplayValue().toString())
+            // quote = 0.5 * 40000.54 = 20000.27, exactly representable at USD's 2-decimal scale.
+            assertEquals("20000.27", trade.from.toDisplayValue().toString())
             // Order type folded into the description as reference.
             assertTrue(trade.description.contains("LIMIT"), "order type recorded: ${trade.description}")
 
-            // The SELL's fiat fee ("-0.525570" USD, more decimals than USD's scale) books as its own
-            // movement to the Fees account, rounded half-up to 0.53 rather than crashing the import.
+            // The SELL's fiat fee books as its own movement to the Fees account.
             val feesAccount =
                 repositories.accountRepository
                     .getAllAccounts()
@@ -137,7 +140,7 @@ class CryptoComExchangeApiE2ETest : DbTest() {
                     ).first()
                     .first { it.targetAccountId == feesAccount.id }
             assertEquals("USD", feeTransfer.amount.currency.code)
-            assertEquals("0.53", feeTransfer.amount.toDisplayValue().toString())
+            assertEquals("0.52", feeTransfer.amount.toDisplayValue().toString())
 
             // Provenance points at the real JSON node so the audit view can expand to it.
             val deposit =
@@ -195,6 +198,26 @@ class CryptoComExchangeApiE2ETest : DbTest() {
                 "re-import must not double-book trades",
             )
             assertEquals(depositsBefore, depositCount(), "re-import must not double-book deposits")
+        }
+
+    @Test
+    fun `a value with more precision than the asset's scale fails the import instead of rounding`() =
+        runTest {
+            // The fiat fee "-0.525570" USD (6 decimals against USD's scale of 100) is not exactly
+            // representable, so the import must throw rather than silently round.
+            val excessPrecisionTrades =
+                """
+                {"code":0,"result":{"data":[
+                  {"instrument_name":"BTC_USD","side":"SELL","traded_quantity":"0.1","traded_price":"41000.00",
+                   "fees":"-0.525570","fee_instrument_name":"USD","create_time":1700000000100,"trade_id":"t9","order_id":"o9"}
+                ]}}
+                """.trimIndent()
+            val failure =
+                assertFailsWith<IllegalArgumentException> {
+                    stageSessionAndImport(trades = excessPrecisionTrades)
+                }
+            assertTrue("t9" in failure.message.orEmpty(), "failure names the trade: ${failure.message}")
+            assertTrue("USD" in failure.message.orEmpty(), "failure names the asset: ${failure.message}")
         }
 
     @Test

--- a/utils/bigdecimal/src/commonMain/kotlin/com/moneymanager/bigdecimal/BigInteger.kt
+++ b/utils/bigdecimal/src/commonMain/kotlin/com/moneymanager/bigdecimal/BigInteger.kt
@@ -85,9 +85,3 @@ expect class BigInteger : Comparable<BigInteger> {
  * Used when turning a scaled display value into integer minor units without silent truncation.
  */
 expect fun BigDecimal.toBigIntegerExact(): BigInteger
-
-/**
- * Converts this [BigDecimal] to a [BigInteger], discarding any fractional part (truncation toward
- * zero). Used after explicit rounding arithmetic, where the fraction is meant to be dropped.
- */
-expect fun BigDecimal.toBigIntegerTruncated(): BigInteger

--- a/utils/bigdecimal/src/commonTest/kotlin/com/moneymanager/bigdecimal/BigDecimalTest.kt
+++ b/utils/bigdecimal/src/commonTest/kotlin/com/moneymanager/bigdecimal/BigDecimalTest.kt
@@ -124,15 +124,4 @@ class BigDecimalTest {
     fun movePointLeft_zeroPlacesIsIdentity() {
         assertEquals("123.45", BigDecimal("123.45").movePointLeft(0).toString())
     }
-
-    @Test
-    fun toBigIntegerTruncated_dropsFraction() {
-        assertEquals("123", BigDecimal("123.999").toBigIntegerTruncated().toString())
-        assertEquals("0", BigDecimal("0.5").toBigIntegerTruncated().toString())
-        // Values far beyond Long.MAX must not overflow.
-        assertEquals(
-            "123456789012345678901",
-            BigDecimal("123456789012345678901.75").toBigIntegerTruncated().toString(),
-        )
-    }
 }

--- a/utils/bigdecimal/src/jvmAndroidMain/kotlin/com/moneymanager/bigdecimal/BigInteger.kt
+++ b/utils/bigdecimal/src/jvmAndroidMain/kotlin/com/moneymanager/bigdecimal/BigInteger.kt
@@ -58,9 +58,3 @@ actual class BigInteger : Comparable<BigInteger> {
  * fractional part. Reconstructs the java value from the plain string so no internal access is needed.
  */
 actual fun BigDecimal.toBigIntegerExact(): BigInteger = BigInteger(java.math.BigDecimal(toString()).toBigIntegerExact())
-
-/**
- * Converts this [BigDecimal] to a [BigInteger], discarding any fractional part (truncation toward
- * zero). Reconstructs the java value from the plain string so no internal access is needed.
- */
-actual fun BigDecimal.toBigIntegerTruncated(): BigInteger = BigInteger(java.math.BigDecimal(toString()).toBigInteger())


### PR DESCRIPTION
## What

Removes `moneyRounded` from the Exchange API import (`ExchangeApiImportService`). The computed quote leg (`traded_quantity × traded_price`) and trade fees are now converted with the exact `Money.fromDisplayValue` path via a new `moneyExact` helper: if a value cannot be represented exactly at the asset's scale, the import throws `IllegalArgumentException` naming the trade, value, asset and scale (e.g. `Trade t9 fee: 0.525570 USD cannot be represented exactly at scale 100`) instead of silently rounding half-up.

Also removes the now-dead `BigDecimal.toBigIntegerTruncated` expect/actual from `utils/bigdecimal` (`moneyRounded` was its only production caller).

## Why

Analysis of a real Exchange API session (70 trades, all BTC-quoted) showed the rounding path never actually fires — every real value is exactly representable at the 18-decimal crypto scale. Silent rounding only ever engages on fiat-quoted trades/fees, where losing sub-cent precision without any signal is worse than failing the import visibly. We prefer to fail loudly and decide what to do if such data ever appears.

## Tests

- `CryptoComExchangeApiE2ETest` fixtures changed to exactly-representable values (price `40000.54` → quote `20000.27`; fee `-0.52`), assertions updated.
- New E2E test: a trade with the old excess-precision fiat fee (`-0.525570` USD, 6 dp vs USD scale 100) makes the import throw, with the trade id and asset in the message.
- `./gradlew build buildHealth` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exchange imports now preserve reported trade and fee values exactly instead of silently rounding them.
  * Imports fail with a clear error when a value contains more precision than the asset supports.
  * Zero-value fees continue to be excluded from imported transactions.

* **Tests**
  * Updated exchange import scenarios and added coverage for precision-related import failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->