### PR TITLE
Re-import perf: batch the empty-account cleanup emptiness checks

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -1065,11 +1065,11 @@ private suspend fun deleteEmptyImportCreatedAccounts(
 ): List<String> {
     val importCreated = csvImportRepository.getAccountsCreatedByImport(csvImport.id)
     val remainingById = accountRepository.getAllAccounts().first().associateBy { it.id }
-    val emptyAccounts =
-        importCreated
-            .mapNotNull { remainingById[it] }
-            .filter { accountRepository.countTransfersByAccount(it.id) == 0L }
-            .filter { (tradeRepository?.countTradesByAccount(it.id) ?: 0L) == 0L }
+    val candidates = importCreated.mapNotNull { remainingById[it] }
+    // Two batched membership checks instead of two COUNT queries per candidate account.
+    val withTransfers = accountRepository.accountsWithTransfers(candidates.map { it.id })
+    val withTrades = tradeRepository?.accountsWithTrades(candidates.map { it.id }).orEmpty()
+    val emptyAccounts = candidates.filter { it.id !in withTransfers && it.id !in withTrades }
     if (emptyAccounts.isEmpty()) return emptyList()
 
     importEngine.import(

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/AccountReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/AccountReadRepositoryImpl.kt
@@ -63,7 +63,7 @@ class AccountReadRepositoryImpl(
                 .asSequence()
                 .map { it.id }
                 .distinct()
-                .chunked(MAX_IDS_PER_QUERY)
+                .chunked(MAX_IDS_PER_TWO_SIDED_QUERY)
                 .flatMap { chunk ->
                     transferSelectQueries.selectAccountsWithTransfers(chunk).executeAsList()
                 }.mapTo(mutableSetOf(), ::AccountId)

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/AccountReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/AccountReadRepositoryImpl.kt
@@ -57,6 +57,18 @@ class AccountReadRepositoryImpl(
             transferSelectQueries.countTransfersByAccount(accountId.id).executeAsOne()
         }
 
+    override suspend fun accountsWithTransfers(accountIds: Collection<AccountId>): Set<AccountId> =
+        withContext(Dispatchers.Default) {
+            accountIds
+                .asSequence()
+                .map { it.id }
+                .distinct()
+                .chunked(MAX_IDS_PER_QUERY)
+                .flatMap { chunk ->
+                    transferSelectQueries.selectAccountsWithTransfers(chunk).executeAsList()
+                }.mapTo(mutableSetOf(), ::AccountId)
+        }
+
     override suspend fun getTransfersBetweenAccounts(
         accountA: AccountId,
         accountB: AccountId,

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/QueryLimits.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/QueryLimits.kt
@@ -2,3 +2,9 @@ package com.moneymanager.database.repository
 
 /** SQLite's default variable limit is 999; batched IN lookups chunk their ids to stay under it. */
 internal const val MAX_IDS_PER_QUERY = 999
+
+/**
+ * Chunk size for queries that bind the same id list twice (`... IN :ids OR ... IN :ids`) —
+ * SQLDelight expands the collection once per use, so each id costs two bind variables.
+ */
+internal const val MAX_IDS_PER_TWO_SIDED_QUERY = MAX_IDS_PER_QUERY / 2

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/QueryLimits.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/QueryLimits.kt
@@ -1,0 +1,4 @@
+package com.moneymanager.database.repository
+
+/** SQLite's default variable limit is 999; batched IN lookups chunk their ids to stay under it. */
+internal const val MAX_IDS_PER_QUERY = 999

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TradeReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TradeReadRepositoryImpl.kt
@@ -34,4 +34,16 @@ class TradeReadRepositoryImpl(
         withContext(Dispatchers.Default) {
             selectQueries.countByAccount(accountId.id).executeAsOne()
         }
+
+    override suspend fun accountsWithTrades(accountIds: Collection<AccountId>): Set<AccountId> =
+        withContext(Dispatchers.Default) {
+            accountIds
+                .asSequence()
+                .map { it.id }
+                .distinct()
+                .chunked(MAX_IDS_PER_QUERY)
+                .flatMap { chunk ->
+                    selectQueries.selectAccountsWithTrades(chunk).executeAsList()
+                }.mapTo(mutableSetOf(), ::AccountId)
+        }
 }

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TradeReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TradeReadRepositoryImpl.kt
@@ -41,7 +41,7 @@ class TradeReadRepositoryImpl(
                 .asSequence()
                 .map { it.id }
                 .distinct()
-                .chunked(MAX_IDS_PER_QUERY)
+                .chunked(MAX_IDS_PER_TWO_SIDED_QUERY)
                 .flatMap { chunk ->
                     selectQueries.selectAccountsWithTrades(chunk).executeAsList()
                 }.mapTo(mutableSetOf(), ::AccountId)

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionReadRepositoryImpl.kt
@@ -33,9 +33,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlin.time.Instant
 
-/** Android's SQLite caps bound variables at 999 per statement. */
-private const val MAX_IDS_PER_QUERY = 999
-
 class TransactionReadRepositoryImpl(
     database: MoneyManagerDatabase,
 ) : TransactionReadRepository {

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransferRelationshipReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransferRelationshipReadRepositoryImpl.kt
@@ -13,8 +13,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
-private const val MAX_IDS_PER_QUERY = 999
-
 class TransferRelationshipReadRepositoryImpl(
     database: MoneyManagerDatabase,
 ) : TransferRelationshipReadRepository {

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransferRelationshipReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/TransferRelationshipReadRepositoryImpl.kt
@@ -43,7 +43,7 @@ class TransferRelationshipReadRepositoryImpl(
                 .asSequence()
                 .map { it.id }
                 .distinct()
-                .chunked(MAX_IDS_PER_QUERY)
+                .chunked(MAX_IDS_PER_TWO_SIDED_QUERY)
                 .flatMap { chunk ->
                     selectQueries.selectByTransfers(chunk).executeAsList()
                 }

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/trade/TradeSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/trade/TradeSelect.sq
@@ -68,3 +68,9 @@ countByAccount:
 SELECT COUNT(*)
 FROM trade
 WHERE from_account_id = :accountId OR to_account_id = :accountId;
+
+-- Which of the given accounts appear on either side of any trade (batch emptiness check).
+selectAccountsWithTrades:
+SELECT DISTINCT from_account_id AS account_id FROM trade WHERE from_account_id IN :accountIds
+UNION
+SELECT DISTINCT to_account_id FROM trade WHERE to_account_id IN :accountIds;

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
@@ -288,6 +288,12 @@ SELECT COUNT(*)
 FROM transfer
 WHERE source_account_id = :accountId OR target_account_id = :accountId;
 
+-- Which of the given accounts appear on either side of any transfer (batch emptiness check).
+selectAccountsWithTransfers:
+SELECT DISTINCT source_account_id AS account_id FROM transfer WHERE source_account_id IN :accountIds
+UNION
+SELECT DISTINCT target_account_id FROM transfer WHERE target_account_id IN :accountIds;
+
 selectTransfersBetweenAccounts:
 SELECT
     transfer.id,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/AccountReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/AccountReadRepository.kt
@@ -23,6 +23,13 @@ interface AccountReadRepository {
 
     suspend fun countTransfersByAccount(accountId: AccountId): Long
 
+    /**
+     * Which of [accountIds] appear on either side of any transfer — for callers checking many
+     * accounts for emptiness that would otherwise issue one [countTransfersByAccount] per account,
+     * e.g. the re-import empty-account cleanup.
+     */
+    suspend fun accountsWithTransfers(accountIds: Collection<AccountId>): Set<AccountId>
+
     suspend fun getTransfersBetweenAccounts(
         accountA: AccountId,
         accountB: AccountId,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TradeReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/TradeReadRepository.kt
@@ -12,4 +12,7 @@ interface TradeReadRepository {
 
     /** Number of trades touching [accountId] on either leg. */
     suspend fun countTradesByAccount(accountId: AccountId): Long
+
+    /** Which of [accountIds] appear on either leg of any trade (batch emptiness check). */
+    suspend fun accountsWithTrades(accountIds: Collection<AccountId>): Set<AccountId>
 }

--- a/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifReimport.kt
+++ b/app/qifimporter/src/commonMain/kotlin/com/moneymanager/qifimporter/QifReimport.kt
@@ -415,10 +415,10 @@ private suspend fun deleteEmptyImportCreatedAccounts(
 ): List<String> {
     val importCreated = qifImportRepository.getAccountsCreatedByImport(qifImport.id)
     val remainingById = accountRepository.getAllAccounts().first().associateBy { it.id }
-    val emptyAccounts =
-        importCreated
-            .mapNotNull { remainingById[it] }
-            .filter { accountRepository.countTransfersByAccount(it.id) == 0L }
+    val candidates = importCreated.mapNotNull { remainingById[it] }
+    // One batched membership check instead of a COUNT query per candidate account.
+    val withTransfers = accountRepository.accountsWithTransfers(candidates.map { it.id })
+    val emptyAccounts = candidates.filter { it.id !in withTransfers }
     if (emptyAccounts.isEmpty()) return emptyList()
 
     importEngine.import(


### PR DESCRIPTION
## What

Follow-up to #667, from the updated re-import-all profile: the next bottleneck was the "Cleaning up empty accounts" phase.

`deleteEmptyImportCreatedAccounts` (both the CSV and QIF variants) issued **two `COUNT(*)` queries per import-created account** (`countTransfersByAccount` + `countTradesByAccount`), each wrapped in its own `withContext` dispatcher hop. Worse, most import-created accounts *do* have transfers — they were just re-imported — so each `COUNT(*)` tallied every row for that account instead of stopping at the first hit. The profile shows the phase almost entirely off-CPU: classic latency-bound N+1.

Both cleanups now make **one batched membership query per table**: new `AccountReadRepository.accountsWithTransfers(ids)` and `TradeReadRepository.accountsWithTrades(ids)` return which of the candidate accounts appear on either side of any transfer/trade (`SELECT DISTINCT ... WHERE id IN :ids UNION ...`, chunked at 999 ids), and the empty set is computed in memory.

Also consolidates the previously file-private `MAX_IDS_PER_QUERY = 999` constants (duplicated across three repository impls) into a shared `QueryLimits.kt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved re-import cleanup by checking imported accounts in batches rather than individually.
  * Empty imported accounts are identified more efficiently using existing transfer and trade activity.
  * Large account lists are processed safely in smaller batches, improving reliability during imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->