### PR TITLE
CSV crypto trades: import crypto_exchange rows as same-account trades

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -155,9 +155,11 @@ private suspend fun cryptoCodesForImport(
         csvImport.lastAppliedStrategyId?.let { id -> strategies.find { it.id == id } }
             ?: strategies.selectForCsv(csvImport.originalFileName, csvImport.columns, sampleRows)
             ?: return emptySet()
+    // Scan ALL rows, not just importable ones: a re-import remaps already-IMPORTED rows too (value
+    // updates, transfer→trade conversions), and their tickers must resolve at plan time. For a fresh
+    // import every row is unimported, so this is the same set.
     val allRows = csvImportRepository.getImportRows(csvImport.id, limit = csvImport.rowCount.coerceAtLeast(1), offset = 0)
-    val rows = allRows.filter { it.importStatus == null || it.importStatus == ImportStatus.ERROR }
-    return collectCryptoCodes(strategy, csvImport.columns, rows, fiatCodes, existingCrypto)
+    return collectCryptoCodes(strategy, csvImport.columns, allRows, fiatCodes, existingCrypto)
 }
 
 /**
@@ -878,28 +880,37 @@ suspend fun runCsvImport(
         }
     }
     // Cross-asset conversion rows are imported as trades, which the engine reports via createdTradeIds
-    // (keyed by LocalTradeKey), NOT via rowOutcomes. Mark those rows IMPORTED and clear their errors too —
-    // otherwise a converted row keeps a stale ERROR status and gets reprocessed on the next import,
-    // creating a duplicate trade (createTrade has no dedup). The key is "csv-<importId>-<rowIndex>".
+    // (keyed by LocalTradeKey), NOT via rowOutcomes. Mark those rows IMPORTED — or DUPLICATE when the
+    // intent matched an existing identical trade (createTrade is idempotent, e.g. a re-import or the
+    // same event arriving from another export) — and clear their errors too, otherwise a converted row
+    // keeps a stale ERROR status and gets reprocessed on the next import. The key is
+    // "csv-<importId>-<rowIndex>".
     val tradeKeyPrefix = "csv-${csvImport.id.id}-"
-    val tradeRowIndices =
-        importResult.createdTradeIds.keys.mapNotNull { key ->
-            if (key.value.startsWith(tradeKeyPrefix)) key.value.removePrefix(tradeKeyPrefix).toLongOrNull() else null
-        }
+
+    fun LocalTradeKey.rowIndexOrNull(): Long? =
+        if (value.startsWith(tradeKeyPrefix)) value.removePrefix(tradeKeyPrefix).toLongOrNull() else null
+
+    val tradeRowsByStatus =
+        importResult.createdTradeIds.keys
+            .mapNotNull { key -> key.rowIndexOrNull()?.let { key to it } }
+            .groupBy(
+                keySelector = { (key, _) -> if (key in importResult.dedupedTradeKeys) ImportStatus.DUPLICATE else ImportStatus.IMPORTED },
+                valueTransform = { (_, rowIndex) -> rowIndex },
+            )
 
     val statusMutations = mutableListOf<CsvImportMutation>()
     if (importedStatuses.isNotEmpty()) {
         statusMutations += CsvImportMutation.UpdateRowStatuses(csvImport.id, ImportStatus.IMPORTED.name, importedStatuses)
         statusMutations += CsvImportMutation.ClearErrors(csvImport.id, importedStatuses.keys.toList())
     }
-    if (tradeRowIndices.isNotEmpty()) {
+    for ((status, rowIndices) in tradeRowsByStatus) {
         statusMutations +=
             CsvImportMutation.UpdateRowStatuses(
                 csvImport.id,
-                ImportStatus.IMPORTED.name,
-                tradeRowIndices.associateWith { null },
+                status.name,
+                rowIndices.associateWith { null },
             )
-        statusMutations += CsvImportMutation.ClearErrors(csvImport.id, tradeRowIndices)
+        statusMutations += CsvImportMutation.ClearErrors(csvImport.id, rowIndices)
     }
     if (duplicateStatuses.isNotEmpty()) {
         statusMutations += CsvImportMutation.UpdateRowStatuses(csvImport.id, ImportStatus.DUPLICATE.name, duplicateStatuses)
@@ -911,13 +922,13 @@ suspend fun runCsvImport(
         statusMutations += CsvImportMutation.ClearErrors(csvImport.id, updatedStatuses.keys.toList())
     }
     importEngine.applyCsvImportMutations(statusMutations)
-    // Trades aren't counted here: createdTradeIds returns the existing id for a deduped conversion too, so
-    // it can't distinguish new from duplicate — counting it would report re-imported conversions as new.
-    val successCount = importResult.transfersImported + importResult.updated
-    val duplicateCount = importResult.duplicates
+    val newTradeCount = tradeRowsByStatus[ImportStatus.IMPORTED]?.size ?: 0
+    val dedupedTradeCount = tradeRowsByStatus[ImportStatus.DUPLICATE]?.size ?: 0
+    val successCount = importResult.transfersImported + importResult.updated + newTradeCount
+    val duplicateCount = importResult.duplicates + dedupedTradeCount
 
     logger.info {
-        "Transfer import complete: $successCount imported/updated, ${importResult.duplicates} duplicate(s)"
+        "Transfer import complete: $successCount imported/updated, $duplicateCount duplicate(s)"
     }
 
     // Refresh materialized views so transfers are visible (skipped in bulk; refreshed once at the end)

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -23,6 +23,7 @@ import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CryptoReadRepository
 import com.moneymanager.domain.repository.CsvImportReadRepository
+import com.moneymanager.domain.repository.TradeReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.domain.repository.TransferSourceReadRepository
@@ -72,6 +73,9 @@ enum class ReimportSkipReason {
 
     /** Reversing a merge whose accounts no longer consolidate failed; the merge was left as-is. */
     REVERSAL_FAILED,
+
+    /** Deleting a row's old transfer for a transfer→trade conversion failed; the row was left as-is. */
+    TRADE_CONVERSION_FAILED,
 }
 
 /** One duplicate-account merge the re-import will perform (or performed). */
@@ -111,6 +115,21 @@ data class ReimportRewrite(
     val conduitNames: List<String>,
     /** The clean merchant the final spend leg pays. */
     val merchantName: String,
+)
+
+/**
+ * One already-imported row that the current strategy maps to a cross-asset TRADE but whose persisted
+ * transaction is a single-asset transfer (imported before the strategy gained TO_CURRENCY/TO_AMOUNT
+ * mappings, so the credited leg was lost and the counterparty is typically a junk description-named
+ * account): the old transfer(s) are deleted, the row's status is reset, and the strategy re-run
+ * imports it as a trade.
+ */
+data class ReimportTradeConversion(
+    val rowIndex: Long,
+    /** The row's existing transfer plus its linked legs, all deleted before the re-run. */
+    val transferIdsToDelete: List<TransferId>,
+    /** The row's statement description, for the preview. */
+    val description: String,
 )
 
 /**
@@ -160,9 +179,17 @@ data class ReimportPlan(
     val valueUpdates: List<ReimportValueUpdate> = emptyList(),
     /** Prior merges to undo because the current mappings no longer consolidate them. */
     val reversals: List<ReimportReversal> = emptyList(),
+    /** Already-imported single-asset transfers the current strategy now maps to cross-asset trades. */
+    val tradeConversions: List<ReimportTradeConversion> = emptyList(),
 ) {
     val isEmpty: Boolean
-        get() = merges.isEmpty() && skipped.isEmpty() && rewrites.isEmpty() && valueUpdates.isEmpty() && reversals.isEmpty()
+        get() =
+            merges.isEmpty() &&
+                skipped.isEmpty() &&
+                rewrites.isEmpty() &&
+                valueUpdates.isEmpty() &&
+                reversals.isEmpty() &&
+                tradeConversions.isEmpty()
 }
 
 /** The outcome of an executed re-import. */
@@ -179,6 +206,8 @@ data class CsvReimportResult(
     val updatedRows: List<ReimportValueUpdate> = emptyList(),
     /** Prior merges undone because the current mappings no longer consolidate them. */
     val reversedMerges: List<ReimportReversal> = emptyList(),
+    /** Rows whose single-asset transfer was deleted and re-imported as a cross-asset trade. */
+    val convertedRows: List<ReimportTradeConversion> = emptyList(),
 )
 
 /** Raw merge detection output: duplicate → single target, plus duplicates with competing targets. */
@@ -379,14 +408,26 @@ suspend fun planCsvReimport(
         computeReimportRewrites(allRows, mappedPrep, relationshipRepository, onProgress) { transferId ->
             transactionRepository.getTransactionById(transferId.id).first()
         }
+    val tradeConversions =
+        computeReimportTradeConversions(
+            allRows = allRows,
+            mappedPrep = mappedPrep,
+            rewrittenRowIndexes = rewrites.map { it.rowIndex }.toSet(),
+            relationshipRepository = relationshipRepository,
+            onProgress = onProgress,
+        ) { transferId -> transactionRepository.getTransactionById(transferId.id).first() }
     // Rows whose transfers a reversal moves back are excluded from value updates: the reversal owns that
     // transfer's account move, and a value update would re-send the pre-reversal (survivor) accounts.
+    // Trade-conversion rows are excluded too — their transfer is deleted, not updated.
     val reversalRowIndexes = reversals.flatMapTo(mutableSetOf()) { it.rowIndexes }
     val valueUpdates =
         computeReimportValueUpdates(
             allRows = allRows,
             mappedPrep = mappedPrep,
-            rewrittenRowIndexes = rewrites.map { it.rowIndex }.toSet() + reversalRowIndexes,
+            rewrittenRowIndexes =
+                rewrites.map { it.rowIndex }.toSet() +
+                    reversalRowIndexes +
+                    tradeConversions.map { it.rowIndex },
             transactionRepository = transactionRepository,
             onProgress = onProgress,
         )
@@ -433,6 +474,7 @@ suspend fun planCsvReimport(
         rewrites = rewrites,
         valueUpdates = valueUpdates,
         reversals = reversals,
+        tradeConversions = tradeConversions,
     )
 }
 
@@ -572,6 +614,43 @@ private suspend fun rewriteFor(
     )
 }
 
