### PR TITLE
Bulk import dialogs: row-weighted determinate progress bar

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/BulkImportProgress.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/BulkImportProgress.kt
@@ -1,0 +1,116 @@
+package com.moneymanager.csvimporter
+
+import com.moneymanager.importengineapi.ImportProgress
+import kotlin.math.roundToLong
+
+/** Engine write-batch size used by bulk imports so the progress bar advances per chunk, not per file. */
+const val BULK_ENGINE_BATCH_SIZE = 250
+
+/**
+ * Overall progress of a bulk import run (CSV or QIF): a file counter plus a row-weighted overall
+ * fraction, so one determinate bar covers the whole run and advances within large files.
+ */
+data class BulkImportProgress(
+    val filesDone: Int,
+    val filesTotal: Int,
+    /** 0..1 across the whole run, monotonically non-decreasing. */
+    val overallFraction: Float,
+    /** Rows processed so far across the run (derived from [overallFraction], so equally monotonic). */
+    val rowsDone: Long,
+    /** Total rows across all files in the run, known upfront. */
+    val rowsTotal: Long,
+    val currentFileName: String? = null,
+    val detail: String? = null,
+)
+
+/**
+ * Aggregates per-file engine [ImportProgress] into one run-wide [BulkImportProgress]. Each file
+ * contributes its row count's share of the bar; within a file the current phase's
+ * [ImportProgress.fraction] scales that share. Re-import files emit several independent 0..1 fraction
+ * sweeps (reversals, value updates, merges, transactions), so emissions are clamped monotonic — the bar
+ * advances on the dominant sweep and holds otherwise, never regressing. [ImportProgress.processed]/
+ * [ImportProgress.total] are deliberately ignored: engine totals are post-dedup transfers, not raw rows,
+ * so only the fraction is comparable across files.
+ */
+class BulkProgressTracker(
+    fileWeights: List<Int>,
+    private val onProgress: suspend (BulkImportProgress) -> Unit,
+) {
+    private val filesTotal = fileWeights.size
+    private val rowsBefore = fileWeights.runningFold(0L) { acc, weight -> acc + weight }
+    private val weights = fileWeights
+    private val rowsTotal = rowsBefore.last()
+    private val totalRows = rowsTotal.coerceAtLeast(1)
+    private var lastFraction = 0f
+
+    /** Emits an initial 0-progress update so the bar appears before any per-file work starts. */
+    suspend fun started(detail: String? = null) {
+        onProgress(
+            BulkImportProgress(
+                filesDone = 0,
+                filesTotal = filesTotal,
+                overallFraction = lastFraction,
+                rowsDone = rowsDone(),
+                rowsTotal = rowsTotal,
+                detail = detail,
+            ),
+        )
+    }
+
+    /** Marks file [index] as the one being processed (its own fraction starts at 0). */
+    suspend fun fileStarted(
+        index: Int,
+        fileName: String,
+    ) {
+        emit(index, fileName, phaseFraction = 0f, detail = null)
+    }
+
+    /** Forwards an engine [progress] update for file [index], scaled into the file's share of the bar. */
+    suspend fun phase(
+        index: Int,
+        fileName: String,
+        progress: ImportProgress,
+    ) {
+        emit(index, fileName, phaseFraction = progress.fraction ?: 0f, detail = progress.detail)
+    }
+
+    /** Emits the terminal 100% update. */
+    suspend fun done() {
+        lastFraction = 1f
+        onProgress(
+            BulkImportProgress(
+                filesDone = filesTotal,
+                filesTotal = filesTotal,
+                overallFraction = 1f,
+                rowsDone = rowsTotal,
+                rowsTotal = rowsTotal,
+            ),
+        )
+    }
+
+    private suspend fun emit(
+        index: Int,
+        fileName: String,
+        phaseFraction: Float,
+        detail: String?,
+    ) {
+        val fileShare = phaseFraction.coerceIn(0f, 1f) * weights[index]
+        val overall = ((rowsBefore[index] + fileShare) / totalRows.toFloat()).coerceIn(0f, 1f)
+        lastFraction = maxOf(lastFraction, overall)
+        onProgress(
+            BulkImportProgress(
+                filesDone = index,
+                filesTotal = filesTotal,
+                overallFraction = lastFraction,
+                rowsDone = rowsDone(),
+                rowsTotal = rowsTotal,
+                currentFileName = fileName,
+                detail = detail,
+            ),
+        )
+    }
+
+    // Derived from the clamped fraction rather than tracked separately, so the row counter is exactly
+    // as monotonic as the bar it sits next to.
+    private fun rowsDone(): Long = (lastFraction * rowsTotal).roundToLong().coerceIn(0L, rowsTotal)
+}

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -223,7 +223,7 @@ data class CsvBulkResult(
  * skipped and counted. Payee/counterparty accounts auto-create with their detected names (no per-file
  * confirmation). The shared [sourceAccountOverride] is used only for files whose strategy needs a
  * user-chosen source (no SOURCE_ACCOUNT mapping); hard-coded and per-row strategies resolve their own.
- * Refreshes materialized views once at the end. Reports progress via [onProgress].
+ * Refreshes materialized views once at the end. Reports row-weighted run-wide progress via [onProgress].
  */
 @Suppress("LongParameterList")
 suspend fun bulkApplyCsv(
@@ -236,7 +236,7 @@ suspend fun bulkApplyCsv(
     csvImportRepository: CsvImportReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
-    onProgress: (done: Int, total: Int) -> Unit,
+    onProgress: suspend (BulkImportProgress) -> Unit,
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
     cryptoRepository: CryptoReadRepository? = null,
 ): CsvBulkResult {
@@ -246,12 +246,15 @@ suspend fun bulkApplyCsv(
     var skippedNoStrategy = 0
     var failed = 0
 
+    val tracker = BulkProgressTracker(imports.map { it.rowCount }, onProgress)
+    tracker.started(detail = "Preparing")
+
     // Create every crypto asset the batch needs up front, sized to the batch-wide max precision per
     // ticker, so cross-file ordering never leaves a ticker missing or a scale factor too small.
     ensureCryptoAssetsForImports(imports, strategies, currencies, csvImportRepository, importEngine, cryptoRepository)
 
     imports.forEachIndexed { index, listedImport ->
-        onProgress(index, imports.size)
+        tracker.fileStarted(index, listedImport.originalFileName)
         // getAllImports() doesn't populate columns, so re-fetch the full import (which loads them)
         // for the strategy match below.
         val csvImport = csvImportRepository.getImport(listedImport.id).first() ?: listedImport
@@ -275,6 +278,8 @@ suspend fun bulkApplyCsv(
                     importEngine = importEngine,
                     refreshViews = false,
                     passThroughAccounts = passThroughAccounts,
+                    onProgress = { tracker.phase(index, csvImport.originalFileName, it) },
+                    engineBatchSize = BULK_ENGINE_BATCH_SIZE,
                     cryptoRepository = cryptoRepository,
                 ) ?: return@forEachIndexed
             filesImported++
@@ -286,7 +291,7 @@ suspend fun bulkApplyCsv(
         }
     }
 
-    onProgress(imports.size, imports.size)
+    tracker.done()
     maintenance.refreshMaterializedViews()
 
     return CsvBulkResult(

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -1096,7 +1096,8 @@ data class CsvBulkReimportResult(
  * then plans and executes a re-import so current strategy/mapping changes apply retroactively (duplicate
  * accounts merged, changed transfer values updated, never-imported/errored rows imported, emptied
  * import-created accounts removed). Files with no resolvable strategy are skipped and counted.
- * Refreshes materialized views once at the end. Mirrors [bulkApplyCsv]; reports per-file [onProgress].
+ * Refreshes materialized views once at the end. Mirrors [bulkApplyCsv]; reports row-weighted
+ * run-wide progress via [onProgress].
  */
 @Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 suspend fun bulkReimportCsv(
@@ -1112,7 +1113,7 @@ suspend fun bulkReimportCsv(
     transferSourceRepository: TransferSourceReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
-    onProgress: (done: Int, total: Int) -> Unit,
+    onProgress: suspend (BulkImportProgress) -> Unit,
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
     cryptoRepository: CryptoReadRepository? = null,
     tradeRepository: TradeReadRepository? = null,
@@ -1131,11 +1132,13 @@ suspend fun bulkReimportCsv(
     // Create every crypto asset the batch needs up front, sized to the batch-wide max precision per
     // ticker, so cross-file ordering never leaves a ticker missing or a scale factor too small (the
     // net-new ERROR rows a re-import picks up are denominated in these assets).
+    val tracker = BulkProgressTracker(imports.map { it.rowCount }, onProgress)
+    tracker.started(detail = "Preparing")
     val cryptoAssets =
         ensureCryptoAssetsForImports(imports, strategies, currencies, csvImportRepository, importEngine, cryptoRepository)
 
     imports.forEachIndexed { index, listedImport ->
-        onProgress(index, imports.size)
+        tracker.fileStarted(index, listedImport.originalFileName)
         // getAllImports() doesn't populate columns; re-fetch the full import so the strategy match works.
         val csvImport = csvImportRepository.getImport(listedImport.id).first() ?: listedImport
         val sampleRows = csvImportRepository.getImportRows(csvImport.id, limit = STRATEGY_CONTENT_SAMPLE_SIZE, offset = 0)
@@ -1162,6 +1165,7 @@ suspend fun bulkReimportCsv(
                     relationshipRepository = relationshipRepository,
                     transferSourceRepository = transferSourceRepository,
                     passThroughAccounts = passThroughAccounts,
+                    onProgress = { tracker.phase(index, csvImport.originalFileName, it) },
                     cryptoAssets = cryptoAssets,
                 )
             val result =
@@ -1177,6 +1181,7 @@ suspend fun bulkReimportCsv(
                     maintenance = maintenance,
                     importEngine = importEngine,
                     passThroughAccounts = passThroughAccounts,
+                    onProgress = { tracker.phase(index, csvImport.originalFileName, it) },
                     refreshViews = false,
                     cryptoRepository = cryptoRepository,
                     tradeRepository = tradeRepository,
@@ -1196,7 +1201,7 @@ suspend fun bulkReimportCsv(
         }
     }
 
-    onProgress(imports.size, imports.size)
+    tracker.done()
     maintenance.refreshMaterializedViews()
 
     return CsvBulkReimportResult(

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/BulkProgressTrackerTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/BulkProgressTrackerTest.kt
@@ -1,0 +1,90 @@
+package com.moneymanager.csvimporter
+
+import com.moneymanager.importengineapi.ImportProgress
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BulkProgressTrackerTest {
+    private val emitted = mutableListOf<BulkImportProgress>()
+
+    private fun tracker(weights: List<Int>) = BulkProgressTracker(weights) { emitted += it }
+
+    @Test
+    fun weightsFilesByRowCount() =
+        runTest {
+            val tracker = tracker(listOf(100, 300))
+
+            tracker.fileStarted(0, "a.csv")
+            tracker.phase(0, "a.csv", ImportProgress("Importing transactions", fraction = 0.5f))
+            tracker.fileStarted(1, "b.csv")
+            tracker.phase(1, "b.csv", ImportProgress("Importing transactions", fraction = 0.5f))
+            tracker.done()
+
+            // a.csv is 1/4 of the run: half of it is 1/8; b.csv half-done adds half of its 3/4 share.
+            assertEquals(listOf(0f, 0.125f, 0.25f, 0.625f, 1f), emitted.map { it.overallFraction })
+            assertEquals(listOf(0L, 50L, 100L, 250L, 400L), emitted.map { it.rowsDone })
+            assertTrue(emitted.all { it.rowsTotal == 400L })
+            assertEquals(2, emitted.last().filesDone)
+            assertEquals(2, emitted.last().filesTotal)
+        }
+
+    @Test
+    fun clampsMultiPhaseSweepsMonotonic() =
+        runTest {
+            val tracker = tracker(listOf(10, 10))
+
+            tracker.fileStarted(0, "a.csv")
+            tracker.phase(0, "a.csv", ImportProgress("Updating transactions", fraction = 1f))
+            // A second 0..1 sweep within the same file must not move the bar backwards.
+            tracker.phase(0, "a.csv", ImportProgress("Importing transactions", fraction = 0.2f))
+            tracker.fileStarted(1, "b.csv")
+
+            assertTrue(emitted.zipWithNext().all { (previous, next) -> next.overallFraction >= previous.overallFraction })
+            assertTrue(emitted.zipWithNext().all { (previous, next) -> next.rowsDone >= previous.rowsDone })
+            assertEquals(0.5f, emitted.last().overallFraction)
+            assertEquals(10L, emitted.last().rowsDone)
+        }
+
+    @Test
+    fun skippedFilesStillAdvanceTheBar() =
+        runTest {
+            val tracker = tracker(listOf(10, 10))
+
+            tracker.fileStarted(0, "a.csv")
+            // File 0 is skipped (no strategy) — starting file 1 must credit file 0's full weight.
+            tracker.fileStarted(1, "b.csv")
+
+            assertEquals(0.5f, emitted.last().overallFraction)
+            assertEquals(1, emitted.last().filesDone)
+        }
+
+    @Test
+    fun nullFractionHoldsAtFileStart() =
+        runTest {
+            val tracker = tracker(listOf(10, 10))
+
+            tracker.fileStarted(0, "a.csv")
+            tracker.phase(0, "a.csv", ImportProgress("Loading rows"))
+
+            assertEquals(0f, emitted.last().overallFraction)
+            assertEquals("Loading rows", emitted.last().detail)
+            assertEquals("a.csv", emitted.last().currentFileName)
+        }
+
+    @Test
+    fun zeroTotalRowsNeverDividesByZero() =
+        runTest {
+            val tracker = tracker(listOf(0, 0))
+
+            tracker.started()
+            tracker.fileStarted(0, "a.csv")
+            tracker.fileStarted(1, "b.csv")
+            tracker.done()
+
+            assertTrue(emitted.all { it.overallFraction in 0f..1f })
+            assertEquals(1f, emitted.last().overallFraction)
+            assertTrue(emitted.all { it.rowsTotal == 0L && it.rowsDone == 0L })
+        }
+}

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BulkProgressAssertions.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/BulkProgressAssertions.kt
@@ -1,0 +1,35 @@
+package com.moneymanager.database
+
+import com.moneymanager.csvimporter.BulkImportProgress
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Asserts the contract every bulk import promises its progress bar: at least one emission, fractions
+ * within 0..1 and never decreasing, a terminal 100% with all files counted, and [filesTotal] matching
+ * the number of files handed to the bulk call.
+ */
+fun assertBulkProgress(
+    progress: List<BulkImportProgress>,
+    filesTotal: Int,
+) {
+    assertTrue(progress.isNotEmpty(), "bulk import should emit progress")
+    progress.forEach {
+        assertEquals(filesTotal, it.filesTotal)
+        assertTrue(it.overallFraction in 0f..1f, "fraction ${it.overallFraction} out of range")
+        assertTrue(it.rowsDone in 0..it.rowsTotal, "rowsDone ${it.rowsDone} out of 0..${it.rowsTotal}")
+    }
+    progress.zipWithNext().forEach { (previous, next) ->
+        assertTrue(
+            next.overallFraction >= previous.overallFraction,
+            "progress went backwards: ${previous.overallFraction} -> ${next.overallFraction}",
+        )
+        assertTrue(
+            next.rowsDone >= previous.rowsDone,
+            "row counter went backwards: ${previous.rowsDone} -> ${next.rowsDone}",
+        )
+    }
+    assertEquals(1f, progress.last().overallFraction, "bulk import should end at 100%")
+    assertEquals(filesTotal, progress.last().filesDone)
+    assertEquals(progress.last().rowsTotal, progress.last().rowsDone, "bulk import should end with all rows counted")
+}

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCryptoE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCryptoE2ETest.kt
@@ -97,7 +97,7 @@ class CryptoComCryptoE2ETest : DbTest() {
             csvImportRepository = repositories.csvImportRepository,
             maintenance = maintenance,
             importEngine = repositories.importEngine,
-            onProgress = { _, _ -> },
+            onProgress = { },
             cryptoRepository = repositories.cryptoRepository,
         )
 
@@ -115,7 +115,7 @@ class CryptoComCryptoE2ETest : DbTest() {
             transferSourceRepository = repositories.transferSourceRepository,
             maintenance = maintenance,
             importEngine = repositories.importEngine,
-            onProgress = { _, _ -> },
+            onProgress = { },
             cryptoRepository = repositories.cryptoRepository,
             tradeRepository = repositories.tradeRepository,
         )

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCsvE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCsvE2ETest.kt
@@ -2,7 +2,10 @@
 
 package com.moneymanager.database.csv
 
+import com.moneymanager.csvimporter.BulkImportProgress
+import com.moneymanager.csvimporter.CsvBulkResult
 import com.moneymanager.csvimporter.bulkApplyCsv
+import com.moneymanager.database.assertBulkProgress
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.Transfer
@@ -106,20 +109,25 @@ class CryptoComCsvE2ETest : DbTest() {
         return repositories.csvImportRepository.getImport(id).first()!!
     }
 
-    private suspend fun applyAll(imports: List<CsvImport>) =
-        bulkApplyCsv(
-            imports = imports,
-            sourceAccountOverride = null,
-            strategies = repositories.csvImportStrategyRepository.getAllStrategies().first(),
-            currencies = repositories.currencyRepository.getAllCurrencies().first(),
-            accountMappingRepository = repositories.accountMappingRepository,
-            accountRepository = repositories.accountRepository,
-            csvImportRepository = repositories.csvImportRepository,
-            maintenance = maintenance,
-            importEngine = repositories.importEngine,
-            onProgress = { _, _ -> },
-            cryptoRepository = repositories.cryptoRepository,
-        )
+    private suspend fun applyAll(imports: List<CsvImport>): CsvBulkResult {
+        val progress = mutableListOf<BulkImportProgress>()
+        val result =
+            bulkApplyCsv(
+                imports = imports,
+                sourceAccountOverride = null,
+                strategies = repositories.csvImportStrategyRepository.getAllStrategies().first(),
+                currencies = repositories.currencyRepository.getAllCurrencies().first(),
+                accountMappingRepository = repositories.accountMappingRepository,
+                accountRepository = repositories.accountRepository,
+                csvImportRepository = repositories.csvImportRepository,
+                maintenance = maintenance,
+                importEngine = repositories.importEngine,
+                onProgress = { progress += it },
+                cryptoRepository = repositories.cryptoRepository,
+            )
+        assertBulkProgress(progress, imports.size)
+        return result
+    }
 
     @Test
     fun importAll_routesFilesByName_mapsKinds_andReconcilesTheSharedTopUp() =

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/qif/QifReimportE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/qif/QifReimportE2ETest.kt
@@ -111,7 +111,7 @@ class QifReimportE2ETest : DbTest() {
             qifImportRepository = repositories.qifImportRepository,
             maintenance = maintenance,
             importEngine = repositories.importEngine,
-            onProgress = { _, _ -> },
+            onProgress = { },
         )
     }
 
@@ -130,7 +130,7 @@ class QifReimportE2ETest : DbTest() {
             transferSourceRepository = repositories.transferSourceRepository,
             maintenance = maintenance,
             importEngine = repositories.importEngine,
-            onProgress = { _, _ -> },
+            onProgress = { },
         )
     }
 

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/qif/SantanderQifE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/qif/SantanderQifE2ETest.kt
@@ -2,6 +2,8 @@
 
 package com.moneymanager.database.qif
 
+import com.moneymanager.csvimporter.BulkImportProgress
+import com.moneymanager.database.assertBulkProgress
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
@@ -110,6 +112,7 @@ class SantanderQifE2ETest : DbTest() {
                 .firstOrNull { it.name == "Santander" }
                 ?.id
                 ?: repositories.accountRepository.createAccount(Account(id = AccountId(0), name = "Santander", openingDate = now))
+        val progress = mutableListOf<BulkImportProgress>()
         bulkApplyQif(
             imports = listOf(qifImport),
             sourceAccountId = sourceId,
@@ -120,8 +123,9 @@ class SantanderQifE2ETest : DbTest() {
             qifImportRepository = repositories.qifImportRepository,
             maintenance = maintenance,
             importEngine = repositories.importEngine,
-            onProgress = { _, _ -> },
+            onProgress = { progress += it },
         )
+        assertBulkProgress(progress, filesTotal = 1)
     }
 
     @Test

--- a/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifImportApplier.kt
+++ b/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifImportApplier.kt
@@ -2,7 +2,10 @@
 
 package com.moneymanager.qifimporter
 
+import com.moneymanager.csvimporter.BULK_ENGINE_BATCH_SIZE
+import com.moneymanager.csvimporter.BulkImportProgress
 import com.moneymanager.csvimporter.BulkImportResult
+import com.moneymanager.csvimporter.BulkProgressTracker
 import com.moneymanager.csvimporter.CsvTransferMapper
 import com.moneymanager.csvimporter.ImportPreparation
 import com.moneymanager.csvimporter.STRATEGY_CONTENT_SAMPLE_SIZE
@@ -39,6 +42,7 @@ import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.ImportOwnershipIntent
 import com.moneymanager.importengineapi.ImportPersonIntent
+import com.moneymanager.importengineapi.ImportProgress
 import com.moneymanager.importengineapi.ImportRowKey
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalPersonKey
@@ -103,7 +107,7 @@ fun List<CsvImportStrategy>.selectForQifContent(
  * currency comes from each file's auto-detected strategy (QIF data has none, so the strategy's
  * configured currency is authoritative), so there is no per-import currency prompt. Payee/counterparty
  * accounts are auto-created with their detected names (no per-file confirmation). Refreshes
- * materialized views once at the end. Reports progress via [onProgress].
+ * materialized views once at the end. Reports row-weighted run-wide progress via [onProgress].
  */
 @Suppress("LongParameterList")
 suspend fun bulkApplyQif(
@@ -116,7 +120,7 @@ suspend fun bulkApplyQif(
     qifImportRepository: QifImportReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
-    onProgress: (done: Int, total: Int) -> Unit,
+    onProgress: suspend (BulkImportProgress) -> Unit,
 ): QifBulkResult {
     val qifStrategies = strategies.qifCompatible()
     var filesImported = 0
@@ -125,8 +129,11 @@ suspend fun bulkApplyQif(
     var skippedNoStrategy = 0
     var failed = 0
 
+    val tracker = BulkProgressTracker(imports.map { it.recordCount }, onProgress)
+    tracker.started()
+
     imports.forEachIndexed { index, qifImport ->
-        onProgress(index, imports.size)
+        tracker.fileStarted(index, qifImport.originalFileName)
         try {
             val count = qifImportRepository.countRecords(qifImport.id)
             val records = qifImportRepository.getImportRecords(qifImport.id, count.coerceAtLeast(1), 0)
@@ -164,6 +171,8 @@ suspend fun bulkApplyQif(
                     maintenance = maintenance,
                     importEngine = importEngine,
                     refreshViews = false,
+                    onProgress = { tracker.phase(index, qifImport.originalFileName, it) },
+                    engineBatchSize = BULK_ENGINE_BATCH_SIZE,
                 )
             filesImported++
             transfers += result.successCount
@@ -174,7 +183,7 @@ suspend fun bulkApplyQif(
         }
     }
 
-    onProgress(imports.size, imports.size)
+    tracker.done()
     maintenance.refreshMaterializedViews()
 
     return QifBulkResult(
@@ -254,6 +263,8 @@ suspend fun runImport(
     maintenance: Maintenance,
     importEngine: ImportEngine,
     refreshViews: Boolean = true,
+    onProgress: (suspend (ImportProgress) -> Unit)? = null,
+    engineBatchSize: Int = Int.MAX_VALUE,
 ): QifImportResult {
     // Persist any "map to existing account" selections so future imports reuse them.
     val selectedMappingsToPersist =
@@ -394,7 +405,7 @@ suspend fun runImport(
             peopleToCreate = peopleToCreate,
             ownerships = ownerships,
         )
-    val importResult = importEngine.import(batch)
+    val importResult = importEngine.import(batch, onProgress = onProgress, batchSize = engineBatchSize)
 
     // Reconcile per-record statuses: a record is IMPORTED if any of its split rows imported, else
     // UPDATED if any updated, else DUPLICATE.

--- a/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifReimport.kt
+++ b/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifReimport.kt
@@ -2,7 +2,10 @@
 
 package com.moneymanager.qifimporter
 
+import com.moneymanager.csvimporter.BULK_ENGINE_BATCH_SIZE
+import com.moneymanager.csvimporter.BulkImportProgress
 import com.moneymanager.csvimporter.BulkImportResult
+import com.moneymanager.csvimporter.BulkProgressTracker
 import com.moneymanager.csvimporter.CsvImportResult
 import com.moneymanager.csvimporter.CsvReimportResult
 import com.moneymanager.csvimporter.ReimportMerge
@@ -240,6 +243,8 @@ suspend fun executeQifReimport(
             qifImportRepository = qifImportRepository,
             maintenance = maintenance,
             importEngine = importEngine,
+            onProgress = onProgress,
+            engineBatchSize = BULK_ENGINE_BATCH_SIZE,
         )
 
     onProgress?.invoke(ImportProgress("Cleaning up empty accounts"))
@@ -361,6 +366,8 @@ private suspend fun applyStagedQif(
     qifImportRepository: QifImportReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
+    onProgress: (suspend (ImportProgress) -> Unit)? = null,
+    engineBatchSize: Int = Int.MAX_VALUE,
 ): QifImportResult? {
     val recordCount = qifImportRepository.countRecords(qifImport.id)
     val records = qifImportRepository.getImportRecords(qifImport.id, recordCount.coerceAtLeast(1), 0)
@@ -391,6 +398,8 @@ private suspend fun applyStagedQif(
         maintenance = maintenance,
         importEngine = importEngine,
         refreshViews = false,
+        onProgress = onProgress,
+        engineBatchSize = engineBatchSize,
     )
 }
 
@@ -465,7 +474,7 @@ data class QifBulkReimportResult(
  * was last imported with ([QifImport.lastAppliedStrategyId], falling back to content-aware
  * auto-selection), then plans and executes a re-import so current strategy/mapping changes apply
  * retroactively. Files with no resolvable strategy are skipped and counted. Refreshes materialized views
- * once at the end. Mirrors [bulkApplyQif]; reports per-file [onProgress].
+ * once at the end. Mirrors [bulkApplyQif]; reports row-weighted run-wide progress via [onProgress].
  */
 @Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 suspend fun bulkReimportQif(
@@ -481,7 +490,7 @@ suspend fun bulkReimportQif(
     transferSourceRepository: TransferSourceReadRepository,
     maintenance: Maintenance,
     importEngine: ImportEngine,
-    onProgress: (done: Int, total: Int) -> Unit,
+    onProgress: suspend (BulkImportProgress) -> Unit,
 ): QifBulkReimportResult {
     val qifStrategies = strategies.qifCompatible()
     var filesImported = 0
@@ -495,8 +504,11 @@ suspend fun bulkReimportQif(
     var emptyAccountsDeleted = 0
     val skipped = mutableListOf<ReimportSkippedAccount>()
 
+    val tracker = BulkProgressTracker(imports.map { it.recordCount }, onProgress)
+    tracker.started()
+
     imports.forEachIndexed { index, qifImport ->
-        onProgress(index, imports.size)
+        tracker.fileStarted(index, qifImport.originalFileName)
         try {
             val count = qifImportRepository.countRecords(qifImport.id)
             val records = qifImportRepository.getImportRecords(qifImport.id, count.coerceAtLeast(1), 0)
@@ -524,6 +536,7 @@ suspend fun bulkReimportQif(
                     qifImportRepository = qifImportRepository,
                     transactionRepository = transactionRepository,
                     transferSourceRepository = transferSourceRepository,
+                    onProgress = { tracker.phase(index, qifImport.originalFileName, it) },
                 )
             val result =
                 executeQifReimport(
@@ -537,6 +550,7 @@ suspend fun bulkReimportQif(
                     qifImportRepository = qifImportRepository,
                     maintenance = maintenance,
                     importEngine = importEngine,
+                    onProgress = { tracker.phase(index, qifImport.originalFileName, it) },
                     refreshViews = false,
                 )
             filesImported++
@@ -553,7 +567,7 @@ suspend fun bulkReimportQif(
         }
     }
 
-    onProgress(imports.size, imports.size)
+    tracker.done()
     maintenance.refreshMaterializedViews()
 
     return QifBulkReimportResult(

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/BulkImportProgressIndicator.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/BulkImportProgressIndicator.kt
@@ -1,0 +1,44 @@
+package com.moneymanager.ui.screens.csv
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.moneymanager.csvimporter.BulkImportProgress
+
+/**
+ * One determinate bar for a whole bulk import run: a file counter + current file/phase label over a
+ * [LinearProgressIndicator] driven by the row-weighted [BulkImportProgress.overallFraction], so the bar
+ * advances within large files instead of jumping once per file. Shared by the CSV and QIF
+ * "Import all"/"Re-import all" dialogs (the QIF module already reuses this package's composables).
+ */
+@Composable
+fun BulkImportProgressIndicator(progress: BulkImportProgress) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        val label =
+            buildString {
+                if (progress.filesDone >= progress.filesTotal) {
+                    append("Finishing up")
+                    append(" — ${progress.rowsDone} of ${progress.rowsTotal} rows")
+                } else {
+                    append("File ${progress.filesDone + 1} of ${progress.filesTotal}")
+                    append(" — ${progress.rowsDone} of ${progress.rowsTotal} rows")
+                    progress.currentFileName?.let { append(" — $it") }
+                    progress.detail?.let { append(": $it") }
+                }
+            }
+        Text(
+            text = "$label…",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        LinearProgressIndicator(progress = { progress.overallFraction }, modifier = Modifier.fillMaxWidth())
+    }
+}

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.csvimporter.BulkImportProgress
 import com.moneymanager.csvimporter.STRATEGY_CONTENT_SAMPLE_SIZE
 import com.moneymanager.csvimporter.bulkApplyCsv
 import com.moneymanager.csvimporter.needsSourceAccountOverride
@@ -73,7 +74,7 @@ fun CsvImportAllDialog(
 
     var sourceAccountId by remember { mutableStateOf<AccountId?>(null) }
     var isImporting by remember { mutableStateOf(false) }
-    var progress by remember { mutableStateOf<Pair<Int, Int>?>(null) }
+    var progress by remember { mutableStateOf<BulkImportProgress?>(null) }
     var summary by remember { mutableStateOf<String?>(null) }
 
     // Match each file's strategy (filename + content aware), so we can tell how many files will be
@@ -127,9 +128,9 @@ fun CsvImportAllDialog(
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
-                    progress?.let { (done, total) ->
+                    progress?.let {
                         Spacer(modifier = Modifier.height(12.dp))
-                        Text("Importing ${done.coerceAtMost(total)} of $total…", style = MaterialTheme.typography.bodySmall)
+                        BulkImportProgressIndicator(it)
                     }
                 }
             }
@@ -155,7 +156,7 @@ fun CsvImportAllDialog(
                                         csvImportRepository = csvImportRepository,
                                         maintenance = maintenance,
                                         importEngine = importEngine,
-                                        onProgress = { done, total -> progress = done to total },
+                                        onProgress = { progress = it },
                                         passThroughAccounts = passThroughAccounts,
                                         cryptoRepository = cryptoRepository,
                                     )

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvReimportAllDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvReimportAllDialog.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.csvimporter.BulkImportProgress
 import com.moneymanager.csvimporter.CsvBulkReimportResult
 import com.moneymanager.csvimporter.STRATEGY_CONTENT_SAMPLE_SIZE
 import com.moneymanager.csvimporter.bulkReimportCsv
@@ -88,7 +89,7 @@ fun CsvReimportAllDialog(
 
     var sourceAccountId by remember { mutableStateOf<AccountId?>(null) }
     var isRunning by remember { mutableStateOf(false) }
-    var progress by remember { mutableStateOf<Pair<Int, Int>?>(null) }
+    var progress by remember { mutableStateOf<BulkImportProgress?>(null) }
     var result by remember { mutableStateOf<CsvBulkReimportResult?>(null) }
 
     // Resolve each file's strategy the same way the re-import will: the one it was last imported with,
@@ -157,12 +158,9 @@ fun CsvReimportAllDialog(
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
-                    progress?.let { (done, total) ->
+                    progress?.let {
                         Spacer(modifier = Modifier.height(12.dp))
-                        Text(
-                            "Re-importing ${done.coerceAtMost(total)} of $total…",
-                            style = MaterialTheme.typography.bodySmall,
-                        )
+                        BulkImportProgressIndicator(it)
                     }
                 }
             }
@@ -191,7 +189,7 @@ fun CsvReimportAllDialog(
                                         transferSourceRepository = transferSourceRepository,
                                         maintenance = maintenance,
                                         importEngine = importEngine,
-                                        onProgress = { done, total -> progress = done to total },
+                                        onProgress = { progress = it },
                                         passThroughAccounts = passThroughAccounts,
                                         cryptoRepository = cryptoRepository,
                                         tradeRepository = tradeRepository,

--- a/app/ui/imports/qif/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
+++ b/app/ui/imports/qif/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.csvimporter.BulkImportProgress
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.qif.QifImport
@@ -31,6 +32,7 @@ import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.setLastQifAccount
 import com.moneymanager.qifimporter.bulkApplyQif
 import com.moneymanager.ui.components.AccountPicker
+import com.moneymanager.ui.screens.csv.BulkImportProgressIndicator
 import com.moneymanager.ui.components.LoadingTextButton
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -67,7 +69,7 @@ fun QifImportAllDialog(
 
     var sourceAccountId by remember { mutableStateOf<AccountId?>(null) }
     var isImporting by remember { mutableStateOf(false) }
-    var progress by remember { mutableStateOf<Pair<Int, Int>?>(null) }
+    var progress by remember { mutableStateOf<BulkImportProgress?>(null) }
     var summary by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(accounts) {
@@ -96,9 +98,9 @@ fun QifImportAllDialog(
                         enabled = !isImporting,
                         isError = sourceAccountId == null,
                     )
-                    progress?.let { (done, total) ->
+                    progress?.let {
                         Spacer(modifier = Modifier.height(12.dp))
-                        Text("Importing ${done.coerceAtMost(total)} of $total…", style = MaterialTheme.typography.bodySmall)
+                        BulkImportProgressIndicator(it)
                     }
                 }
             }
@@ -124,7 +126,7 @@ fun QifImportAllDialog(
                                         qifImportRepository = qifImportRepository,
                                         maintenance = maintenance,
                                         importEngine = importEngine,
-                                        onProgress = { done, total -> progress = done to total },
+                                        onProgress = { progress = it },
                                     )
                                 importEngine.setLastQifAccount(source)
                                 summary = result.toSummary()

--- a/app/ui/imports/qif/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
+++ b/app/ui/imports/qif/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifImportAllDialog.kt
@@ -32,10 +32,10 @@ import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.setLastQifAccount
 import com.moneymanager.qifimporter.bulkApplyQif
 import com.moneymanager.ui.components.AccountPicker
-import com.moneymanager.ui.screens.csv.BulkImportProgressIndicator
 import com.moneymanager.ui.components.LoadingTextButton
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import com.moneymanager.ui.screens.csv.BulkImportProgressIndicator
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 

--- a/app/ui/imports/qif/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifReimportAllDialog.kt
+++ b/app/ui/imports/qif/src/commonMain/kotlin/com/moneymanager/ui/screens/qif/QifReimportAllDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.csvimporter.BulkImportProgress
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.CurrencyId
@@ -40,6 +41,7 @@ import com.moneymanager.ui.components.CurrencyPicker
 import com.moneymanager.ui.components.LoadingTextButton
 import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
+import com.moneymanager.ui.screens.csv.BulkImportProgressIndicator
 import com.moneymanager.ui.screens.csv.BulkMergeReport
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -80,7 +82,7 @@ fun QifReimportAllDialog(
     var sourceAccountId by remember { mutableStateOf<AccountId?>(null) }
     var selectedCurrencyId by remember { mutableStateOf<CurrencyId?>(null) }
     var isRunning by remember { mutableStateOf(false) }
-    var progress by remember { mutableStateOf<Pair<Int, Int>?>(null) }
+    var progress by remember { mutableStateOf<BulkImportProgress?>(null) }
     var result by remember { mutableStateOf<QifBulkReimportResult?>(null) }
 
     LaunchedEffect(accounts) {
@@ -137,12 +139,9 @@ fun QifReimportAllDialog(
                         personRepository = personRepository,
                         enabled = !isRunning,
                     )
-                    progress?.let { (done, total) ->
+                    progress?.let {
                         Spacer(modifier = Modifier.height(12.dp))
-                        Text(
-                            "Re-importing ${done.coerceAtMost(total)} of $total…",
-                            style = MaterialTheme.typography.bodySmall,
-                        )
+                        BulkImportProgressIndicator(it)
                     }
                 }
             }
@@ -171,7 +170,7 @@ fun QifReimportAllDialog(
                                         transferSourceRepository = transferSourceRepository,
                                         maintenance = maintenance,
                                         importEngine = importEngine,
-                                        onProgress = { done, total -> progress = done to total },
+                                        onProgress = { progress = it },
                                     )
                             } finally {
                                 isRunning = false


### PR DESCRIPTION
## What

The CSV/QIF **Import all** and **Re-import all** dialogs previously showed only a per-file text counter ("Importing X of Y…"), so a run dominated by one large file looked stuck. This PR gives all four dialogs one determinate progress bar for the whole run, weighted by row count and advancing as rows are imported, with a label like:

`File 2 of 5 — 1250 of 4000 rows — statement.csv: Importing transactions…`

## How

- **New `BulkImportProgress` + `BulkProgressTracker`** (`app/csvimporter`): each file contributes its `rowCount`/`recordCount` share of the bar; within a file the engine's per-chunk `ImportProgress.fraction` scales that share. Emissions are clamped monotonic because re-import phases (reversals, value updates, merges, transactions) each sweep 0→1 within a file. `rowsDone`/`rowsTotal` derive from the same clamped fraction so the counter never runs backwards either. Only `fraction` is used — engine `processed/total` counts are post-dedup transfers, not raw rows.
- **Plumbing**: `bulkApplyCsv`, `bulkReimportCsv`, `bulkApplyQif`, `bulkReimportQif` now take `onProgress: suspend (BulkImportProgress) -> Unit` and forward engine progress with a 250-row batch size (`BULK_ENGINE_BATCH_SIZE`, matching `REIMPORT_ENGINE_BATCH_SIZE`). QIF's `runImport`/`applyStagedQif` gained defaulted `onProgress`/`engineBatchSize` params; `executeQifReimport` now forwards progress into its re-run step, so the single-file QIF re-import dialog also gets finer progress.
- **UI**: new shared `BulkImportProgressIndicator` composable (CSV imports UI module, reused by QIF like `BulkMergeReport`) with a determinate `LinearProgressIndicator`; all four dialogs swap their `Pair<Int, Int>` text counter for it.
- **Tests**: `BulkProgressTrackerTest` (weighting, monotonic clamp, skipped files advance the bar, null-fraction phases, zero-row guard) plus a shared `assertBulkProgress` helper wired into the CSV/QIF E2E suites (fractions and row counters in range, non-decreasing, terminal at 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed progress tracking for bulk CSV and QIF imports and re-imports.
  * Progress now reflects overall completion, files, rows, current file, and processing phase.
  * Added smooth, non-regressing progress indicators to import and re-import dialogs.

* **Bug Fixes**
  * Improved progress accuracy across multi-file and multi-phase imports, including skipped files and empty datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->