### PR TITLE
Re-import planning: batch-load row transfers instead of per-row queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ webpage/modules-graph.md
 
 # Guard against a literal "~" directory accidentally created by un-expanded tilde paths
 /~/
+/profile.jfr

--- a/.idea/runConfigurations/Gradle_JVM_APP_JFR.xml
+++ b/.idea/runConfigurations/Gradle_JVM_APP_JFR.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Gradle JVM APP (JFR)" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-Pjfr --console=plain" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":app:main:jvm:run" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.profileconfig.json
+++ b/.profileconfig.json
@@ -47,6 +47,7 @@
         ],
         "minRequiredItemsPerThread": 3
     },
+    "defaultViewer": "FIREFOX_PROFILER",
     "additionalGradleTargets": [
         {
             "targetPrefix": "quarkus",

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -404,9 +404,13 @@ suspend fun planCsvReimport(
             rowIndexForSource = { source -> (source as? Source.Csv)?.takeIf { it.importId == csvImport.id }?.rowIndex },
             onProgress = onProgress,
         )
+    // One batched load instead of a per-row getTransactionById round trip in each of the three
+    // row scans below — on large files those thousands of single-row flow queries dominate the plan phase.
+    onProgress?.invoke(ImportProgress("Loading existing transactions"))
+    val existingTransfers = transactionRepository.getTransactionsByIds(allRows.mapNotNull { it.transferId })
     val rewrites =
         computeReimportRewrites(allRows, mappedPrep, relationshipRepository, onProgress) { transferId ->
-            transactionRepository.getTransactionById(transferId.id).first()
+            existingTransfers[transferId]
         }
     val tradeConversions =
         computeReimportTradeConversions(
@@ -415,7 +419,7 @@ suspend fun planCsvReimport(
             rewrittenRowIndexes = rewrites.map { it.rowIndex }.toSet(),
             relationshipRepository = relationshipRepository,
             onProgress = onProgress,
-        ) { transferId -> transactionRepository.getTransactionById(transferId.id).first() }
+        ) { transferId -> existingTransfers[transferId] }
     // Rows whose transfers a reversal moves back are excluded from value updates: the reversal owns that
     // transfer's account move, and a value update would re-send the pre-reversal (survivor) accounts.
     // Trade-conversion rows are excluded too — their transfer is deleted, not updated.
@@ -428,7 +432,7 @@ suspend fun planCsvReimport(
                 rewrites.map { it.rowIndex }.toSet() +
                     reversalRowIndexes +
                     tradeConversions.map { it.rowIndex },
-            transactionRepository = transactionRepository,
+            existingTransferLookup = { transferId -> existingTransfers[transferId] },
             onProgress = onProgress,
         )
 
@@ -485,12 +489,13 @@ suspend fun planCsvReimport(
  * whose account was mapped away is matched pre-merge, so comparing accounts here would misfire).
  * Pass-through rows are excluded — value changes there invalidate every leg of the chain, so they
  * are handled by the rewrite path instead (see [computeReimportRewrites]).
+ * [existingTransferLookup] loads a row's persisted transfer for the diff; a null result skips the row.
  */
 suspend fun computeReimportValueUpdates(
     allRows: List<CsvRow>,
     mappedPrep: ImportPreparation,
     rewrittenRowIndexes: Set<Long>,
-    transactionRepository: TransactionReadRepository,
+    existingTransferLookup: suspend (TransferId) -> Transfer?,
     onProgress: (suspend (ImportProgress) -> Unit)? = null,
 ): List<ReimportValueUpdate> {
     val rowsByIndex = allRows.associateBy { it.rowIndex }
@@ -498,7 +503,7 @@ suspend fun computeReimportValueUpdates(
     val total = mappedPrep.validTransfers.size
     mappedPrep.validTransfers.forEachIndexed { index, mapped ->
         emitRowProgress(onProgress, "Checking rows for value changes", index, total)
-        valueUpdateFor(mapped, rowsByIndex, rewrittenRowIndexes, transactionRepository)?.let { updates += it }
+        valueUpdateFor(mapped, rowsByIndex, rewrittenRowIndexes, existingTransferLookup)?.let { updates += it }
     }
     return updates
 }
@@ -507,13 +512,13 @@ private suspend fun valueUpdateFor(
     mapped: CsvTransferWithAttributes,
     rowsByIndex: Map<Long, CsvRow>,
     rewrittenRowIndexes: Set<Long>,
-    transactionRepository: TransactionReadRepository,
+    existingTransferLookup: suspend (TransferId) -> Transfer?,
 ): ReimportValueUpdate? {
     if (mapped.passThrough != null || mapped.rowIndex in rewrittenRowIndexes) return null
     val row = rowsByIndex[mapped.rowIndex] ?: return null
     if (row.importStatus != ImportStatus.IMPORTED && row.importStatus != ImportStatus.UPDATED) return null
     val transferId = row.transferId ?: return null
-    val existing = transactionRepository.getTransactionById(transferId.id).first() ?: return null
+    val existing = existingTransferLookup(transferId) ?: return null
     val changes =
         buildList {
             if (mapped.transfer.amount != existing.amount) {

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionReadRepositoryImpl.kt
@@ -33,6 +33,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlin.time.Instant
 
+/** Android's SQLite caps bound variables at 999 per statement. */
+private const val MAX_IDS_PER_QUERY = 999
+
 class TransactionReadRepositoryImpl(
     database: MoneyManagerDatabase,
 ) : TransactionReadRepository {
@@ -75,6 +78,20 @@ class TransactionReadRepositoryImpl(
             .asFlow()
             .mapToOneOrNull(Dispatchers.Default)
             .map { loadAttributesForTransfer(it) }
+
+    override suspend fun getTransactionsByIds(ids: Collection<TransferId>): Map<TransferId, Transfer> =
+        withContext(Dispatchers.Default) {
+            ids
+                .asSequence()
+                .map { it.id }
+                .distinct()
+                .chunked(MAX_IDS_PER_QUERY)
+                .flatMap { chunk ->
+                    loadAttributesForTransfers(
+                        transferSelectQueries.selectByIds(chunk, TransferMapper::mapRaw).executeAsList(),
+                    )
+                }.associateBy { it.id }
+        }
 
     override fun getTransactionsByAccount(accountId: AccountId): Flow<List<Transfer>> =
         transferSelectQueries

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
@@ -16,6 +16,24 @@ FROM transfer
 JOIN asset_details ON transfer.asset_id = asset_details.id
 WHERE transfer.id = ?;
 
+selectByIds:
+SELECT
+    transfer.id,
+    transfer.revision_id,
+    transfer.timestamp,
+    transfer.description,
+    transfer.source_account_id,
+    transfer.target_account_id,
+    transfer.amount,
+    asset_details.id AS asset_id,
+    asset_details.code AS asset_code,
+    asset_details.name AS asset_name,
+    asset_details.scale_factor AS asset_scale_factor,
+    asset_details.kind AS asset_kind
+FROM transfer
+JOIN asset_details ON transfer.asset_id = asset_details.id
+WHERE transfer.id IN ?;
+
 selectByAccount:
 SELECT
     transfer.id,

--- a/app/main/jvm/build.gradle.kts
+++ b/app/main/jvm/build.gradle.kts
@@ -65,6 +65,14 @@ compose.desktop {
                 "java.sql",
             )
 
+        // Opt-in CPU profiling: `./gradlew :app:main:jvm:run -Pjfr` records the app JVM
+        // with method sampling enabled and dumps to profile.jfr on exit.
+        if (providers.gradleProperty("jfr").isPresent) {
+            jvmArgs +=
+                "-XX:StartFlightRecording=settings=profile," +
+                "filename=${rootDir.resolve("profile.jfr")},dumponexit=true"
+        }
+
         nativeDistributions {
             // Include java.sql module in the custom runtime
             modules("java.sql")

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionReadRepository.kt
@@ -21,6 +21,13 @@ import kotlin.time.Instant
 interface TransactionReadRepository {
     fun getTransactionById(id: Long): Flow<Transfer?>
 
+    /**
+     * Batch lookup of transfers (with attributes) by id, for callers that would otherwise issue one
+     * [getTransactionById] round trip per id — e.g. the re-import planner diffing thousands of
+     * already-imported rows. Ids that no longer resolve are simply absent from the result.
+     */
+    suspend fun getTransactionsByIds(ids: Collection<TransferId>): Map<TransferId, Transfer>
+
     fun getTransactionsByAccount(accountId: AccountId): Flow<List<Transfer>>
 
     fun getTransactionsByDateRange(

--- a/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifReimport.kt
+++ b/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifReimport.kt
@@ -111,12 +111,15 @@ suspend fun planQifReimport(
             onProgress = onProgress,
         )
     val reversalRowIndexes = reversals.flatMapTo(mutableSetOf()) { it.rowIndexes }
+    // One batched load instead of a per-record getTransactionById round trip in the value-update scan.
+    onProgress?.invoke(ImportProgress("Loading existing transactions"))
+    val existingTransfers = transactionRepository.getTransactionsByIds(allRows.mapNotNull { it.transferId })
     val valueUpdates =
         computeReimportValueUpdates(
             allRows = allRows,
             mappedPrep = mappedPrep,
             rewrittenRowIndexes = splitRecordIndexes + reversalRowIndexes,
-            transactionRepository = transactionRepository,
+            existingTransferLookup = { transferId -> existingTransfers[transferId] },
             onProgress = onProgress,
         )
 


### PR DESCRIPTION
## What

Speeds up the plan phase of CSV/QIF re-import (and "Re-import all") by replacing per-row transfer lookups with one batched load per file.

## Why

A JFR recording of a "Re-import all" run showed the plan phase issuing one `getTransactionById(id).first()` per already-imported row, in up to three separate scans (pass-through rewrites, trade conversions, value updates) — **6,460 single-row flow queries in one run**. Each call pays for a SQLDelight listener-Flow setup, a `Dispatchers.Default` hop, two SQL statements (transfer + attributes) and an `AbortFlowException` to terminate the flow. The phase is latency-bound on these round trips, not CPU-bound.

## How

- New `TransactionReadRepository.getTransactionsByIds(ids): Map<TransferId, Transfer>` — a suspend batch lookup backed by a new `selectByIds` query, chunked at 999 ids (Android's SQLite bound-variable cap) with one batched attribute load per chunk.
- `CsvReimport.createReimportPlan` and `QifReimport.planQifReimport` load each file's row transfers once; the row scans now hit an in-memory map. `computeReimportValueUpdates` takes a lookup lambda instead of the repository.
- Profiling support used to find this: opt-in JFR recording for the desktop app (`./gradlew :app:main:jvm:run -Pjfr`), a matching "Gradle JVM APP (JFR)" IDEA run configuration, and `profile.jfr` gitignored.

## Testing

- `:app:csvimporter:jvmTest`, `:app:qifimporter:jvmTest` pass; full `./gradlew build` green locally.
- Manually re-ran "Re-import all" against a real database: significant speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved CSV and QIF reimport planning by loading existing transactions in batches, reducing repeated database lookups.
  * Added support for larger reimport operations while respecting database query limits.

* **Progress Updates**
  * Added a progress step while existing transactions are loaded during QIF reimport.

* **Developer Tools**
  * Added optional JVM profiling support for diagnosing application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->