### PR TITLE
Crypto.com Card: route old-format "GBP -> GBP" top-up rows to Cash

### DIFF
--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoComCsvMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoComCsvMapperTest.kt
@@ -204,6 +204,28 @@ class CryptoComCsvMapperTest {
         assertTrue(r.newAccounts.isEmpty())
     }
 
+    @Test
+    fun `old-format card top-up described as GBP - GBP is Cash to Card`() {
+        // Pre-mid-2022 card exports describe top-ups as "GBP -> GBP" (with the To columns populated)
+        // instead of "GBP Deposit"; they must resolve the same Cash -> Card pair so cross-source
+        // reconciliation still links them to the fiat file's viban_card_top_up rows.
+        val r = map(cardStrategy, row("GBP -> GBP", "GBP", "1500.0", "GBP", "1500.0", "1500.0", ""))
+        assertEquals(cash.id, r.transfer.sourceAccountId)
+        assertEquals(card.id, r.transfer.targetAccountId)
+        assertEquals(Money.fromDisplayValue(BigDecimal("1500.0"), gbp), r.transfer.amount)
+        assertNull(r.tradeTo)
+        assertTrue(r.newAccounts.isEmpty(), "old-format top-ups must not create a 'GBP -> GBP' account")
+    }
+
+    @Test
+    fun `cross-currency card arrow row keeps the description counterparty`() {
+        // "TGBP -> GBP" top-ups are funded by a conversion the crypto export records separately, so
+        // routing them to Cash would double-count; they stay a description-derived conduit account.
+        val r = map(cardStrategy, row("TGBP -> GBP", "GBP", "4000.0", "TGBP", "4000.0", "4000.0", ""))
+        assertEquals(card.id, r.transfer.targetAccountId)
+        assertEquals("TGBP -> GBP", r.newAccountName())
+    }
+
     // ---- Crypto strategy: cross-asset rows become trades ----
 
     @Test

--- a/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
+++ b/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
@@ -151,9 +151,10 @@ object BuiltInCsvStrategies {
      * Built-in strategy for crypto.com's card_transactions_record_*.csv export (the Visa card
      * statement). Every row has a blank Transaction Kind — the content rule that identifies the file
      * when it has been renamed. Spends are negative Native Amounts to a merchant account looked up
-     * from the description; "GBP Deposit" rows are card top-ups arriving from the crypto.com Cash
-     * account (the fiat export records the same movement as viban_card_top_up, which cross-source
-     * reconciliation links instead of double-counting).
+     * from the description; "GBP Deposit" rows (described as "GBP -> GBP" in pre-mid-2022 exports)
+     * are card top-ups arriving from the crypto.com Cash account (the fiat export records the same
+     * movement as viban_card_top_up, which cross-source reconciliation links instead of
+     * double-counting).
      */
     fun buildCryptoComCardStrategy(now: Instant): CsvImportStrategy {
         val fieldMappings =
@@ -177,6 +178,11 @@ object BuiltInCsvStrategies {
                             listOf(
                                 // Top-ups ("GBP Deposit", "EUR Deposit", …) come from the Cash account.
                                 RegexRule(pattern = "^[A-Z]{3,5} Deposit$", accountName = CRYPTO_COM_CASH_ACCOUNT),
+                                // Pre-mid-2022 exports describe the same top-up as "GBP -> GBP" (same
+                                // currency on both sides). Cross-currency arrows (e.g. "TGBP -> GBP") are
+                                // conversion-funded and deliberately NOT matched — the crypto export
+                                // records that movement separately.
+                                RegexRule(pattern = "^([A-Z]{3,5}) -> \\1$", accountName = CRYPTO_COM_CASH_ACCOUNT),
                             ),
                         // Everything else looks up/creates a merchant account from the raw description.
                     ),


### PR DESCRIPTION
## What

Adds a second target-account rule to the built-in **Crypto.com Card** CSV strategy: descriptions matching `^([A-Z]{3,5}) -> \1$` (the same currency code on both sides, e.g. `GBP -> GBP`) now route to the **Crypto.com Cash** account, alongside the existing `^[A-Z]{3,5} Deposit$` rule.

## Why

Pre-mid-2022 card exports describe card top-ups as `GBP -> GBP` (with the To Currency/To Amount columns populated) instead of the newer `GBP Deposit`. Those rows didn't match any rule, so they fell through to the "create a merchant account from the description" path — producing an account literally named `GBP -> GBP` receiving the top-ups instead of Cash → Card transfers. Because reconciliation requires the identical directed account pair, this also stopped cross-source reconciliation from linking these rows with the fiat export's `viban_card_top_up` records of the same movement.

The backreference deliberately restricts the rule to *same-currency* arrows: cross-currency rows like `TGBP -> GBP` are funded by a conversion the crypto export records separately, so rerouting them to Cash would double-count. They keep their description-derived conduit account.

Direction needed no change — these rows have a positive Native Amount and the existing `flipAccountsOnPositive` already yields Cash → Card. No engine change either: `RegexRule` patterns are Kotlin `Regex`, which supports backreferences.

## Tests

- Old-format `GBP -> GBP` row (To-columns populated, as in real files) maps to Cash → Card, single-asset GBP, no new account, no trade.
- `TGBP -> GBP` row still resolves to a description counterparty, locking in the same-currency-only scope.

Existing users pick the fix up by updating their installed Crypto.com Card strategy and using Re-import, which merges the import-created `GBP -> GBP` account into Cash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Crypto.com card top-up import handling for older `CURRENCY -> CURRENCY` transaction descriptions.
  * Correctly routes cross-currency card top-ups to the Card account while preserving the appropriate counterparty.
  * Prevents duplicate or incorrect accounts and avoids double-counting transactions reconciled across exports.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->