### PR TITLE
Import-all CSV perf: batch reversal lookups, index dedupe, cache compiled patterns

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -280,17 +280,17 @@ class CsvTransferMapper(
     private val dateFormatCache = HashMap<String, DateTimeFormat<LocalDate>>()
     private val timeFormatCache = HashMap<String, DateTimeFormat<LocalTime>>()
 
-    private fun dateTimeFormat(pattern: String): DateTimeFormat<LocalDateTime> =
+    private fun cachedDateTimeFormat(pattern: String): DateTimeFormat<LocalDateTime> =
         dateTimeFormatCache.getOrPut(pattern) {
             LocalDateTime.Format { byUnicodePattern(pattern) }
         }
 
-    private fun dateFormat(pattern: String): DateTimeFormat<LocalDate> =
+    private fun cachedDateFormat(pattern: String): DateTimeFormat<LocalDate> =
         dateFormatCache.getOrPut(pattern) {
             LocalDate.Format { byUnicodePattern(pattern) }
         }
 
-    private fun timeFormat(pattern: String): DateTimeFormat<LocalTime> =
+    private fun cachedTimeFormat(pattern: String): DateTimeFormat<LocalTime> =
         timeFormatCache.getOrPut(pattern) {
             LocalTime.Format { byUnicodePattern(pattern) }
         }
@@ -1115,7 +1115,7 @@ class CsvTransferMapper(
         return try {
             if (dateTimeFormat != null) {
                 // Single column holding a combined date+time value
-                dateTimeFormat(dateTimeFormat)
+                cachedDateTimeFormat(dateTimeFormat)
                     .parse(dateValue.trim())
                     .toInstant(timezone)
             } else {
@@ -1134,13 +1134,13 @@ class CsvTransferMapper(
         timeFormat: String?,
         timezone: TimeZone,
     ): Instant {
-        val date = dateFormat(dateFormat).parse(dateValue.trim())
+        val date = cachedDateFormat(dateFormat).parse(dateValue.trim())
 
         val time =
             if (timeValue.isBlank()) {
                 LocalTime(12, 0, 0)
             } else {
-                timeFormat(timeFormat ?: "HH:mm[:ss]").parse(timeValue.trim())
+                cachedTimeFormat(timeFormat ?: "HH:mm[:ss]").parse(timeValue.trim())
             }
 
         return LocalDateTime(date, time).toInstant(timezone)

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -280,11 +280,20 @@ class CsvTransferMapper(
     private val dateFormatCache = HashMap<String, DateTimeFormat<LocalDate>>()
     private val timeFormatCache = HashMap<String, DateTimeFormat<LocalTime>>()
 
-    private fun dateTimeFormat(pattern: String) = dateTimeFormatCache.getOrPut(pattern) { LocalDateTime.Format { byUnicodePattern(pattern) } }
+    private fun dateTimeFormat(pattern: String): DateTimeFormat<LocalDateTime> =
+        dateTimeFormatCache.getOrPut(pattern) {
+            LocalDateTime.Format { byUnicodePattern(pattern) }
+        }
 
-    private fun dateFormat(pattern: String) = dateFormatCache.getOrPut(pattern) { LocalDate.Format { byUnicodePattern(pattern) } }
+    private fun dateFormat(pattern: String): DateTimeFormat<LocalDate> =
+        dateFormatCache.getOrPut(pattern) {
+            LocalDate.Format { byUnicodePattern(pattern) }
+        }
 
-    private fun timeFormat(pattern: String) = timeFormatCache.getOrPut(pattern) { LocalTime.Format { byUnicodePattern(pattern) } }
+    private fun timeFormat(pattern: String): DateTimeFormat<LocalTime> =
+        timeFormatCache.getOrPut(pattern) {
+            LocalTime.Format { byUnicodePattern(pattern) }
+        }
 
     // Precompiled conversion detection (null when the strategy declares no conversionConfig). Regexes
     // are case-insensitive, matching the file's existing account/content-rule matching convention.

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -49,6 +49,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format.DateTimeFormat
 import kotlinx.datetime.format.byUnicodePattern
 import kotlinx.datetime.toInstant
 import kotlin.time.Duration
@@ -266,6 +267,24 @@ class CsvTransferMapper(
 ) {
     private val columnIndexByName: Map<String, Int> =
         columns.associate { it.originalName to it.columnIndex }
+
+    // Compiled once per pattern: account rules and column extractions run against every row, so
+    // compiling in place would dominate the mapping cost. Case-insensitive like all rule matching here.
+    private val patternCache = HashMap<String, Regex>()
+
+    private fun compiledPattern(pattern: String): Regex = patternCache.getOrPut(pattern) { Regex(pattern, RegexOption.IGNORE_CASE) }
+
+    // Likewise for date/time formats: building a kotlinx-datetime Format compiles a parser, which is
+    // far more expensive than the parse itself.
+    private val dateTimeFormatCache = HashMap<String, DateTimeFormat<LocalDateTime>>()
+    private val dateFormatCache = HashMap<String, DateTimeFormat<LocalDate>>()
+    private val timeFormatCache = HashMap<String, DateTimeFormat<LocalTime>>()
+
+    private fun dateTimeFormat(pattern: String) = dateTimeFormatCache.getOrPut(pattern) { LocalDateTime.Format { byUnicodePattern(pattern) } }
+
+    private fun dateFormat(pattern: String) = dateFormatCache.getOrPut(pattern) { LocalDate.Format { byUnicodePattern(pattern) } }
+
+    private fun timeFormat(pattern: String) = timeFormatCache.getOrPut(pattern) { LocalTime.Format { byUnicodePattern(pattern) } }
 
     // Precompiled conversion detection (null when the strategy declares no conversionConfig). Regexes
     // are case-insensitive, matching the file's existing account/content-rule matching convention.
@@ -1030,13 +1049,13 @@ class CsvTransferMapper(
         // Try each rule in order; first match wins
         if (primaryValue.isNotBlank()) {
             for (rule in mapping.rules) {
-                val match = Regex(rule.pattern, RegexOption.IGNORE_CASE).find(primaryValue)
+                val match = compiledPattern(rule.pattern).find(primaryValue)
                 if (match != null) {
                     // When a template is configured, derive the name from the matched text via
                     // capture-group substitution; otherwise use the fixed account name (legacy behaviour).
                     val accountName =
                         rule.accountNameTemplate
-                            ?.let { substituteTemplate(it, match).replace(Regex("\\s+"), " ").trim() }
+                            ?.let { substituteTemplate(it, match).replace(WHITESPACE_RUN_REGEX, " ").trim() }
                             ?.takeIf { it.isNotBlank() }
                             ?: rule.accountName
                     return RegexAccountResult(
@@ -1087,8 +1106,7 @@ class CsvTransferMapper(
         return try {
             if (dateTimeFormat != null) {
                 // Single column holding a combined date+time value
-                LocalDateTime
-                    .Format { byUnicodePattern(dateTimeFormat) }
+                dateTimeFormat(dateTimeFormat)
                     .parse(dateValue.trim())
                     .toInstant(timezone)
             } else {
@@ -1107,15 +1125,13 @@ class CsvTransferMapper(
         timeFormat: String?,
         timezone: TimeZone,
     ): Instant {
-        val date = LocalDate.Format { byUnicodePattern(dateFormat) }.parse(dateValue.trim())
+        val date = dateFormat(dateFormat).parse(dateValue.trim())
 
         val time =
             if (timeValue.isBlank()) {
                 LocalTime(12, 0, 0)
-            } else if (timeFormat != null) {
-                LocalTime.Format { byUnicodePattern(timeFormat) }.parse(timeValue.trim())
             } else {
-                LocalTime.Format { byUnicodePattern("HH:mm[:ss]") }.parse(timeValue.trim())
+                timeFormat(timeFormat ?: "HH:mm[:ss]").parse(timeValue.trim())
             }
 
         return LocalDateTime(date, time).toInstant(timezone)
@@ -1193,7 +1209,7 @@ class CsvTransferMapper(
         value: String,
         extraction: ColumnExtraction,
     ): String? {
-        val match = Regex(extraction.pattern, RegexOption.IGNORE_CASE).find(value) ?: return null
+        val match = compiledPattern(extraction.pattern).find(value) ?: return null
         return substituteTemplate(extraction.outputTemplate, match)
     }
 
@@ -1424,5 +1440,8 @@ class CsvTransferMapper(
     private companion object {
         /** Posting dates of the same transaction can drift between bank exports by a day or two. */
         val DUPLICATE_DATE_TOLERANCE: Duration = 3.days
+
+        /** Collapses whitespace runs in template-derived account names. */
+        val WHITESPACE_RUN_REGEX = Regex("\\s+")
     }
 }

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionReadRepositoryImpl.kt
@@ -129,20 +129,18 @@ class TransactionReadRepositoryImpl(
             .mapToList(Dispatchers.Default)
             .map { loadAttributesForTransfers(it) }
 
-    override suspend fun getUnreversedTransfersBetween(
-        sourceAccountId: AccountId,
-        targetAccountId: AccountId,
-        amount: Money,
+    override suspend fun getUnreversedTransfersTouchingAccounts(
+        accountIds: Set<AccountId>,
+        amounts: Set<Money>,
         maxTimestamp: Instant,
         reversalTypeId: RelationshipTypeId,
     ): List<Transfer> =
         withContext(Dispatchers.Default) {
+            if (accountIds.isEmpty() || amounts.isEmpty()) return@withContext emptyList()
             transferSelectQueries
-                .selectUnreversedTransfersBetweenAccountsByAmount(
-                    sourceAccountId = sourceAccountId.id,
-                    targetAccountId = targetAccountId.id,
-                    amount = amount.amount.toString(),
-                    currencyId = amount.currency.id.id,
+                .selectUnreversedTransfersTouchingAccounts(
+                    accountIds = accountIds.map { it.id },
+                    amounts = amounts.map { it.amount.toString() },
                     maxTimestamp = maxTimestamp.toEpochMilliseconds(),
                     reversalTypeId = reversalTypeId.id,
                     TransferMapper::mapRaw,

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
@@ -308,10 +308,11 @@ WHERE (source_account_id = :accountA AND target_account_id = :accountB)
    OR (source_account_id = :accountB AND target_account_id = :accountA)
 ORDER BY timestamp DESC;
 
--- Candidate originals for a reversal (refund/cancellation) link: directed transfers of the same amount
--- not yet reversed (never id2 of a :reversalTypeId relationship), newest first. Used by the import
--- engine to pair a pass-through refund's spend leg with the charge it reverses.
-selectUnreversedTransfersBetweenAccountsByAmount:
+-- Candidate originals for reversal (refund/cancellation) links: transfers touching any of the given
+-- accounts with one of the given amounts, not yet reversed (never id2 of a :reversalTypeId
+-- relationship), newest first. The import engine loads these once per batch (every pass-through
+-- spend leg has a conduit endpoint) and pairs legs with charges in memory.
+selectUnreversedTransfersTouchingAccounts:
 SELECT
     transfer.id,
     transfer.revision_id,
@@ -327,10 +328,8 @@ SELECT
     asset_details.kind AS asset_kind
 FROM transfer
 JOIN asset_details ON transfer.asset_id = asset_details.id
-WHERE transfer.source_account_id = :sourceAccountId
-  AND transfer.target_account_id = :targetAccountId
-  AND transfer.amount = :amount
-  AND transfer.asset_id = :currencyId
+WHERE (transfer.source_account_id IN :accountIds OR transfer.target_account_id IN :accountIds)
+  AND transfer.amount IN :amounts
   AND transfer.timestamp <= :maxTimestamp
   AND NOT EXISTS (
       SELECT 1 FROM transfer_relationship

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/Transfer.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/Transfer.sq
@@ -15,8 +15,8 @@ CREATE TABLE transfer (
     FOREIGN KEY (asset_id) REFERENCES asset(id) ON DELETE RESTRICT
 );
 
-CREATE INDEX IF NOT EXISTS idx_transfer_src_account ON transfer(source_account_id);
-CREATE INDEX IF NOT EXISTS idx_transfer_target_account ON transfer(target_account_id);
+CREATE INDEX IF NOT EXISTS idx_transfer_src_target_amount ON transfer(source_account_id, target_account_id, amount);
+CREATE INDEX IF NOT EXISTS idx_transfer_target_timestamp ON transfer(target_account_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_transfer_asset ON transfer(asset_id);
 
 -- Materialized table for account balances (manually refreshed)

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/transferRelationship/TransferRelationship.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/transferRelationship/TransferRelationship.sq
@@ -15,5 +15,5 @@ CREATE TABLE transfer_relationship (
 );
 
 CREATE INDEX idx_transfer_relationship_id1 ON transfer_relationship(id1);
-CREATE INDEX idx_transfer_relationship_id2 ON transfer_relationship(id2);
+CREATE INDEX idx_transfer_relationship_id2_type ON transfer_relationship(id2, relationship_type_id);
 CREATE INDEX idx_transfer_relationship_type ON transfer_relationship(relationship_type_id);

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
@@ -17,6 +17,7 @@ import com.moneymanager.importengineapi.DedupePolicy
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.StringSimilarity
 import kotlin.time.Duration
+import kotlin.time.Instant
 
 /**
  * Information about an existing transfer, used by [ImportDeduper] for duplicate detection.
@@ -106,7 +107,42 @@ class ImportDeduper(
     private val policy: DedupePolicy,
     existing: List<ExistingTransferInfo>,
 ) {
-    private val existingList = existing
+    /**
+     * Exact-match key over a transfer's core fields. Incoming-side fields are nullable, so an
+     * incomplete incoming transfer builds a key that simply misses every (fully populated) existing
+     * entry — the same outcome as the field-by-field comparison it replaces.
+     */
+    private data class CoreKey(
+        val timestamp: Instant?,
+        val sourceAccountId: AccountId,
+        val targetAccountId: AccountId,
+        val amount: Money?,
+        val description: String?,
+    )
+
+    /** Directed (source, target, amount) key for exact-account reconcile/candidate lookups. */
+    private data class DirectedAmountKey(
+        val sourceAccountId: AccountId,
+        val targetAccountId: AccountId,
+        val amount: Money?,
+    )
+
+    private fun Transfer.coreKey() = CoreKey(timestamp, sourceAccountId, targetAccountId, amount, description)
+
+    private fun ImportTransfer.coreKey() =
+        CoreKey(timestamp, fromAccount.requireId(), toAccount.requireId(), amount, description)
+
+    // Indexes over the existing transfers so classification is a hash lookup (plus a scan of the small
+    // matching bucket) instead of a linear pass over the whole DB history per incoming row. Buckets
+    // preserve input order, so first-match-in-list-order semantics are unchanged.
+    private val existingByCoreKey: Map<CoreKey, ExistingTransferInfo> = buildMap {
+        for (info in existing) {
+            val key = info.transfer.coreKey()
+            if (key !in this) put(key, info)
+        }
+    }
+    private val existingByAmount: Map<Money, List<ExistingTransferInfo>> =
+        existing.groupBy { it.transfer.amount }
 
     // The reconciliation exclusion attribute type (when the policy enables cross-source reconciliation),
     // ignored in attribute comparison so a reconciled transfer still dedupes cleanly on re-import.
@@ -129,14 +165,23 @@ class ImportDeduper(
         existing.mapNotNull { info -> info.apiId?.let { it to info.transferId } }.toMap()
     private val existingUniqueKeyId: Map<Map<String, String>, TransferId> =
         existing.filter { it.uniqueKey.isNotEmpty() }.associate { it.uniqueKey to it.transferId }
-    private val existingMatchCandidates: List<Pair<TransferId, Transfer>> =
-        existing.map { it.transferId to it.transfer }
+
+    // apiMatches needs an exact timestamp+amount, so bucket the candidates by that pair.
+    private val existingMatchCandidates: Map<Pair<Instant, Money>, List<Pair<TransferId, Transfer>>> =
+        existing
+            .map { it.transferId to it.transfer }
+            .groupBy { (_, t) -> t.timestamp to t.amount }
 
     // Reconciliation only considers existing transfers this provider cannot identify by its own id
     // (apiId == null) — i.e. transfers from a different source — so genuine repeats from the same
     // provider (which carry an apiId) are never reconciled away.
     private val reconcileCandidates: List<Pair<TransferId, Transfer>> =
         existing.filter { it.apiId == null }.map { it.transferId to it.transfer }
+
+    // reconcileMatches needs exact source+target+amount (only the timestamp window varies), so bucket
+    // the reconcile candidates by that triple.
+    private val reconcileCandidatesByDirectedAmount: Map<DirectedAmountKey, List<Pair<TransferId, Transfer>>> =
+        reconcileCandidates.groupBy { (_, t) -> DirectedAmountKey(t.sourceAccountId, t.targetAccountId, t.amount) }
     private val batchApiId = mutableMapOf<String, Int>()
     private val batchUniqueKey = mutableMapOf<Map<String, String>, Int>()
     private val batchMatchCandidates = mutableListOf<Pair<Int, Transfer>>()
@@ -164,7 +209,7 @@ class ImportDeduper(
         val existingId =
             transfer.apiId?.let { existingApiId[it] }
                 ?: transfer.uniqueKey?.takeIf { it.isNotEmpty() }?.let { existingUniqueKeyId[it] }
-                ?: existingMatchCandidates.firstOrNull { (_, e) -> apiMatches(transfer, e) }?.first
+                ?: apiMatchCandidatesFor(transfer).firstOrNull { (_, e) -> apiMatches(transfer, e) }?.first
         if (existingId != null) return Classified(transfer, ImportStatus.DUPLICATE, existingId)
 
         // Cross-source reconciliation: the same real movement seen from another provider. Keep this
@@ -213,8 +258,11 @@ class ImportDeduper(
         relationshipTypeId: RelationshipTypeId?,
     ): Classified? {
         if (window == null || exclusionTypeId == null || relationshipTypeId == null) return null
+        val key = DirectedAmountKey(transfer.fromAccount.requireId(), transfer.toAccount.requireId(), transfer.amount)
         val matchId =
-            reconcileCandidates.firstOrNull { (_, existing) -> reconcileMatches(transfer, existing, window) }?.first
+            reconcileCandidatesByDirectedAmount[key]
+                ?.firstOrNull { (_, existing) -> reconcileMatches(transfer, existing, window) }
+                ?.first
                 ?: return null
         val attributes =
             if (transfer.attributes.any { it.typeId == exclusionTypeId }) {
@@ -312,6 +360,13 @@ class ImportDeduper(
         return delta <= window
     }
 
+    /** The existing transfers that could satisfy [apiMatches] (exact timestamp + amount bucket). */
+    private fun apiMatchCandidatesFor(transfer: ImportTransfer): List<Pair<TransferId, Transfer>> {
+        val timestamp = transfer.timestamp ?: return emptyList()
+        val amount = transfer.amount ?: return emptyList()
+        return existingMatchCandidates[timestamp to amount].orEmpty()
+    }
+
     private fun apiMatches(
         transfer: ImportTransfer,
         existing: Transfer,
@@ -356,17 +411,18 @@ class ImportDeduper(
         policy: DedupePolicy.FuzzyAllFields,
     ): Classified {
         // First pass: an exact core-field match preserves the DUPLICATE/UPDATED distinction.
-        for (existing in existingList) {
-            if (coreFieldsMatch(transfer, existing.transfer)) {
-                val status =
-                    if (attributesAreIdentical(transfer, existing)) ImportStatus.DUPLICATE else ImportStatus.UPDATED
-                return Classified(transfer, status, existing.transferId)
-            }
+        existingByCoreKey[transfer.coreKey()]?.let { existing ->
+            val status =
+                if (attributesAreIdentical(transfer, existing)) ImportStatus.DUPLICATE else ImportStatus.UPDATED
+            return Classified(transfer, status, existing.transferId)
         }
-        // Second pass: tolerate bank re-export drift (close date, similar description).
-        for (existing in existingList) {
-            if (isFuzzyDuplicate(transfer, existing.transfer, policy)) {
-                return Classified(transfer, ImportStatus.DUPLICATE, existing.transferId)
+        // Second pass: tolerate bank re-export drift (close date, similar description) — the amount
+        // must still match exactly, so only that bucket needs scanning.
+        transfer.amount?.let { amount ->
+            existingByAmount[amount]?.forEach { existing ->
+                if (isFuzzyDuplicate(transfer, existing.transfer, policy)) {
+                    return Classified(transfer, ImportStatus.DUPLICATE, existing.transferId)
+                }
             }
         }
         // Third pass: cross-source reconciliation (opt-in per strategy) — the same real movement

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
@@ -129,18 +129,18 @@ class ImportDeduper(
 
     private fun Transfer.coreKey() = CoreKey(timestamp, sourceAccountId, targetAccountId, amount, description)
 
-    private fun ImportTransfer.coreKey() =
-        CoreKey(timestamp, fromAccount.requireId(), toAccount.requireId(), amount, description)
+    private fun ImportTransfer.coreKey() = CoreKey(timestamp, fromAccount.requireId(), toAccount.requireId(), amount, description)
 
     // Indexes over the existing transfers so classification is a hash lookup (plus a scan of the small
     // matching bucket) instead of a linear pass over the whole DB history per incoming row. Buckets
     // preserve input order, so first-match-in-list-order semantics are unchanged.
-    private val existingByCoreKey: Map<CoreKey, ExistingTransferInfo> = buildMap {
-        for (info in existing) {
-            val key = info.transfer.coreKey()
-            if (key !in this) put(key, info)
+    private val existingByCoreKey: Map<CoreKey, ExistingTransferInfo> =
+        buildMap {
+            for (info in existing) {
+                val key = info.transfer.coreKey()
+                if (key !in this) put(key, info)
+            }
         }
-    }
     private val existingByAmount: Map<Money, List<ExistingTransferInfo>> =
         existing.groupBy { it.transfer.amount }
 

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -470,6 +470,7 @@ class ImportEngineImpl(
         val claimedExisting = mutableSetOf<TransferId>()
         val claimedInBatch = mutableSetOf<LegKey>()
         val batchSpendLegs = mutableListOf<BatchSpendLeg>()
+        val existingCandidates = loadReversalCandidates(toImport, reversalTypeId)
         return toImport.mapIndexed { index, classified ->
             val t = classified.transfer
             val passThrough = t.passThrough ?: return@mapIndexed classified
@@ -495,9 +496,8 @@ class ImportEngineImpl(
                                 leg.timestamp <= timestamp
                         }.maxWithOrNull(compareBy({ it.timestamp }, { it.toImportIndex }))
                 val existingMatch =
-                    transactionRepository
-                        .getUnreversedTransfersBetween(spendTarget, spendSource, amount, timestamp, reversalTypeId)
-                        .firstOrNull { it.id !in claimedExisting }
+                    existingCandidates[ReversalCandidateKey(spendTarget, spendSource, amount)]
+                        ?.firstOrNull { it.timestamp <= timestamp && it.id !in claimedExisting }
 
                 val link =
                     when {
@@ -517,6 +517,41 @@ class ImportEngineImpl(
             if (links.isEmpty()) classified else classified.copy(reversalLinks = links)
         }
     }
+
+    /**
+     * Loads the existing-DB reversal candidates for every pass-through spend leg of [toImport] in one
+     * query, grouped by directed (source, target, amount), newest first within each group. Every spend
+     * leg has at least one conduit endpoint, so bounding the query by the batch's conduit accounts (and
+     * the legs' amounts and max timestamp) covers all per-leg lookups; the currency check the old
+     * per-leg query did via asset_id happens here through the [Money] group key. The DB is not written
+     * while legs are resolved, so this snapshot is equivalent to querying per leg.
+     */
+    private suspend fun loadReversalCandidates(
+        toImport: List<Classified>,
+        reversalTypeId: RelationshipTypeId,
+    ): Map<ReversalCandidateKey, List<Transfer>> {
+        val conduitAccounts = mutableSetOf<AccountId>()
+        val amounts = mutableSetOf<Money>()
+        var maxTimestamp: Instant? = null
+        for (classified in toImport) {
+            val passThrough = classified.transfer.passThrough ?: continue
+            passThrough.conduits.forEach { conduitAccounts += it.requireExistingId() }
+            amounts += passThrough.amount
+            val timestamp = requireNotNull(classified.transfer.timestamp)
+            if (maxTimestamp == null || timestamp > maxTimestamp) maxTimestamp = timestamp
+        }
+        if (conduitAccounts.isEmpty() || maxTimestamp == null) return emptyMap()
+        return transactionRepository
+            .getUnreversedTransfersTouchingAccounts(conduitAccounts, amounts, maxTimestamp, reversalTypeId)
+            .groupBy { ReversalCandidateKey(it.sourceAccountId, it.targetAccountId, it.amount) }
+    }
+
+    /** Directed reversal-candidate lookup key: candidates running source → target of exactly amount. */
+    private data class ReversalCandidateKey(
+        val source: AccountId,
+        val target: AccountId,
+        val amount: Money,
+    )
 
     /** Identifies one spend leg of one to-import row: (index into the to-import list, leg index). */
     private data class LegKey(

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransactionReadRepository.kt
@@ -56,14 +56,14 @@ interface TransactionReadRepository {
     ): Flow<List<TransferMissingCompanion>>
 
     /**
-     * Directed transfers [sourceAccountId] → [targetAccountId] of exactly [amount] at or before
-     * [maxTimestamp] that are not yet the target (id2) of a [reversalTypeId] relationship, newest
-     * first. Used by the import engine to pair a refund/cancellation with the movement it reverses.
+     * Transfers touching any of [accountIds] (as source or target) whose amount is one of [amounts]
+     * at or before [maxTimestamp] and not yet the target (id2) of a [reversalTypeId] relationship,
+     * newest first. Loaded once per import batch by the import engine, which pairs
+     * refunds/cancellations with the movements they reverse in memory.
      */
-    suspend fun getUnreversedTransfersBetween(
-        sourceAccountId: AccountId,
-        targetAccountId: AccountId,
-        amount: Money,
+    suspend fun getUnreversedTransfersTouchingAccounts(
+        accountIds: Set<AccountId>,
+        amounts: Set<Money>,
         maxTimestamp: Instant,
         reversalTypeId: RelationshipTypeId,
     ): List<Transfer>


### PR DESCRIPTION
## Problem

"Import all CSV" slows down dramatically as it reaches the last files. A JFR profile of a full run showed:

- **32% of all SQLite samples** (and growing through the tail of the run) were statement *prepares* for `selectUnreversedTransfersBetweenAccountsByAmount`, issued **once per pass-through spend leg per row** from `ImportEngineImpl.resolveReversalLinks`. The SQLDelight JDBC driver has no statement cache, so every call re-prepares a query whose planning/execution cost grows with the transfer table.
- `ImportDeduper.classifyByAllFields` linearly scanned the **entire** existing-transfers list up to 3 times per incoming row (exact, fuzzy, reconcile passes) — O(rows × existing transfers), the top app CPU frames.
- `CsvTransferMapper` recompiled rule/extraction regexes and kotlinx-datetime `byUnicodePattern` formats per row — `java.util.regex` were the top 3 CPU methods and ~12% of allocation pressure.

## Changes

- **Bulk reversal-candidate load**: new `selectUnreversedTransfersTouchingAccounts` runs once per import batch, bounded by the batch's conduit accounts (every spend leg has a conduit endpoint), leg amounts and max timestamp. Legs are paired in memory via a directed (source, target, amount) map; currency filtering happens through the `Money` key. The per-leg query and `getUnreversedTransfersBetween` are removed (the engine was the sole caller). Semantics unchanged: the DB is not written while legs resolve, so the snapshot is equivalent, and claimed-set / in-batch tie-break logic is untouched.
- **Indexed dedupe**: `ImportDeduper` precomputes hash indexes (exact core-key map; amount buckets for the fuzzy pass; source/target/amount buckets for reconcile; timestamp+amount buckets for `apiMatches`). Buckets preserve input order, so first-match-in-list-order semantics are unchanged.
- **Pattern caches in `CsvTransferMapper`**: per-instance caches for rule/extraction regexes and date/time formats (building a kotlinx-datetime `Format` compiles a whole parser); `\s+` hoisted to a constant.
- **Composite indexes** matching the import-time query shapes — `transfer(source_account_id, target_account_id, amount)`, `transfer(target_account_id, timestamp)`, `transfer_relationship(id2, relationship_type_id)` — superseding the single-column indexes on the same leading columns. Verified with `EXPLAIN QUERY PLAN` on a real ~19k-transfer database: the bulk query runs as MULTI-INDEX OR index probes with a covering index on the `NOT EXISTS` reversal probe.

> [!NOTE]
> The index change is a schema change, so under the BETA no-migration rule local databases are recreated on next launch and data must be re-imported.

## Testing

- `:app:importer`, `:app:csvimporter`, `:app:db:core` JVM test suites pass (dedupe classification, reversal linking, CSV E2E).
- `./gradlew build buildHealth` green.
- Real-world run of "Import all CSV" after the change shows a massive improvement (user-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved import deduplication and reconciliation accuracy across transfers with matching amounts, accounts, and timestamps.
  * Enhanced reversal detection for pass-through and multi-account transfer scenarios.
  * Improved import performance, especially for larger transaction files.
  * Faster CSV parsing and account-name processing during imports.
* **Database**
  * Optimized transfer lookups to improve responsiveness during import and reconciliation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->