### PR TITLE
Disable Qodana CI job while the Qodana Cloud license is expired

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,11 @@ jobs:
     needs: [changes, lint-format]
     # Unlike the other heavy jobs this one also runs on workflow_dispatch, so it has no
     # event-name condition.
+    # Disabled: the Qodana Cloud open-source license expired on 2026-07-06, so every run
+    # fails before producing a SARIF. Re-enable (drop the leading `false &&`) once a new
+    # license is granted.
     if: >-
+      false &&
       !cancelled() &&
       needs.changes.outputs.code == 'true' &&
       (needs.lint-format.result == 'success' || needs.lint-format.result == 'skipped')


### PR DESCRIPTION
## What

Disables the `qodana` job in `.github/workflows/build.yml` by prepending `false &&` to its `if:` condition, with a comment explaining why and how to re-enable.

## Why

The Qodana Cloud open-source license expired on 2026-07-06, so every scan fails within seconds and produces no SARIF (`Path does not exist: .../qodana.sarif.json`). Re-running does not help — it's a licensing failure, not the old transient Gradle-import flake. Until a new open-source license is granted there's no point burning CI minutes on a guaranteed-red job.

Qodana is **not** a required status check on `main` (those are Build and Test, Android Instrumented Tests, Auto-format PR, and Dependency Health), so disabling it blocks nothing.

## Re-enabling

Remove the `false &&` line (and the accompanying comment) from the qodana job's `if:` condition once the license is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)