+/**
+ * Finds already-imported rows the current strategy maps to a cross-asset TRADE (`tradeTo` set) whose
+ * persisted transaction is still a single-asset transfer: their old transfer(s) are deleted and the
+ * row re-runs as a trade. Only IMPORTED/UPDATED rows with a transfer id are considered — a DUPLICATE
+ * row's transfer belongs to another row, and an already-converted row has a null transfer id (trades
+ * don't write one back), which keeps this pass idempotent. Rows already planned as pass-through
+ * rewrites are skipped: the rewrite deletes the old legs itself and the re-run imports the row fresh.
+ * [existingTransferLookup] must return null when the id no longer resolves to a transfer.
+ */
+internal suspend fun computeReimportTradeConversions(
+    allRows: List<CsvRow>,
+    mappedPrep: ImportPreparation,
+    rewrittenRowIndexes: Set<Long>,
+    relationshipRepository: TransferRelationshipReadRepository,
+    onProgress: (suspend (ImportProgress) -> Unit)? = null,
+    existingTransferLookup: suspend (TransferId) -> Transfer?,
+): List<ReimportTradeConversion> {
+    val rowsByIndex = allRows.associateBy { it.rowIndex }
+    val conversions = mutableListOf<ReimportTradeConversion>()
+    val total = mappedPrep.validTransfers.size
+    mappedPrep.validTransfers.forEachIndexed { index, mapped ->
+        emitRowProgress(onProgress, "Checking rows converting to trades", index, total)
+        if (mapped.tradeTo == null || mapped.rowIndex in rewrittenRowIndexes) return@forEachIndexed
+        val row = rowsByIndex[mapped.rowIndex] ?: return@forEachIndexed
+        if (row.importStatus != ImportStatus.IMPORTED && row.importStatus != ImportStatus.UPDATED) return@forEachIndexed
+        val transferId = row.transferId ?: return@forEachIndexed
+        if (existingTransferLookup(transferId) == null) return@forEachIndexed
+        conversions +=
+            ReimportTradeConversion(
+                rowIndex = row.rowIndex,
+                transferIdsToDelete = collectLinkedLegs(transferId, relationshipRepository).transferIds,
+                description = mapped.transfer.description,
+            )
+    }
+    return conversions
+}
+
 /** A row's transfer plus everything hanging off it via forward relationships. */
 private class LinkedLegs(
     val transferIds: List<TransferId>,
@@ -625,10 +704,13 @@ private suspend fun collectLinkedLegs(
  *    on the newly-mapped accounts, miss the ones still sitting on the duplicates, and import them twice;
  * 3. rewrites each planned pass-through row: deletes its old transfer(s) and resets the row's status —
  *    deleting BEFORE re-running rows for the same reason (dedupe must not match the stale transfer);
- * 4. re-runs the strategy over rows never imported, errored, or just reset, which now resolve via the
+ * 4. converts each planned trade row the same way: deletes its stale single-asset transfer(s) and
+ *    resets the row so the re-run imports it as a cross-asset trade;
+ * 5. re-runs the strategy over rows never imported, errored, or just reset, which now resolve via the
  *    new mappings and route through the current pass-through chains;
- * 5. deletes import-created accounts left with no transfers (e.g. the raw "CRV*…" merchants);
- * 6. refreshes materialized views.
+ * 6. deletes import-created accounts left with no transfers (e.g. the raw "CRV*…" merchants or the
+ *    description-named counterparties emptied by trade conversions);
+ * 7. refreshes materialized views.
  *
  * [onProgress] reports each step (with counts where known) for a progress UI. [valueUpdateChunkSize]
  * is exposed for tests to force multiple update chunks with a small fixture.
@@ -650,6 +732,7 @@ suspend fun executeCsvReimport(
     valueUpdateChunkSize: Int = REIMPORT_VALUE_UPDATE_CHUNK,
     refreshViews: Boolean = true,
     cryptoRepository: CryptoReadRepository? = null,
+    tradeRepository: TradeReadRepository? = null,
 ): CsvReimportResult {
     val merged = mutableListOf<ReimportMerge>()
     val skipped = plan.skipped.toMutableList()
@@ -730,6 +813,46 @@ suspend fun executeCsvReimport(
         }
     }
 
+    // One batch per conversion, mirroring the rewrite loop: the row's stale single-asset transfer(s)
+    // are deleted and its status reset in the same batch, so the re-run below re-imports it as a trade.
+    val converted = mutableListOf<ReimportTradeConversion>()
+    for ((index, conversion) in plan.tradeConversions.withIndex()) {
+        onProgress?.invoke(
+            ImportProgress(
+                "Converting transfers to trades",
+                fraction = index.toFloat() / plan.tradeConversions.size,
+                processed = index,
+                total = plan.tradeConversions.size,
+            ),
+        )
+        try {
+            importEngine.import(
+                ImportBatch(
+                    transfers =
+                        conversion.transferIdsToDelete.map { id ->
+                            ImportTransfer(
+                                source = Source.Csv(csvImport.id),
+                                operation = ImportOperation.DELETE,
+                                existingId = id,
+                            )
+                        },
+                    dedupePolicy = DedupePolicy.None,
+                    csvImportMutations = listOf(CsvImportMutation.ResetRowStatuses(csvImport.id, listOf(conversion.rowIndex))),
+                ),
+            )
+            converted += conversion
+        } catch (expected: Exception) {
+            logger.warn(expected) { "Re-import trade conversion of row ${conversion.rowIndex} ('${conversion.description}') failed" }
+            skipped +=
+                ReimportSkippedAccount(
+                    accountId = null,
+                    accountName = conversion.description,
+                    reason = ReimportSkipReason.TRADE_CONVERSION_FAILED,
+                    detail = expected.message ?: "Trade conversion failed",
+                )
+        }
+    }
+
     val importResult =
         applyStagedCsv(
             csvImport = csvImport,
@@ -749,7 +872,8 @@ suspend fun executeCsvReimport(
         )
 
     onProgress?.invoke(ImportProgress("Cleaning up empty accounts"))
-    val deletedEmptyAccounts = deleteEmptyImportCreatedAccounts(csvImport, accountRepository, csvImportRepository, importEngine)
+    val deletedEmptyAccounts =
+        deleteEmptyImportCreatedAccounts(csvImport, accountRepository, csvImportRepository, importEngine, tradeRepository)
 
     if (refreshViews) {
         onProgress?.invoke(ImportProgress("Refreshing views"))
@@ -764,6 +888,7 @@ suspend fun executeCsvReimport(
         rewrittenRows = rewritten,
         updatedRows = updatedRows,
         reversedMerges = reversedMerges,
+        convertedRows = converted,
     )
 }
 
@@ -888,14 +1013,17 @@ private suspend fun applyValueUpdates(
 }
 
 /**
- * Deletes accounts this import created that hold no transfers (merged-away duplicates are already
- * gone — this catches ones emptied without being merge targets). Returns the deleted names.
+ * Deletes accounts this import created that hold no transactions (merged-away duplicates are already
+ * gone — this catches ones emptied without being merge targets). Returns the deleted names. Trades
+ * count as activity: deleting an account cascades to its trades, so an account whose only movements
+ * are trades (e.g. the wallet a transfer→trade conversion just re-imported into) must survive.
  */
 private suspend fun deleteEmptyImportCreatedAccounts(
     csvImport: CsvImport,
     accountRepository: AccountReadRepository,
     csvImportRepository: CsvImportReadRepository,
     importEngine: ImportEngine,
+    tradeRepository: TradeReadRepository?,
 ): List<String> {
     val importCreated = csvImportRepository.getAccountsCreatedByImport(csvImport.id)
     val remainingById = accountRepository.getAllAccounts().first().associateBy { it.id }
@@ -903,6 +1031,7 @@ private suspend fun deleteEmptyImportCreatedAccounts(
         importCreated
             .mapNotNull { remainingById[it] }
             .filter { accountRepository.countTransfersByAccount(it.id) == 0L }
+            .filter { (tradeRepository?.countTradesByAccount(it.id) ?: 0L) == 0L }
     if (emptyAccounts.isEmpty()) return emptyList()
 
     importEngine.import(
@@ -936,6 +1065,7 @@ data class CsvBulkReimportResult(
     val merges: List<ReimportMerge>,
     val reversals: List<ReimportReversal>,
     val valueUpdates: Int,
+    val tradeConversions: Int,
     val emptyAccountsDeleted: Int,
     val skipped: List<ReimportSkippedAccount>,
 ) : BulkImportResult {
@@ -944,6 +1074,7 @@ data class CsvBulkReimportResult(
             append("Re-imported $filesImported file${if (filesImported == 1) "" else "s"}")
             append(" · $transfersCreated new")
             if (valueUpdates > 0) append(" · $valueUpdates updated")
+            if (tradeConversions > 0) append(" · $tradeConversions converted to trades")
             if (merges.isNotEmpty()) append(" · ${merges.size} account${if (merges.size == 1) "" else "s"} merged")
             if (reversals.isNotEmpty()) append(" · ${reversals.size} merge${if (reversals.size == 1) "" else "s"} reversed")
             if (emptyAccountsDeleted > 0) append(" · $emptyAccountsDeleted empty removed")
@@ -979,6 +1110,7 @@ suspend fun bulkReimportCsv(
     onProgress: (done: Int, total: Int) -> Unit,
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
     cryptoRepository: CryptoReadRepository? = null,
+    tradeRepository: TradeReadRepository? = null,
 ): CsvBulkReimportResult {
     var filesImported = 0
     var transfers = 0
@@ -988,6 +1120,7 @@ suspend fun bulkReimportCsv(
     val merges = mutableListOf<ReimportMerge>()
     val reversals = mutableListOf<ReimportReversal>()
     var valueUpdates = 0
+    var tradeConversions = 0
     var emptyAccountsDeleted = 0
     val skipped = mutableListOf<ReimportSkippedAccount>()
     // Create every crypto asset the batch needs up front, sized to the batch-wide max precision per
@@ -1040,6 +1173,8 @@ suspend fun bulkReimportCsv(
                     importEngine = importEngine,
                     passThroughAccounts = passThroughAccounts,
                     refreshViews = false,
+                    cryptoRepository = cryptoRepository,
+                    tradeRepository = tradeRepository,
                 )
             filesImported++
             transfers += result.importResult?.successCount ?: 0
@@ -1047,6 +1182,7 @@ suspend fun bulkReimportCsv(
             merges += result.mergedAccounts
             reversals += result.reversedMerges
             valueUpdates += result.updatedRows.size
+            tradeConversions += result.convertedRows.size
             emptyAccountsDeleted += result.deletedEmptyAccounts.size
             skipped += result.skipped
         } catch (expected: Exception) {
@@ -1067,6 +1203,7 @@ suspend fun bulkReimportCsv(
         merges = merges,
         reversals = reversals,
         valueUpdates = valueUpdates,
+        tradeConversions = tradeConversions,
         emptyAccountsDeleted = emptyAccountsDeleted,
         skipped = skipped,
     )

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -397,6 +397,23 @@ class CsvTransferMapper(
                 parseCurrency(currencyMapping, values)
                     ?: return MappingResult.Error(row.rowIndex, "Currency not found")
 
+            // Cross-asset conversion: when the strategy maps a TO_CURRENCY/TO_AMOUNT and the credited
+            // asset differs from the debited one, this row is a trade — the credited leg is captured
+            // here and the importer emits a `trade` (debit `amount`, credit `tradeTo`) instead of a
+            // single-asset transfer. Computed before account resolution because a trade may legally
+            // keep both legs in ONE account (e.g. a crypto→crypto exchange inside the same wallet),
+            // which the same-account checks below must not treat as a collision.
+            val tradeTo: Money? =
+                run {
+                    val toCurrencyMapping = strategy.fieldMappings[TransferField.TO_CURRENCY] ?: return@run null
+                    val toAmountMapping = strategy.fieldMappings[TransferField.TO_AMOUNT] ?: return@run null
+                    val toAsset = parseCurrency(toCurrencyMapping, values) ?: return@run null
+                    if (toAsset.id == currency.id) return@run null
+                    val toRaw = parseAmount(toAmountMapping, values).abs()
+                    if (toRaw.compareTo(BigDecimal.ZERO) == 0) return@run null
+                    Money.fromDisplayValue(toRaw, toAsset)
+                }
+
             // Determine if we need to flip accounts (sign-based flip XOR preprocessing flip)
             val amountFlip =
                 amountMapping is AmountParsingMapping &&
@@ -437,9 +454,12 @@ class CsvTransferMapper(
             // description can hijack the source leg too and collapse both onto one account. When the source
             // came from the strategy's own SOURCE_ACCOUNT mapping (no UI override) and now collides with the
             // target, re-resolve the source ignoring persisted mappings — its rule/historical name only —
-            // which restores the intended own-account (e.g. "Crypto.com Card").
+            // which restores the intended own-account (e.g. "Crypto.com Card"). A trade row is exempt:
+            // both legs landing in the same account is the intended shape (cross-asset, same wallet),
+            // so re-resolving would silently move one leg off a user-mapped account.
             var sourceUsedPersistedMappings = true
-            if (sourceAccountOverride == null &&
+            if (tradeTo == null &&
+                sourceAccountOverride == null &&
                 sourceAccountId == targetAccountId &&
                 sourceAccountId != AccountId(-1)
             ) {
@@ -509,7 +529,12 @@ class CsvTransferMapper(
             // resolved to the same real account (e.g. an account mapping that matches this row on both
             // sides), surface it as a per-row error instead of letting one bad row abort the whole file.
             // AccountId(-1) is the "new account" placeholder; two not-yet-created accounts stay distinct.
-            if (effectiveSourceAccountId == effectiveTargetAccountId && effectiveSourceAccountId != AccountId(-1)) {
+            // A trade row is exempt: the trade CHECK only requires the ASSETS to differ, so a same-account
+            // cross-asset exchange (e.g. BTC→ETH inside one wallet) is valid.
+            if (tradeTo == null &&
+                effectiveSourceAccountId == effectiveTargetAccountId &&
+                effectiveSourceAccountId != AccountId(-1)
+            ) {
                 val accountName =
                     existingAccounts.entries.firstOrNull { it.value.id == effectiveSourceAccountId }?.key
                 return MappingResult.Error(
@@ -532,21 +557,6 @@ class CsvTransferMapper(
 
             // Create Money with absolute value (direction is indicated by source/target)
             val amount = Money.fromDisplayValue(rawAmount.abs(), currency)
-
-            // Cross-asset conversion: when the strategy maps a TO_CURRENCY/TO_AMOUNT and the credited
-            // asset differs from the debited one, this row is a trade — the credited leg is captured
-            // here and the importer emits a `trade` (debit `amount`, credit `tradeTo`) instead of a
-            // single-asset transfer.
-            val tradeTo: Money? =
-                run {
-                    val toCurrencyMapping = strategy.fieldMappings[TransferField.TO_CURRENCY] ?: return@run null
-                    val toAmountMapping = strategy.fieldMappings[TransferField.TO_AMOUNT] ?: return@run null
-                    val toAsset = parseCurrency(toCurrencyMapping, values) ?: return@run null
-                    if (toAsset.id == currency.id) return@run null
-                    val toRaw = parseAmount(toAmountMapping, values).abs()
-                    if (toRaw.compareTo(BigDecimal.ZERO) == 0) return@run null
-                    Money.fromDisplayValue(toRaw, toAsset)
-                }
 
             // A fee is modelled as its own movement (linked to this transfer), not folded into the amount.
             val feeMagnitude = parseFeeMagnitude(amountMapping, values)

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoComCsvMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoComCsvMapperTest.kt
@@ -34,10 +34,12 @@ class CryptoComCsvMapperTest {
     private val now = Clock.System.now()
     private val cardStrategy = BuiltInCsvStrategies.buildCryptoComCardStrategy(now)
     private val fiatStrategy = BuiltInCsvStrategies.buildCryptoComFiatStrategy(now)
+    private val cryptoStrategy = BuiltInCsvStrategies.buildCryptoComCryptoStrategy(now)
 
     private val gbp = Currency(id = CurrencyId(1), code = "GBP", name = "British Pound")
     private val card = Account(id = AccountId(1), name = "Crypto.com Card", openingDate = now)
     private val cash = Account(id = AccountId(2), name = "Crypto.com Cash", openingDate = now)
+    private val cryptoWallet = Account(id = AccountId(3), name = "Crypto.com", openingDate = now)
 
     private val columns =
         listOf(
@@ -54,18 +56,29 @@ class CryptoComCsvMapperTest {
             "Transaction Hash",
         ).mapIndexed { index, name -> CsvColumn(CsvColumnId(Uuid.random()), index, name) }
 
-    // TGBP is a crypto asset (created on demand by ensureCryptoAssets in the real flow); provide it here
-    // so the mapper resolves it and the conversion rows map to cross-asset trades.
-    private val tgbp = CryptoAsset(id = CryptoId(100), code = "TGBP", name = "TGBP", scaleFactor = 100)
+    // TGBP/CRO are crypto assets (created on demand by ensureCryptoAssets in the real flow); provide
+    // them here so the mapper resolves them and the conversion rows map to cross-asset trades.
+    private val tgbp = CryptoAsset(id = CryptoId(100), code = "TGBP", name = "TGBP")
+    private val cro = CryptoAsset(id = CryptoId(101), code = "CRO", name = "CRO")
 
-    private fun mapper(strategy: CsvImportStrategy): CsvTransferMapper =
+    private fun mapper(
+        strategy: CsvImportStrategy,
+        cryptoWalletExists: Boolean = false,
+    ): CsvTransferMapper =
         CsvTransferMapper(
             strategy = strategy,
             columns = columns,
-            existingAccounts = mapOf(card.name to card, cash.name to cash),
+            existingAccounts =
+                buildMap {
+                    put(card.name, card)
+                    put(cash.name, cash)
+                    // The crypto-strategy tests resolve both legs of a same-account trade to this real
+                    // account; the fiat tests keep it absent so they can assert it gets discovered.
+                    if (cryptoWalletExists) put(cryptoWallet.name, cryptoWallet)
+                },
             existingCurrencies = mapOf(gbp.id to gbp),
             existingCurrenciesByCode = mapOf(gbp.code to gbp),
-            existingCryptoByCode = mapOf(tgbp.code to tgbp),
+            existingCryptoByCode = mapOf(tgbp.code to tgbp, cro.code to cro),
         )
 
     @Suppress("LongParameterList")
@@ -99,7 +112,12 @@ class CryptoComCsvMapperTest {
     private fun map(
         strategy: CsvImportStrategy,
         row: CsvRow,
-    ): MappingResult.Success = assertIs<MappingResult.Success>(mapper(strategy).mapRow(row), "mapping failed")
+        cryptoWalletExists: Boolean = false,
+    ): MappingResult.Success {
+        val result = mapper(strategy, cryptoWalletExists).mapRow(row)
+        if (result is MappingResult.Error) throw AssertionError("mapping failed: ${result.errorMessage}")
+        return assertIs<MappingResult.Success>(result, "mapping failed")
+    }
 
     private fun MappingResult.Success.newAccountName(): String {
         assertTrue(newAccounts.isNotEmpty(), "expected a discovered counterparty account")
@@ -184,6 +202,95 @@ class CryptoComCsvMapperTest {
         assertEquals(cash.id, r.transfer.sourceAccountId)
         assertEquals(card.id, r.transfer.targetAccountId)
         assertTrue(r.newAccounts.isEmpty())
+    }
+
+    // ---- Crypto strategy: cross-asset rows become trades ----
+
+    @Test
+    fun `crypto_exchange is a same-account trade inside the Crypto_com wallet`() {
+        val r =
+            map(
+                cryptoStrategy,
+                row("TGBP -> CRO", "TGBP", "-1499.936259", "CRO", "4965.5", "1499.94", "crypto_exchange"),
+                cryptoWalletExists = true,
+            )
+        // Both legs stay in the one wallet; only the assets differ. Must not be rejected as a
+        // source==target collision, and must not invent a "TGBP -> CRO" counterparty account.
+        assertEquals(cryptoWallet.id, r.transfer.sourceAccountId)
+        assertEquals(cryptoWallet.id, r.transfer.targetAccountId)
+        assertEquals(Money.fromDisplayValue(BigDecimal("1499.936259"), tgbp), r.transfer.amount)
+        assertEquals(Money.fromDisplayValue(BigDecimal("4965.5"), cro), r.tradeTo)
+        assertTrue(r.newAccounts.isEmpty(), "a same-account trade must not create counterparty accounts")
+    }
+
+    @Test
+    fun `crypto file viban_purchase mirrors the fiat trade - Cash GBP into Crypto_com as TGBP`() {
+        // Same event as the fiat file's viban_purchase (identical timestamp/description/amounts, but the
+        // crypto file's Amount is NEGATIVE) — identical accounts make the two files' trades dedupe.
+        val r =
+            map(
+                cryptoStrategy,
+                row("GBP -> TGBP", "GBP", "-5000.0", "TGBP", "5000.0", "5000.0", "viban_purchase"),
+                cryptoWalletExists = true,
+            )
+        assertEquals(cash.id, r.transfer.sourceAccountId)
+        assertEquals(cryptoWallet.id, r.transfer.targetAccountId)
+        assertEquals(Money.fromDisplayValue(BigDecimal("5000.0"), gbp), r.transfer.amount)
+        assertEquals(Money.fromDisplayValue(BigDecimal("5000.0"), tgbp), r.tradeTo)
+    }
+
+    @Test
+    fun `crypto file crypto_viban_exchange mirrors the fiat trade - Crypto_com TGBP into Cash as GBP`() {
+        val r =
+            map(
+                cryptoStrategy,
+                row("TGBP -> GBP", "TGBP", "-46.03", "GBP", "46.03", "46.03", "crypto_viban_exchange"),
+                cryptoWalletExists = true,
+            )
+        assertEquals(cryptoWallet.id, r.transfer.sourceAccountId)
+        assertEquals(cash.id, r.transfer.targetAccountId)
+        assertEquals(Money.fromDisplayValue(BigDecimal("46.03"), tgbp), r.transfer.amount)
+        assertEquals(Money.fromDisplayValue(BigDecimal("46.03"), gbp), r.tradeTo)
+    }
+
+    @Test
+    fun `crypto_payment with matching To Currency stays a plain transfer`() {
+        val r =
+            map(
+                cryptoStrategy,
+                row("Crypto payment", "CRO", "-100.0", "CRO", "-100.0", "10.0", "crypto_payment"),
+                cryptoWalletExists = true,
+            )
+        assertNull(r.tradeTo, "same-asset To Currency must not become a trade")
+        assertEquals(cryptoWallet.id, r.transfer.sourceAccountId)
+        assertEquals("Crypto payment", r.newAccountName())
+    }
+
+    @Test
+    fun `reward row with blank To Currency keeps the description counterparty`() {
+        val r =
+            map(
+                cryptoStrategy,
+                row("Card Cashback", "CRO", "0.37", "", "", "0.09", "referral_card_cashback"),
+                cryptoWalletExists = true,
+            )
+        assertNull(r.tradeTo)
+        // Positive amount flips: the cashback flows INTO the wallet from the discovered counterparty.
+        assertEquals(cryptoWallet.id, r.transfer.targetAccountId)
+        assertEquals("Card Cashback", r.newAccountName())
+    }
+
+    @Test
+    fun `App wallet transfer still routes to the Exchange account`() {
+        val r =
+            map(
+                cryptoStrategy,
+                row("Withdraw to Exchange from App wallet", "CRO", "-500.0", "", "", "50.0", "crypto_to_exchange_transfer"),
+                cryptoWalletExists = true,
+            )
+        assertNull(r.tradeTo)
+        assertEquals(cryptoWallet.id, r.transfer.sourceAccountId)
+        assertEquals("Crypto.com Exchange", r.newAccountName())
     }
 
     // ---- Selection across the three crypto.com export flavours ----

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvReimportDetectionTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvReimportDetectionTest.kt
@@ -21,6 +21,7 @@ import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
 import com.moneymanager.domain.model.csvstrategy.DateTimeParsingMapping
 import com.moneymanager.domain.model.csvstrategy.DirectColumnMapping
 import com.moneymanager.domain.model.csvstrategy.FieldMappingId
@@ -563,5 +564,139 @@ class CsvReimportDetectionTest {
             val rewrites = computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(emptyMap())) { null }
 
             assertTrue(rewrites.isEmpty())
+        }
+
+    // ============= Retroactive transfer→trade conversions =============
+
+    private val eur = Currency(id = CurrencyId(2), code = "EUR", name = "Euro")
+    private val feeType = RelationshipType(RelationshipTypeId(2), "fee")
+
+    private val tradeColumns =
+        columns +
+            listOf(
+                CsvColumn(CsvColumnId(Uuid.random()), 4, "To Currency"),
+                CsvColumn(CsvColumnId(Uuid.random()), 5, "To Amount"),
+            )
+
+    /** The base strategy plus TO_CURRENCY/TO_AMOUNT mappings, so cross-currency rows map to trades. */
+    private fun tradeStrategy(): CsvImportStrategy {
+        val base = strategy()
+        return base.copy(
+            fieldMappings =
+                base.fieldMappings +
+                    mapOf(
+                        TransferField.TO_CURRENCY to
+                            CurrencyLookupMapping(
+                                id = FieldMappingId(Uuid.random()),
+                                fieldType = TransferField.TO_CURRENCY,
+                                columnName = "To Currency",
+                            ),
+                        TransferField.TO_AMOUNT to
+                            AmountParsingMapping(
+                                id = FieldMappingId(Uuid.random()),
+                                fieldType = TransferField.TO_AMOUNT,
+                                mode = AmountMode.SINGLE_COLUMN,
+                                amountColumnName = "To Amount",
+                            ),
+                    ),
+        )
+    }
+
+    private fun tradePrep(rows: List<CsvRow>): ImportPreparation =
+        CsvTransferMapper(
+            strategy = tradeStrategy(),
+            columns = tradeColumns,
+            existingAccounts = listOf(account(1, "Wallet"), account(10, "Broker")).associateBy { it.name },
+            existingCurrencies = mapOf(currencyId to currency, eur.id to eur),
+            existingCurrenciesByCode = mapOf(currency.code.uppercase() to currency, eur.code.uppercase() to eur),
+        ).prepareImport(rows)
+
+    private fun tradeRow(
+        index: Long = 1,
+        toCurrency: String = "EUR",
+        transferId: TransferId? = TransferId(100),
+        importStatus: ImportStatus? = ImportStatus.IMPORTED,
+    ) = CsvRow(
+        rowIndex = index,
+        values = listOf("15/12/2024", "GBP -> EUR", "-50.00", "Broker", toCurrency, "55.00"),
+        transferId = transferId,
+        importStatus = importStatus,
+    )
+
+    @Test
+    fun `imported single-leg transfer whose row now maps to a trade is converted with its linked legs`() =
+        runTest {
+            val rows = listOf(tradeRow())
+            val mappedPrep = tradePrep(rows)
+            val existing =
+                mappedPrep.validTransfers
+                    .single()
+                    .transfer
+                    .copy(id = TransferId(100))
+            // The old transfer carries a linked fee leg; both must be deleted with the conversion.
+            val relationships =
+                mapOf(TransferId(100) to listOf(TransferRelationship(TransferId(100), TransferId(101), feeType)))
+
+            val conversions =
+                computeReimportTradeConversions(rows, mappedPrep, emptySet(), FakeRelationshipRepository(relationships)) { existing }
+
+            val conversion = conversions.single()
+            assertEquals(1L, conversion.rowIndex)
+            assertEquals(listOf(TransferId(100), TransferId(101)), conversion.transferIdsToDelete)
+        }
+
+    @Test
+    fun `duplicate, unimported and already-converted rows are never trade-converted`() =
+        runTest {
+            val rows =
+                listOf(
+                    // DUPLICATE: its transfer belongs to another row.
+                    tradeRow(index = 1, importStatus = ImportStatus.DUPLICATE),
+                    // Already converted: trades write no transfer id back.
+                    tradeRow(index = 2, transferId = null),
+                    // Never imported: applyStagedCsv picks it up anyway.
+                    tradeRow(index = 3, transferId = null, importStatus = null),
+                )
+            val mappedPrep = tradePrep(rows)
+            val existing =
+                mappedPrep.validTransfers
+                    .first()
+                    .transfer
+                    .copy(id = TransferId(100))
+
+            val conversions =
+                computeReimportTradeConversions(rows, mappedPrep, emptySet(), FakeRelationshipRepository(emptyMap())) { existing }
+
+            assertTrue(conversions.isEmpty())
+        }
+
+    @Test
+    fun `rows already planned as rewrites or with dangling transfers are skipped`() =
+        runTest {
+            val rows = listOf(tradeRow(index = 1), tradeRow(index = 2))
+            val mappedPrep = tradePrep(rows)
+
+            // Row 1 is owned by a pass-through rewrite; row 2's transfer id no longer resolves.
+            val conversions =
+                computeReimportTradeConversions(rows, mappedPrep, setOf(1L), FakeRelationshipRepository(emptyMap())) { null }
+
+            assertTrue(conversions.isEmpty())
+        }
+
+    @Test
+    fun `same-currency To column does not convert the row`() =
+        runTest {
+            val rows = listOf(tradeRow(toCurrency = "GBP"))
+            val mappedPrep = tradePrep(rows)
+            val existing =
+                mappedPrep.validTransfers
+                    .single()
+                    .transfer
+                    .copy(id = TransferId(100))
+
+            val conversions =
+                computeReimportTradeConversions(rows, mappedPrep, emptySet(), FakeRelationshipRepository(emptyMap())) { existing }
+
+            assertTrue(conversions.isEmpty())
         }
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/Application.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/Application.kt
@@ -27,6 +27,7 @@ import com.moneymanager.domain.repository.PersonWriteRepository
 import com.moneymanager.domain.repository.QifImportWriteRepository
 import com.moneymanager.domain.repository.RelationshipTypeWriteRepository
 import com.moneymanager.domain.repository.SettingsWriteRepository
+import com.moneymanager.domain.repository.TradeWriteRepository
 import com.moneymanager.domain.repository.TransactionWriteRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.domain.repository.TransferSourceReadRepository
@@ -71,6 +72,7 @@ data class Transactions(
     val attributeTypeRepository: AttributeTypeWriteRepository,
     val relationshipTypeRepository: RelationshipTypeWriteRepository,
     val transferRelationshipRepository: TransferRelationshipReadRepository,
+    val tradeRepository: TradeWriteRepository,
 )
 
 data class People(

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCryptoE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCryptoE2ETest.kt
@@ -6,12 +6,18 @@ import com.moneymanager.csvimporter.bulkApplyCsv
 import com.moneymanager.csvimporter.bulkReimportCsv
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.csv.CsvImport
+import com.moneymanager.domain.model.csv.ImportStatus
+import com.moneymanager.domain.model.csvstrategy.RegexAccountMapping
+import com.moneymanager.domain.model.csvstrategy.RegexRule
+import com.moneymanager.domain.model.csvstrategy.TransferField
+import com.moneymanager.importengineapi.updateCsvStrategy
 import com.moneymanager.test.database.DbTest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.time.Clock
 import kotlin.time.Duration
 
@@ -61,7 +67,9 @@ class CryptoComCryptoE2ETest : DbTest() {
         amount: String,
         nativeAmount: String,
         kind: String,
-    ): List<String> = listOf(timestamp, description, currency, amount, "", "", "GBP", nativeAmount, "0.0", kind, "")
+        toCurrency: String = "",
+        toAmount: String = "",
+    ): List<String> = listOf(timestamp, description, currency, amount, toCurrency, toAmount, "GBP", nativeAmount, "0.0", kind, "")
 
     private suspend fun stage(
         fileName: String,
@@ -109,6 +117,7 @@ class CryptoComCryptoE2ETest : DbTest() {
             importEngine = repositories.importEngine,
             onProgress = { _, _ -> },
             cryptoRepository = repositories.cryptoRepository,
+            tradeRepository = repositories.tradeRepository,
         )
 
     @Test
@@ -172,6 +181,240 @@ class CryptoComCryptoE2ETest : DbTest() {
                     .balance
             assertEquals("CRO", balance.currency.code)
             assertEquals("0.79", balance.toDisplayValue().toString())
+        }
+
+    private suspend fun accountByName(name: String) =
+        repositories.accountRepository
+            .getAllAccounts()
+            .first()
+            .firstOrNull { it.name == name }
+
+    private suspend fun balanceOf(
+        accountName: String,
+        assetCode: String,
+    ): String {
+        repositories.maintenanceService.refreshMaterializedViews()
+        val account = assertNotNull(accountByName(accountName))
+        return repositories.transactionRepository
+            .getAccountBalances()
+            .first()
+            .first { it.accountId == account.id && it.balance.currency.code == assetCode }
+            .balance
+            .toDisplayValue()
+            .toString()
+    }
+
+    @Test
+    fun cryptoExchange_importsAsSameAccountTrade() =
+        runTest {
+            // A crypto→crypto exchange inside the App wallet: one row, TGBP out and CRO in, both legs
+            // in the single "Crypto.com" account. Previously this imported as a single-leg transfer
+            // into a junk "TGBP -> CRO" account, losing the bought leg.
+            val file =
+                stage(
+                    "crypto_transactions_record_exchange.csv",
+                    listOf(
+                        row(
+                            "2022-03-12 12:17:57",
+                            "TGBP -> CRO",
+                            "TGBP",
+                            "-1499.936259",
+                            "1499.94",
+                            "crypto_exchange",
+                            toCurrency = "CRO",
+                            toAmount = "4965.5",
+                        ),
+                    ),
+                )
+            applyAll(listOf(file))
+
+            val wallet = assertNotNull(accountByName("Crypto.com"))
+            assertNull(accountByName("TGBP -> CRO"), "must not create a junk description-named account")
+
+            val trades = repositories.tradeRepository.getTradesByAccount(wallet.id).first()
+            assertEquals(1, trades.size)
+            val trade = trades.single()
+            assertEquals(wallet.id, trade.fromAccountId)
+            assertEquals(wallet.id, trade.toAccountId)
+            assertEquals("TGBP", trade.from.currency.code)
+            assertEquals("1499.936259", trade.from.toDisplayValue().toString())
+            assertEquals("CRO", trade.to.currency.code)
+            assertEquals("4965.5", trade.to.toDisplayValue().toString())
+
+            // Both per-asset balances move inside the one account.
+            assertEquals("-1499.936259", balanceOf("Crypto.com", "TGBP"))
+            assertEquals("4965.5", balanceOf("Crypto.com", "CRO"))
+
+            val staged =
+                repositories.csvImportRepository
+                    .getImportRows(file.id, limit = 10, offset = 0)
+                    .single()
+            assertEquals(ImportStatus.IMPORTED, staged.importStatus)
+        }
+
+    @Test
+    fun vibanRows_dedupeAgainstFiatTrades_eitherImportOrder() =
+        runTest {
+            // The same viban purchase appears in BOTH exports (identical timestamp/description/amounts;
+            // the fiat file's Amount is positive, the crypto file's negative). Both strategies must
+            // produce the identical trade so createTrade's exact match books it once — whichever file
+            // imports first — and the second file's row surfaces as DUPLICATE.
+            val fiatRow =
+                row("2022-03-24 22:34:02", "GBP -> TGBP", "GBP", "5000.0", "5000.0", "viban_purchase", "TGBP", "5000.0")
+            val cryptoRow =
+                row("2022-03-24 22:34:02", "GBP -> TGBP", "GBP", "-5000.0", "5000.0", "viban_purchase", "TGBP", "5000.0")
+            val fiat = stage("fiat_transactions_record_20220325_000000.csv", listOf(fiatRow))
+            val crypto = stage("crypto_transactions_record_20220325_000000.csv", listOf(cryptoRow))
+
+            // Fiat first, then crypto.
+            applyAll(listOf(fiat))
+            applyAll(listOf(crypto))
+
+            val wallet = assertNotNull(accountByName("Crypto.com"))
+            val cash = assertNotNull(accountByName("Crypto.com Cash"))
+            val trades = repositories.tradeRepository.getTradesByAccount(wallet.id).first()
+            assertEquals(1, trades.size, "the two files record ONE purchase — exactly one trade")
+            assertEquals(cash.id, trades.single().fromAccountId)
+            assertEquals(wallet.id, trades.single().toAccountId)
+
+            val cryptoStaged = repositories.csvImportRepository.getImportRows(crypto.id, limit = 10, offset = 0).single()
+            assertEquals(ImportStatus.DUPLICATE, cryptoStaged.importStatus, "second source's row must surface as DUPLICATE")
+            val fiatStaged = repositories.csvImportRepository.getImportRows(fiat.id, limit = 10, offset = 0).single()
+            assertEquals(ImportStatus.IMPORTED, fiatStaged.importStatus)
+        }
+
+    @Test
+    fun vibanRows_dedupeAgainstFiatTrades_cryptoFileFirst() =
+        runTest {
+            val fiatRow =
+                row("2022-06-16 04:55:30", "TGBP -> GBP", "TGBP", "46.03", "46.03", "crypto_viban", "GBP", "46.03")
+            val cryptoRow =
+                row("2022-06-16 04:55:30", "TGBP -> GBP", "TGBP", "-46.03", "46.03", "crypto_viban_exchange", "GBP", "46.03")
+            val crypto = stage("crypto_transactions_record_20220617_000000.csv", listOf(cryptoRow))
+            val fiat = stage("fiat_transactions_record_20220617_000000.csv", listOf(fiatRow))
+
+            // Crypto first, then fiat: the dedupe must be symmetric.
+            applyAll(listOf(crypto))
+            applyAll(listOf(fiat))
+
+            val wallet = assertNotNull(accountByName("Crypto.com"))
+            val cash = assertNotNull(accountByName("Crypto.com Cash"))
+            val trades = repositories.tradeRepository.getTradesByAccount(wallet.id).first()
+            assertEquals(1, trades.size)
+            assertEquals(wallet.id, trades.single().fromAccountId)
+            assertEquals(cash.id, trades.single().toAccountId)
+
+            assertEquals(
+                ImportStatus.IMPORTED,
+                repositories.csvImportRepository
+                    .getImportRows(crypto.id, limit = 10, offset = 0)
+                    .single()
+                    .importStatus,
+            )
+            assertEquals(
+                ImportStatus.DUPLICATE,
+                repositories.csvImportRepository
+                    .getImportRows(fiat.id, limit = 10, offset = 0)
+                    .single()
+                    .importStatus,
+            )
+        }
+
+    @Test
+    fun reimport_convertsOldSingleLegTransferToTrade() =
+        runTest {
+            // Upgrade path: a crypto_exchange row imported under the OLD strategy definition (no
+            // TO_CURRENCY/TO_AMOUNT mappings) produced a single-leg transfer into a junk
+            // description-named account. Re-importing under the CURRENT definition must delete that
+            // transfer, import the row as a trade, and remove the emptied junk account.
+            val strategies = repositories.csvImportStrategyRepository.getAllStrategies().first()
+            val current = strategies.first { it.name == "Crypto.com Crypto" }
+            val old =
+                current.copy(
+                    fieldMappings =
+                        current.fieldMappings
+                            .filterKeys { it != TransferField.TO_CURRENCY && it != TransferField.TO_AMOUNT }
+                            .mapValues { (field, mapping) ->
+                                if (field == TransferField.TARGET_ACCOUNT) {
+                                    RegexAccountMapping(
+                                        id = mapping.id,
+                                        fieldType = TransferField.TARGET_ACCOUNT,
+                                        columnName = "Transaction Description",
+                                        rules = listOf(RegexRule(pattern = "App wallet", accountName = "Crypto.com Exchange")),
+                                    )
+                                } else {
+                                    mapping
+                                }
+                            },
+                )
+            repositories.importEngine.updateCsvStrategy(old)
+
+            val file =
+                stage(
+                    "crypto_transactions_record_old.csv",
+                    listOf(
+                        row(
+                            "2021-10-15 03:49:59",
+                            "BTC -> CRO",
+                            "BTC",
+                            "-0.00002502",
+                            "1.06",
+                            "crypto_exchange",
+                            toCurrency = "CRO",
+                            toAmount = "7.8",
+                        ),
+                    ),
+                )
+            applyAll(listOf(file))
+            val wallet = assertNotNull(accountByName("Crypto.com"))
+            assertNotNull(accountByName("BTC -> CRO"), "old strategy creates the junk counterparty account")
+            assertEquals(
+                0,
+                repositories.tradeRepository
+                    .getTradesByAccount(wallet.id)
+                    .first()
+                    .size,
+            )
+
+            // The strategy definition is updated (the catalog-update path) and the file re-imported.
+            repositories.importEngine.updateCsvStrategy(current)
+            val result = reimportAll(repositories.csvImportRepository.getAllImports().first())
+            assertEquals(1, result.tradeConversions, "the junk transfer row must convert to a trade")
+
+            val trades = repositories.tradeRepository.getTradesByAccount(wallet.id).first()
+            assertEquals(1, trades.size)
+            assertEquals(
+                "BTC",
+                trades
+                    .single()
+                    .from.currency.code,
+            )
+            assertEquals(
+                "CRO",
+                trades
+                    .single()
+                    .to.currency.code,
+            )
+            assertNull(accountByName("BTC -> CRO"), "emptied junk account must be deleted")
+            assertEquals(
+                ImportStatus.IMPORTED,
+                repositories.csvImportRepository
+                    .getImportRows(file.id, limit = 10, offset = 0)
+                    .single()
+                    .importStatus,
+            )
+
+            // A second re-import is a no-op: the row now has no transfer id, so the conversion pass
+            // must not fire again, and createTrade's idempotency keeps the single trade.
+            val again = reimportAll(repositories.csvImportRepository.getAllImports().first())
+            assertEquals(0, again.tradeConversions)
+            assertEquals(
+                1,
+                repositories.tradeRepository
+                    .getTradesByAccount(wallet.id)
+                    .first()
+                    .size,
+            )
         }
 
     @Test

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TradeReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TradeReadRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.moneymanager.domain.model.TradeId
 import com.moneymanager.domain.repository.TradeReadRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 
 class TradeReadRepositoryImpl(
     database: MoneyManagerDatabase,
@@ -28,4 +29,9 @@ class TradeReadRepositoryImpl(
             .selectByAccount(accountId.id, accountId.id, TradeMapper::mapRaw)
             .asFlow()
             .mapToList(Dispatchers.Default)
+
+    override suspend fun countTradesByAccount(accountId: AccountId): Long =
+        withContext(Dispatchers.Default) {
+            selectQueries.countByAccount(accountId.id).executeAsOne()
+        }
 }

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/trade/TradeSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/trade/TradeSelect.sq
@@ -63,3 +63,8 @@ JOIN asset_details fa ON trade.from_asset_id = fa.id
 JOIN asset_details ta ON trade.to_asset_id = ta.id
 WHERE trade.from_account_id = ? OR trade.to_account_id = ?
 ORDER BY trade.timestamp DESC;
+
+countByAccount:
+SELECT COUNT(*)
+FROM trade
+WHERE from_account_id = :accountId OR to_account_id = :accountId;

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/TradeWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/TradeWriteRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.moneymanager.domain.model.EntityType
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.TradeId
+import com.moneymanager.domain.repository.TradeCreateResult
 import com.moneymanager.domain.repository.TradeReadRepository
 import com.moneymanager.domain.repository.TradeWriteRepository
 import kotlinx.coroutines.Dispatchers
@@ -34,7 +35,7 @@ class TradeWriteRepositoryImpl(
         toAccountId: AccountId,
         toAmount: Money,
         source: Source,
-    ): TradeId {
+    ): TradeCreateResult {
         // A trade is a cross-asset exchange; a same-asset movement is a transfer. The DB CHECK only
         // blocks the same-account+same-asset degenerate case, so enforce the cross-asset rule here.
         require(fromAmount.currency.id != toAmount.currency.id) {
@@ -57,7 +58,7 @@ class TradeWriteRepositoryImpl(
                             to_amount = toAmount.amount.toString(),
                         ).executeAsOneOrNull()
                 if (existing != null) {
-                    return@transactionWithResult TradeId(existing)
+                    return@transactionWithResult TradeCreateResult(TradeId(existing), created = false)
                 }
                 // Allocate a transaction id (insert + last_insert_rowid must share a connection).
                 transactionIdWriteQueries.insert()
@@ -75,7 +76,7 @@ class TradeWriteRepositoryImpl(
                     to_amount = toAmount.amount.toString(),
                 )
                 database.recordSource(deviceId, EntityType.TRADE, id, 1L, source)
-                TradeId(id)
+                TradeCreateResult(TradeId(id), created = true)
             }
         }
     }

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/ApplicationMapper.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/ApplicationMapper.kt
@@ -43,6 +43,7 @@ fun DatabaseComponent.toApplication() =
                 attributeTypeRepository = attributeTypeRepository,
                 relationshipTypeRepository = relationshipTypeRepository,
                 transferRelationshipRepository = transferRelationshipRepository,
+                tradeRepository = tradeRepository,
             ),
         people =
             People(

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportResult.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportResult.kt
@@ -62,6 +62,11 @@ data class ImportResult(
     val createdCurrencyIds: Map<LocalCurrencyKey, CurrencyId> = emptyMap(),
     val createdCryptoIds: Map<LocalCryptoKey, CryptoId> = emptyMap(),
     val createdTradeIds: Map<LocalTradeKey, TradeId> = emptyMap(),
+    /**
+     * Keys of trade intents that matched an existing identical trade instead of inserting a new one
+     * (createTrade is idempotent). [createdTradeIds] still maps these keys to the existing trade's id.
+     */
+    val dedupedTradeKeys: Set<LocalTradeKey> = emptySet(),
     /** Resolved (get-or-create) attribute-type ids for each name in [ImportBatch.attributeTypeNames]. */
     val attributeTypeIds: Map<String, AttributeTypeId> = emptyMap(),
     /** Resolved (get-or-create) relationship-type ids for each name in [ImportBatch.relationshipTypeNames]. */

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -153,8 +153,9 @@ class ImportEngineImpl(
                 cryptoRepository.upsertCryptoByCode(requireNotNull(intent.code), intent.name, intent.source)
         }
         val createdTradeIds = mutableMapOf<LocalTradeKey, TradeId>()
+        val dedupedTradeKeys = mutableSetOf<LocalTradeKey>()
         for (intent in batch.trades) {
-            createdTradeIds[intent.key] =
+            val tradeResult =
                 tradeRepository.createTrade(
                     timestamp = intent.timestamp,
                     description = intent.description,
@@ -164,6 +165,8 @@ class ImportEngineImpl(
                     toAmount = intent.toAmount,
                     source = intent.source,
                 )
+            createdTradeIds[intent.key] = tradeResult.id
+            if (!tradeResult.created) dedupedTradeKeys += intent.key
         }
         val createdCategoryIds = mutableMapOf<LocalCategoryKey, Long>()
         for (intent in batch.categories.creates()) {
@@ -261,6 +264,7 @@ class ImportEngineImpl(
             createdCurrencyIds = createdCurrencyIds,
             createdCryptoIds = createdCryptoIds,
             createdTradeIds = createdTradeIds,
+            dedupedTradeKeys = dedupedTradeKeys,
             attributeTypeIds = attributeTypeIds,
             relationshipTypeIds = relationshipTypeIds,
             createdCsvStrategyIds = config.csvStrategyIds,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TradeReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TradeReadRepository.kt
@@ -9,4 +9,7 @@ interface TradeReadRepository {
     fun getTradeById(id: TradeId): Flow<Trade?>
 
     fun getTradesByAccount(accountId: AccountId): Flow<List<Trade>>
+
+    /** Number of trades touching [accountId] on either leg. */
+    suspend fun countTradesByAccount(accountId: AccountId): Long
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TradeWriteRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TradeWriteRepository.kt
@@ -8,11 +8,22 @@ import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.TradeId
 import kotlin.time.Instant
 
+/**
+ * Outcome of [TradeWriteRepository.createTrade]: the trade's id plus whether a new row was inserted.
+ * [created] is false when an identical trade already existed (the idempotent re-import/cross-source
+ * path), letting callers surface the row as a duplicate instead of a fresh import.
+ */
+data class TradeCreateResult(
+    val id: TradeId,
+    val created: Boolean,
+)
+
 interface TradeWriteRepository : TradeReadRepository {
     /**
      * Creates a cross-asset trade: [fromAmount] leaves [fromAccountId], [toAmount] enters
      * [toAccountId] (the two [Money] legs may be denominated in different assets). Allocates a
-     * `transaction_id`, inserts the trade, and records provenance.
+     * `transaction_id`, inserts the trade, and records provenance. Idempotent: if an identical
+     * trade already exists it is returned with [TradeCreateResult.created] = false.
      */
     @Suppress("LongParameterList")
     suspend fun createTrade(
@@ -23,7 +34,7 @@ interface TradeWriteRepository : TradeReadRepository {
         toAccountId: AccountId,
         toAmount: Money,
         source: Source,
-    ): TradeId
+    ): TradeCreateResult
 
     suspend fun deleteTrade(id: TradeId)
 }

--- a/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
+++ b/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
@@ -331,7 +331,7 @@ object BuiltInCsvStrategies {
                 // demand as a crypto asset, so the conversion becomes a trade.
                 TransferField.TO_AMOUNT to
                     AmountParsingMapping(
-                        id = cryptoComFiatMappingId(9),
+                        id = cryptoComFiatMappingId(11),
                         fieldType = TransferField.TO_AMOUNT,
                         mode = AmountMode.SINGLE_COLUMN,
                         amountColumnName = "To Amount",
@@ -406,29 +406,76 @@ object BuiltInCsvStrategies {
      * Cashback") the TARGET; [AmountParsingMapping.flipAccountsOnPositive] then makes a positive amount
      * (rewards) flow INTO the account and a negative amount (a spend/swap out) flow OUT of it —
      * mirroring the card strategy's sign convention.
+     *
+     * Cross-asset rows (To Currency present and different from Currency) become TRADES, exactly like
+     * the fiat strategy's viban conversions:
+     *
+     * - crypto_exchange ("TGBP -> CRO"): a crypto→crypto exchange inside the App wallet — a
+     *   same-account trade Crypto.com(sold) → Crypto.com(bought).
+     * - viban_purchase ("GBP -> TGBP", fiat buy) debits the Cash account and credits Crypto.com;
+     *   crypto_viban_exchange ("TGBP -> GBP", sell) debits Crypto.com and credits Cash. Both events
+     *   ALSO appear in the fiat export (kinds viban_purchase/crypto_viban) with identical
+     *   timestamp/description/amounts, so routing them to the same accounts here makes both files
+     *   produce byte-identical trades — createTrade's exact-match idempotency then books each event
+     *   once regardless of which file imports first. (A UI source-account override bypasses the
+     *   kind-based source rule and would defeat that dedupe; built-ins assume no override.)
+     *
+     * All cross-asset rows carry a NEGATIVE Amount (the debited leg), so flip-on-positive never fires
+     * for them and the debit stays on the source side.
      */
     fun buildCryptoComCryptoStrategy(now: Instant): CsvImportStrategy {
         val fieldMappings =
             mapOf(
                 // All crypto lands in the single "Crypto.com" account (one balance per asset), not a
-                // separate wallet per ticker. The always-matching "^" rule routes every row there.
+                // separate wallet per ticker — except viban_purchase, whose debited leg is the fiat
+                // balance held in the Cash account. The "^" fallback rule routes every other row to
+                // the Crypto.com account.
                 TransferField.SOURCE_ACCOUNT to
                     RegexAccountMapping(
                         id = cryptoComCryptoMappingId(1),
                         fieldType = TransferField.SOURCE_ACCOUNT,
-                        columnName = "Transaction Description",
-                        rules = listOf(RegexRule(pattern = "^", accountName = CRYPTO_COM_CRYPTO_ACCOUNT)),
+                        columnName = "Transaction Kind",
+                        rules =
+                            listOf(
+                                RegexRule(pattern = "^viban_purchase$", accountName = CRYPTO_COM_CASH_ACCOUNT),
+                                RegexRule(pattern = "^", accountName = CRYPTO_COM_CRYPTO_ACCOUNT),
+                            ),
                     ),
-                // Counterparty (reward source / merchant) looked up from the description, except App<->Exchange
-                // transfers which route to the shared "Crypto.com Exchange" account (see the constant's KDoc).
-                // Both descriptions contain "App wallet"; the flip-on-positive turns the pre-flip target into
-                // the source for the "Exchange -> App wallet" (received) direction.
+                // Cross-asset rows (a trade's credited leg) route to the account holding the credited
+                // asset: fiat from a sell goes to the Cash account, crypto stays in Crypto.com. The
+                // IS_NOT_BLANK condition matters: most rows have a BLANK To Currency and must keep the
+                // single-asset routing below.
+                // Single-asset rows keep the description-derived counterparty (reward source / merchant),
+                // except App<->Exchange transfers which route to the shared "Crypto.com Exchange" account
+                // (see the constant's KDoc). Both descriptions contain "App wallet"; the flip-on-positive
+                // turns the pre-flip target into the source for the "Exchange -> App wallet" direction.
                 TransferField.TARGET_ACCOUNT to
-                    RegexAccountMapping(
+                    ConditionalAccountMapping(
                         id = cryptoComCryptoMappingId(2),
                         fieldType = TransferField.TARGET_ACCOUNT,
-                        columnName = "Transaction Description",
-                        rules = listOf(RegexRule(pattern = "App wallet", accountName = CRYPTO_COM_EXCHANGE_ACCOUNT)),
+                        conditions =
+                            listOf(
+                                RowCondition("To Currency", RowConditionOperator.IS_NOT_BLANK),
+                                RowCondition("Currency", RowConditionOperator.NOT_EQUALS_COLUMN, otherColumnName = "To Currency"),
+                            ),
+                        whenTrue =
+                            RegexAccountMapping(
+                                id = cryptoComCryptoMappingId(10),
+                                fieldType = TransferField.TARGET_ACCOUNT,
+                                columnName = "Transaction Kind",
+                                rules =
+                                    listOf(
+                                        RegexRule(pattern = "^crypto_viban_exchange$", accountName = CRYPTO_COM_CASH_ACCOUNT),
+                                        RegexRule(pattern = "^", accountName = CRYPTO_COM_CRYPTO_ACCOUNT),
+                                    ),
+                            ),
+                        whenFalse =
+                            RegexAccountMapping(
+                                id = cryptoComCryptoMappingId(11),
+                                fieldType = TransferField.TARGET_ACCOUNT,
+                                columnName = "Transaction Description",
+                                rules = listOf(RegexRule(pattern = "App wallet", accountName = CRYPTO_COM_EXCHANGE_ACCOUNT)),
+                            ),
                     ),
                 TransferField.TIMESTAMP to
                     DateTimeParsingMapping(
@@ -465,6 +512,22 @@ object BuiltInCsvStrategies {
                         id = cryptoComCryptoMappingId(7),
                         fieldType = TransferField.TIMEZONE,
                         timezoneId = "UTC",
+                    ),
+                // Credit leg of a cross-asset row → the importer emits a trade when To Currency differs
+                // from Currency (blank To Currency rows are unaffected). Any non-fiat To/From Currency
+                // is created on demand as a crypto asset.
+                TransferField.TO_AMOUNT to
+                    AmountParsingMapping(
+                        id = cryptoComCryptoMappingId(8),
+                        fieldType = TransferField.TO_AMOUNT,
+                        mode = AmountMode.SINGLE_COLUMN,
+                        amountColumnName = "To Amount",
+                    ),
+                TransferField.TO_CURRENCY to
+                    CurrencyLookupMapping(
+                        id = cryptoComCryptoMappingId(9),
+                        fieldType = TransferField.TO_CURRENCY,
+                        columnName = "To Currency",
                     ),
             )
         val attributeMappings =

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppServices.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppServices.kt
@@ -27,6 +27,7 @@ import com.moneymanager.domain.repository.PersonAttributeReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.domain.repository.QifImportReadRepository
 import com.moneymanager.domain.repository.SettingsReadRepository
+import com.moneymanager.domain.repository.TradeReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.domain.repository.TransferSourceReadRepository
@@ -77,6 +78,7 @@ data class TransactionsDomain(
     val transferSourceRepository: TransferSourceReadRepository,
     val attributeTypeRepository: AttributeTypeReadRepository,
     val transferRelationshipRepository: TransferRelationshipReadRepository,
+    val tradeRepository: TradeReadRepository,
     val importEngine: ImportEngine,
 )
 
@@ -131,6 +133,7 @@ fun Application.toAppServices(importEngine: ImportEngine) =
                 transferSourceRepository = transactions.transferSourceRepository,
                 attributeTypeRepository = transactions.attributeTypeRepository,
                 transferRelationshipRepository = transactions.transferRelationshipRepository,
+                tradeRepository = transactions.tradeRepository,
                 importEngine = importEngine,
             ),
         people =

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -516,6 +516,7 @@ fun MoneyManagerApp(
                                                 transactionRepository = services.transactions.transactionRepository,
                                                 transferRelationshipRepository = services.transactions.transferRelationshipRepository,
                                                 transferSourceRepository = services.transactions.transferSourceRepository,
+                                                tradeRepository = services.transactions.tradeRepository,
                                                 maintenance = services.imports.maintenance,
                                                 personRepository = services.people.personRepository,
                                                 importEngine = services.transactions.importEngine,
@@ -618,6 +619,7 @@ fun MoneyManagerApp(
                                                 transactionRepository = services.transactions.transactionRepository,
                                                 transferSourceRepository = services.transactions.transferSourceRepository,
                                                 transferRelationshipRepository = services.transactions.transferRelationshipRepository,
+                                                tradeRepository = services.transactions.tradeRepository,
                                                 importEngine = services.transactions.importEngine,
                                                 onBack = { navigationHistory.navigateBack() },
                                                 onDeleted = { navigationHistory.navigateTo(Screen.Imports(ImportTab.CSV)) },
@@ -670,6 +672,7 @@ fun MoneyManagerApp(
                                                 currencyRepository = services.accounts.currencyRepository,
                                                 personRepository = services.people.personRepository,
                                                 csvStrategyImportExport = services.imports.csvStrategyImportExport,
+                                                strategyLibrary = services.imports.strategyLibrary,
                                                 appVersion = appVersion,
                                                 onBack = { navigationHistory.navigateBack() },
                                                 onEditStrategy = { strategyId, importId ->

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
@@ -35,6 +35,7 @@ import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.domain.repository.QifImportReadRepository
 import com.moneymanager.domain.repository.SettingsReadRepository
+import com.moneymanager.domain.repository.TradeReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.domain.repository.TransferSourceReadRepository
@@ -69,6 +70,7 @@ fun ImportsScreen(
     transactionRepository: TransactionReadRepository,
     transferRelationshipRepository: TransferRelationshipReadRepository,
     transferSourceRepository: TransferSourceReadRepository,
+    tradeRepository: TradeReadRepository,
     maintenance: Maintenance,
     personRepository: PersonReadRepository,
     importEngine: ImportEngine,
@@ -138,6 +140,7 @@ fun ImportsScreen(
                     transactionRepository = transactionRepository,
                     transferRelationshipRepository = transferRelationshipRepository,
                     transferSourceRepository = transferSourceRepository,
+                    tradeRepository = tradeRepository,
                     maintenance = maintenance,
                     importEngine = importEngine,
                     onImportClick = onCsvImportClick,

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportDetailScreen.kt
@@ -44,6 +44,7 @@ import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
+import com.moneymanager.domain.repository.TradeReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.domain.repository.TransferSourceReadRepository
@@ -74,6 +75,7 @@ fun CsvImportDetailScreen(
     transactionRepository: TransactionReadRepository,
     transferSourceRepository: TransferSourceReadRepository,
     transferRelationshipRepository: TransferRelationshipReadRepository,
+    tradeRepository: TradeReadRepository,
     importEngine: ImportEngine,
     onBack: () -> Unit,
     onDeleted: () -> Unit,
@@ -462,6 +464,8 @@ fun CsvImportDetailScreen(
             transactionRepository = transactionRepository,
             transferRelationshipRepository = transferRelationshipRepository,
             transferSourceRepository = transferSourceRepository,
+            cryptoRepository = cryptoRepository,
+            tradeRepository = tradeRepository,
             maintenance = maintenance,
             importEngine = importEngine,
             onDismiss = { showReimportDialog = false },
@@ -478,6 +482,9 @@ fun CsvImportDetailScreen(
                         }
                         if (result.updatedRows.isNotEmpty()) {
                             append(", ${result.updatedRows.size} transaction(s) updated to new values")
+                        }
+                        if (result.convertedRows.isNotEmpty()) {
+                            append(", ${result.convertedRows.size} transfer(s) converted to trades")
                         }
                         result.importResult?.let { append(", ${it.successCount} row(s) imported") }
                         if (result.deletedEmptyAccounts.isNotEmpty()) {

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
@@ -47,6 +47,7 @@ import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
+import com.moneymanager.domain.repository.TradeReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.domain.repository.TransferSourceReadRepository
@@ -78,6 +79,7 @@ fun CsvImportsScreen(
     transactionRepository: TransactionReadRepository,
     transferRelationshipRepository: TransferRelationshipReadRepository,
     transferSourceRepository: TransferSourceReadRepository,
+    tradeRepository: TradeReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     onImportClick: (CsvImportId) -> Unit,
@@ -288,6 +290,7 @@ fun CsvImportsScreen(
                     transactionRepository = transactionRepository,
                     transferRelationshipRepository = transferRelationshipRepository,
                     transferSourceRepository = transferSourceRepository,
+                    tradeRepository = tradeRepository,
                     maintenance = maintenance,
                     importEngine = importEngine,
                     onDismiss = { showReimportAll = false },

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvReimportAllDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvReimportAllDialog.kt
@@ -38,6 +38,7 @@ import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
+import com.moneymanager.domain.repository.TradeReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.domain.repository.TransferSourceReadRepository
@@ -74,6 +75,7 @@ fun CsvReimportAllDialog(
     transactionRepository: TransactionReadRepository,
     transferRelationshipRepository: TransferRelationshipReadRepository,
     transferSourceRepository: TransferSourceReadRepository,
+    tradeRepository: TradeReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     onDismiss: () -> Unit,
@@ -192,6 +194,7 @@ fun CsvReimportAllDialog(
                                         onProgress = { done, total -> progress = done to total },
                                         passThroughAccounts = passThroughAccounts,
                                         cryptoRepository = cryptoRepository,
+                                        tradeRepository = tradeRepository,
                                     )
                             } finally {
                                 isRunning = false

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
@@ -38,11 +38,13 @@ import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
+import com.moneymanager.domain.repository.CryptoReadRepository
 import com.moneymanager.domain.repository.CsvImportReadRepository
 import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
+import com.moneymanager.domain.repository.TradeReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
 import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.domain.repository.TransferSourceReadRepository
@@ -84,6 +86,8 @@ fun ReimportDialog(
     transactionRepository: TransactionReadRepository,
     transferRelationshipRepository: TransferRelationshipReadRepository,
     transferSourceRepository: TransferSourceReadRepository,
+    cryptoRepository: CryptoReadRepository,
+    tradeRepository: TradeReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
     onDismiss: () -> Unit,
@@ -143,6 +147,9 @@ fun ReimportDialog(
                     relationshipRepository = transferRelationshipRepository,
                     transferSourceRepository = transferSourceRepository,
                     passThroughAccounts = passThroughAccounts,
+                    // Crypto tickers on already-imported rows must resolve for the value-update and
+                    // transfer→trade conversion scans, so pass the full asset set.
+                    cryptoAssets = cryptoRepository.getAllCryptoAssets().first(),
                     onProgress = { planProgress = it },
                 )
             errorMessage = null
@@ -244,6 +251,8 @@ fun ReimportDialog(
                                     importEngine = importEngine,
                                     passThroughAccounts = passThroughAccounts,
                                     onProgress = { executeProgress = it },
+                                    cryptoRepository = cryptoRepository,
+                                    tradeRepository = tradeRepository,
                                 )
                             onComplete(result)
                         } catch (expected: CancellationException) {
@@ -407,6 +416,37 @@ private fun ReimportPlanPreview(
                 text =
                     "Each row's old transaction(s) are deleted — including any manual edits made to " +
                         "them — and the row is re-imported through the conduit chain.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (plan.tradeConversions.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Transfers to convert to trades (${plan.tradeConversions.size}):",
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            plan.tradeConversions.take(VALUE_UPDATE_PREVIEW_LIMIT).forEach { conversion ->
+                Text(
+                    text = "• ${conversion.description}",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            if (plan.tradeConversions.size > VALUE_UPDATE_PREVIEW_LIMIT) {
+                Text(
+                    text = "…and ${plan.tradeConversions.size - VALUE_UPDATE_PREVIEW_LIMIT} more",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text =
+                    "These rows exchange one asset for another: each row's old single-asset transaction(s) " +
+                        "are deleted — including any manual edits made to them — and the row is re-imported " +
+                        "as a trade.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/CsvStrategiesScreen.kt
@@ -46,6 +46,7 @@ import com.moneymanager.compose.scrollbar.VerticalScrollbarForLazyList
 import com.moneymanager.database.json.CsvStrategyExportCodec
 import com.moneymanager.domain.CsvImportParseResult
 import com.moneymanager.domain.CsvStrategyImportExport
+import com.moneymanager.domain.StrategyLibrary
 import com.moneymanager.domain.model.AppVersion
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
@@ -73,6 +74,7 @@ fun CsvStrategiesScreen(
     currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
     csvStrategyImportExport: CsvStrategyImportExport,
+    strategyLibrary: StrategyLibrary,
     appVersion: AppVersion,
     onStrategyClick: (CsvImportStrategy) -> Unit = {},
     onBrowseCatalog: () -> Unit = {},
@@ -311,7 +313,7 @@ fun CsvStrategiesScreen(
         ImportStrategyDialog(
             parseResult = currentParseResult,
             csvImportStrategyRepository = csvImportStrategyRepository,
-            csvStrategyImportExport = csvStrategyImportExport,
+            strategyLibrary = strategyLibrary,
             accountRepository = accountRepository,
             categoryRepository = categoryRepository,
             currencyRepository = currencyRepository,

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ImportStrategyDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/ImportStrategyDialog.kt
@@ -22,21 +22,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.database.json.CsvStrategyExportCodec
 import com.moneymanager.domain.CsvImportParseResult
 import com.moneymanager.domain.CsvReferenceType
 import com.moneymanager.domain.CsvResolution
-import com.moneymanager.domain.CsvStrategyImportExport
 import com.moneymanager.domain.CsvUnresolvedReference
-import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.StrategyKey
+import com.moneymanager.domain.StrategyKind
+import com.moneymanager.domain.StrategyLibrary
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
 import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
-import com.moneymanager.importengineapi.createAccountMappings
-import com.moneymanager.importengineapi.createCsvStrategy
-import com.moneymanager.importengineapi.deleteCsvStrategy
-import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.components.ReferenceResolutionRow
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -45,12 +43,15 @@ import kotlinx.coroutines.launch
 /**
  * Dialog for importing a CSV strategy from a JSON file.
  * Shows unresolved references and allows the user to map them to existing entities or create new ones.
+ * Persistence goes through [StrategyLibrary.applyIncoming] — the same path as a catalog/library
+ * install — so a strategy with the same name is updated IN PLACE (keeping its id, so staged imports
+ * referencing it keep working) and its per-strategy account mappings are replaced by the file's.
  */
 @Composable
 fun ImportStrategyDialog(
     parseResult: CsvImportParseResult,
     csvImportStrategyRepository: CsvImportStrategyReadRepository,
-    csvStrategyImportExport: CsvStrategyImportExport,
+    strategyLibrary: StrategyLibrary,
     accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
     currencyRepository: CurrencyReadRepository,
@@ -58,7 +59,6 @@ fun ImportStrategyDialog(
     onDismiss: () -> Unit,
     onImportSuccess: () -> Unit,
 ) {
-    val importEngine = LocalImportEngine.current
     val accounts by accountRepository
         .getAllAccounts()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
@@ -84,11 +84,11 @@ fun ImportStrategyDialog(
             reference.type == CsvReferenceType.ACCOUNT && reference !in resolutions.keys
         }
 
-    // Check for name conflict
+    // A same-named strategy is overwritten in place rather than blocking the import.
     val existingStrategies by csvImportStrategyRepository
         .getAllStrategies()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val nameConflict = existingStrategies.any { it.name == strategyName }
+    val existingWithName = existingStrategies.firstOrNull { it.name == strategyName }
 
     AlertDialog(
         onDismissRequest = { if (!isImporting) onDismiss() },
@@ -107,14 +107,15 @@ fun ImportStrategyDialog(
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true,
                     enabled = !isImporting,
-                    isError = strategyName.isBlank() || nameConflict,
+                    isError = strategyName.isBlank(),
                     supportingText = {
                         when {
                             strategyName.isBlank() -> Text("Name is required")
-                            nameConflict ->
+                            existingWithName != null ->
                                 Text(
-                                    "A strategy with this name already exists",
-                                    color = MaterialTheme.colorScheme.error,
+                                    "A strategy with this name already exists — it will be updated in " +
+                                        "place and its per-strategy account mappings replaced.",
+                                    color = MaterialTheme.colorScheme.tertiary,
                                 )
                         }
                     },
@@ -188,39 +189,25 @@ fun ImportStrategyDialog(
                     isImporting = true
                     errorMessage = null
                     scope.launch {
-                        var createdStrategyId: CsvImportStrategyId? = null
                         try {
-                            // Update the export with the new name if changed
-                            val exportWithNewName = parseResult.export.copy(name = strategyName)
-
-                            // Create the strategy
-                            val result =
-                                csvStrategyImportExport.createStrategyFromExport(
-                                    export = exportWithNewName,
-                                    resolutions = resolutions,
-                                )
-
-                            val persistedStrategyId = importEngine.createCsvStrategy(result.strategy)
-                            createdStrategyId = persistedStrategyId
-                            // Persist the strategy's embedded per-strategy account mappings (they
-                            // FK-reference the strategy row, so create them after the strategy).
-                            if (result.accountMappings.isNotEmpty()) {
-                                importEngine.createAccountMappings(result.accountMappings)
-                            }
+                            // The library path creates or updates-in-place by name, applying the
+                            // strategy and its per-strategy mappings as one engine batch. The key
+                            // carries the (possibly renamed) target name; CSV and QIF strategy files
+                            // share the same artifact format and apply path.
+                            strategyLibrary.applyIncoming(
+                                key = StrategyKey(StrategyKind.CSV, strategyName),
+                                json = CsvStrategyExportCodec.encode(parseResult.export.copy(name = strategyName)),
+                                resolutions = resolutions,
+                            )
                             onImportSuccess()
                             onDismiss()
                         } catch (expected: Exception) {
-                            createdStrategyId?.let { strategyId ->
-                                runCatching {
-                                    importEngine.deleteCsvStrategy(strategyId)
-                                }
-                            }
                             errorMessage = "Failed to import: ${expected.message}"
                             isImporting = false
                         }
                     }
                 },
-                enabled = allResolved && strategyName.isNotBlank() && !nameConflict && !isImporting,
+                enabled = allResolved && strategyName.isNotBlank() && !isImporting,
             ) {
                 if (isImporting) {
                     CircularProgressIndicator(
@@ -228,7 +215,7 @@ fun ImportStrategyDialog(
                         strokeWidth = 2.dp,
                     )
                 }
-                Text("Import")
+                Text(if (existingWithName != null) "Overwrite" else "Import")
             }
         },
         dismissButton = {


### PR DESCRIPTION
## What

Adds generic CSV support for single-row crypto→crypto trades and updates the built-in **Crypto.com Crypto** strategy to use it. A `crypto_exchange` row ("TGBP -> CRO", Currency/Amount = sold leg, To Currency/To Amount = bought leg) now imports as one same-account cross-asset **trade** inside the "Crypto.com" wallet, instead of a single-leg transfer into a junk description-named counterparty account that lost the bought leg entirely.

## How

- **Mapper** (`CsvTransferMapper`): the trade's credited leg (`tradeTo`) is computed before the source==target account checks, and trade rows are exempt from them — a same-account cross-asset exchange is valid (the `trade` DB CHECK only requires the assets to differ; the API importer already produces such trades).
- **Crypto.com Crypto strategy**: adds `TO_CURRENCY`/`TO_AMOUNT` mappings and kind-aware account routing (`viban_purchase` debits Crypto.com Cash; `crypto_viban_exchange` credits it). viban events appear in BOTH the fiat and crypto exports with identical timestamp/description/amounts (verified against real exports), so routing them to the same accounts makes the two files produce byte-identical trades — `createTrade`'s exact-match idempotency books each event once regardless of import order, fixing the previous double-count. Also fixes the fiat strategy's duplicate mapping id (TO_AMOUNT and TIMEZONE both used id 9).
- **DUPLICATE status for deduped trades**: `createTrade` returns a `TradeCreateResult(id, created)`, the engine surfaces `ImportResult.dedupedTradeKeys`, and CSV rows/import counts report deduped trades as DUPLICATE instead of a misleading IMPORTED.
- **Re-import conversion**: a new pass in `CsvReimport` detects already-imported rows whose current mapping now yields a trade, deletes the stale single-leg transfer(s) (with linked legs), resets the row, and the re-run imports it as a trade; emptied junk accounts are then auto-deleted. The re-import preview shows "Transfers to convert to trades". Latent bugs fixed en route: the crypto-asset pre-pass only scanned unimported rows (tickers on IMPORTED rows unresolvable at plan time), `bulkReimportCsv` never forwarded `cryptoRepository` to the execute step, and the empty-account cleanup counted only transfers — deleting a trades-only account would have CASCADE-deleted its trades (new `countTradesByAccount` guard).
- **Strategy import overwrite**: the strategy file-import dialog no longer blocks on a name conflict — it routes through `StrategyLibrary.applyIncoming` (the catalog/library install path), updating a same-named strategy in place (keeping its id) and replacing its per-strategy mappings.

## Tests

Mapper cases (same-account trade, viban routing, crypto_payment/blank-To/App-wallet unchanged), E2E cases (same-account trade import, cross-source viban dedupe in both import orders, old-strategy→re-import transfer→trade conversion with idempotency check), and plan-level conversion-detection unit tests. Export/catalog round-trip coverage picks up the strategy changes automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crypto.com imports now better support exchanges, conversions, rewards, and same-wallet trades.
  * Re-imports can convert eligible transfer records into trades, with conversion details shown in previews and completion summaries.
  * Imported trade rows now accurately distinguish new imports from duplicates.
  * Strategy imports can overwrite an existing strategy with the same name.

* **Bug Fixes**
  * Improved duplicate detection across crypto and fiat trade imports.
  * Prevented unnecessary counterparty accounts for same-wallet crypto trades.
  * Preserved accounts containing trades during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->