### PR TITLE
API imports: strategy filter dropdown + Outstanding/Imported session tabs

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -14,9 +14,11 @@ sent to the nested display stay inside it (they never touch the user's real poin
 ```bash
 # 1. Nested X display (opens one contained window on the user's screen)
 Xwayland :9 -geometry 1600x1000 -decorate -retro &
+XWAYLAND_PID=$!
 
-# 2. Launch the app inside it (background; first window paint takes ~15s after gradle is warm)
-DISPLAY=:9 ./gradlew :app:main:jvm:run --console=plain
+# 2. Launch the app inside it in the background (first window paint takes ~15s once gradle is warm)
+DISPLAY=:9 ./gradlew :app:main:jvm:run --console=plain &
+APP_PID=$!
 
 # 3. Screenshot (ImageMagick `import` works against the nested server; no WM needed)
 DISPLAY=:9 import -window root shot.png
@@ -39,7 +41,8 @@ Settings); Imports screen has top tabs Directories/CSV/QIF/API/Misc.
   Navigation, tabs, and dropdowns are read-only — but do NOT click Download/Import/Delete
   buttons: they hit real provider APIs / mutate real data.
 - `xset` is not installed; test the server with `import` or `pgrep -f 'Xwayland :9'` instead.
-- Closing the app window (or killing the gradle run task) exits cleanly; kill the Xwayland
-  pid afterwards.
+- Cleanup: `kill $APP_PID` (or close the app window — either exits cleanly), then
+  `kill $XWAYLAND_PID`. Kill the captured PIDs, not by pattern, to avoid hitting the user's
+  own `Xwayland :1` session process.
 - Don't run the GUI while a full `./gradlew build` is running — they contend for the
   configuration cache lock.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: verify
+description: Verify a change by driving the real Compose Desktop app on an isolated nested X display, clicking through it with java.awt.Robot, and capturing screenshots as evidence.
+---
+
+# Verify (money-manager, JVM desktop GUI)
+
+The host session is Wayland with no xdotool/ydotool/wtype and no Xvfb — but `Xwayland` is
+installed, so run a **rootful nested X server** hosted by the user's compositor. Robot events
+sent to the nested display stay inside it (they never touch the user's real pointer).
+
+## Recipe
+
+```bash
+# 1. Nested X display (opens one contained window on the user's screen)
+Xwayland :9 -geometry 1600x1000 -decorate -retro &
+
+# 2. Launch the app inside it (background; first window paint takes ~15s after gradle is warm)
+DISPLAY=:9 ./gradlew :app:main:jvm:run --console=plain
+
+# 3. Screenshot (ImageMagick `import` works against the nested server; no WM needed)
+DISPLAY=:9 import -window root shot.png
+# Poll for content: identify -format '%k' shot.png  → >10 unique colors means the window painted
+
+# 4. Drive clicks with a java.awt.Robot one-file driver (java 25 runs .java sources directly)
+DISPLAY=:9 java Drive.java click X Y     # also: move X Y | scroll N | where
+```
+
+`Drive.java`: Robot with `setAutoDelay(40)`, click = `mouseMove` → 150ms → press/release
+BUTTON1 with 60ms between. Write it to the scratchpad, not the repo.
+
+Read each screenshot before clicking — compute coordinates from the image (scale is 1:1 on
+the nested display). App layout: bottom nav bar (Accounts/Assets/Categories/People/Imports/
+Settings); Imports screen has top tabs Directories/CSV/QIF/API/Misc.
+
+## Gotchas
+
+- The app opens the **user's real last-used database** (path shown in the purple header bar).
+  Navigation, tabs, and dropdowns are read-only — but do NOT click Download/Import/Delete
+  buttons: they hit real provider APIs / mutate real data.
+- `xset` is not installed; test the server with `import` or `pgrep -f 'Xwayland :9'` instead.
+- Closing the app window (or killing the gradle run task) exits cleanly; kill the Xwayland
+  pid afterwards.
+- Don't run the GUI while a full `./gradlew build` is running — they contend for the
+  configuration cache lock.

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class)
+@file:OptIn(kotlin.time.ExperimentalTime::class, androidx.compose.material3.ExperimentalMaterial3Api::class)
 
 package com.moneymanager.ui.screens
 
@@ -25,11 +25,17 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SecondaryTabRow
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -78,6 +84,7 @@ import com.moneymanager.domain.model.DeviceId
 import com.moneymanager.domain.model.MonzoCredential
 import com.moneymanager.domain.model.MonzoCredentialId
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
+import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.ApiImportStrategyReadRepository
@@ -148,6 +155,10 @@ fun ApiSessionsScreen(
     var strategyNameByCredential by remember { mutableStateOf<Map<MonzoCredentialId, String>>(emptyMap()) }
     var requiresSigningByCredential by remember { mutableStateOf<Map<MonzoCredentialId, Boolean>>(emptyMap()) }
     var transactionsBlockReasonByCredential by remember { mutableStateOf<Map<MonzoCredentialId, String>>(emptyMap()) }
+    var strategies by remember { mutableStateOf<List<ApiImportStrategy>>(emptyList()) }
+    var strategyIdByCredential by remember { mutableStateOf<Map<MonzoCredentialId, ApiImportStrategyId?>>(emptyMap()) }
+    var selectedStrategyId by remember { mutableStateOf<ApiImportStrategyId?>(null) }
+    var selectedTab by remember { mutableStateOf(0) }
     var isLoading by remember { mutableStateOf(true) }
     // Per-session import state
     var importResultBySession by remember { mutableStateOf<Map<ApiSessionId, ApiSessionImportResult>>(emptyMap()) }
@@ -197,6 +208,11 @@ fun ApiSessionsScreen(
                 // change once additional providers (e.g. Wise) are seeded.
                 val fallbackStrategy = legacyDefaultStrategy(allStrategies)
                 val fallbackStrategyRevision = fallbackStrategy?.revisionId
+                strategies = allStrategies.sortedBy { it.name.lowercase() }
+                strategyIdByCredential =
+                    allCredentials.associate { credential ->
+                        credential.id to (credential.strategyId ?: fallbackStrategy?.id)
+                    }
                 currentStrategyRevisionByCredential =
                     allCredentials.associate { credential ->
                         credential.id to (
@@ -381,11 +397,76 @@ fun ApiSessionsScreen(
                 }
             }
             else -> {
+                val filteredCredentials =
+                    filterCredentialsByStrategy(
+                        credentials = credentials,
+                        strategyIdByCredential = strategyIdByCredential,
+                        selectedStrategyId = selectedStrategyId,
+                    )
+                val split =
+                    splitSessionsByImportState(
+                        credentials = filteredCredentials,
+                        sessionsByCredential = sessionsByCredential,
+                        currentStrategyRevisionByCredential = currentStrategyRevisionByCredential,
+                        importedSessionRevisions = importedSessionRevisions,
+                    )
+
+                StrategyFilterDropdown(
+                    strategies = strategies,
+                    selectedStrategyId = selectedStrategyId,
+                    onStrategySelected = { selectedStrategyId = it },
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                SecondaryTabRow(selectedTabIndex = selectedTab) {
+                    Tab(
+                        selected = selectedTab == 0,
+                        onClick = { selectedTab = 0 },
+                        text = { Text("Outstanding (${split.outstandingCount})") },
+                    )
+                    Tab(
+                        selected = selectedTab == 1,
+                        onClick = { selectedTab = 1 },
+                        text = { Text("Imported (${split.importedCount})") },
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // The Outstanding tab is the working tab: credential cards stay visible even with no
+                // outstanding sessions so Download remains reachable. The Imported tab only lists
+                // credentials that actually have imported sessions.
+                val visibleCredentials =
+                    if (selectedTab == 0) {
+                        filteredCredentials
+                    } else {
+                        filteredCredentials.filter { split.importedByCredential[it.id].orEmpty().isNotEmpty() }
+                    }
+
                 val lazyListState = rememberLazyListState()
                 Box(modifier = Modifier.fillMaxSize()) {
+                    if (visibleCredentials.isEmpty()) {
+                        Text(
+                            text =
+                                if (selectedTab == 0) {
+                                    "No credentials for this strategy. Click '+ Connect' to add one."
+                                } else {
+                                    "No imported sessions yet."
+                                },
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.align(Alignment.Center),
+                        )
+                    }
                     LazyColumn(state = lazyListState, verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                        items(credentials) { credential ->
-                            val credentialSessions = sessionsByCredential[credential.id].orEmpty()
+                        items(visibleCredentials) { credential ->
+                            val credentialSessions =
+                                if (selectedTab == 0) {
+                                    split.outstandingByCredential[credential.id].orEmpty()
+                                } else {
+                                    split.importedByCredential[credential.id].orEmpty()
+                                }
                             val isDownloading = backgroundTasks.isRunning(monzoDownloadTaskKey(credential.id))
                             CredentialCard(
                                 credential = credential,
@@ -830,9 +911,11 @@ private fun CredentialCard(
                         session = session,
                         isImporting = isImportingSession(session.id),
                         isAlreadyImported =
-                            selectedStrategyRevision?.let { revision ->
-                                ApiSessionImportRevision(session.id, revision) in importedSessionRevisions
-                            } == true,
+                            sessionImportedAtCurrentRevision(
+                                sessionId = session.id,
+                                currentRevision = selectedStrategyRevision,
+                                importedSessionRevisions = importedSessionRevisions,
+                            ),
                         importResult = importResultBySession[session.id],
                         importError = importErrorBySession[session.id],
                         importProgress = importProgressBySession[session.id],
@@ -1753,6 +1836,112 @@ private const val LEGACY_DEFAULT_STRATEGY_NAME = "Monzo"
  */
 private fun legacyDefaultStrategy(strategies: List<ApiImportStrategy>): ApiImportStrategy? =
     strategies.firstOrNull { it.name == LEGACY_DEFAULT_STRATEGY_NAME }
+
+/**
+ * A session counts as imported only at the credential's current strategy revision — a session
+ * imported under an older revision is outstanding again, because re-importing it would apply the
+ * updated strategy.
+ */
+internal fun sessionImportedAtCurrentRevision(
+    sessionId: ApiSessionId,
+    currentRevision: Long?,
+    importedSessionRevisions: Set<ApiSessionImportRevision>,
+): Boolean =
+    currentRevision?.let { revision ->
+        ApiSessionImportRevision(sessionId, revision) in importedSessionRevisions
+    } == true
+
+internal fun filterCredentialsByStrategy(
+    credentials: List<MonzoCredential>,
+    strategyIdByCredential: Map<MonzoCredentialId, ApiImportStrategyId?>,
+    selectedStrategyId: ApiImportStrategyId?,
+): List<MonzoCredential> =
+    if (selectedStrategyId == null) {
+        credentials
+    } else {
+        credentials.filter { strategyIdByCredential[it.id] == selectedStrategyId }
+    }
+
+internal data class ApiSessionsSplit(
+    val outstandingByCredential: Map<MonzoCredentialId, List<ApiSession>>,
+    val importedByCredential: Map<MonzoCredentialId, List<ApiSession>>,
+) {
+    val outstandingCount: Int get() = outstandingByCredential.values.sumOf { it.size }
+    val importedCount: Int get() = importedByCredential.values.sumOf { it.size }
+}
+
+internal fun splitSessionsByImportState(
+    credentials: List<MonzoCredential>,
+    sessionsByCredential: Map<MonzoCredentialId, List<ApiSession>>,
+    currentStrategyRevisionByCredential: Map<MonzoCredentialId, Long?>,
+    importedSessionRevisions: Set<ApiSessionImportRevision>,
+): ApiSessionsSplit {
+    val outstanding = mutableMapOf<MonzoCredentialId, List<ApiSession>>()
+    val imported = mutableMapOf<MonzoCredentialId, List<ApiSession>>()
+    credentials.forEach { credential ->
+        val (importedSessions, outstandingSessions) =
+            sessionsByCredential[credential.id].orEmpty().partition { session ->
+                sessionImportedAtCurrentRevision(
+                    sessionId = session.id,
+                    currentRevision = currentStrategyRevisionByCredential[credential.id],
+                    importedSessionRevisions = importedSessionRevisions,
+                )
+            }
+        outstanding[credential.id] = outstandingSessions
+        imported[credential.id] = importedSessions
+    }
+    return ApiSessionsSplit(outstandingByCredential = outstanding, importedByCredential = imported)
+}
+
+@Composable
+private fun StrategyFilterDropdown(
+    strategies: List<ApiImportStrategy>,
+    selectedStrategyId: ApiImportStrategyId?,
+    onStrategySelected: (ApiImportStrategyId?) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selectedName = strategies.firstOrNull { it.id == selectedStrategyId }?.name ?: ALL_STRATEGIES_LABEL
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+    ) {
+        OutlinedTextField(
+            value = selectedName,
+            onValueChange = {},
+            readOnly = true,
+            singleLine = true,
+            label = { Text("Strategy") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text(ALL_STRATEGIES_LABEL) },
+                onClick = {
+                    onStrategySelected(null)
+                    expanded = false
+                },
+            )
+            strategies.forEach { strategy ->
+                DropdownMenuItem(
+                    text = { Text(strategy.name) },
+                    onClick = {
+                        onStrategySelected(strategy.id)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
+}
+
+private const val ALL_STRATEGIES_LABEL = "All strategies"
 
 private fun monzoDownloadTaskKey(credentialId: MonzoCredentialId): String = "monzo-download-cred-${credentialId.id}"
 

--- a/app/ui/imports/api/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
+++ b/app/ui/imports/api/src/commonTest/kotlin/com/moneymanager/ui/screens/ApiSessionsScreenLogicTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
 package com.moneymanager.ui.screens
 
 import com.moneymanager.domain.model.ApiRequest
@@ -7,13 +9,22 @@ import com.moneymanager.domain.model.ApiResponseId
 import com.moneymanager.domain.model.ApiResponseTransaction
 import com.moneymanager.domain.model.ApiResponseTransactionId
 import com.moneymanager.domain.model.ApiResponseTransactionState
+import com.moneymanager.domain.model.ApiSession
 import com.moneymanager.domain.model.ApiSessionId
+import com.moneymanager.domain.model.ApiSessionType
+import com.moneymanager.domain.model.DeviceId
 import com.moneymanager.domain.model.JsonPath
+import com.moneymanager.domain.model.MonzoCredential
+import com.moneymanager.domain.model.MonzoCredentialId
+import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
+import com.moneymanager.domain.repository.ApiSessionImportRevision
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class ApiSessionsScreenLogicTest {
     @Test
@@ -102,6 +113,115 @@ class ApiSessionsScreenLogicTest {
             )
         assertTrue(highlighted)
     }
+
+    @Test
+    fun sessionImportedAtCurrentRevision_onlyMatchesCurrentRevision() {
+        val imported = setOf(ApiSessionImportRevision(ApiSessionId(1), revisionId = 2))
+        assertTrue(sessionImportedAtCurrentRevision(ApiSessionId(1), currentRevision = 2, imported))
+        // Imported under an older strategy revision only -> outstanding again.
+        assertFalse(sessionImportedAtCurrentRevision(ApiSessionId(1), currentRevision = 3, imported))
+        assertFalse(sessionImportedAtCurrentRevision(ApiSessionId(2), currentRevision = 2, imported))
+        assertFalse(sessionImportedAtCurrentRevision(ApiSessionId(1), currentRevision = null, imported))
+    }
+
+    @Test
+    fun filterCredentialsByStrategy_nullSelectsAll() {
+        val credentials = listOf(credential(1, strategyA), credential(2, strategyB), credential(3, strategyId = null))
+        val strategyByCredential = credentials.associate { it.id to it.strategyId }
+        assertEquals(credentials, filterCredentialsByStrategy(credentials, strategyByCredential, selectedStrategyId = null))
+    }
+
+    @Test
+    fun filterCredentialsByStrategy_keepsOnlyMatchingCredentialsIncludingLegacyFallback() {
+        val modern = credential(1, strategyA)
+        val other = credential(2, strategyB)
+        val legacy = credential(3, strategyId = null)
+        val credentials = listOf(modern, other, legacy)
+        // The screen resolves legacy (null-strategy) credentials to the fallback strategy before filtering.
+        val strategyByCredential =
+            mapOf(modern.id to strategyA, other.id to strategyB, legacy.id to strategyA)
+        assertEquals(
+            listOf(modern, legacy),
+            filterCredentialsByStrategy(credentials, strategyByCredential, selectedStrategyId = strategyA),
+        )
+        assertEquals(
+            listOf(other),
+            filterCredentialsByStrategy(credentials, strategyByCredential, selectedStrategyId = strategyB),
+        )
+    }
+
+    @Test
+    fun splitSessionsByImportState_partitionsPerCredentialAndCounts() {
+        val credentialA = credential(1, strategyA)
+        val credentialB = credential(2, strategyB)
+        val importedSession = session(10, credentialA.id)
+        val oldRevisionSession = session(11, credentialA.id)
+        val neverImportedSession = session(12, credentialB.id)
+        val split =
+            splitSessionsByImportState(
+                credentials = listOf(credentialA, credentialB),
+                sessionsByCredential =
+                    mapOf(
+                        credentialA.id to listOf(importedSession, oldRevisionSession),
+                        credentialB.id to listOf(neverImportedSession),
+                    ),
+                currentStrategyRevisionByCredential = mapOf(credentialA.id to 2L, credentialB.id to 1L),
+                importedSessionRevisions =
+                    setOf(
+                        ApiSessionImportRevision(importedSession.id, revisionId = 2),
+                        ApiSessionImportRevision(oldRevisionSession.id, revisionId = 1),
+                    ),
+            )
+        assertEquals(listOf(importedSession), split.importedByCredential[credentialA.id])
+        assertEquals(listOf(oldRevisionSession), split.outstandingByCredential[credentialA.id])
+        assertEquals(listOf(neverImportedSession), split.outstandingByCredential[credentialB.id])
+        assertEquals(emptyList(), split.importedByCredential[credentialB.id])
+        assertEquals(2, split.outstandingCount)
+        assertEquals(1, split.importedCount)
+    }
+
+    @Test
+    fun splitSessionsByImportState_retainsSessionlessCredentials() {
+        val sessionless = credential(1, strategyA)
+        val split =
+            splitSessionsByImportState(
+                credentials = listOf(sessionless),
+                sessionsByCredential = emptyMap(),
+                currentStrategyRevisionByCredential = mapOf(sessionless.id to 1L),
+                importedSessionRevisions = emptySet(),
+            )
+        assertEquals(emptyList(), split.outstandingByCredential[sessionless.id])
+        assertEquals(emptyList(), split.importedByCredential[sessionless.id])
+        assertEquals(0, split.outstandingCount)
+        assertEquals(0, split.importedCount)
+    }
+
+    private val strategyA = ApiImportStrategyId(Uuid.parse("00000000-0000-0000-0000-00000000000a"))
+    private val strategyB = ApiImportStrategyId(Uuid.parse("00000000-0000-0000-0000-00000000000b"))
+
+    private fun credential(
+        id: Long,
+        strategyId: ApiImportStrategyId?,
+    ) = MonzoCredential(
+        id = MonzoCredentialId(id),
+        type = ApiSessionType.MONZO,
+        token = "token-$id",
+        createdAt = Instant.DISTANT_PAST,
+        strategyId = strategyId,
+    )
+
+    private fun session(
+        id: Long,
+        credentialId: MonzoCredentialId,
+    ) = ApiSession(
+        id = ApiSessionId(id),
+        type = ApiSessionType.MONZO,
+        token = "token",
+        deviceId = DeviceId(1),
+        createdAt = Instant.DISTANT_PAST,
+        expiresAt = null,
+        credentialId = credentialId,
+    )
 
     private fun request(id: Long) =
         ApiRequest(


### PR DESCRIPTION
## What

Improves the **Imports → API** screen:

- **Strategy dropdown** ("All strategies" default) above the list that filters credential cards to the selected API strategy. Legacy credentials with no linked strategy resolve to the Monzo fallback before filtering, so they appear under the Monzo selection.
- **Outstanding / Imported tabs** (with counts, same pattern as the CSV/QIF screens) splitting sessions by whether they were imported at the credential's **current** strategy revision — a session imported under an older revision counts as outstanding again, since re-importing applies the updated strategy.
- The Outstanding tab keeps session-less credential cards visible so Download stays reachable; the Imported tab only lists credentials that actually have imported sessions. Both states get proper empty-state text.

## Why

Sessions were previously rendered flat under every credential card, so with several providers (Monzo, Wise, Crypto.com Exchange, …) it was hard to find a given strategy's sessions and impossible to see at a glance which downloaded sessions still needed importing.

## How

- All UI changes in `ApiSessionsScreen.kt`; no schema or repository changes — the strategy id per credential and the imported-revision set were already loaded in `refresh()`.
- Filtering/partition logic extracted into pure top-level helpers (`sessionImportedAtCurrentRevision`, `filterCredentialsByStrategy`, `splitSessionsByImportState`) with unit tests in `ApiSessionsScreenLogicTest`.
- Also adds `.claude/skills/verify/SKILL.md` documenting how to drive the desktop app on a nested Xwayland display for GUI verification.

## Testing

- New unit tests for the partition (current/old/never-imported revisions), the strategy filter (all / matching / legacy fallback / session-less credentials retained), and tab counts.
- `./gradlew build buildHealth` green locally.
- Verified end-to-end in the running desktop app: dropdown lists all strategies, filtering hides other providers' cards, tab counts and empty states correct, Imported tab shows the imported session with disabled Import button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering of API sessions by import strategy.
  * Added separate “Outstanding” and “Imported” tabs for clearer session tracking.
  * Sessions imported under older strategy revisions are now correctly identified as outstanding.
  * Legacy credentials continue to appear under the appropriate default strategy.

* **Documentation**
  * Added guidance for validating the desktop interface with automated interaction and screenshots.

* **Tests**
  * Expanded coverage for strategy filtering, import-status tracking, and session grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->