### PR TITLE
Fix Constraints overflow crash in account matrix virtualization

### DIFF
--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Density
@@ -149,6 +150,20 @@ private fun visibleColumnRange(
     if (last < first) return IntRange.EMPTY
     val overscan = 3
     return (first - overscan).coerceAtLeast(0)..(last + overscan).coerceAtMost(count - 1)
+}
+
+/**
+ * Zero-height filler standing in for the virtualized (off-screen) matrix columns. This cannot be a
+ * `Spacer(Modifier.width(...))`: with 1000+ accounts the combined column width exceeds the ~262k px
+ * a [androidx.compose.ui.unit.Constraints] can represent, so the width modifier crashes creating its
+ * fixed constraints. Reporting the size from measure skips that limit — inside `horizontalScroll`
+ * the incoming max width is unbounded, so the reported width is never coerced.
+ */
+@Composable
+private fun MatrixColumnsFiller(width: Dp) {
+    Layout(modifier = Modifier) { _, _ ->
+        layout(width.roundToPx(), 0) {}
+    }
 }
 
 @Composable
@@ -565,7 +580,7 @@ fun AccountTransactionsScreen(
                                         .linuxHorizontalScrollWheel(horizontalScrollState)
                                         .horizontalScroll(horizontalScrollState),
                             ) {
-                                Spacer(modifier = Modifier.width(leadingWidth))
+                                MatrixColumnsFiller(leadingWidth)
                                 for (columnIndex in range) {
                                     val account = allAccounts[columnIndex]
                                     val isSelectedColumn = selectedAccountId == account.id
@@ -618,7 +633,7 @@ fun AccountTransactionsScreen(
                                     }
                                     Spacer(modifier = Modifier.width(8.dp))
                                 }
-                                Spacer(modifier = Modifier.width(trailingWidth))
+                                MatrixColumnsFiller(trailingWidth)
                             }
                         }
 
@@ -678,7 +693,7 @@ fun AccountTransactionsScreen(
                                         Row(
                                             verticalAlignment = Alignment.CenterVertically,
                                         ) {
-                                            Spacer(modifier = Modifier.width(leadingWidth))
+                                            MatrixColumnsFiller(leadingWidth)
                                             // Balance for each visible account
                                             for (columnIndex in range) {
                                                 val account = allAccounts[columnIndex]
@@ -731,7 +746,7 @@ fun AccountTransactionsScreen(
                                                 }
                                                 Spacer(modifier = Modifier.width(8.dp))
                                             }
-                                            Spacer(modifier = Modifier.width(trailingWidth))
+                                            MatrixColumnsFiller(trailingWidth)
                                         }
                                     }
                                 }

--- a/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -78,6 +78,46 @@ import kotlin.time.Duration
 @OptIn(ExperimentalTestApi::class)
 class AccountTransactionsScreenTest {
     @Test
+    fun accountMatrix_rendersWhenTotalColumnWidthExceedsComposeConstraintsLimit() =
+        runMoneyManagerComposeUiTest {
+            // Given: enough accounts that the matrix's total scrollable width (~120dp per column)
+            // exceeds the ~262k px a Compose Constraints value can represent. The virtualization
+            // fillers standing in for the off-screen columns must not crash the measure pass
+            // ("Can't represent a width of X and height of 0 in Constraints").
+            val now = Clock.System.now()
+            val usdCurrency =
+                Currency(
+                    id = CurrencyId(1L),
+                    code = "USD",
+                    name = "US Dollar",
+                )
+            val accounts =
+                (1L..3000L).map { Account(id = AccountId(it), name = "Account $it", openingDate = now) }
+
+            setContent {
+                ProvideSchemaAwareScope {
+                    AccountTransactionsScreen(
+                        accountId = accounts.first().id,
+                        transactionRepository = createTransactionRepository(emptyList()),
+                        accountRepository = createAccountRepository(accounts),
+                        accountAttributeRepository = createAccountAttributeRepository(),
+                        categoryRepository = createCategoryRepository(),
+                        currencyRepository = createCurrencyRepository(listOf(usdCurrency)),
+                        attributeTypeRepository = createAttributeTypeRepository(),
+                        personRepository = createPersonRepository(),
+                        personAccountOwnershipRepository = createPersonAccountOwnershipRepository(),
+                        maintenance = createMaintenance(),
+                        onAccountIdChange = {},
+                        onCurrencyIdChange = {},
+                    )
+                }
+            }
+
+            // Then: the screen measures without throwing and the selected account's column is composed
+            waitUntilExactlyOneExists(hasText("Account 1"))
+        }
+
+    @Test
     fun accountTransactionCard_flipsAccountDisplay_whenPerspectiveChanges() =
         runMoneyManagerComposeUiTest {
             // Given: Two accounts and a transfer between them


### PR DESCRIPTION
## What

Fixes an Android crash loop on app launch: the Transactions screen died in the measure pass with

```
java.lang.IllegalArgumentException: Can't represent a width of 477047 and height of 0 in Constraints
```

## Why

The account matrix virtualizes its columns and stands in for the off-screen ones with `Spacer(Modifier.width(leading/trailingWidth))`. Compose `Constraints` bit-packing caps any dimension at ~262,142 px, and `Modifier.width()` throws above it. With 1,000+ accounts (~155dp per column) the total scroll width is ~181k dp — under the cap at desktop 1.0x density, but over it once Android's density multiplier (2.625x at 420dpi) applies, so the phone crashed on every launch while desktop was fine.

## How

- Replace the four filler spacers with `MatrixColumnsFiller`, a contentless `Layout` that reports its width from the measure result instead of creating fixed constraints. Inside `horizontalScroll` the incoming max width is unbounded, so the reported size is never coerced and the scroll-range pixel math (scrollbar, auto-scroll centring) is byte-identical to before.
- Regression test renders the screen with 3,000 mock accounts (~360k px of matrix even at 1.0x density). Verified it fails with the exact production exception on the unfixed code and passes with the fix.

Also verified end-to-end on a physical device (420dpi, 1,152 accounts): app launches, matrix renders, crash buffer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account transaction matrix rendering when many account columns extend beyond layout size limits.
  * Preserved horizontal scrolling and column positioning for large account lists.

* **Tests**
  * Added coverage confirming the account matrix renders successfully with thousands of accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->