### PR TITLE
Re-import perf: batch pass-through leg lookups, cache persisted-mapping matches

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -655,19 +655,17 @@ internal suspend fun computeReimportTradeConversions(
         if (row.importStatus != ImportStatus.IMPORTED && row.importStatus != ImportStatus.UPDATED) return null
         return row.transferId
     }
-    val linkedLegsByRoot =
-        collectLinkedLegs(
-            mappedPrep.validTransfers
-                .mapNotNull(::tradeConversionRoot)
-                .filter { existingTransferLookup(it) != null },
-            relationshipRepository,
-        )
+    val eligibleRoots =
+        mappedPrep.validTransfers
+            .mapNotNull(::tradeConversionRoot)
+            .filterTo(mutableSetOf()) { existingTransferLookup(it) != null }
+    val linkedLegsByRoot = collectLinkedLegs(eligibleRoots, relationshipRepository)
     val conversions = mutableListOf<ReimportTradeConversion>()
     val total = mappedPrep.validTransfers.size
     mappedPrep.validTransfers.forEachIndexed { index, mapped ->
         emitRowProgress(onProgress, "Checking rows converting to trades", index, total)
         val transferId = tradeConversionRoot(mapped) ?: return@forEachIndexed
-        if (existingTransferLookup(transferId) == null) return@forEachIndexed
+        if (transferId !in eligibleRoots) return@forEachIndexed
         conversions +=
             ReimportTradeConversion(
                 rowIndex = mapped.rowIndex,

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -579,11 +579,22 @@ internal suspend fun computeReimportRewrites(
     existingTransferLookup: suspend (TransferId) -> Transfer?,
 ): List<ReimportRewrite> {
     val rowsByIndex = allRows.associateBy { it.rowIndex }
+    onProgress?.invoke(ImportProgress("Loading transfer links"))
+    val linkedLegsByRoot =
+        collectLinkedLegs(
+            mappedPrep.validTransfers.mapNotNull { mapped ->
+                if (mapped.passThrough == null) return@mapNotNull null
+                rowsByIndex[mapped.rowIndex]
+                    ?.takeIf { it.importStatus == ImportStatus.IMPORTED }
+                    ?.transferId
+            },
+            relationshipRepository,
+        )
     val rewrites = mutableListOf<ReimportRewrite>()
     val total = mappedPrep.validTransfers.size
     mappedPrep.validTransfers.forEachIndexed { index, mapped ->
         emitRowProgress(onProgress, "Checking pass-through rows", index, total)
-        rewriteFor(mapped, rowsByIndex, relationshipRepository, existingTransferLookup)?.let { rewrites += it }
+        rewriteFor(mapped, rowsByIndex, linkedLegsByRoot, existingTransferLookup)?.let { rewrites += it }
     }
     return rewrites
 }
@@ -591,14 +602,14 @@ internal suspend fun computeReimportRewrites(
 private suspend fun rewriteFor(
     mapped: CsvTransferWithAttributes,
     rowsByIndex: Map<Long, CsvRow>,
-    relationshipRepository: TransferRelationshipReadRepository,
+    linkedLegsByRoot: Map<TransferId, LinkedLegs>,
     existingTransferLookup: suspend (TransferId) -> Transfer?,
 ): ReimportRewrite? {
     val passThrough = mapped.passThrough ?: return null
     val row = rowsByIndex[mapped.rowIndex] ?: return null
     if (row.importStatus != ImportStatus.IMPORTED) return null
     val transferId = row.transferId ?: return null
-    val linked = collectLinkedLegs(transferId, relationshipRepository)
+    val linked = linkedLegsByRoot.getValue(transferId)
     val chainChanged = linked.passThroughLegCount != passThrough.conduitNames.size
     // A value change (e.g. the strategy's amount/currency columns moved) must propagate to every
     // spend leg of the chain, so the row is rewritten rather than updated in place.
@@ -637,19 +648,30 @@ internal suspend fun computeReimportTradeConversions(
     existingTransferLookup: suspend (TransferId) -> Transfer?,
 ): List<ReimportTradeConversion> {
     val rowsByIndex = allRows.associateBy { it.rowIndex }
+
+    fun tradeConversionRoot(mapped: CsvTransferWithAttributes): TransferId? {
+        if (mapped.tradeTo == null || mapped.rowIndex in rewrittenRowIndexes) return null
+        val row = rowsByIndex[mapped.rowIndex] ?: return null
+        if (row.importStatus != ImportStatus.IMPORTED && row.importStatus != ImportStatus.UPDATED) return null
+        return row.transferId
+    }
+    val linkedLegsByRoot =
+        collectLinkedLegs(
+            mappedPrep.validTransfers
+                .mapNotNull(::tradeConversionRoot)
+                .filter { existingTransferLookup(it) != null },
+            relationshipRepository,
+        )
     val conversions = mutableListOf<ReimportTradeConversion>()
     val total = mappedPrep.validTransfers.size
     mappedPrep.validTransfers.forEachIndexed { index, mapped ->
         emitRowProgress(onProgress, "Checking rows converting to trades", index, total)
-        if (mapped.tradeTo == null || mapped.rowIndex in rewrittenRowIndexes) return@forEachIndexed
-        val row = rowsByIndex[mapped.rowIndex] ?: return@forEachIndexed
-        if (row.importStatus != ImportStatus.IMPORTED && row.importStatus != ImportStatus.UPDATED) return@forEachIndexed
-        val transferId = row.transferId ?: return@forEachIndexed
+        val transferId = tradeConversionRoot(mapped) ?: return@forEachIndexed
         if (existingTransferLookup(transferId) == null) return@forEachIndexed
         conversions +=
             ReimportTradeConversion(
-                rowIndex = row.rowIndex,
-                transferIdsToDelete = collectLinkedLegs(transferId, relationshipRepository).transferIds,
+                rowIndex = mapped.rowIndex,
+                transferIdsToDelete = linkedLegsByRoot.getValue(transferId).transferIds,
                 description = mapped.transfer.description,
             )
     }
@@ -664,39 +686,52 @@ private class LinkedLegs(
 )
 
 /**
- * Collects [rootId] plus every transfer reachable through FORWARD relationships (this transfer as
- * id1): fee legs and pass-through spend legs, transitively. Reversal links are not followed — their
- * id2 is another row's leg and must never be deleted with this row.
+ * For each root in [rootIds], collects the root plus every transfer reachable through FORWARD
+ * relationships (this transfer as id1): fee legs and pass-through spend legs, transitively.
+ * Reversal links are not followed — their id2 is another row's leg and must never be deleted with
+ * that row. All roots are walked together, one batched relationship query per BFS depth, instead
+ * of one query per transfer — on large files those thousands of single-id round trips used to
+ * dominate the pass-through and trade-conversion scans.
  */
 private suspend fun collectLinkedLegs(
-    rootId: TransferId,
+    rootIds: Collection<TransferId>,
     relationshipRepository: TransferRelationshipReadRepository,
-): LinkedLegs {
-    val collected = mutableListOf(rootId)
-    val visited = mutableSetOf(rootId)
-    var passThroughLegCount = 0
-    var frontier = listOf(rootId)
+): Map<TransferId, LinkedLegs> {
+    class MutableLegs(
+        rootId: TransferId,
+    ) {
+        val collected = mutableListOf(rootId)
+        val visited = mutableSetOf(rootId)
+        var passThroughLegCount = 0
+    }
+
+    val legsByRoot = LinkedHashMap<TransferId, MutableLegs>()
+    for (root in rootIds) legsByRoot.getOrPut(root) { MutableLegs(root) }
+    // Each frontier entry pairs the root whose chain is being walked with the transfer to expand.
+    var frontier: List<Pair<TransferId, TransferId>> = legsByRoot.keys.map { it to it }
     while (frontier.isNotEmpty()) {
-        val next = mutableListOf<TransferId>()
-        for (id in frontier) {
+        val forwardById =
             relationshipRepository
-                .getByTransfer(id)
-                .first()
-                .asSequence()
-                .filter { it.id1 == id }
+                .getByTransfers(frontier.map { it.second })
                 .filterNot { it.relationshipType.name == WellKnownIds.REVERSAL_RELATIONSHIP_TYPE_NAME }
-                .filter { visited.add(it.id2) }
+                .groupBy { it.id1 }
+        val next = mutableListOf<Pair<TransferId, TransferId>>()
+        for ((root, id) in frontier) {
+            val legs = legsByRoot.getValue(root)
+            forwardById[id]
+                .orEmpty()
+                .filter { legs.visited.add(it.id2) }
                 .forEach { rel ->
                     if (rel.relationshipType.id.id == WellKnownIds.PASS_THROUGH_RELATIONSHIP_TYPE_ID) {
-                        passThroughLegCount++
+                        legs.passThroughLegCount++
                     }
-                    collected += rel.id2
-                    next += rel.id2
+                    legs.collected += rel.id2
+                    next += root to rel.id2
                 }
         }
         frontier = next
     }
-    return LinkedLegs(collected, passThroughLegCount)
+    return legsByRoot.mapValues { (_, legs) -> LinkedLegs(legs.collected, legs.passThroughLegCount) }
 }
 
 /**

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -333,6 +333,10 @@ class CsvTransferMapper(
         existingAccounts.values.associateBy { it.id }
     }
 
+    // CSV account values repeat heavily across rows, and findPersistedMapping is called several
+    // times per row — memoizing collapses an O(rows x mappings) regex scan to one pass per value.
+    private val persistedMappingCache = HashMap<String, AccountId?>()
+
     /**
      * Prepares an import by mapping all rows and collecting new accounts to create.
      */
@@ -950,12 +954,10 @@ class CsvTransferMapper(
      * @return The mapped AccountId, or null if no match found
      */
     private fun findPersistedMapping(value: String): AccountId? {
-        for (mapping in scopedAccountMappings) {
-            if (mapping.valuePattern.containsMatchIn(value)) {
-                return mapping.accountId
-            }
-        }
-        return null
+        if (value in persistedMappingCache) return persistedMappingCache[value]
+        val result = scopedAccountMappings.firstOrNull { it.valuePattern.containsMatchIn(value) }?.accountId
+        persistedMappingCache[value] = result
+        return result
     }
 
     /**

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvReimportDetectionTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvReimportDetectionTest.kt
@@ -417,6 +417,9 @@ class CsvReimportDetectionTest {
         private val byTransfer: Map<TransferId, List<TransferRelationship>>,
     ) : TransferRelationshipReadRepository {
         override fun getByTransfer(transferId: TransferId): Flow<List<TransferRelationship>> = flowOf(byTransfer[transferId].orEmpty())
+
+        override suspend fun getByTransfers(transferIds: Collection<TransferId>): List<TransferRelationship> =
+            transferIds.distinct().flatMap { byTransfer[it].orEmpty() }
     }
 
     private val passThroughType = RelationshipType(RelationshipTypeId(3), "pass-through")
@@ -537,10 +540,13 @@ class CsvReimportDetectionTest {
 
             computeReimportRewrites(rows, mappedPrep, FakeRelationshipRepository(emptyMap()), { progress += it }) { null }
 
-            // Emissions every 25 rows plus the final one; monotonic and complete.
-            assertEquals(listOf(25, 30), progress.mapNotNull { it.processed })
-            assertTrue(progress.all { it.total == 30 })
-            assertTrue(progress.all { it.detail == "Checking pass-through rows" })
+            // A phase emission for the batched relationship load, then per-row progress
+            // every 25 rows plus the final one; monotonic and complete.
+            assertEquals("Loading transfer links", progress.first().detail)
+            val rowProgress = progress.filter { it.processed != null }
+            assertEquals(listOf(25, 30), rowProgress.map { it.processed })
+            assertTrue(rowProgress.all { it.total == 30 })
+            assertTrue(rowProgress.all { it.detail == "Checking pass-through rows" })
         }
 
     @Test

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransferRelationshipReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransferRelationshipReadRepositoryImpl.kt
@@ -11,6 +11,9 @@ import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+private const val MAX_IDS_PER_QUERY = 999
 
 class TransferRelationshipReadRepositoryImpl(
     database: MoneyManagerDatabase,
@@ -35,4 +38,29 @@ class TransferRelationshipReadRepositoryImpl(
                     )
                 }
             }
+
+    override suspend fun getByTransfers(transferIds: Collection<TransferId>): List<TransferRelationship> =
+        withContext(Dispatchers.Default) {
+            transferIds
+                .asSequence()
+                .map { it.id }
+                .distinct()
+                .chunked(MAX_IDS_PER_QUERY)
+                .flatMap { chunk ->
+                    selectQueries.selectByTransfers(chunk).executeAsList()
+                }
+                // A relationship whose two sides fall into different chunks is returned by both.
+                .distinct()
+                .map { row ->
+                    TransferRelationship(
+                        id1 = TransferId(row.id1),
+                        id2 = TransferId(row.id2),
+                        relationshipType =
+                            RelationshipType(
+                                id = RelationshipTypeId(row.relationship_type_id),
+                                name = row.relationship_type_name,
+                            ),
+                    )
+                }.toList()
+        }
 }

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transferRelationship/TransferRelationshipSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transferRelationship/TransferRelationshipSelect.sq
@@ -10,3 +10,16 @@ FROM transfer_relationship
 JOIN relationship_type ON transfer_relationship.relationship_type_id = relationship_type.id
 WHERE transfer_relationship.id1 = ? OR transfer_relationship.id2 = ?
 ORDER BY relationship_type.name;
+
+-- All relationships touching any of the given transfers, from either side of the pair.
+selectByTransfers:
+SELECT
+    transfer_relationship.id1,
+    transfer_relationship.id2,
+    transfer_relationship.relationship_type_id,
+    relationship_type.id AS relationship_type_id,
+    relationship_type.name AS relationship_type_name
+FROM transfer_relationship
+JOIN relationship_type ON transfer_relationship.relationship_type_id = relationship_type.id
+WHERE transfer_relationship.id1 IN :ids OR transfer_relationship.id2 IN :ids
+ORDER BY relationship_type.name;

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransferRelationshipReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TransferRelationshipReadRepository.kt
@@ -10,4 +10,11 @@ interface TransferRelationshipReadRepository {
      * Results are ordered by relationship type name.
      */
     fun getByTransfer(transferId: TransferId): Flow<List<TransferRelationship>>
+
+    /**
+     * Batch lookup of all relationships touching any of [transferIds], from either side of the
+     * pair — for callers that would otherwise issue one [getByTransfer] round trip per id, e.g.
+     * the re-import planner walking the conduit chains of thousands of pass-through rows.
+     */
+    suspend fun getByTransfers(transferIds: Collection<TransferId>): List<TransferRelationship>
 }


### PR DESCRIPTION
## What

Two performance fixes for the re-import planner, found by profiling a "Re-import all" run (JFR):

1. **Batch the pass-through / trade-conversion relationship lookups.** The "Checking pass-through rows" and "Checking rows converting to trades" scans issued one `getByTransfer` flow query per row, plus one per conduit leg (a card→Curve→merchant chain is 2–3 queries per row). Each call built a SQLDelight flow (`asFlow().mapToList().first()`), costing listener registration and two dispatcher hops per row — thousands of latency-bound round trips on large files. `collectLinkedLegs` now walks all roots together, issuing one batched `selectByTransfers` query per BFS depth (chain depth is 2–3), via a new `TransferRelationshipReadRepository.getByTransfers` chunked `IN` lookup mirroring the `getTransactionsByIds` pattern from #663.

2. **Memoize `findPersistedMapping`.** The profile's biggest on-CPU cost was `CsvTransferMapper.prepareImport` regex-scanning every persisted account mapping (`Regex.containsMatchIn`) several times per row, across the three `prepareImport` passes the planner runs. CSV account values repeat heavily, so the first-match result is now cached per source value, collapsing the O(rows × mappings) scan to one pass per distinct value.

## Why

On a full "Re-import all" over the real database, the plan phase spent most of its wall clock in per-row relationship queries (off-CPU waits) and most of its CPU in repeated mapping regex scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Faster re-import processing through batched transfer-link lookups.
  - Reduced repeated account-mapping searches during CSV imports.
  - Improved handling of large sets of transfer relationships.

- **Progress Updates**
  - Re-import scans now clearly indicate when transfer links are loading and when pass-through rows are being checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->