### PR TITLE
Fix account transactions scroll stopping before the newest/oldest rows

### DIFF
--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
@@ -240,6 +241,10 @@ fun AccountTransactionsScreen(
     // Backward paging state - tracks if there are more items at the start of the list
     var hasPreviousPage by remember { mutableStateOf(false) }
     var isLoadingPreviousPage by remember { mutableStateOf(false) }
+    // Bumped after every completed first-page (re)load. The scroll-to-target effect keys on this
+    // rather than on runningBalances: list contents can be equal across a reload (so an
+    // equals-based key would not re-fire), while pagination prepends/appends must NOT re-fire it.
+    var pageLoadGeneration by remember { mutableStateOf(0) }
 
     // Loading state - separate tracking for matrix (top) and transactions (bottom)
     var hasLoadedMatrix by remember { mutableStateOf(false) }
@@ -400,6 +405,7 @@ fun AccountTransactionsScreen(
                 logger.error(expected) { "Failed to load transactions: ${expected.message}" }
             } finally {
                 isLoadingPage = false
+                pageLoadGeneration++
             }
         }
 
@@ -893,19 +899,36 @@ fun AccountTransactionsScreen(
 
                 val listState = rememberLazyListState()
 
-                // Scroll to specific transaction if requested
-                LaunchedEffect(scrollToTransferId, runningBalances) {
+                // Scroll to specific transaction if requested. The scroll must run exactly once per
+                // target: keying on pageLoadGeneration re-fires the effect after each first-page
+                // (re)load — including the currency-filtered reload the first pass triggers — while
+                // pagination prepends/appends don't re-fire it, so they can't yank the viewport back
+                // to the anchor. The latch stops later reloads (e.g. after edits) from re-centering.
+                var hasScrolledToTarget by remember(scrollToTransferId) { mutableStateOf(false) }
+                LaunchedEffect(scrollToTransferId, pageLoadGeneration) {
+                    if (hasScrolledToTarget) return@LaunchedEffect
                     scrollToTransferId?.let { targetTransferId ->
                         // Set highlighted transaction (TransferId implements TransactionId)
                         highlightedTransactionId = targetTransferId
 
                         // First find the transaction in unfiltered list to get its currency
-                        val transaction =
-                            runningBalances.find { it.transactionId.id == targetTransferId.id }
-                                ?: return@let
+                        val transaction = runningBalances.find { it.transactionId.id == targetTransferId.id }
+                        if (transaction == null) {
+                            // Absent from a fully loaded page means it doesn't exist in this account;
+                            // latch anyway so pagination (gated on the latch) isn't blocked forever.
+                            if (hasLoadedFirstPage && !isLoadingPage && runningBalances.isNotEmpty()) {
+                                hasScrolledToTarget = true
+                            }
+                            return@let
+                        }
 
-                        // Set currency filter to match the transaction
-                        selectedCurrencyId = CurrencyId(transaction.transactionAmount.currency.id.id)
+                        // Set currency filter to match the transaction; that reloads the page, so the
+                        // centering scroll happens on the next pass over the filtered list
+                        val targetCurrencyId = CurrencyId(transaction.transactionAmount.currency.id.id)
+                        if (selectedCurrencyId != targetCurrencyId) {
+                            selectedCurrencyId = targetCurrencyId
+                            return@let
+                        }
 
                         // Now find the index in the filtered list (which now includes this currency)
                         val index =
@@ -926,7 +949,13 @@ fun AccountTransactionsScreen(
                                     .firstOrNull()
                                     ?.size ?: 0
                             val centeringOffset = -(viewportHeight / 2 - rowHeight / 2)
-                            listState.animateScrollToItem(index, centeringOffset)
+                            try {
+                                listState.animateScrollToItem(index, centeringOffset)
+                            } finally {
+                                // Latch even when the animation is cancelled (e.g. the user grabs the
+                                // list), otherwise auto-pagination would stay gated forever.
+                                hasScrolledToTarget = true
+                            }
 
                             // Scroll matrix to show the account and currency
                             val accountIndex = allAccounts.indexOfFirst { it.id == accountId }
@@ -954,15 +983,29 @@ fun AccountTransactionsScreen(
                     }
                 }
 
-                // Trigger pagination when user scrolls near the end
-                LaunchedEffect(listState, isLoadingPage, currentPagingInfo?.hasMore) {
+                // While a target scroll is pending, the list sits at position 0 (near the trigger
+                // thresholds) and a prepend would shift item indices under the in-flight centering
+                // animation, so hold off auto-pagination until the anchor scroll has run.
+                val anchorScrollPending = scrollToTransferId != null && !hasScrolledToTarget
+
+                // Trigger pagination when user scrolls near the end.
+                // The loading/hasMore flags must NOT be keys of these effects: loadNextPage /
+                // loadPreviousPage flip them, and a key change restarts the effect — cancelling the
+                // very load it just started (withContext discards the result on cancellation even if
+                // the query finished). Loading a page then only succeeded when the query beat the
+                // next recomposition; once a boundary's query was slower than a frame, every retry
+                // was cancelled and scrolling stopped dead. The flags are snapshot state, so the
+                // collect body always reads their current values without them being keys.
+                LaunchedEffect(listState, anchorScrollPending) {
+                    if (anchorScrollPending) return@LaunchedEffect
                     snapshotFlow {
-                        val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()
-                        lastVisibleItem?.index
-                    }.collect { lastVisibleIndex ->
+                        val layoutInfo = listState.layoutInfo
+                        val lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index
+                        lastVisibleIndex?.let { it to layoutInfo.totalItemsCount }
+                    }.collect { indexAndCount ->
+                        val (lastVisibleIndex, totalItemsCount) = indexAndCount ?: return@collect
                         // Load more when within 10 items of the end
-                        if (lastVisibleIndex != null &&
-                            lastVisibleIndex >= displayedRunningBalances.size - 10 &&
+                        if (lastVisibleIndex >= totalItemsCount - 10 &&
                             !isLoadingPage &&
                             currentPagingInfo?.hasMore == true
                         ) {
@@ -972,7 +1015,8 @@ fun AccountTransactionsScreen(
                 }
 
                 // Trigger backward pagination when user scrolls near the beginning
-                LaunchedEffect(listState, isLoadingPreviousPage, hasPreviousPage) {
+                LaunchedEffect(listState, anchorScrollPending) {
+                    if (anchorScrollPending) return@LaunchedEffect
                     snapshotFlow {
                         val firstVisibleItem = listState.layoutInfo.visibleItemsInfo.firstOrNull()
                         firstVisibleItem?.index
@@ -991,6 +1035,7 @@ fun AccountTransactionsScreen(
                 Box(modifier = Modifier.fillMaxSize()) {
                     LazyColumn(
                         state = listState,
+                        modifier = Modifier.testTag("accountTransactionsList"),
                         verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         items(

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -930,55 +930,60 @@ fun AccountTransactionsScreen(
                             return@let
                         }
 
-                        // Now find the index in the filtered list (which now includes this currency)
+                        // Find the index in the list the LazyColumn actually renders (currency-filtered
+                        // pages minus hidden excluded rows) so the centering lands on the right row
                         val index =
-                            runningBalances
+                            displayedRunningBalances
                                 .filter {
                                     it.transactionAmount.currency.id == transaction.transactionAmount.currency.id
                                 }.indexOfFirst { it.transactionId.id == targetTransferId.id }
 
-                        if (index >= 0) {
-                            // Centre the target in the viewport instead of pinning it to the very top.
-                            // animateScrollToItem places the item's top at viewport top + scrollOffset, so a
-                            // negative offset of (half viewport - half row) drops it to the middle. Wait for
-                            // the list to be measured first, otherwise viewportSize is still 0.
-                            val viewportHeight =
-                                snapshotFlow { listState.layoutInfo.viewportSize.height }.first { it > 0 }
-                            val rowHeight =
-                                listState.layoutInfo.visibleItemsInfo
-                                    .firstOrNull()
-                                    ?.size ?: 0
-                            val centeringOffset = -(viewportHeight / 2 - rowHeight / 2)
-                            try {
-                                listState.animateScrollToItem(index, centeringOffset)
-                            } finally {
-                                // Latch even when the animation is cancelled (e.g. the user grabs the
-                                // list), otherwise auto-pagination would stay gated forever.
-                                hasScrolledToTarget = true
-                            }
+                        if (index < 0) {
+                            // The target is loaded but not rendered (e.g. excluded while excluded rows
+                            // are hidden) — give up so pagination (gated on the latch) isn't blocked.
+                            hasScrolledToTarget = true
+                            return@let
+                        }
+                        // Centre the target in the viewport instead of pinning it to the very top.
+                        // animateScrollToItem places the item's top at viewport top + scrollOffset, so a
+                        // negative offset of (half viewport - half row) drops it to the middle. Wait for
+                        // the list to be measured first, otherwise viewportSize is still 0.
+                        val viewportHeight =
+                            snapshotFlow { listState.layoutInfo.viewportSize.height }.first { it > 0 }
+                        val rowHeight =
+                            listState.layoutInfo.visibleItemsInfo
+                                .firstOrNull()
+                                ?.size ?: 0
+                        val centeringOffset = -(viewportHeight / 2 - rowHeight / 2)
+                        try {
+                            listState.animateScrollToItem(index, centeringOffset)
+                        } finally {
+                            // Latch even when the animation is cancelled (e.g. the user grabs the
+                            // list), otherwise auto-pagination would stay gated forever.
+                            hasScrolledToTarget = true
+                        }
 
-                            // Scroll matrix to show the account and currency
-                            val accountIndex = allAccounts.indexOfFirst { it.id == accountId }
-                            val currencyIndex = uniqueAssets.indexOfAsset(transaction.transactionAmount.currency.id.id)
+                        // Scroll matrix to show the account and currency
+                        val accountIndex = allAccounts.indexOfFirst { it.id == accountId }
+                        val currencyIndex = uniqueAssets.indexOfAsset(transaction.transactionAmount.currency.id.id)
 
-                            if (accountIndex >= 0 && currencyIndex >= 0) {
-                                val targetScrollX =
-                                    horizontalMatrixScrollTarget(
-                                        accountIndex = accountIndex,
-                                        allAccounts = allAccounts,
-                                        accountColumnWidths = accountColumnWidths,
-                                        containerWidthDp = containerWidthDp,
-                                        density = density,
-                                    )
-                                val targetScrollY =
-                                    verticalMatrixScrollTarget(
-                                        currencyIndex = currencyIndex,
-                                        containerHeightDp = containerHeightDp,
-                                        density = density,
-                                    )
-                                launch { horizontalScrollState.animateScrollTo(targetScrollX) }
-                                launch { verticalScrollState.animateScrollTo(targetScrollY) }
-                            }
+                        if (accountIndex >= 0 && currencyIndex >= 0) {
+                            val targetScrollX =
+                                horizontalMatrixScrollTarget(
+                                    accountIndex = accountIndex,
+                                    allAccounts = allAccounts,
+                                    accountColumnWidths = accountColumnWidths,
+                                    containerWidthDp = containerWidthDp,
+                                    density = density,
+                                )
+                            val targetScrollY =
+                                verticalMatrixScrollTarget(
+                                    currencyIndex = currencyIndex,
+                                    containerHeightDp = containerHeightDp,
+                                    density = density,
+                                )
+                            launch { horizontalScrollState.animateScrollTo(targetScrollX) }
+                            launch { verticalScrollState.animateScrollTo(targetScrollY) }
                         }
                     }
                 }

--- a/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -12,8 +12,10 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.waitUntilAtLeastOneExists
@@ -37,6 +39,7 @@ import com.moneymanager.domain.model.PagingInfo
 import com.moneymanager.domain.model.PagingResult
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.TransactionId
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.repository.AccountAttributeWriteRepository
@@ -65,6 +68,7 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
@@ -74,6 +78,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 
 @OptIn(ExperimentalTestApi::class)
 class AccountTransactionsScreenTest {
@@ -353,6 +359,121 @@ class AccountTransactionsScreenTest {
             // screen scrolls to the same transfer instead of landing on the first page.
             assertEquals(savings.id, clickedAccountId)
             assertEquals(transfer.id, clickedTransferId)
+        }
+
+    @Test
+    fun scrollingUpAfterNavigatingToTransfer_loadsNewerPage_withoutYankingBackToAnchor() =
+        runMoneyManagerComposeUiTest {
+            // Given: a long history where navigation lands on an old transfer, so the screen loads
+            // a window centred on it with newer pages available above (hasPrevious = true).
+            val now = Clock.System.now()
+            val usdCurrency = Currency(id = CurrencyId(1L), code = "USD", name = "US Dollar")
+            val checking = Account(id = AccountId(1L), name = "Checking", openingDate = now)
+            val savings = Account(id = AccountId(2L), name = "Savings", openingDate = now)
+            val transfers =
+                (0 until 200).map { i ->
+                    Transfer(
+                        id = TransferId(i.toLong()),
+                        timestamp = now - i.minutes,
+                        description = "Tx $i",
+                        sourceAccountId = checking.id,
+                        targetAccountId = savings.id,
+                        amount = Money.fromDisplayValue("100", usdCurrency),
+                    )
+                }
+            // Rows are newest-first, so row index i is "Tx i"; the anchor sits 30 rows below the
+            // top of the initial window (rows 160..199) — far enough that a yank back to it would
+            // scroll the window's newest rows out of the viewport.
+            val anchor = transfers[190]
+            val allRows = buildAccountRows(transfers, checking.id)
+            var backwardCalls = 0
+            val transactionRepository: TransactionWriteRepository =
+                mock(MockMode.autoUnit) {
+                    every { getTransactionById(any()) } calls { (id: Long) -> flowOf(transfers.find { it.id.id == id }) }
+                    every { getAccountBalances() } returns flowOf(emptyList())
+                    everySuspend { getRunningBalanceByAccountPaginated(any(), any(), any(), any()) } returns
+                        PagingResult(emptyList(), PagingInfo(null, null, hasMore = false))
+                    everySuspend { getPageContainingTransaction(any(), any(), any(), any()) } calls
+                        { args ->
+                            val currencyId = args.arg<CurrencyId?>(3)
+                            val rows = allRows.filterByCurrency(currencyId)
+                            val window = rows.subList(160, 200)
+                            PageWithTargetIndex(
+                                items = window,
+                                targetIndex = window.indexOfFirst { it.transactionId.id == anchor.id.id },
+                                pagingInfo =
+                                    PagingInfo(
+                                        lastTimestamp = window.last().timestamp,
+                                        lastId = window.last().transactionId,
+                                        hasMore = false,
+                                    ),
+                                hasPrevious = true,
+                            )
+                        }
+                    everySuspend { getRunningBalanceByAccountPaginatedBackward(any(), any(), any(), any(), any()) } calls
+                        { args ->
+                            val firstTimestamp = args.arg<Instant>(2)
+                            val firstId = args.arg<TransactionId>(3)
+                            val currencyId = args.arg<CurrencyId?>(4)
+                            backwardCalls++
+                            // Suspend like a real DB query: setting isLoadingPreviousPage recomposes
+                            // before this returns, so if the trigger effect keys on that flag it
+                            // restarts and cancels this very call — the load then never completes.
+                            delay(50)
+                            val rows = allRows.filterByCurrency(currencyId)
+                            val idx =
+                                rows.indexOfFirst {
+                                    it.transactionId.id == firstId.id && it.timestamp == firstTimestamp
+                                }
+                            val start = (idx - 10).coerceAtLeast(0)
+                            PagingResult(
+                                items = rows.subList(start, idx),
+                                pagingInfo = PagingInfo(null, null, hasMore = start > 0),
+                            )
+                        }
+                }
+
+            setContent {
+                ProvideSchemaAwareScope {
+                    AccountTransactionsScreen(
+                        accountId = checking.id,
+                        transactionRepository = transactionRepository,
+                        accountRepository = createAccountRepository(listOf(checking, savings)),
+                        accountAttributeRepository = createAccountAttributeRepository(),
+                        categoryRepository = createCategoryRepository(),
+                        currencyRepository = createCurrencyRepository(listOf(usdCurrency)),
+                        attributeTypeRepository = createAttributeTypeRepository(),
+                        personRepository = createPersonRepository(),
+                        personAccountOwnershipRepository = createPersonAccountOwnershipRepository(),
+                        maintenance = createMaintenance(),
+                        scrollToTransferId = anchor.id,
+                    )
+                }
+            }
+
+            // The screen centres the viewport on the anchor transaction.
+            waitUntilAtLeastOneExists(hasText("Tx 190"), timeoutMillis = 5_000)
+            waitForIdle()
+
+            // When: the user scrolls to the top of the loaded window, which triggers a backward
+            // load of newer transactions that get prepended to the list. Keep nudging to the top
+            // until the prepended page (Tx 150..159) lands and becomes the new list head.
+            val list = onNodeWithTag("accountTransactionsList")
+            var attempts = 0
+            while (onAllNodesWithText("Tx 150").fetchSemanticsNodes().isEmpty() && attempts < 40) {
+                list.performScrollToIndex(0)
+                mainClock.advanceTimeBy(100)
+                waitForIdle()
+                attempts++
+            }
+
+            // Then: the backward load completed and prepended newer rows (a load that keeps getting
+            // cancelled — e.g. by the trigger effect restarting on its own loading flag — never
+            // completes and Tx 150 never appears), and the viewport followed the user to the top
+            // instead of being yanked back to the anchor.
+            assertTrue(backwardCalls >= 1, "scrolling to the top should trigger a backward page load")
+            onNodeWithText("Tx 150").assertIsDisplayed()
+            onNodeWithText("Tx 190").assertDoesNotExist()
         }
 
     @Test


### PR DESCRIPTION
## Problem

Opening an account by clicking a transfer in another account's view centers the transaction list on that transfer (e.g. landing in 2022 for a crypto.com account). Scrolling toward newer transactions then **stopped partway** even though years of newer transactions existed — same for scrolling down. No error was logged.

## Root cause

The two pagination trigger effects used their own loading flags as `LaunchedEffect` keys:

```kotlin
LaunchedEffect(listState, isLoadingPreviousPage, hasPreviousPage) { ... loadPreviousPage() ... }
```

`loadPreviousPage()` sets `isLoadingPreviousPage = true` → key change → the effect restarts and **cancels the load it just started** (`withContext` discards its result on cancellation even when the query finished). Whether a page ever loaded was a race between the DB query and the next recomposition (~one frame). Near the anchor the query won; deeper into a large account it consistently lost, producing an invisible ~30ms cancel/retry loop — scrolling dead-stops in both directions.

Diagnosed by driving the real desktop app on the real database with debug logging, which showed an endless `loadPreviousPage CANCELLED at boundary=…` loop while the SQL-level paging (verified by simulation over all 7,257 rows of the affected account/asset) was provably correct.

## Fix

- The loading/hasMore flags are snapshot state read fresh inside the `collect` body, so they are **no longer effect keys** — the triggers key only on `(listState, anchorScrollPending)`.
- The forward trigger previously compared against a **stale captured** `displayedRunningBalances`; it now reads `layoutInfo.totalItemsCount`.
- Secondary bug fixed alongside: the scroll-to-transfer effect was keyed on `runningBalances`, so every prepend/append re-fired it and yanked the viewport back to the anchor. It now keys on a `pageLoadGeneration` counter (list contents can be `equals()`-identical across the currency-filtered reload, so a content key would not re-fire) with a one-shot `hasScrolledToTarget` latch, and auto-pagination is gated until the anchor scroll has run.

## Verification

- Real-app end-to-end: navigated to the crypto.com account via a 2022 transfer click and scrolled the entire four-year history to the newest transaction (2026-06) with zero stalls — previously it froze within two page loads.
- New regression test `scrollingUpAfterNavigatingToTransfer_loadsNewerPage_withoutYankingBackToAnchor` (fails against the previous code with the viewport yanked back to the anchor). Note: the effect-self-cancellation race is not reproducible under the Compose test scheduler — it resolves the race benignly — so that half of the fix is guarded by the explanatory comment plus the real-app verification.
- `./gradlew build buildHealth` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation to specific transactions so the list reliably scrolls to the selected transaction after initial loads and currency-filtered reloads.
  - Prevented automatic pagination from interrupting or shifting the list while navigating to a transaction.
  - Improved loading of newer transactions when scrolling upward, without unexpectedly returning to the original transaction.
- **Tests**
  - Added coverage for transaction navigation and paginated scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->