### PR TITLE
Import timeline view, trade audit history, transaction type column

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -7,6 +7,7 @@
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/money-manager.app.iml" filepath="$PROJECT_DIR$/.idea/modules/app/money-manager.app.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/db/core/money-manager.app.db.core.commonTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/db/core/money-manager.app.db.core.commonTest.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/remotestorage/money-manager.app.remotestorage.iml" filepath="$PROJECT_DIR$/.idea/modules/app/remotestorage/money-manager.app.remotestorage.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/ui/imports/money-manager.app.ui.imports.iml" filepath="$PROJECT_DIR$/.idea/modules/app/ui/imports/money-manager.app.ui.imports.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/test/app/money-manager.test.app.iml" filepath="$PROJECT_DIR$/.idea/modules/test/app/money-manager.test.app.iml" />
     </modules>
   </component>

--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
@@ -1838,9 +1838,9 @@ private suspend fun prepareValidTransactionItem(
     val amount =
         if (fee != null &&
             setup.strategy.transactionMappings.feeIncludedInAmount &&
-            fee.amount.currency.id == data.money.currency.id
+            fee.amount.asset.id == data.money.asset.id
         ) {
-            Money((data.money.amount - fee.amount.amount).coerceAtLeast(BigInteger.ZERO), data.money.currency)
+            Money((data.money.amount - fee.amount.amount).coerceAtLeast(BigInteger.ZERO), data.money.asset)
         } else {
             data.money
         }

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -545,7 +545,7 @@ private suspend fun valueUpdateFor(
     )
 }
 
-private fun Money.display(): String = "${toDisplayValue()} ${currency.code}"
+private fun Money.display(): String = "${toDisplayValue()} ${asset.code}"
 
 /** Emits a throttled per-row [ImportProgress] (every [PLAN_PROGRESS_EVERY_ROWS] rows and at the end). */
 private suspend fun emitRowProgress(

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/ApplyStrategyDialogTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/ApplyStrategyDialogTest.kt
@@ -250,7 +250,7 @@ class ApplyStrategyDialogTest {
                     amount =
                         Money.fromDisplayValue(
                             displayValue = BigDecimal("1.00"),
-                            currency =
+                            asset =
                                 Currency(
                                     id = CurrencyId(1),
                                     code = "GBP",

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoAssetCsvResolutionTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoAssetCsvResolutionTest.kt
@@ -83,8 +83,8 @@ class CryptoAssetCsvResolutionTest {
         val result = mapper.mapRow(CsvRow(rowIndex = 1, values = listOf("2021-07-04", "48.78055303", "CRO")))
         val success = assertIs<MappingResult.Success>(result, "crypto row should map: ${(result as? MappingResult.Error)?.errorMessage}")
 
-        assertTrue(success.transfer.amount.currency is CryptoAsset, "denominated in a crypto asset")
-        assertEquals("CRO", success.transfer.amount.currency.code)
+        assertTrue(success.transfer.amount.asset is CryptoAsset, "denominated in a crypto asset")
+        assertEquals("CRO", success.transfer.amount.asset.code)
         assertEquals(Money.fromDisplayValue("48.78055303", cro), success.transfer.amount)
     }
 

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvTransferMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvTransferMapperTest.kt
@@ -575,7 +575,7 @@ class CsvTransferMapperTest {
 
         assertIs<MappingResult.Success>(result)
         assertEquals("Test payment", result.transfer.description)
-        assertEquals(testCurrencyId, result.transfer.amount.currency.id)
+        assertEquals(testCurrencyId, result.transfer.amount.asset.id)
         assertEquals(BigInteger(5000L), result.transfer.amount.amount)
     }
 

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/database/csv/WiseCsvMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/database/csv/WiseCsvMapperTest.kt
@@ -150,7 +150,7 @@ class WiseCsvMapperTest {
         assertEquals(AccountId(-1), result.transfer.targetAccountId)
         assertEquals(listOf(NewAccount("Avolta - Tenerife", -1L)), result.newAccounts)
         assertEquals(BigInteger(2210L), result.transfer.amount.amount)
-        assertEquals(eur, result.transfer.amount.currency)
+        assertEquals(eur, result.transfer.amount.asset)
     }
 
     @Test
@@ -173,7 +173,7 @@ class WiseCsvMapperTest {
         assertEquals(AccountId(30), result.transfer.sourceAccountId)
         assertEquals(wiseGbp.id, result.transfer.targetAccountId)
         assertEquals(BigInteger(250000L), result.transfer.amount.amount)
-        assertEquals(gbp, result.transfer.amount.currency)
+        assertEquals(gbp, result.transfer.amount.asset)
         assertTrue(result.newAccounts.isEmpty())
     }
 
@@ -194,7 +194,7 @@ class WiseCsvMapperTest {
         assertEquals(wiseGbp.id, result.transfer.targetAccountId)
         // Wise-side (source) amount is recorded
         assertEquals(BigInteger(10000L), result.transfer.amount.amount)
-        assertEquals(eur, result.transfer.amount.currency)
+        assertEquals(eur, result.transfer.amount.asset)
     }
 
     @Test
@@ -284,8 +284,8 @@ class WiseCsvMapperTest {
         // 89.19 converted is the main movement; the 1.18 fee is its own linked fee transfer.
         assertEquals(BigInteger(8919L), result.transfer.amount.amount)
         assertEquals(BigInteger(118L), result.feeAmount?.amount)
-        assertEquals(gbp, result.transfer.amount.currency)
-        assertEquals(gbp, result.feeAmount?.currency)
+        assertEquals(gbp, result.transfer.amount.asset)
+        assertEquals(gbp, result.feeAmount?.asset)
         assertTrue(result.attributes.contains("wise-exchange-rate" to "2.24251"))
     }
 

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/Application.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/Application.kt
@@ -20,6 +20,7 @@ import com.moneymanager.domain.repository.CsvImportWriteRepository
 import com.moneymanager.domain.repository.CurrencyWriteRepository
 import com.moneymanager.domain.repository.DeviceReadRepository
 import com.moneymanager.domain.repository.ImportDirectoryReadRepository
+import com.moneymanager.domain.repository.ImportTimelineReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipWriteRepository
 import com.moneymanager.domain.repository.PersonAttributeWriteRepository
@@ -62,6 +63,7 @@ data class Imports(
     val strategyLibrary: StrategyLibrary,
     val qifImportRepository: QifImportWriteRepository,
     val importDirectoryRepository: ImportDirectoryReadRepository,
+    val importTimelineRepository: ImportTimelineReadRepository,
     val passThroughAccountRepository: PassThroughAccountReadRepository,
     val maintenance: Maintenance,
 )

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/api/CryptoComExchangeApiE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/api/CryptoComExchangeApiE2ETest.kt
@@ -115,10 +115,10 @@ class CryptoComExchangeApiE2ETest : DbTest() {
             // Two trades (BUY + SELL BTC/USD) on the exchange account.
             val trades = repositories.tradeRepository.getTradesByAccount(exchange.id).first()
             assertEquals(2, trades.size, "both trades imported")
-            val trade = trades.first { it.to.currency.code == "BTC" }
+            val trade = trades.first { it.to.asset.code == "BTC" }
             // BUY: USD leaves, BTC arrives.
-            assertEquals("USD", trade.from.currency.code)
-            assertEquals("BTC", trade.to.currency.code)
+            assertEquals("USD", trade.from.asset.code)
+            assertEquals("BTC", trade.to.asset.code)
             // 0.5 BTC in.
             assertEquals("0.5", trade.to.toDisplayValue().toString())
             // quote = 0.5 * 40000.54 = 20000.27, exactly representable at USD's 2-decimal scale.
@@ -139,7 +139,7 @@ class CryptoComExchangeApiE2ETest : DbTest() {
                         endDate = Instant.fromEpochMilliseconds(1_700_000_000_150L),
                     ).first()
                     .first { it.targetAccountId == feesAccount.id }
-            assertEquals("USD", feeTransfer.amount.currency.code)
+            assertEquals("USD", feeTransfer.amount.asset.code)
             assertEquals("0.52", feeTransfer.amount.toDisplayValue().toString())
 
             // Provenance points at the real JSON node so the audit view can expand to it.
@@ -149,7 +149,7 @@ class CryptoComExchangeApiE2ETest : DbTest() {
                         startDate = Instant.fromEpochMilliseconds(1_700_000_000_500L),
                         endDate = Instant.fromEpochMilliseconds(1_700_000_001_500L),
                     ).first()
-                    .first { it.targetAccountId == exchange.id && it.amount.currency.code == "CRO" }
+                    .first { it.targetAccountId == exchange.id && it.amount.asset.code == "CRO" }
             val depositSource =
                 repositories.transferSourceRepository
                     .getSourcesForTransaction(deposit.id)
@@ -262,7 +262,7 @@ class CryptoComExchangeApiE2ETest : DbTest() {
                         Instant.fromEpochMilliseconds(1_700_000_000_980L),
                         Instant.fromEpochMilliseconds(1_700_000_001_020L),
                     ).first()
-                    .first { it.amount.currency.code == "CRO" }
+                    .first { it.amount.asset.code == "CRO" }
             // Booked directly App -> Exchange (not via a funding/wallet account).
             assertEquals(app, apiDeposit.sourceAccountId, "internal deposit source should be the App account")
             assertEquals(exchange, apiDeposit.targetAccountId, "internal deposit target should be the Exchange account")
@@ -315,7 +315,7 @@ class CryptoComExchangeApiE2ETest : DbTest() {
                         endDate = Instant.fromEpochMilliseconds(1_700_000_002_000L),
                     ).first()
             val croDeposit =
-                exchangeTransfers.firstOrNull { it.targetAccountId == exchange.id && it.amount.currency.code == "CRO" }
+                exchangeTransfers.firstOrNull { it.targetAccountId == exchange.id && it.amount.asset.code == "CRO" }
             assertNotNull(croDeposit, "the CRO deposit should target the Exchange account")
             assertEquals(appAccount, croDeposit.sourceAccountId, "deposit rewritten to come from the App account")
 

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/audit/TradeAuditHistoryTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/audit/TradeAuditHistoryTest.kt
@@ -1,0 +1,69 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.moneymanager.database.audit
+
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AuditType
+import com.moneymanager.domain.model.Money
+import com.moneymanager.importengineapi.createCrypto
+import com.moneymanager.importengineapi.createTrade
+import com.moneymanager.test.database.DbTest
+import com.moneymanager.test.database.createAccount
+import com.moneymanager.test.database.upsertCurrencyByCode
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * Trades write their audit trail through DB triggers like transfers do; the audit history read
+ * must surface the audited field values so the UI can render a full "Created with" card.
+ */
+class TradeAuditHistoryTest : DbTest() {
+    @Test
+    fun `engine-created trade has an INSERT audit entry carrying its field values`() =
+        runTest {
+            val now = Clock.System.now()
+            val usdId = repositories.currencyRepository.upsertCurrencyByCode("USD", "US Dollar")
+            val usd = repositories.currencyRepository.getCurrencyById(usdId).first()!!
+            val btcId = repositories.importEngine.createCrypto("BTC")
+            val btc = repositories.cryptoRepository.getCryptoAssetByCode("BTC").first()!!
+            check(btcId.id == btc.id.id)
+            repositories.accountRepository.createAccount(
+                Account(id = AccountId(0), name = "Exchange", openingDate = now),
+            )
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Exchange" }
+
+            val fromAmount = Money.fromDisplayValue("100.00", usd)
+            val toAmount = Money.fromDisplayValue("0.001", btc)
+            val tradeId =
+                repositories.importEngine.createTrade(
+                    timestamp = now,
+                    description = "Sell USD/BTC",
+                    fromAccountId = exchange.id,
+                    fromAmount = fromAmount,
+                    toAccountId = exchange.id,
+                    toAmount = toAmount,
+                )
+
+            val entries = repositories.auditRepository.getAuditHistoryForTrade(tradeId)
+
+            val insert = entries.single()
+            assertEquals(AuditType.INSERT, insert.auditType)
+            assertEquals(tradeId, insert.tradeId)
+            assertEquals("Sell USD/BTC", insert.description)
+            assertEquals(exchange.id, insert.fromAccountId)
+            assertEquals(exchange.id, insert.toAccountId)
+            assertEquals(fromAmount, insert.fromAmount)
+            assertEquals(toAmount, insert.toAmount)
+            assertNotNull(insert.source)
+        }
+}

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCryptoE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCryptoE2ETest.kt
@@ -179,7 +179,7 @@ class CryptoComCryptoE2ETest : DbTest() {
                     .first()
                     .first { it.accountId == wallet.id }
                     .balance
-            assertEquals("CRO", balance.currency.code)
+            assertEquals("CRO", balance.asset.code)
             assertEquals("0.79", balance.toDisplayValue().toString())
         }
 
@@ -198,7 +198,7 @@ class CryptoComCryptoE2ETest : DbTest() {
         return repositories.transactionRepository
             .getAccountBalances()
             .first()
-            .first { it.accountId == account.id && it.balance.currency.code == assetCode }
+            .first { it.accountId == account.id && it.balance.asset.code == assetCode }
             .balance
             .toDisplayValue()
             .toString()
@@ -236,9 +236,9 @@ class CryptoComCryptoE2ETest : DbTest() {
             val trade = trades.single()
             assertEquals(wallet.id, trade.fromAccountId)
             assertEquals(wallet.id, trade.toAccountId)
-            assertEquals("TGBP", trade.from.currency.code)
+            assertEquals("TGBP", trade.from.asset.code)
             assertEquals("1499.936259", trade.from.toDisplayValue().toString())
-            assertEquals("CRO", trade.to.currency.code)
+            assertEquals("CRO", trade.to.asset.code)
             assertEquals("4965.5", trade.to.toDisplayValue().toString())
 
             // Both per-asset balances move inside the one account.
@@ -387,13 +387,13 @@ class CryptoComCryptoE2ETest : DbTest() {
                 "BTC",
                 trades
                     .single()
-                    .from.currency.code,
+                    .from.asset.code,
             )
             assertEquals(
                 "CRO",
                 trades
                     .single()
-                    .to.currency.code,
+                    .to.asset.code,
             )
             assertNull(accountByName("BTC -> CRO"), "emptied junk account must be deleted")
             assertEquals(
@@ -448,9 +448,9 @@ class CryptoComCryptoE2ETest : DbTest() {
             val credit = conversionLegs.single { it.sourceAccountId == conversions.id }
             val debits = conversionLegs.filter { it.targetAccountId == conversions.id }
             assertEquals(wallet.id, credit.targetAccountId)
-            assertEquals("CRO", credit.amount.currency.code)
+            assertEquals("CRO", credit.amount.asset.code)
             assertEquals(3, debits.size)
-            assertEquals(setOf("LUNA2", "DOT", "ALI"), debits.map { it.amount.currency.code }.toSet())
+            assertEquals(setOf("LUNA2", "DOT", "ALI"), debits.map { it.amount.asset.code }.toSet())
 
             // Each debit links to the credit with a `conversion` relationship (credit is id2).
             val links = repositories.transferRelationshipRepository.getByTransfer(credit.id).first()
@@ -465,7 +465,7 @@ class CryptoComCryptoE2ETest : DbTest() {
                 repositories.transactionRepository
                     .getAccountBalances()
                     .first()
-                    .first { it.accountId == wallet.id && it.balance.currency.code == "CRO" }
+                    .first { it.accountId == wallet.id && it.balance.asset.code == "CRO" }
                     .balance
             assertEquals("0.53", cro.toDisplayValue().toString())
         }

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCsvE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoComCsvE2ETest.kt
@@ -174,7 +174,7 @@ class CryptoComCsvE2ETest : DbTest() {
                     .getAccountBalances()
                     .first()
                     .filter { it.accountId == cryptoAccountId }
-                    .associate { it.balance.currency.code to it.balance.toDisplayValue().toString() }
+                    .associate { it.balance.asset.code to it.balance.toDisplayValue().toString() }
             assertEquals("0.79", cryptoBalances["CRO"], "CRO cashback 0.37 + 0.42, created on demand")
             // TGBP is an unknown ticker created on demand as crypto; net of the two conversions.
             assertEquals("-9.86", cryptoBalances["TGBP"], "TGBP bought 5000 - sold 5009.86")
@@ -184,18 +184,18 @@ class CryptoComCsvE2ETest : DbTest() {
             assertTrue(
                 cryptoTrades.any {
                     it.fromAccountId == cashId &&
-                        it.from.currency.code == "GBP" &&
+                        it.from.asset.code == "GBP" &&
                         it.toAccountId == cryptoAccountId &&
-                        it.to.currency.code == "TGBP"
+                        it.to.asset.code == "TGBP"
                 },
                 "viban_purchase: Cash GBP -> Crypto.com TGBP",
             )
             assertTrue(
                 cryptoTrades.any {
                     it.fromAccountId == cryptoAccountId &&
-                        it.from.currency.code == "TGBP" &&
+                        it.from.asset.code == "TGBP" &&
                         it.toAccountId == cashId &&
-                        it.to.currency.code == "GBP"
+                        it.to.asset.code == "GBP"
                 },
                 "crypto_viban: Crypto.com TGBP -> Cash GBP",
             )
@@ -316,16 +316,16 @@ class CryptoComCsvE2ETest : DbTest() {
                     .first()
                     .single()
             assertEquals(cashId, trade.fromAccountId)
-            assertEquals("GBP", trade.from.currency.code)
+            assertEquals("GBP", trade.from.asset.code)
             assertEquals("100", trade.from.toDisplayValue().toString())
-            assertEquals("BTC", trade.to.currency.code)
+            assertEquals("BTC", trade.to.asset.code)
             assertEquals("0.005", trade.to.toDisplayValue().toString())
 
             val balances = repositories.transactionRepository.getAccountBalances().first()
             assertEquals(
                 "0.005",
                 balances
-                    .first { it.accountId == cryptoAccountId && it.balance.currency.code == "BTC" }
+                    .first { it.accountId == cryptoAccountId && it.balance.asset.code == "BTC" }
                     .balance
                     .toDisplayValue()
                     .toString(),

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoCsvReimportE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoCsvReimportE2ETest.kt
@@ -133,7 +133,7 @@ class CryptoCsvReimportE2ETest : DbTest() {
                     .first()
                     .first { it.accountId == wallet }
                     .balance
-            assertEquals("CRO", walletBalance.currency.code)
+            assertEquals("CRO", walletBalance.asset.code)
             assertEquals("48.78055303", walletBalance.toDisplayValue().toString())
 
             // Re-import the same file (fresh staged copy): deduped, no new transfer, no new asset.

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoTradeCsvE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CryptoTradeCsvE2ETest.kt
@@ -140,10 +140,10 @@ class CryptoTradeCsvE2ETest : DbTest() {
             assertEquals(1, trades.size)
             val trade = trades.single()
             assertEquals(cash, trade.fromAccountId)
-            assertEquals("GBP", trade.from.currency.code)
+            assertEquals("GBP", trade.from.asset.code)
             assertEquals("100", trade.from.toDisplayValue().toString())
             assertEquals(wallet, trade.toAccountId)
-            assertEquals("BTC", trade.to.currency.code)
+            assertEquals("BTC", trade.to.asset.code)
             assertEquals("0.005", trade.to.toDisplayValue().toString())
 
             // Balances reflect both legs.

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -1286,19 +1286,19 @@ class ImportEngineDbTest : DbTest() {
 
             // The trade round-trips with both legs' assets.
             val trade = repositories.tradeRepository.getTradeById(tradeId).first()!!
-            assertEquals("GBP", trade.from.currency.code)
-            assertEquals("ETH", trade.to.currency.code)
+            assertEquals("GBP", trade.from.asset.code)
+            assertEquals("ETH", trade.to.asset.code)
             assertEquals(BigInteger("100000000000000000000"), trade.to.amount)
 
             // Balances reflect the trade's two legs at full precision.
             val balances = repositories.transactionRepository.getAccountBalances().first()
             val walletBalance = balances.first { it.accountId == wallet }.balance
-            assertEquals("ETH", walletBalance.currency.code)
+            assertEquals("ETH", walletBalance.asset.code)
             assertEquals("100", walletBalance.toDisplayValue().toString())
             assertEquals(BigInteger("100000000000000000000"), walletBalance.amount)
 
             val bankBalance = balances.first { it.accountId == bank }.balance
-            assertEquals("GBP", bankBalance.currency.code)
+            assertEquals("GBP", bankBalance.asset.code)
             assertEquals("-250000", bankBalance.toDisplayValue().toString())
 
             // The trade appears in the wallet's transaction list (running balance) as a +100 ETH row.
@@ -1307,7 +1307,7 @@ class ImportEngineDbTest : DbTest() {
                     .getRunningBalanceByAccountPaginated(wallet, pageSize = 10, pagingInfo = null)
                     .items
             val tradeRow = walletRows.single { it.transactionId.id == tradeId.id }
-            assertEquals("ETH", tradeRow.transactionAmount.currency.code)
+            assertEquals("ETH", tradeRow.transactionAmount.asset.code)
             assertEquals(BigInteger("100000000000000000000"), tradeRow.transactionAmount.amount)
             assertEquals(bank, tradeRow.sourceAccountId)
             assertEquals(wallet, tradeRow.targetAccountId)

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/ImportTimelineRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/ImportTimelineRepositoryImplTest.kt
@@ -1,0 +1,332 @@
+@file:OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)
+
+package com.moneymanager.database.repository
+
+import com.moneymanager.bigdecimal.BigDecimal
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.ApiSessionType
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.csv.CsvImportId
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.model.csvstrategy.CsvImportStrategyId
+import com.moneymanager.domain.model.qif.QifImportId
+import com.moneymanager.domain.model.timeline.TimelineSourceKind
+import com.moneymanager.test.database.DbTest
+import com.moneymanager.test.database.createAccount
+import com.moneymanager.test.database.upsertCurrencyByCode
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+class ImportTimelineRepositoryImplTest : DbTest() {
+    private val headers = listOf("Date", "Amount", "Description")
+    private val rows = listOf(listOf("2024-01-01", "100.00", "row"))
+    private val fileLastModified = Instant.fromEpochMilliseconds(1700000000000L)
+    private val appliedAt = Instant.fromEpochMilliseconds(1701000000000L)
+    private val earliestTimestamp = Instant.parse("2024-01-05T10:00:00Z")
+    private val latestTimestamp = Instant.parse("2024-03-20T18:30:00Z")
+
+    private lateinit var currency: Currency
+    private var counter = 0
+
+    private suspend fun setupAccountsAndCurrency() {
+        val currencyId = repositories.currencyRepository.upsertCurrencyByCode("GBP", "British Pound")
+        currency = repositories.currencyRepository.getCurrencyById(currencyId).first()!!
+        repositories.accountRepository.createAccount(
+            Account(id = AccountId(0), name = "Source", openingDate = Clock.System.now()),
+        )
+        repositories.accountRepository.createAccount(
+            Account(id = AccountId(0), name = "Target", openingDate = Clock.System.now()),
+        )
+    }
+
+    private suspend fun createTransferAt(
+        timestamp: Instant,
+        source: Source = Source.SampleGenerator,
+    ): Transfer {
+        val accounts = repositories.accountRepository.getAllAccounts().first()
+        val transfer =
+            Transfer(
+                id = TransferId(0),
+                timestamp = timestamp,
+                description = "transfer-${counter++}",
+                sourceAccountId = accounts.first { it.name == "Source" }.id,
+                targetAccountId = accounts.first { it.name == "Target" }.id,
+                amount = Money.fromDisplayValue(BigDecimal("12.34"), currency),
+            )
+        repositories.transactionRepository.createTransfers(
+            transfers = listOf(transfer),
+            sources = listOf(source),
+        )
+        return repositories.transactionRepository
+            .getTransactionsByDateRange(startDate = timestamp, endDate = timestamp)
+            .first()
+            .first { it.description == transfer.description }
+    }
+
+    private suspend fun attachCsvProvenance(
+        transfer: Transfer,
+        importId: CsvImportId,
+        rowIndex: Long,
+    ) {
+        val source =
+            repositories.transferSourceRepository.getSourceByRevision(
+                transactionId = transfer.id,
+                revisionId = transfer.revisionId,
+            )
+        assertNotNull(source)
+        entitySourceQueries.insertCsvSource(
+            id = source.id,
+            csv_import_id = importId.id.toString(),
+            csv_row_index = rowIndex,
+        )
+    }
+
+    private suspend fun createCsvImport(fileName: String): CsvImportId =
+        repositories.csvImportRepository.createImport(
+            fileName = fileName,
+            headers = headers,
+            rows = rows,
+            fileChecksum = "checksum-$fileName",
+            fileLastModified = fileLastModified,
+        )
+
+    private suspend fun createStrategy(name: String): CsvImportStrategy {
+        val strategy =
+            CsvImportStrategy(
+                id = CsvImportStrategyId(Uuid.random()),
+                name = name,
+                identificationColumns = headers.toSet(),
+                fieldMappings = emptyMap(),
+                createdAt = Clock.System.now(),
+                updatedAt = Clock.System.now(),
+            )
+        repositories.csvImportStrategyRepository.createStrategy(strategy, Source.Manual)
+        return strategy
+    }
+
+    @Test
+    fun `csv ranges cover min max timestamps and strategy of the latest application`() =
+        runTest {
+            setupAccountsAndCurrency()
+            val importId = createCsvImport("statement.csv")
+            val strategy = createStrategy("Monzo")
+            repositories.csvImportRepository.recordImportApplication(importId, strategy.id, strategy.name, appliedAt)
+            attachCsvProvenance(createTransferAt(earliestTimestamp), importId, rowIndex = 0)
+            attachCsvProvenance(createTransferAt(latestTimestamp), importId, rowIndex = 1)
+
+            val ranges = repositories.importTimelineRepository.getCsvImportDateRanges().first()
+
+            val range = ranges.single()
+            assertEquals(TimelineSourceKind.CSV, range.kind)
+            assertEquals(importId.id.toString(), range.fileId)
+            assertEquals("statement.csv", range.fileName)
+            assertEquals("Monzo", range.strategyName)
+            assertEquals(earliestTimestamp, range.earliest)
+            assertEquals(latestTimestamp, range.latest)
+            assertEquals(2, range.transactionCount)
+        }
+
+    @Test
+    fun `re-imported transfer with multiple provenance revisions is counted once`() =
+        runTest {
+            setupAccountsAndCurrency()
+            val importId = createCsvImport("statement.csv")
+            val transfer = createTransferAt(earliestTimestamp)
+            attachCsvProvenance(transfer, importId, rowIndex = 0)
+            // A re-import records fresh provenance under the next revision for the same transfer.
+            // Sample-generator type keeps getSourceByRevision reconstructable before the CSV side
+            // row lands; the timeline join only follows csv_entity_source, not the source type.
+            entitySourceQueries.insertSource(
+                entity_type_id = 7,
+                entity_id = transfer.id.id,
+                revision_id = transfer.revisionId + 1,
+                source_type_id = 3,
+                device_id = repositories.deviceId.id,
+            )
+            val reimportSource =
+                repositories.transferSourceRepository.getSourceByRevision(
+                    transactionId = transfer.id,
+                    revisionId = transfer.revisionId + 1,
+                )
+            assertNotNull(reimportSource)
+            entitySourceQueries.insertCsvSource(
+                id = reimportSource.id,
+                csv_import_id = importId.id.toString(),
+                csv_row_index = 0,
+            )
+
+            val range =
+                repositories.importTimelineRepository
+                    .getCsvImportDateRanges()
+                    .first()
+                    .single()
+            assertEquals(1, range.transactionCount)
+        }
+
+    @Test
+    fun `imports without transactions are absent`() =
+        runTest {
+            createCsvImport("unapplied.csv")
+
+            assertTrue(
+                repositories.importTimelineRepository
+                    .getCsvImportDateRanges()
+                    .first()
+                    .isEmpty(),
+            )
+            assertTrue(
+                repositories.importTimelineRepository
+                    .getAllDateRanges()
+                    .first()
+                    .isEmpty(),
+            )
+        }
+
+    @Test
+    fun `qif ranges mirror csv shape`() =
+        runTest {
+            setupAccountsAndCurrency()
+            val qifImportId: QifImportId =
+                repositories.qifImportRepository.createImport(
+                    fileName = "statement.qif",
+                    records = emptyList(),
+                    accountType = "Bank",
+                    fileChecksum = "qif-checksum",
+                    fileLastModified = fileLastModified,
+                )
+            val strategy = createStrategy("Monzo")
+            repositories.qifImportRepository.recordImportApplication(qifImportId, strategy.id, strategy.name, appliedAt)
+            val transfer = createTransferAt(earliestTimestamp)
+            val source =
+                repositories.transferSourceRepository.getSourceByRevision(
+                    transactionId = transfer.id,
+                    revisionId = transfer.revisionId,
+                )
+            assertNotNull(source)
+            entitySourceQueries.insertQifSource(
+                id = source.id,
+                qif_import_id = qifImportId.id.toString(),
+                qif_record_index = 0,
+            )
+
+            val range =
+                repositories.importTimelineRepository
+                    .getQifImportDateRanges()
+                    .first()
+                    .single()
+            assertEquals(TimelineSourceKind.QIF, range.kind)
+            assertEquals("statement.qif", range.fileName)
+            assertEquals("Monzo", range.strategyName)
+            assertEquals(earliestTimestamp, range.earliest)
+            assertEquals(earliestTimestamp, range.latest)
+            assertEquals(1, range.transactionCount)
+        }
+
+    @Test
+    fun `api session ranges group by session with type fallback`() =
+        runTest {
+            setupAccountsAndCurrency()
+            val sessionId =
+                repositories.apiSessionRepository.createSession(
+                    token = "token",
+                    deviceId = repositories.deviceId,
+                    createdAt = Clock.System.now(),
+                    expiresAt = null,
+                )
+            val requestId =
+                repositories.apiSessionRepository.insertRequest(
+                    sessionId = sessionId,
+                    method = "GET",
+                    url = "https://api.example.com/transactions",
+                    headers = emptyMap(),
+                )
+            val transfer = createTransferAt(latestTimestamp)
+            val source =
+                repositories.transferSourceRepository.getSourceByRevision(
+                    transactionId = transfer.id,
+                    revisionId = transfer.revisionId,
+                )
+            assertNotNull(source)
+            entitySourceQueries.insertApiSource(
+                id = source.id,
+                api_session_id = sessionId.id,
+                api_request_id = requestId.id,
+                json_path = "$.transactions[0]",
+            )
+
+            val range =
+                repositories.importTimelineRepository
+                    .getApiSessionDateRanges()
+                    .first()
+                    .single()
+            assertEquals(TimelineSourceKind.API, range.kind)
+            assertEquals(sessionId.id.toString(), range.fileId)
+            assertNull(range.strategyName)
+            assertEquals(ApiSessionType.MONZO, range.apiSessionType)
+            assertEquals(latestTimestamp, range.earliest)
+            assertEquals(latestTimestamp, range.latest)
+        }
+
+    @Test
+    fun `manual range covers manually created transfers only`() =
+        runTest {
+            setupAccountsAndCurrency()
+            createTransferAt(earliestTimestamp, source = Source.Manual)
+            createTransferAt(latestTimestamp, source = Source.Manual)
+            // A CSV-created transfer later edited manually must stay out of the Manual row: its
+            // creation revision is CSV even though a later revision is MANUAL.
+            val imported = createTransferAt(Instant.parse("2020-06-01T00:00:00Z"))
+            entitySourceQueries.insertSource(
+                entity_type_id = 7,
+                entity_id = imported.id.id,
+                revision_id = imported.revisionId + 1,
+                source_type_id = 1,
+                device_id = repositories.deviceId.id,
+            )
+
+            val manual = repositories.importTimelineRepository.getManualDateRange().first()
+
+            assertNotNull(manual)
+            assertEquals(TimelineSourceKind.MANUAL, manual.kind)
+            assertEquals(earliestTimestamp, manual.earliest)
+            assertEquals(latestTimestamp, manual.latest)
+            assertEquals(2, manual.transactionCount)
+        }
+
+    @Test
+    fun `manual range is null when nothing was entered manually`() =
+        runTest {
+            setupAccountsAndCurrency()
+            createTransferAt(earliestTimestamp)
+
+            assertNull(repositories.importTimelineRepository.getManualDateRange().first())
+        }
+
+    @Test
+    fun `getAllDateRanges combines every source`() =
+        runTest {
+            setupAccountsAndCurrency()
+            val importId = createCsvImport("statement.csv")
+            attachCsvProvenance(createTransferAt(earliestTimestamp), importId, rowIndex = 0)
+            createTransferAt(latestTimestamp, source = Source.Manual)
+
+            val all = repositories.importTimelineRepository.getAllDateRanges().first()
+
+            assertEquals(setOf(TimelineSourceKind.CSV, TimelineSourceKind.MANUAL), all.map { it.kind }.toSet())
+        }
+}

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/RunningBalancePaginationCurrencyFilterTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/RunningBalancePaginationCurrencyFilterTest.kt
@@ -92,14 +92,14 @@ class RunningBalancePaginationCurrencyFilterTest : DbTest() {
                 repositories.transactionRepository
                     .getRunningBalanceByAccountPaginated(card, pageSize = 5, pagingInfo = null)
             assertEquals(5, unfiltered.items.size)
-            assertTrue(unfiltered.items.all { it.transactionAmount.currency.code == "GBP" })
+            assertTrue(unfiltered.items.all { it.transactionAmount.asset.code == "GBP" })
 
             // Filtered by USD: both old rows arrive on the FIRST page.
             val usdPage =
                 repositories.transactionRepository
                     .getRunningBalanceByAccountPaginated(card, pageSize = 5, pagingInfo = null, currencyId = usd.id)
             assertEquals(listOf("Old USD 2", "Old USD 1"), usdPage.items.map { it.description })
-            assertTrue(usdPage.items.all { it.transactionAmount.currency.code == "USD" })
+            assertTrue(usdPage.items.all { it.transactionAmount.asset.code == "USD" })
             assertEquals(false, usdPage.pagingInfo.hasMore)
 
             // Running balances accumulate within the filtered currency only (card is the source side).
@@ -112,7 +112,7 @@ class RunningBalancePaginationCurrencyFilterTest : DbTest() {
                     .getPageContainingTransaction(card, TransferId(usdTransferId.id), pageSize = 5, currencyId = usd.id)
             assertEquals(2, page.items.size)
             assertTrue(page.targetIndex >= 0)
-            assertTrue(page.items.all { it.transactionAmount.currency.code == "USD" })
+            assertTrue(page.items.all { it.transactionAmount.asset.code == "USD" })
 
             // Backward pagination from the older USD row: only the newer USD row is returned —
             // the GBP rows between them are skipped by the filter.

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/TransactionRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/TransactionRepositoryImplTest.kt
@@ -55,7 +55,7 @@ class TransactionRepositoryImplTest : DbTest() {
             assertNotNull(retrieved, "Retrieved transaction should not be null for ID: ${createdTransfer.id}")
             assertEquals(sourceAccountId, retrieved.sourceAccountId)
             assertEquals(targetAccountId, retrieved.targetAccountId)
-            assertEquals(currencyId, retrieved.amount.currency.id)
+            assertEquals(currencyId, retrieved.amount.asset.id)
             assertEquals(Money.fromDisplayValue("100", currency), retrieved.amount)
         }
 
@@ -189,8 +189,8 @@ class TransactionRepositoryImplTest : DbTest() {
             val balances = repositories.transactionRepository.getAccountBalances().first()
 
             // Find balances for each account
-            val checkingBalance = balances.find { it.accountId == checkingAccountId && it.balance.currency.id == usdId }
-            val savingsBalance = balances.find { it.accountId == savingsAccountId && it.balance.currency.id == usdId }
+            val checkingBalance = balances.find { it.accountId == checkingAccountId && it.balance.asset.id == usdId }
+            val savingsBalance = balances.find { it.accountId == savingsAccountId && it.balance.asset.id == usdId }
 
             // Verify balances
             assertNotNull(checkingBalance, "Checking account should have a balance")
@@ -266,9 +266,9 @@ class TransactionRepositoryImplTest : DbTest() {
             val balances = repositories.transactionRepository.getAccountBalances().first()
 
             // Find balances for each account
-            val checkingBalance = balances.find { it.accountId == checkingAccountId && it.balance.currency.id == usdId }
-            val savingsBalance = balances.find { it.accountId == savingsAccountId && it.balance.currency.id == usdId }
-            val creditCardBalance = balances.find { it.accountId == creditCardAccountId && it.balance.currency.id == usdId }
+            val checkingBalance = balances.find { it.accountId == checkingAccountId && it.balance.asset.id == usdId }
+            val savingsBalance = balances.find { it.accountId == savingsAccountId && it.balance.asset.id == usdId }
+            val creditCardBalance = balances.find { it.accountId == creditCardAccountId && it.balance.asset.id == usdId }
 
             // Verify balances
             assertNotNull(checkingBalance)
@@ -338,12 +338,12 @@ class TransactionRepositoryImplTest : DbTest() {
             val balances = repositories.transactionRepository.getAccountBalances().first()
 
             // Find balances for checking account
-            val checkingUsdBalance = balances.find { it.accountId == checkingAccountId && it.balance.currency.id == usdId }
-            val checkingEurBalance = balances.find { it.accountId == checkingAccountId && it.balance.currency.id == eurId }
+            val checkingUsdBalance = balances.find { it.accountId == checkingAccountId && it.balance.asset.id == usdId }
+            val checkingEurBalance = balances.find { it.accountId == checkingAccountId && it.balance.asset.id == eurId }
 
             // Find balances for savings account
-            val savingsUsdBalance = balances.find { it.accountId == savingsAccountId && it.balance.currency.id == usdId }
-            val savingsEurBalance = balances.find { it.accountId == savingsAccountId && it.balance.currency.id == eurId }
+            val savingsUsdBalance = balances.find { it.accountId == savingsAccountId && it.balance.asset.id == usdId }
+            val savingsEurBalance = balances.find { it.accountId == savingsAccountId && it.balance.asset.id == eurId }
 
             // Verify balances
             assertNotNull(checkingUsdBalance)

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountRowMapper.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountRowMapper.kt
@@ -6,6 +6,7 @@ import com.moneymanager.bigdecimal.BigInteger
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AccountRow
 import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.TransactionKind
 import com.moneymanager.domain.model.TransferId
 import kotlin.time.Instant.Companion.fromEpochMilliseconds
 
@@ -33,6 +34,7 @@ object AccountRowMapper {
         feeParentTransferId: Long?,
         passThroughSpendId: Long?,
         passThroughFundingId: Long?,
+        transactionKind: String,
     ): AccountRow {
         val asset = AssetRowMapper.buildAsset(assetId, assetCode, assetName, assetScaleFactor, assetKind)
         return AccountRow(
@@ -50,6 +52,7 @@ object AccountRowMapper {
             feeParentTransferId = feeParentTransferId?.let { TransferId(it) },
             passThroughSpendId = passThroughSpendId?.let { TransferId(it) },
             passThroughFundingId = passThroughFundingId?.let { TransferId(it) },
+            kind = TransactionKind.valueOf(transactionKind),
         )
     }
 }

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/mapper/TradeAuditEntryMapper.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/mapper/TradeAuditEntryMapper.kt
@@ -2,8 +2,10 @@
 
 package com.moneymanager.database.mapper
 
+import com.moneymanager.bigdecimal.BigInteger
 import com.moneymanager.database.sql.audit.SelectAuditHistoryForTrade
 import com.moneymanager.domain.model.EntityType
+import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.SourceRecord
 import com.moneymanager.domain.model.TradeAuditEntry
 import tech.mappie.api.ObjectMappie
@@ -15,9 +17,29 @@ object TradeAuditEntryMapper :
     AuditTypeConversions {
     override fun map(from: SelectAuditHistoryForTrade): TradeAuditEntry =
         mapping {
+            TradeAuditEntry::fromAmount fromValue Money(BigInteger(from.from_amount), from.fromAsset())
+            TradeAuditEntry::toAmount fromValue Money(BigInteger(from.to_amount), from.toAsset())
             TradeAuditEntry::source fromValue from.toSourceRecord()
         }
 }
+
+private fun SelectAuditHistoryForTrade.fromAsset() =
+    AssetRowMapper.buildAsset(
+        id = from_asset_id,
+        code = from_asset_code,
+        name = from_asset_name,
+        scaleFactor = from_asset_scale_factor,
+        kind = from_asset_kind,
+    )
+
+private fun SelectAuditHistoryForTrade.toAsset() =
+    AssetRowMapper.buildAsset(
+        id = to_asset_id,
+        code = to_asset_code,
+        name = to_asset_name,
+        scaleFactor = to_asset_scale_factor,
+        kind = to_asset_kind,
+    )
 
 private fun SelectAuditHistoryForTrade.toSourceRecord(): SourceRecord? =
     buildSourceRecord(

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/ImportTimelineReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/ImportTimelineReadRepositoryImpl.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class)
+@file:OptIn(ExperimentalTime::class)
 
 package com.moneymanager.database.repository
 
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 class ImportTimelineReadRepositoryImpl(

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/ImportTimelineReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/ImportTimelineReadRepositoryImpl.kt
@@ -1,0 +1,136 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.database.repository
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOne
+import com.moneymanager.database.sql.read.MoneyManagerDatabase
+import com.moneymanager.domain.model.ApiSessionType
+import com.moneymanager.domain.model.timeline.ImportFileDateRange
+import com.moneymanager.domain.model.timeline.TimelineSourceKind
+import com.moneymanager.domain.repository.ImportTimelineReadRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Instant
+
+class ImportTimelineReadRepositoryImpl(
+    database: MoneyManagerDatabase,
+    private val coroutineContext: CoroutineContext = Dispatchers.Default,
+) : ImportTimelineReadRepository {
+    private val queries = database.timelineSelectQueries
+
+    override fun getCsvImportDateRanges(): Flow<List<ImportFileDateRange>> =
+        queries
+            .selectCsvImportDateRanges()
+            .asFlow()
+            .mapToList(coroutineContext)
+            .map { rows ->
+                rows.map { row ->
+                    fileRange(
+                        kind = TimelineSourceKind.CSV,
+                        fileId = row.import_id,
+                        fileName = row.file_name,
+                        ignored = row.ignored,
+                        strategyName = row.strategy_name,
+                        earliestMs = row.earliest_ms,
+                        latestMs = row.latest_ms,
+                        transactionCount = row.transaction_count,
+                    )
+                }
+            }
+
+    override fun getQifImportDateRanges(): Flow<List<ImportFileDateRange>> =
+        queries
+            .selectQifImportDateRanges()
+            .asFlow()
+            .mapToList(coroutineContext)
+            .map { rows ->
+                rows.map { row ->
+                    fileRange(
+                        kind = TimelineSourceKind.QIF,
+                        fileId = row.import_id,
+                        fileName = row.file_name,
+                        ignored = row.ignored,
+                        strategyName = row.strategy_name,
+                        earliestMs = row.earliest_ms,
+                        latestMs = row.latest_ms,
+                        transactionCount = row.transaction_count,
+                    )
+                }
+            }
+
+    override fun getApiSessionDateRanges(): Flow<List<ImportFileDateRange>> =
+        queries
+            .selectApiSessionDateRanges()
+            .asFlow()
+            .mapToList(coroutineContext)
+            .map { rows ->
+                rows.map { row ->
+                    ImportFileDateRange(
+                        kind = TimelineSourceKind.API,
+                        fileId = row.session_id.toString(),
+                        fileName = "Session ${row.session_id}",
+                        strategyName = row.strategy_name,
+                        apiSessionType = ApiSessionType.fromId(row.session_type_id),
+                        earliest = Instant.fromEpochMilliseconds(requireNotNull(row.earliest_ms)),
+                        latest = Instant.fromEpochMilliseconds(requireNotNull(row.latest_ms)),
+                        transactionCount = row.transaction_count,
+                    )
+                }
+            }
+
+    override fun getManualDateRange(): Flow<ImportFileDateRange?> =
+        queries
+            .selectManualDateRange()
+            .asFlow()
+            .mapToOne(coroutineContext)
+            .map { row ->
+                val earliestMs = row.earliest_ms ?: return@map null
+                val latestMs = row.latest_ms ?: return@map null
+                ImportFileDateRange(
+                    kind = TimelineSourceKind.MANUAL,
+                    fileId = "",
+                    fileName = "Manual entries",
+                    strategyName = null,
+                    earliest = Instant.fromEpochMilliseconds(earliestMs),
+                    latest = Instant.fromEpochMilliseconds(latestMs),
+                    transactionCount = requireNotNull(row.transaction_count),
+                )
+            }
+
+    override fun getAllDateRanges(): Flow<List<ImportFileDateRange>> =
+        combine(
+            getCsvImportDateRanges(),
+            getQifImportDateRanges(),
+            getApiSessionDateRanges(),
+            getManualDateRange(),
+        ) { csv, qif, api, manual ->
+            csv + qif + api + listOfNotNull(manual)
+        }
+
+    @Suppress("LongParameterList")
+    private fun fileRange(
+        kind: TimelineSourceKind,
+        fileId: String,
+        fileName: String,
+        ignored: Long,
+        strategyName: String?,
+        earliestMs: Long?,
+        latestMs: Long?,
+        transactionCount: Long,
+    ): ImportFileDateRange =
+        ImportFileDateRange(
+            kind = kind,
+            fileId = fileId,
+            fileName = fileName,
+            strategyName = strategyName,
+            ignored = ignored != 0L,
+            earliest = Instant.fromEpochMilliseconds(requireNotNull(earliestMs)),
+            latest = Instant.fromEpochMilliseconds(requireNotNull(latestMs)),
+            transactionCount = transactionCount,
+        )
+}

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/AuditSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/AuditSelect.sq
@@ -599,6 +599,22 @@ SELECT
     audit_type.name AS audit_type,
     trade_audit.trade_id,
     trade_audit.revision_id,
+    trade_audit.timestamp,
+    trade_audit.description,
+    trade_audit.from_account_id,
+    trade_audit.from_amount,
+    trade_audit.to_account_id,
+    trade_audit.to_amount,
+    from_asset.id AS from_asset_id,
+    from_asset.code AS from_asset_code,
+    from_asset.name AS from_asset_name,
+    from_asset.scale_factor AS from_asset_scale_factor,
+    from_asset.kind AS from_asset_kind,
+    to_asset.id AS to_asset_id,
+    to_asset.code AS to_asset_code,
+    to_asset.name AS to_asset_name,
+    to_asset.scale_factor AS to_asset_scale_factor,
+    to_asset.kind AS to_asset_kind,
     -- Source information
     entity_source.id AS source_id,
     entity_source.device_id AS source_device_id,
@@ -621,6 +637,8 @@ SELECT
     qif_import_metadata.original_file_name AS source_qif_file_name
 FROM trade_audit
 JOIN audit_type ON trade_audit.audit_type_id = audit_type.id
+JOIN asset_details from_asset ON trade_audit.from_asset_id = from_asset.id
+JOIN asset_details to_asset ON trade_audit.to_asset_id = to_asset.id
 LEFT JOIN entity_source ON trade_audit.trade_id = entity_source.entity_id
     AND trade_audit.revision_id = entity_source.revision_id
     AND entity_source.entity_type_id = 11

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/timeline/TimelineSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/timeline/TimelineSelect.sq
@@ -1,0 +1,91 @@
+-- Per-import transaction date ranges for the import Timeline view. Transfers are linked to their
+-- originating file via entity_source (entity_type_id = 7) + the per-format side tables. A transfer
+-- can carry several entity_source revisions for the same import (re-imports), so counts use
+-- DISTINCT transfer ids; the INNER JOIN on transfer drops provenance rows whose transfer was
+-- since deleted (entity_source.entity_id has no FK to transfer).
+-- Strategy attribution uses the latest application's snapshot name, so files imported before and
+-- after a strategy rename group separately.
+selectCsvImportDateRanges:
+SELECT
+    csv_import_metadata.id AS import_id,
+    csv_import_metadata.original_file_name AS file_name,
+    csv_import_metadata.ignored,
+    latest_application.strategy_id AS strategy_id,
+    latest_application.strategy_name AS strategy_name,
+    MIN(transfer.timestamp) AS earliest_ms,
+    MAX(transfer.timestamp) AS latest_ms,
+    COUNT(DISTINCT transfer.id) AS transaction_count
+FROM csv_import_metadata
+JOIN csv_entity_source ON csv_entity_source.csv_import_id = csv_import_metadata.id
+JOIN entity_source ON entity_source.id = csv_entity_source.id AND entity_source.entity_type_id = 7
+JOIN transfer ON transfer.id = entity_source.entity_id
+LEFT JOIN csv_import_application latest_application
+    ON latest_application.id = (
+        SELECT application.id
+        FROM csv_import_application application
+        WHERE application.csv_import_id = csv_import_metadata.id
+        ORDER BY application.applied_at DESC, application.id DESC
+        LIMIT 1
+    )
+GROUP BY csv_import_metadata.id;
+
+selectQifImportDateRanges:
+SELECT
+    qif_import_metadata.id AS import_id,
+    qif_import_metadata.original_file_name AS file_name,
+    qif_import_metadata.ignored,
+    latest_application.strategy_id AS strategy_id,
+    latest_application.strategy_name AS strategy_name,
+    MIN(transfer.timestamp) AS earliest_ms,
+    MAX(transfer.timestamp) AS latest_ms,
+    COUNT(DISTINCT transfer.id) AS transaction_count
+FROM qif_import_metadata
+JOIN qif_entity_source ON qif_entity_source.qif_import_id = qif_import_metadata.id
+JOIN entity_source ON entity_source.id = qif_entity_source.id AND entity_source.entity_type_id = 7
+JOIN transfer ON transfer.id = entity_source.entity_id
+LEFT JOIN qif_import_application latest_application
+    ON latest_application.id = (
+        SELECT application.id
+        FROM qif_import_application application
+        WHERE application.qif_import_id = qif_import_metadata.id
+        ORDER BY application.applied_at DESC, application.id DESC
+        LIMIT 1
+    )
+GROUP BY qif_import_metadata.id;
+
+-- One row per API session that produced transactions. strategy_name is NULL for legacy
+-- credential-less / strategy-less (Monzo) sessions — callers fall back to the session type name.
+selectApiSessionDateRanges:
+SELECT
+    api_session.id AS session_id,
+    api_session.created_at AS session_created_at,
+    api_session.type_id AS session_type_id,
+    api_credential.strategy_id AS strategy_id,
+    api_import_strategy.name AS strategy_name,
+    MIN(transfer.timestamp) AS earliest_ms,
+    MAX(transfer.timestamp) AS latest_ms,
+    COUNT(DISTINCT transfer.id) AS transaction_count
+FROM api_session
+JOIN api_entity_source ON api_entity_source.api_session_id = api_session.id
+JOIN entity_source ON entity_source.id = api_entity_source.id AND entity_source.entity_type_id = 7
+JOIN transfer ON transfer.id = entity_source.entity_id
+LEFT JOIN api_credential ON api_credential.id = api_session.credential_id
+LEFT JOIN api_import_strategy ON api_import_strategy.id = api_credential.strategy_id
+GROUP BY api_session.id;
+
+-- Manually *created* transfers only: restricting to each transfer's earliest revision keeps a
+-- later manual edit of an imported transfer out of the Manual row.
+selectManualDateRange:
+SELECT
+    MIN(transfer.timestamp) AS earliest_ms,
+    MAX(transfer.timestamp) AS latest_ms,
+    COUNT(DISTINCT transfer.id) AS transaction_count
+FROM entity_source
+JOIN transfer ON transfer.id = entity_source.entity_id
+WHERE entity_source.entity_type_id = 7
+  AND entity_source.source_type_id = 1
+  AND entity_source.revision_id = (
+      SELECT MIN(creation.revision_id)
+      FROM entity_source creation
+      WHERE creation.entity_type_id = 7 AND creation.entity_id = entity_source.entity_id
+  );

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
@@ -138,7 +138,9 @@ SELECT
     -- Pass-through (conduit) link, e.g. Curve: the spend leg when this row is the funding leg (id1),
     -- and the funding leg when this row is the spend leg (id2). PASS_THROUGH_RELATIONSHIP_TYPE_ID = 3.
     pass_through_as_funding.id2 AS pass_through_spend_id,
-    pass_through_as_spend.id1 AS pass_through_funding_id
+    pass_through_as_spend.id1 AS pass_through_funding_id,
+    -- Whether this row is a trade (same-transaction asset conversion) or a plain transfer.
+    CASE WHEN trade.id IS NOT NULL THEN 'TRADE' ELSE 'TRANSFER' END AS transaction_kind
 FROM running_balance_materialized_view
 JOIN asset_details ON running_balance_materialized_view.asset_id = asset_details.id
 LEFT JOIN transfer ON running_balance_materialized_view.id = transfer.id
@@ -194,7 +196,9 @@ SELECT
     -- Pass-through (conduit) link, e.g. Curve: the spend leg when this row is the funding leg (id1),
     -- and the funding leg when this row is the spend leg (id2). PASS_THROUGH_RELATIONSHIP_TYPE_ID = 3.
     pass_through_as_funding.id2 AS pass_through_spend_id,
-    pass_through_as_spend.id1 AS pass_through_funding_id
+    pass_through_as_spend.id1 AS pass_through_funding_id,
+    -- Whether this row is a trade (same-transaction asset conversion) or a plain transfer.
+    CASE WHEN trade.id IS NOT NULL THEN 'TRADE' ELSE 'TRANSFER' END AS transaction_kind
 FROM running_balance_materialized_view
 JOIN asset_details ON running_balance_materialized_view.asset_id = asset_details.id
 LEFT JOIN transfer ON running_balance_materialized_view.id = transfer.id
@@ -258,7 +262,9 @@ SELECT
     -- Pass-through (conduit) link, e.g. Curve: the spend leg when this row is the funding leg (id1),
     -- and the funding leg when this row is the spend leg (id2). PASS_THROUGH_RELATIONSHIP_TYPE_ID = 3.
     pass_through_as_funding.id2 AS pass_through_spend_id,
-    pass_through_as_spend.id1 AS pass_through_funding_id
+    pass_through_as_spend.id1 AS pass_through_funding_id,
+    -- Whether this row is a trade (same-transaction asset conversion) or a plain transfer.
+    CASE WHEN trade.id IS NOT NULL THEN 'TRADE' ELSE 'TRANSFER' END AS transaction_kind
 FROM running_balance_materialized_view
 JOIN asset_details ON running_balance_materialized_view.asset_id = asset_details.id
 LEFT JOIN transfer ON running_balance_materialized_view.id = transfer.id

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/TradeWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/TradeWriteRepositoryImpl.kt
@@ -38,8 +38,8 @@ class TradeWriteRepositoryImpl(
     ): TradeCreateResult {
         // A trade is a cross-asset exchange; a same-asset movement is a transfer. The DB CHECK only
         // blocks the same-account+same-asset degenerate case, so enforce the cross-asset rule here.
-        require(fromAmount.currency.id != toAmount.currency.id) {
-            "A trade must exchange two different assets (from and to assets are both ${fromAmount.currency.code})"
+        require(fromAmount.asset.id != toAmount.asset.id) {
+            "A trade must exchange two different assets (from and to assets are both ${fromAmount.asset.code})"
         }
         return withContext(Dispatchers.Default) {
             writeQueries.transactionWithResult {
@@ -51,10 +51,10 @@ class TradeWriteRepositoryImpl(
                             timestamp = timestamp.toEpochMilliseconds(),
                             description = description,
                             from_account_id = fromAccountId.id,
-                            from_asset_id = fromAmount.currency.id.id,
+                            from_asset_id = fromAmount.asset.id.id,
                             from_amount = fromAmount.amount.toString(),
                             to_account_id = toAccountId.id,
-                            to_asset_id = toAmount.currency.id.id,
+                            to_asset_id = toAmount.asset.id.id,
                             to_amount = toAmount.amount.toString(),
                         ).executeAsOneOrNull()
                 if (existing != null) {
@@ -69,10 +69,10 @@ class TradeWriteRepositoryImpl(
                     timestamp = timestamp.toEpochMilliseconds(),
                     description = description,
                     from_account_id = fromAccountId.id,
-                    from_asset_id = fromAmount.currency.id.id,
+                    from_asset_id = fromAmount.asset.id.id,
                     from_amount = fromAmount.amount.toString(),
                     to_account_id = toAccountId.id,
-                    to_asset_id = toAmount.currency.id.id,
+                    to_asset_id = toAmount.asset.id.id,
                     to_amount = toAmount.amount.toString(),
                 )
                 database.recordSource(deviceId, EntityType.TRADE, id, 1L, source)

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionWriteRepositoryImpl.kt
@@ -96,7 +96,7 @@ class TransactionWriteRepositoryImpl(
                         description = transfer.description,
                         source_account_id = transfer.sourceAccountId.id,
                         target_account_id = transfer.targetAccountId.id,
-                        asset_id = transfer.amount.currency.id.id,
+                        asset_id = transfer.amount.asset.id.id,
                         amount = transfer.amount.amount.toString(),
                         id = transfer.id.id,
                     )
@@ -190,7 +190,7 @@ class TransactionWriteRepositoryImpl(
                         description = updatedTransfer.description,
                         source_account_id = updatedTransfer.sourceAccountId.id,
                         target_account_id = updatedTransfer.targetAccountId.id,
-                        asset_id = updatedTransfer.amount.currency.id.id,
+                        asset_id = updatedTransfer.amount.asset.id.id,
                         amount = updatedTransfer.amount.amount.toString(),
                         id = updatedTransfer.id.id,
                     )
@@ -273,7 +273,7 @@ class TransactionWriteRepositoryImpl(
                 description = transfer.description,
                 source_account_id = transfer.sourceAccountId.id,
                 target_account_id = transfer.targetAccountId.id,
-                asset_id = transfer.amount.currency.id.id,
+                asset_id = transfer.amount.asset.id.id,
                 amount = transfer.amount.amount.toString(),
             )
             newAttributes[transfer.id].orEmpty().forEach { attr ->

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/ApplicationMapper.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/ApplicationMapper.kt
@@ -33,6 +33,7 @@ fun DatabaseComponent.toApplication() =
                 strategyLibrary = strategyLibrary,
                 qifImportRepository = qifImportRepository,
                 importDirectoryRepository = importDirectoryRepository,
+                importTimelineRepository = importTimelineRepository,
                 passThroughAccountRepository = passThroughAccountRepository,
                 maintenance = DbMaintenance(maintenanceService),
             ),

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/DatabaseComponent.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/DatabaseComponent.kt
@@ -21,6 +21,7 @@ import com.moneymanager.domain.repository.CsvImportWriteRepository
 import com.moneymanager.domain.repository.CurrencyWriteRepository
 import com.moneymanager.domain.repository.DeviceWriteRepository
 import com.moneymanager.domain.repository.ImportDirectoryWriteRepository
+import com.moneymanager.domain.repository.ImportTimelineReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountWriteRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipWriteRepository
 import com.moneymanager.domain.repository.PersonAttributeWriteRepository
@@ -68,6 +69,7 @@ interface DatabaseComponent {
     val tradeRepository: TradeWriteRepository
     val deviceRepository: DeviceWriteRepository
     val importDirectoryRepository: ImportDirectoryWriteRepository
+    val importTimelineRepository: ImportTimelineReadRepository
     val maintenanceService: DatabaseMaintenanceService
     val personAccountOwnershipRepository: PersonAccountOwnershipWriteRepository
     val personAttributeRepository: PersonAttributeWriteRepository

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/RepositoryModule.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/RepositoryModule.kt
@@ -30,6 +30,7 @@ import com.moneymanager.database.repository.DeviceReadRepositoryImpl
 import com.moneymanager.database.repository.DeviceWriteRepositoryImpl
 import com.moneymanager.database.repository.ImportDirectoryReadRepositoryImpl
 import com.moneymanager.database.repository.ImportDirectoryWriteRepositoryImpl
+import com.moneymanager.database.repository.ImportTimelineReadRepositoryImpl
 import com.moneymanager.database.repository.PassThroughAccountReadRepositoryImpl
 import com.moneymanager.database.repository.PassThroughAccountWriteRepositoryImpl
 import com.moneymanager.database.repository.PersonAccountOwnershipReadRepositoryImpl
@@ -88,6 +89,7 @@ import com.moneymanager.domain.repository.DeviceReadRepository
 import com.moneymanager.domain.repository.DeviceWriteRepository
 import com.moneymanager.domain.repository.ImportDirectoryReadRepository
 import com.moneymanager.domain.repository.ImportDirectoryWriteRepository
+import com.moneymanager.domain.repository.ImportTimelineReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountWriteRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipReadRepository
@@ -263,6 +265,11 @@ interface RepositoryModule {
         deviceId: DeviceId,
         reader: ImportDirectoryReadRepository,
     ): ImportDirectoryWriteRepository = ImportDirectoryWriteRepositoryImpl(database, deviceId, reader)
+
+    @Provides
+    @SingleIn(DatabaseScope::class)
+    fun provideImportTimelineReadRepository(database: MoneyManagerDatabaseWrapper): ImportTimelineReadRepository =
+        ImportTimelineReadRepositoryImpl(database)
 
     @Provides
     @SingleIn(DatabaseScope::class)

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
@@ -309,7 +309,7 @@ class ImportDeduper(
             } else {
                 reconcileCandidates
                     .firstOrNull { (_, existing) ->
-                        existing.amount.currency.id == amount.currency.id &&
+                        existing.amount.asset.id == amount.asset.id &&
                             amountWithinTolerance(amount, existing.amount, policy.internalTransferAmountTolerance) &&
                             (timestamp - existing.timestamp).absoluteValue <= window &&
                             (

--- a/app/importer/src/commonTest/kotlin/com/moneymanager/importer/ImportDeduperTest.kt
+++ b/app/importer/src/commonTest/kotlin/com/moneymanager/importer/ImportDeduperTest.kt
@@ -31,7 +31,7 @@ class ImportDeduperTest {
     private val target = AccountId(2)
     private val baseTime = Instant.fromEpochMilliseconds(1_700_000_000_000)
 
-    private fun money(major: Long) = Money(amount = major * 100, currency = currency)
+    private fun money(major: Long) = Money(amount = major * 100, asset = currency)
 
     private fun importTransfer(
         rowIndex: Long,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AccountRow.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AccountRow.kt
@@ -26,4 +26,5 @@ data class AccountRow(
     val passThroughSpendId: TransferId? = null,
     /** When this row IS the spend leg of a pass-through charge, the id of its funding leg. */
     val passThroughFundingId: TransferId? = null,
+    val kind: TransactionKind = TransactionKind.TRANSFER,
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Money.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/Money.kt
@@ -12,26 +12,23 @@ import com.moneymanager.bigdecimal.toBigIntegerExact
  * determines the conversion between stored amounts and display amounts. A [BigInteger] (rather than a
  * [Long]) is required because high-precision crypto scale factors would otherwise overflow.
  *
- * The denominating asset is exposed as [currency] for historical reasons — it may be any [Asset],
- * fiat or crypto, not only a fiat [Currency].
- *
  * For example:
  * - £123.45 is stored as amount=12345 with GBP (scaleFactor=100)
  * - ¥1000 is stored as amount=1000 with JPY (scaleFactor=1)
  * - 0.5 BTC is stored as amount=5·10^17 with BTC (scaleFactor=10^18)
  *
  * @property amount The amount in the asset's smallest unit (pence, satoshis, wei, …)
- * @property currency The asset this monetary amount is denominated in
+ * @property asset The asset this monetary amount is denominated in (fiat or crypto)
  */
 data class Money(
     val amount: BigInteger,
-    val currency: Asset,
+    val asset: Asset,
 ) : Comparable<Money> {
     /** Convenience for constructing from a minor-unit amount that fits in a [Long]. */
-    constructor(amount: Long, currency: Asset) : this(BigInteger(amount), currency)
+    constructor(amount: Long, asset: Asset) : this(BigInteger(amount), asset)
 
     /** Convenience for constructing from a minor-unit amount that fits in an [Int]. */
-    constructor(amount: Int, currency: Asset) : this(BigInteger(amount.toLong()), currency)
+    constructor(amount: Int, asset: Asset) : this(BigInteger(amount.toLong()), asset)
 
     /**
      * Converts the stored amount to a display value using BigDecimal for precision.
@@ -41,7 +38,7 @@ data class Money(
      *
      * @return The display value as BigDecimal (e.g., 12345 with scaleFactor=100 becomes 123.45)
      */
-    fun toDisplayValue(): BigDecimal = amount.toBigDecimal().movePointLeft(currency.decimalPlaces)
+    fun toDisplayValue(): BigDecimal = amount.toBigDecimal().movePointLeft(asset.decimalPlaces)
 
     /**
      * Adds another Money amount to this one.
@@ -50,7 +47,7 @@ data class Money(
      */
     operator fun plus(other: Money): Money {
         requireSameAsset(other)
-        return Money(amount + other.amount, currency)
+        return Money(amount + other.amount, asset)
     }
 
     /**
@@ -60,13 +57,13 @@ data class Money(
      */
     operator fun minus(other: Money): Money {
         requireSameAsset(other)
-        return Money(amount - other.amount, currency)
+        return Money(amount - other.amount, asset)
     }
 
     /**
      * Multiplies this Money amount by a scalar value.
      */
-    operator fun times(multiplier: Long): Money = Money(amount * BigInteger(multiplier), currency)
+    operator fun times(multiplier: Long): Money = Money(amount * BigInteger(multiplier), asset)
 
     /**
      * Multiplies this Money amount by a scalar value.
@@ -76,7 +73,7 @@ data class Money(
     /**
      * Divides this Money amount by a scalar value (integer division, truncated toward zero).
      */
-    operator fun div(divisor: Long): Money = Money(amount / BigInteger(divisor), currency)
+    operator fun div(divisor: Long): Money = Money(amount / BigInteger(divisor), asset)
 
     /**
      * Divides this Money amount by a scalar value (integer division, truncated toward zero).
@@ -86,7 +83,7 @@ data class Money(
     /**
      * Negates this Money amount.
      */
-    operator fun unaryMinus(): Money = Money(-amount, currency)
+    operator fun unaryMinus(): Money = Money(-amount, asset)
 
     /**
      * Compares this Money amount with another.
@@ -116,11 +113,11 @@ data class Money(
     /**
      * Returns the absolute value of this Money amount.
      */
-    fun abs(): Money = if (isNegative()) Money(amount.abs(), currency) else this
+    fun abs(): Money = if (isNegative()) Money(amount.abs(), asset) else this
 
     private fun requireSameAsset(other: Money) {
-        require(currency.id == other.currency.id) {
-            "Cannot perform operation on Money with different assets: ${currency.code} and ${other.currency.code}"
+        require(asset.id == other.asset.id) {
+            "Cannot perform operation on Money with different assets: ${asset.code} and ${other.asset.code}"
         }
     }
 
@@ -136,10 +133,10 @@ data class Money(
          */
         fun fromDisplayValue(
             displayValue: BigDecimal,
-            currency: Asset,
+            asset: Asset,
         ): Money {
-            val scaled = displayValue * BigDecimal(currency.scaleFactor)
-            return Money(scaled.toBigIntegerExact(), currency)
+            val scaled = displayValue * BigDecimal(asset.scaleFactor)
+            return Money(scaled.toBigIntegerExact(), asset)
         }
 
         /**
@@ -147,12 +144,12 @@ data class Money(
          */
         fun fromDisplayValue(
             displayValue: String,
-            currency: Asset,
-        ): Money = fromDisplayValue(BigDecimal(displayValue), currency)
+            asset: Asset,
+        ): Money = fromDisplayValue(BigDecimal(displayValue), asset)
 
         /**
          * Creates a zero Money instance for a given asset.
          */
-        fun zero(currency: Asset): Money = Money(BigInteger.ZERO, currency)
+        fun zero(asset: Asset): Money = Money(BigInteger.ZERO, asset)
     }
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TradeAuditEntry.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TradeAuditEntry.kt
@@ -4,12 +4,18 @@ package com.moneymanager.domain.model
 
 import kotlin.time.Instant
 
-/** One historical revision of a trade, with its provenance. */
+/** One historical revision of a trade, with its audited field values and provenance. */
 data class TradeAuditEntry(
     val id: Long,
     val auditTimestamp: Instant,
     val auditType: AuditType,
     val tradeId: TradeId,
     val revisionId: Long,
+    val timestamp: Instant,
+    val description: String,
+    val fromAccountId: AccountId,
+    val fromAmount: Money,
+    val toAccountId: AccountId,
+    val toAmount: Money,
     val source: SourceRecord? = null,
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TransactionKind.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TransactionKind.kt
@@ -1,0 +1,11 @@
+package com.moneymanager.domain.model
+
+/**
+ * What kind of transaction a row represents: a [Transfer] between accounts, a [Trade] converting
+ * one asset to another, or an order (declared ahead of the order entity landing).
+ */
+enum class TransactionKind {
+    TRANSFER,
+    TRADE,
+    ORDER,
+}

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/timeline/ImportTimeline.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/timeline/ImportTimeline.kt
@@ -1,0 +1,34 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.moneymanager.domain.model.timeline
+
+import com.moneymanager.domain.model.ApiSessionType
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+enum class TimelineSourceKind {
+    CSV,
+    QIF,
+    API,
+    MANUAL,
+}
+
+/**
+ * Transaction date coverage of one imported file (CSV/QIF), API session, or the aggregate of all
+ * manually created transactions. Only files that actually produced transactions have a range.
+ */
+data class ImportFileDateRange(
+    val kind: TimelineSourceKind,
+    /** CSV/QIF import uuid or API session id as a string; empty for the manual aggregate. */
+    val fileId: String,
+    /** Original file name; API sessions and the manual aggregate use a synthetic label. */
+    val fileName: String,
+    /** Latest applied strategy name (CSV/QIF) or API strategy name; null for manual/legacy API. */
+    val strategyName: String?,
+    /** Row-grouping fallback for legacy API sessions without a strategy. */
+    val apiSessionType: ApiSessionType? = null,
+    val ignored: Boolean = false,
+    val earliest: Instant,
+    val latest: Instant,
+    val transactionCount: Long,
+)

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ImportTimelineReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ImportTimelineReadRepository.kt
@@ -1,0 +1,25 @@
+package com.moneymanager.domain.repository
+
+import com.moneymanager.domain.model.timeline.ImportFileDateRange
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Read-only aggregate of per-import transaction date ranges, powering the import Timeline view
+ * and the date-range lines on the CSV/QIF/API import screens.
+ */
+interface ImportTimelineReadRepository {
+    /** One entry per CSV import that produced transactions. */
+    fun getCsvImportDateRanges(): Flow<List<ImportFileDateRange>>
+
+    /** One entry per QIF import that produced transactions. */
+    fun getQifImportDateRanges(): Flow<List<ImportFileDateRange>>
+
+    /** One entry per API session that produced transactions. */
+    fun getApiSessionDateRanges(): Flow<List<ImportFileDateRange>>
+
+    /** Aggregate range of manually created transactions, or null when there are none. */
+    fun getManualDateRange(): Flow<ImportFileDateRange?>
+
+    /** All of the above combined — the timeline screen's single input. */
+    fun getAllDateRanges(): Flow<List<ImportFileDateRange>>
+}

--- a/app/model/core/src/commonTest/kotlin/com/moneymanager/domain/model/MoneyTest.kt
+++ b/app/model/core/src/commonTest/kotlin/com/moneymanager/domain/model/MoneyTest.kt
@@ -54,7 +54,7 @@ class MoneyTest {
     fun fromDisplayValue_bigDecimal_convertsCorrectly() {
         val money = Money.fromDisplayValue(BigDecimal("123.45"), usd)
         assertEquals(BigInteger(12345L), money.amount)
-        assertEquals(usd.id, money.currency.id)
+        assertEquals(usd.id, money.asset.id)
     }
 
     @Test
@@ -70,7 +70,7 @@ class MoneyTest {
         val result = a + b
 
         assertEquals(BigInteger(15000L), result.amount) // $150.00
-        assertEquals(usd.id, result.currency.id)
+        assertEquals(usd.id, result.asset.id)
     }
 
     @Test
@@ -90,7 +90,7 @@ class MoneyTest {
         val result = a - b
 
         assertEquals(BigInteger(7000L), result.amount) // $70.00
-        assertEquals(usd.id, result.currency.id)
+        assertEquals(usd.id, result.asset.id)
     }
 
     @Test
@@ -109,7 +109,7 @@ class MoneyTest {
         val result = money * 5L
 
         assertEquals(BigInteger(5000L), result.amount) // $50.00
-        assertEquals(usd.id, result.currency.id)
+        assertEquals(usd.id, result.asset.id)
     }
 
     @Test
@@ -118,7 +118,7 @@ class MoneyTest {
         val result = money * 3
 
         assertEquals(BigInteger(3000L), result.amount) // $30.00
-        assertEquals(usd.id, result.currency.id)
+        assertEquals(usd.id, result.asset.id)
     }
 
     @Test
@@ -127,7 +127,7 @@ class MoneyTest {
         val result = money / 4L
 
         assertEquals(BigInteger(2500L), result.amount) // $25.00
-        assertEquals(usd.id, result.currency.id)
+        assertEquals(usd.id, result.asset.id)
     }
 
     @Test
@@ -136,7 +136,7 @@ class MoneyTest {
         val result = money / 2
 
         assertEquals(BigInteger(5000L), result.amount) // $50.00
-        assertEquals(usd.id, result.currency.id)
+        assertEquals(usd.id, result.asset.id)
     }
 
     @Test
@@ -145,7 +145,7 @@ class MoneyTest {
         val result = -money
 
         assertEquals(BigInteger(-10000L), result.amount) // -$100.00
-        assertEquals(usd.id, result.currency.id)
+        assertEquals(usd.id, result.asset.id)
     }
 
     @Test
@@ -232,7 +232,7 @@ class MoneyTest {
     fun zero_createsZeroMoney() {
         val money = Money.zero(usd)
         assertEquals(BigInteger(0L), money.amount)
-        assertEquals(usd.id, money.currency.id)
+        assertEquals(usd.id, money.asset.id)
     }
 
     @Test
@@ -285,7 +285,7 @@ class MoneyTest {
         val money = Money.fromDisplayValue("0.5", btc)
         assertEquals(BigInteger(50_000_000L), money.amount)
         assertEquals("0.5", money.toDisplayValue().toString())
-        assertEquals(btc.id, money.currency.id)
+        assertEquals(btc.id, money.asset.id)
     }
 
     @Test

--- a/app/ui/accounts/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
+++ b/app/ui/accounts/src/commonMain/kotlin/com/moneymanager/ui/screens/AccountsScreen.kt
@@ -114,7 +114,7 @@ fun AccountsScreen(
     // Unique assets that appear in at least one account balance, sorted by code for stable display.
     val availableAssets: List<Asset> =
         remember(balances) {
-            balances.map { it.balance.currency }.distinctBy { it.id }.sortedBy { it.code }
+            balances.map { it.balance.asset }.distinctBy { it.id }.sortedBy { it.code }
         }
 
     // Drop asset selections for assets that no longer have any balances.
@@ -132,7 +132,7 @@ fun AccountsScreen(
                         ownerIdsByAccount[account.id].orEmpty().any { it in selectedOwnerIds }
                 val matchesAsset =
                     selectedAssetIds.isEmpty() ||
-                        balancesByAccount[account.id].orEmpty().any { it.balance.currency.id in selectedAssetIds }
+                        balancesByAccount[account.id].orEmpty().any { it.balance.asset.id in selectedAssetIds }
                 matchesName && matchesOwner && matchesAsset
             }
         }
@@ -519,7 +519,7 @@ fun AccountCard(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
-                            text = balance.balance.currency.code,
+                            text = balance.balance.asset.code,
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )

--- a/app/ui/categories/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
+++ b/app/ui/categories/src/commonMain/kotlin/com/moneymanager/ui/screens/CategoriesScreen.kt
@@ -132,7 +132,7 @@ fun CategoriesScreen(
     // Get unique currencies that have balances (for column headers)
     val currenciesWithBalances =
         remember(categoryBalances, currencies) {
-            val currencyIdsWithBalances = categoryBalances.map { it.balance.currency.id }.toSet()
+            val currencyIdsWithBalances = categoryBalances.map { it.balance.asset.id }.toSet()
             currencies.filter { it.id in currencyIdsWithBalances }
         }
 
@@ -142,7 +142,7 @@ fun CategoriesScreen(
             currenciesWithBalances.associate { currency ->
                 val maxMoney =
                     categoryBalances
-                        .filter { it.balance.currency.id == currency.id }
+                        .filter { it.balance.asset.id == currency.id }
                         .maxByOrNull { it.balance.amount.abs() }
                         ?.balance
                 val formattedMax = maxMoney?.let { formatAmount(it) } ?: formatAmount(BigDecimal.ZERO, currency)
@@ -449,7 +449,7 @@ fun CategoryTreeItem(
     // Create a map for quick balance lookup by currency
     val balancesByCurrency =
         remember(balances) {
-            balances.associateBy { it.balance.currency.id }
+            balances.associateBy { it.balance.asset.id }
         }
 
     // Main row with two sections: fixed hierarchy column + scrollable balances

--- a/app/ui/core/build.gradle.kts
+++ b/app/ui/core/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
                 api(projects.app.ui.imports.csv)
                 api(projects.app.ui.imports.importDirectory)
                 api(projects.app.ui.imports.qif)
+                api(projects.app.ui.imports.timeline)
                 api(projects.app.ui.people)
                 api(projects.app.ui.settings)
                 api(projects.app.ui.transactions)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppServices.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppServices.kt
@@ -21,6 +21,7 @@ import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.DeviceReadRepository
 import com.moneymanager.domain.repository.ImportDirectoryReadRepository
+import com.moneymanager.domain.repository.ImportTimelineReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipReadRepository
 import com.moneymanager.domain.repository.PersonAttributeReadRepository
@@ -69,6 +70,7 @@ data class ImportsDomain(
     val strategyLibrary: StrategyLibrary,
     val qifImportRepository: QifImportReadRepository,
     val importDirectoryRepository: ImportDirectoryReadRepository,
+    val importTimelineRepository: ImportTimelineReadRepository,
     val passThroughAccountRepository: PassThroughAccountReadRepository,
     val maintenance: Maintenance,
 )
@@ -124,6 +126,7 @@ fun Application.toAppServices(importEngine: ImportEngine) =
                 strategyLibrary = imports.strategyLibrary,
                 qifImportRepository = imports.qifImportRepository,
                 importDirectoryRepository = imports.importDirectoryRepository,
+                importTimelineRepository = imports.importTimelineRepository,
                 passThroughAccountRepository = imports.passThroughAccountRepository,
                 maintenance = imports.maintenance,
             ),

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -43,12 +43,16 @@ import androidx.navigation3.ui.NavDisplay
 import com.moneymanager.database.MoneyManagerDatabaseWrapper
 import com.moneymanager.domain.StrategyKind
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.ApiSessionId
 import com.moneymanager.domain.model.AppVersion
 import com.moneymanager.domain.model.CryptoCatalogRefresher
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.DbLocation
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.TransferId
+import com.moneymanager.domain.model.csv.CsvImportId
+import com.moneymanager.domain.model.qif.QifImportId
+import com.moneymanager.domain.model.timeline.TimelineSourceKind
 import com.moneymanager.importfilesource.DriveFolderBrowser
 import com.moneymanager.importfilesource.ImportFileSourceFactory
 import com.moneymanager.remotestorage.sync.RemoteDatabaseController
@@ -100,6 +104,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlin.uuid.Uuid
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -496,6 +501,7 @@ fun MoneyManagerApp(
                                                     navigationHistory.replaceCurrentScreen(Screen.Imports(tab))
                                                 },
                                                 importDirectoryRepository = services.imports.importDirectoryRepository,
+                                                importTimelineRepository = services.imports.importTimelineRepository,
                                                 importFileSourceFactory = importFileSourceFactory,
                                                 driveFolderBrowser = driveFolderBrowser,
                                                 csvImportRepository = services.imports.csvImportRepository,
@@ -523,6 +529,23 @@ fun MoneyManagerApp(
                                                 deviceId = services.deviceId,
                                                 onCsvImportClick = { importId ->
                                                     navigationHistory.navigateTo(Screen.CsvImportDetail(importId))
+                                                },
+                                                onTimelineFileClick = { file ->
+                                                    when (file.kind) {
+                                                        TimelineSourceKind.CSV ->
+                                                            navigationHistory.navigateTo(
+                                                                Screen.CsvImportDetail(CsvImportId(Uuid.parse(file.fileId))),
+                                                            )
+                                                        TimelineSourceKind.QIF ->
+                                                            navigationHistory.navigateTo(
+                                                                Screen.QifImportDetail(QifImportId(Uuid.parse(file.fileId))),
+                                                            )
+                                                        TimelineSourceKind.API ->
+                                                            navigationHistory.navigateTo(
+                                                                Screen.ApiSessionTraffic(ApiSessionId(file.fileId.toLong())),
+                                                            )
+                                                        TimelineSourceKind.MANUAL -> {}
+                                                    }
                                                 },
                                                 onCsvStrategiesClick = {
                                                     navigationHistory.navigateTo(Screen.CsvStrategies)

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
@@ -20,6 +20,7 @@ import com.moneymanager.domain.model.DeviceId
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.importdirectory.ImportDirectory
 import com.moneymanager.domain.model.qif.QifImportId
+import com.moneymanager.domain.model.timeline.ImportFileDateRange
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
 import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
@@ -31,6 +32,7 @@ import com.moneymanager.domain.repository.CsvImportReadRepository
 import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.ImportDirectoryReadRepository
+import com.moneymanager.domain.repository.ImportTimelineReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.domain.repository.QifImportReadRepository
@@ -44,12 +46,14 @@ import com.moneymanager.importfilesource.DriveFolderBrowser
 import com.moneymanager.importfilesource.ImportFileSourceFactory
 import com.moneymanager.ui.navigation.ImportTab
 import com.moneymanager.ui.screens.accountmapping.AccountMappingsScreen
+import com.moneymanager.ui.screens.timeline.ImportTimelineScreen
 
 @Composable
 fun ImportsScreen(
     selectedTab: ImportTab,
     onTabSelected: (ImportTab) -> Unit,
     importDirectoryRepository: ImportDirectoryReadRepository,
+    importTimelineRepository: ImportTimelineReadRepository,
     importFileSourceFactory: ImportFileSourceFactory?,
     driveFolderBrowser: DriveFolderBrowser?,
     csvImportRepository: CsvImportReadRepository,
@@ -76,6 +80,7 @@ fun ImportsScreen(
     importEngine: ImportEngine,
     deviceId: DeviceId,
     onCsvImportClick: (CsvImportId) -> Unit,
+    onTimelineFileClick: (ImportFileDateRange) -> Unit,
     onCsvStrategiesClick: () -> Unit,
     onQifImportClick: (QifImportId) -> Unit,
     onAddCredentialClick: () -> Unit,
@@ -112,6 +117,11 @@ fun ImportsScreen(
                 onClick = { onTabSelected(ImportTab.MISC) },
                 text = { Text("Misc") },
             )
+            Tab(
+                selected = selectedTab == ImportTab.TIMELINE,
+                onClick = { onTabSelected(ImportTab.TIMELINE) },
+                text = { Text("Timeline") },
+            )
         }
 
         when (selectedTab) {
@@ -129,6 +139,7 @@ fun ImportsScreen(
             ImportTab.CSV ->
                 CsvImportsScreen(
                     csvImportRepository = csvImportRepository,
+                    importTimelineRepository = importTimelineRepository,
                     csvImportStrategyRepository = csvImportStrategyRepository,
                     accountMappingRepository = accountMappingRepository,
                     accountRepository = accountRepository,
@@ -149,6 +160,7 @@ fun ImportsScreen(
             ImportTab.QIF ->
                 QifImportsScreen(
                     qifImportRepository = qifImportRepository,
+                    importTimelineRepository = importTimelineRepository,
                     csvImportStrategyRepository = csvImportStrategyRepository,
                     accountMappingRepository = accountMappingRepository,
                     accountRepository = accountRepository,
@@ -166,6 +178,7 @@ fun ImportsScreen(
             ImportTab.API ->
                 ApiSessionsScreen(
                     apiSessionRepository = apiSessionRepository,
+                    importTimelineRepository = importTimelineRepository,
                     apiImportStrategyRepository = apiImportStrategyRepository,
                     accountAttributeRepository = accountAttributeRepository,
                     accountRepository = accountRepository,
@@ -194,6 +207,11 @@ fun ImportsScreen(
                     maintenance = maintenance,
                     onTransactionsImported = onTransactionsImported,
                     onBrowsePassThroughCatalog = onBrowsePassThroughCatalog,
+                )
+            ImportTab.TIMELINE ->
+                ImportTimelineScreen(
+                    importTimelineRepository = importTimelineRepository,
+                    onOpenFile = onTimelineFileClick,
                 )
         }
     }

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
@@ -1718,7 +1718,7 @@ class MonzoImportE2ETest : DbTest() {
 
             // API import mirrors CSV semantics: transfer money remains in account currency.
             val foreignTransfer = transfers.single { it.description == "FOREIGN SPEND" }
-            assertEquals("GBP", foreignTransfer.amount.currency.code, "Foreign transfer should remain in account currency")
+            assertEquals("GBP", foreignTransfer.amount.asset.code, "Foreign transfer should remain in account currency")
             assertEquals(
                 com.moneymanager.bigdecimal.BigInteger(1250L),
                 foreignTransfer.amount.amount,
@@ -1726,7 +1726,7 @@ class MonzoImportE2ETest : DbTest() {
             )
 
             val domesticTransfer = transfers.single { it.description == "DOMESTIC SPEND" }
-            assertEquals("GBP", domesticTransfer.amount.currency.code, "Domestic transfer should remain in account currency")
+            assertEquals("GBP", domesticTransfer.amount.asset.code, "Domestic transfer should remain in account currency")
             assertEquals(
                 com.moneymanager.bigdecimal.BigInteger(5000L),
                 domesticTransfer.amount.amount,
@@ -1820,7 +1820,7 @@ class MonzoImportE2ETest : DbTest() {
 
             val feeTransfer = transfers.single { it.description == "Fee" }
             assertEquals(com.moneymanager.bigdecimal.BigInteger(350L), feeTransfer.amount.amount, "Fee transfer carries the atm fee amount")
-            assertEquals("GBP", feeTransfer.amount.currency.code)
+            assertEquals("GBP", feeTransfer.amount.asset.code)
             assertEquals(monzoAccount.id, feeTransfer.sourceAccountId, "Fee leaves the Monzo account")
             assertEquals(feeAccount.id, feeTransfer.targetAccountId, "Fee goes to the consolidated Monzo Fees account")
 

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ManualEntriesE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/ManualEntriesE2ETest.kt
@@ -153,7 +153,7 @@ class ManualEntriesE2ETest {
                 assertEquals(transferwise, companion.sourceAccountId)
                 assertEquals(wiseEur, companion.targetAccountId)
                 assertEquals(feeTimestamp.toEpochMilliseconds(), companion.timestamp.toEpochMilliseconds())
-                assertEquals("EUR", companion.amount.currency.code)
+                assertEquals("EUR", companion.amount.asset.code)
                 assertEquals(com.moneymanager.bigdecimal.BigInteger(123L), companion.amount.amount)
                 val link = companion.attributes.single { it.attributeType.name == "wise-interest-for" }
                 assertEquals("ACCRUAL_CHARGE-18326272", link.value)

--- a/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
+++ b/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
@@ -17,7 +17,7 @@ import com.moneymanager.domain.model.importdirectory.ImportDirectoryId
 import com.moneymanager.domain.model.qif.QifImportId
 import kotlinx.serialization.Serializable
 
-enum class ImportTab { DIRECTORIES, CSV, QIF, API, MISC }
+enum class ImportTab { DIRECTORIES, CSV, QIF, API, MISC, TIMELINE }
 
 /**
  * Navigation destinations. Serializable [NavKey]s so the back stack survives process death via

--- a/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/util/CurrencyFormatting.kt
+++ b/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/util/CurrencyFormatting.kt
@@ -39,4 +39,4 @@ fun formatAmount(
  * @param money The Money value to format
  * @return Formatted string (e.g., "$1,234.56" for USD, "0.5 BTC" for a crypto asset)
  */
-fun formatAmount(money: Money): String = formatAmount(money.toDisplayValue(), money.currency)
+fun formatAmount(money: Money): String = formatAmount(money.toDisplayValue(), money.asset)

--- a/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/util/FormatTimestamp.kt
+++ b/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/util/FormatTimestamp.kt
@@ -20,3 +20,5 @@ private val DISPLAY_FORMAT =
     }
 
 fun Instant.displayDateTime(timeZone: TimeZone = TimeZone.currentSystemDefault()) = toLocalDateTime(timeZone).format(DISPLAY_FORMAT)
+
+fun Instant.displayDate(timeZone: TimeZone = TimeZone.currentSystemDefault()) = toLocalDateTime(timeZone).date.format(LocalDate.Formats.ISO)

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/ApiSessionsScreen.kt
@@ -85,12 +85,14 @@ import com.moneymanager.domain.model.MonzoCredential
 import com.moneymanager.domain.model.MonzoCredentialId
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
+import com.moneymanager.domain.model.timeline.ImportFileDateRange
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.ApiImportStrategyReadRepository
 import com.moneymanager.domain.repository.ApiSessionImportRevision
 import com.moneymanager.domain.repository.ApiSessionReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
+import com.moneymanager.domain.repository.ImportTimelineReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.importengineapi.createApiSession
 import com.moneymanager.importengineapi.markApiSessionImported
@@ -107,11 +109,13 @@ import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.util.ContentCopyIcon
 import com.moneymanager.ui.util.currentCountryCode
+import com.moneymanager.ui.util.displayDate
 import com.moneymanager.ui.util.displayDateTime
 import com.moneymanager.ui.util.setPlainText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -127,6 +131,7 @@ import kotlin.time.Instant
 @Composable
 fun ApiSessionsScreen(
     apiSessionRepository: ApiSessionReadRepository,
+    importTimelineRepository: ImportTimelineReadRepository,
     apiImportStrategyRepository: ApiImportStrategyReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
     accountRepository: AccountReadRepository,
@@ -146,6 +151,9 @@ fun ApiSessionsScreen(
     val clipboard = LocalClipboard.current
     val passThroughAccounts by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
         passThroughAccountRepository.getAll()
+    }
+    val dateRangeBySession by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyMap()) {
+        importTimelineRepository.getApiSessionDateRanges().map { ranges -> ranges.associateBy { it.fileId } }
     }
 
     var credentials by remember { mutableStateOf<List<MonzoCredential>>(emptyList()) }
@@ -470,6 +478,7 @@ fun ApiSessionsScreen(
                             val isDownloading = backgroundTasks.isRunning(monzoDownloadTaskKey(credential.id))
                             CredentialCard(
                                 credential = credential,
+                                dateRangeBySession = dateRangeBySession,
                                 providerLabel = strategyNameByCredential[credential.id],
                                 requiresSigning = requiresSigningByCredential[credential.id] == true,
                                 transactionsBlockReason = transactionsBlockReasonByCredential[credential.id],
@@ -813,6 +822,7 @@ private fun SigningKeySection(
 @Composable
 private fun CredentialCard(
     credential: MonzoCredential,
+    dateRangeBySession: Map<String, ImportFileDateRange>,
     providerLabel: String?,
     requiresSigning: Boolean,
     transactionsBlockReason: String?,
@@ -909,6 +919,7 @@ private fun CredentialCard(
                 sessions.forEach { session ->
                     SessionRow(
                         session = session,
+                        dateRange = dateRangeBySession[session.id.toString()],
                         isImporting = isImportingSession(session.id),
                         isAlreadyImported =
                             sessionImportedAtCurrentRevision(
@@ -932,6 +943,7 @@ private fun CredentialCard(
 @Composable
 private fun SessionRow(
     session: ApiSession,
+    dateRange: ImportFileDateRange?,
     isImporting: Boolean,
     isAlreadyImported: Boolean,
     importResult: ApiSessionImportResult?,
@@ -978,6 +990,16 @@ private fun SessionRow(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+
+        dateRange?.let { range ->
+            Text(
+                text =
+                    "Transactions ${range.earliest.displayDate()} → ${range.latest.displayDate()} " +
+                        "(${range.transactionCount})",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
 
         session.importDurationMillis?.let { durationMillis ->
             Text(

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/CsvImportsScreen.kt
@@ -38,6 +38,7 @@ import com.moneymanager.csv.CsvParser
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csv.CsvImportId
+import com.moneymanager.domain.model.timeline.ImportFileDateRange
 import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
@@ -45,6 +46,7 @@ import com.moneymanager.domain.repository.CryptoReadRepository
 import com.moneymanager.domain.repository.CsvImportReadRepository
 import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
+import com.moneymanager.domain.repository.ImportTimelineReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.domain.repository.TradeReadRepository
@@ -58,8 +60,10 @@ import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.screens.csv.CsvImportAllDialog
 import com.moneymanager.ui.screens.csv.CsvReimportAllDialog
+import com.moneymanager.ui.util.displayDate
 import com.moneymanager.ui.util.displayDateTime
 import com.moneymanager.ui.util.sha256Hex
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 
@@ -68,6 +72,7 @@ import kotlin.time.Clock
 @Composable
 fun CsvImportsScreen(
     csvImportRepository: CsvImportReadRepository,
+    importTimelineRepository: ImportTimelineReadRepository,
     csvImportStrategyRepository: CsvImportStrategyReadRepository,
     accountMappingRepository: AccountMappingReadRepository,
     accountRepository: AccountReadRepository,
@@ -88,6 +93,9 @@ fun CsvImportsScreen(
     val scope = rememberSchemaAwareCoroutineScope()
     val imports by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
         csvImportRepository.getAllImports()
+    }
+    val dateRanges by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyMap()) {
+        importTimelineRepository.getCsvImportDateRanges().map { ranges -> ranges.associateBy { it.fileId } }
     }
     var isImporting by remember { mutableStateOf(false) }
     var importMessage by remember { mutableStateOf<String?>(null) }
@@ -328,6 +336,7 @@ fun CsvImportsScreen(
                     items(shown, key = { it.id.toString() }) { import ->
                         CsvImportCard(
                             import = import,
+                            dateRange = dateRanges[import.id.id.toString()],
                             onClick = { onImportClick(import.id) },
                             ignored = ignoredTab,
                             onSetIgnored = { ignore ->
@@ -346,6 +355,7 @@ fun CsvImportsScreen(
 @Composable
 private fun CsvImportCard(
     import: CsvImport,
+    dateRange: ImportFileDateRange?,
     onClick: () -> Unit,
     ignored: Boolean,
     onSetIgnored: (Boolean) -> Unit,
@@ -454,6 +464,16 @@ private fun CsvImportCard(
                         MaterialTheme.colorScheme.secondary
                     },
             )
+            if (dateRange != null) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text =
+                        "Transactions ${dateRange.earliest.displayDate()} → ${dateRange.latest.displayDate()} " +
+                            "(${dateRange.transactionCount})",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = metadataColor,
+                )
+            }
             if (isImported && import.lastAppliedStrategyName.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(

--- a/app/ui/imports/qif/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportsScreen.kt
+++ b/app/ui/imports/qif/src/commonMain/kotlin/com/moneymanager/ui/screens/QifImportsScreen.kt
@@ -36,11 +36,13 @@ import com.moneymanager.compose.filepicker.rememberMultipleFilePicker
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.qif.QifImport
 import com.moneymanager.domain.model.qif.QifImportId
+import com.moneymanager.domain.model.timeline.ImportFileDateRange
 import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
 import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
+import com.moneymanager.domain.repository.ImportTimelineReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.domain.repository.QifImportReadRepository
 import com.moneymanager.domain.repository.SettingsReadRepository
@@ -56,8 +58,10 @@ import com.moneymanager.ui.screens.qif.QifImportAllDialog
 import com.moneymanager.ui.screens.qif.QifReimportAllDialog
 import com.moneymanager.ui.screens.qif.dominantAccountType
 import com.moneymanager.ui.screens.qif.toImportRecords
+import com.moneymanager.ui.util.displayDate
 import com.moneymanager.ui.util.displayDateTime
 import com.moneymanager.ui.util.sha256Hex
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 
@@ -66,6 +70,7 @@ import kotlin.time.Clock
 @Suppress("LongParameterList", "DuplicatedCode")
 fun QifImportsScreen(
     qifImportRepository: QifImportReadRepository,
+    importTimelineRepository: ImportTimelineReadRepository,
     csvImportStrategyRepository: CsvImportStrategyReadRepository,
     accountMappingRepository: AccountMappingReadRepository,
     accountRepository: AccountReadRepository,
@@ -83,6 +88,9 @@ fun QifImportsScreen(
     val scope = rememberSchemaAwareCoroutineScope()
     val imports by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
         qifImportRepository.getAllImports()
+    }
+    val dateRanges by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyMap()) {
+        importTimelineRepository.getQifImportDateRanges().map { ranges -> ranges.associateBy { it.fileId } }
     }
     var isImporting by remember { mutableStateOf(false) }
     var importMessage by remember { mutableStateOf<String?>(null) }
@@ -310,6 +318,7 @@ fun QifImportsScreen(
                     items(shown, key = { it.id.toString() }) { import ->
                         QifImportCard(
                             import = import,
+                            dateRange = dateRanges[import.id.id.toString()],
                             onClick = { onImportClick(import.id) },
                             ignored = ignoredTab,
                             onSetIgnored = { ignore ->
@@ -328,6 +337,7 @@ fun QifImportsScreen(
 @Composable
 private fun QifImportCard(
     import: QifImport,
+    dateRange: ImportFileDateRange?,
     onClick: () -> Unit,
     ignored: Boolean,
     onSetIgnored: (Boolean) -> Unit,
@@ -429,6 +439,16 @@ private fun QifImportCard(
                 style = MaterialTheme.typography.bodySmall,
                 color = if (isImported) metadataColor else MaterialTheme.colorScheme.secondary,
             )
+            if (dateRange != null) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text =
+                        "Transactions ${dateRange.earliest.displayDate()} → ${dateRange.latest.displayDate()} " +
+                            "(${dateRange.transactionCount})",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = metadataColor,
+                )
+            }
         }
     }
 }

--- a/app/ui/imports/timeline/build.gradle.kts
+++ b/app/ui/imports/timeline/build.gradle.kts
@@ -1,0 +1,75 @@
+plugins {
+    id("moneymanager.compose-ui-feature-convention")
+    alias(libs.plugins.compose.compiler)
+}
+
+kotlin {
+    sourceSets {
+        getByName("commonMain") {
+            dependencies {
+                api(libs.kotlinx.datetime)
+                api(projects.app.model.core)
+
+                implementation(projects.app.ui.foundation)
+            }
+        }
+        getByName("commonTest") {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(projects.test.app.ui)
+            }
+        }
+        getByName("androidMain") {
+            dependencies {
+                api(libs.androidx.compose.foundation.layout)
+                api(libs.androidx.compose.runtime)
+                api(libs.androidx.compose.ui)
+
+                implementation(libs.androidx.compose.foundation)
+                implementation(libs.androidx.compose.material3)
+                implementation(libs.androidx.compose.ui.geometry)
+                implementation(libs.androidx.compose.ui.graphics)
+                implementation(libs.androidx.compose.ui.text)
+                implementation(libs.androidx.compose.ui.unit)
+                implementation(libs.kotlinx.coroutines.core)
+            }
+        }
+        getByName("jvmMain") {
+            dependencies {
+                api(libs.androidx.compose.runtime.desktop)
+                api(projects.app.model.core)
+
+                implementation(libs.compose.foundation.desktop)
+                implementation(libs.compose.foundation.layout.desktop)
+                implementation(libs.compose.material3.desktop)
+                implementation(libs.compose.ui.desktop)
+                implementation(libs.compose.ui.geometry.desktop)
+                implementation(libs.compose.ui.graphics.desktop)
+                implementation(libs.compose.ui.text.desktop)
+                implementation(libs.compose.ui.unit.desktop)
+                implementation(libs.kotlinx.coroutines.core)
+            }
+        }
+        getByName("jvmTest") {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.compose.ui.test.desktop)
+                implementation(libs.kotlinx.coroutines.core)
+
+                runtimeOnly(compose.desktop.currentOs)
+            }
+        }
+        getByName("androidDeviceTest") {
+            dependencies {
+                implementation(libs.androidx.compose.ui.test)
+                implementation(libs.kotlinx.coroutines.core)
+                implementation(projects.test.app.ui)
+            }
+        }
+        getByName("androidHostTest") {
+            dependencies {
+                implementation(libs.kotlinx.coroutines.core)
+            }
+        }
+    }
+}

--- a/app/ui/imports/timeline/src/androidDeviceTest/AndroidManifest.xml
+++ b/app/ui/imports/timeline/src/androidDeviceTest/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="androidx.activity.ComponentActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/ui/imports/timeline/src/commonMain/kotlin/com/moneymanager/ui/screens/timeline/ImportTimelineScreen.kt
+++ b/app/ui/imports/timeline/src/commonMain/kotlin/com/moneymanager/ui/screens/timeline/ImportTimelineScreen.kt
@@ -1,0 +1,434 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.ui.screens.timeline
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import com.moneymanager.domain.model.timeline.ImportFileDateRange
+import com.moneymanager.domain.model.timeline.TimelineSourceKind
+import com.moneymanager.domain.repository.ImportTimelineReadRepository
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.util.displayDate
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlin.math.roundToInt
+import kotlin.time.Clock
+
+private val ROW_LABEL_WIDTH = 200.dp
+private val ROW_BAR_HEIGHT = 24.dp
+private val TOOLTIP_OFFSET = 12.dp
+
+/**
+ * Matrix of import coverage: one row per import strategy (plus manual entries), a shared time
+ * axis spanning the earliest to the latest imported transaction. Gaps in a row are periods no
+ * file covers; darker stretches are covered by more than one file. Hovering a row (desktop) or
+ * tapping it (touch) lists the files covering that day; clicking a covered spot opens the file
+ * (with a chooser when several files overlap). A table of every gap sits under the timeline.
+ */
+@Composable
+fun ImportTimelineScreen(
+    importTimelineRepository: ImportTimelineReadRepository,
+    onOpenFile: (ImportFileDateRange) -> Unit = {},
+) {
+    val ranges by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        importTimelineRepository.getAllDateRanges()
+    }
+    val timeZone = remember { TimeZone.currentSystemDefault() }
+    val matrix =
+        remember(ranges) {
+            val todayDay =
+                Clock.System
+                    .now()
+                    .toLocalDateTime(timeZone)
+                    .date
+                    .toEpochDays()
+            buildTimelineMatrix(ranges, timeZone, todayDay)
+        }
+
+    if (matrix == null) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(
+                text = "No imported transactions yet",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        return
+    }
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+    ) {
+        TimelineLegend()
+        Spacer(modifier = Modifier.height(12.dp))
+        matrix.rows.forEach { row ->
+            TimelineRowItem(row = row, minDay = matrix.minDay, maxDay = matrix.maxDay, onOpenFile = onOpenFile)
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+        TimelineAxis(minDay = matrix.minDay, maxDay = matrix.maxDay)
+        Spacer(modifier = Modifier.height(24.dp))
+        GapsTable(matrix)
+    }
+}
+
+@Composable
+private fun GapsTable(matrix: TimelineMatrix) {
+    val gaps = matrix.rows.flatMap { row -> row.gaps.map { gap -> row.label to gap } }
+    Text(text = "Gaps", style = MaterialTheme.typography.titleSmall)
+    Spacer(modifier = Modifier.height(4.dp))
+    if (gaps.isEmpty()) {
+        Text(
+            text = "No gaps — every strategy is fully covered up to today.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        return
+    }
+    GapsTableRow(strategy = "Strategy", from = "From", to = "To", days = "Days", header = true)
+    gaps.forEach { (label, gap) ->
+        GapsTableRow(
+            strategy = label,
+            from = LocalDate.fromEpochDays(gap.startDay).toString(),
+            to = LocalDate.fromEpochDays(gap.endDay).toString(),
+            days = (gap.endDay - gap.startDay + 1).toString(),
+        )
+    }
+}
+
+@Composable
+private fun GapsTableRow(
+    strategy: String,
+    from: String,
+    to: String,
+    days: String,
+    header: Boolean = false,
+) {
+    val style = if (header) MaterialTheme.typography.labelMedium else MaterialTheme.typography.bodySmall
+    Row(modifier = Modifier.padding(vertical = 2.dp)) {
+        Text(text = strategy, style = style, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.width(ROW_LABEL_WIDTH))
+        Text(text = from, style = style, modifier = Modifier.width(110.dp))
+        Text(text = to, style = style, modifier = Modifier.width(110.dp))
+        Text(text = days, style = style, modifier = Modifier.width(60.dp))
+    }
+}
+
+@Composable
+private fun TimelineLegend() {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        LegendSwatch(color = MaterialTheme.colorScheme.primary.copy(alpha = 0.45f), label = "Covered")
+        Spacer(modifier = Modifier.width(16.dp))
+        LegendSwatch(color = MaterialTheme.colorScheme.primary, label = "Overlapping files")
+        Spacer(modifier = Modifier.width(16.dp))
+        LegendSwatch(color = MaterialTheme.colorScheme.error.copy(alpha = 0.5f), label = "Gap")
+    }
+}
+
+@Composable
+private fun LegendSwatch(
+    color: Color,
+    label: String,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(modifier = Modifier.size(12.dp).clip(CircleShape).background(color))
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(text = label, style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+@Composable
+private fun TimelineRowItem(
+    row: TimelineRow,
+    minDay: Long,
+    maxDay: Long,
+    onOpenFile: (ImportFileDateRange) -> Unit,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Column(modifier = Modifier.width(ROW_LABEL_WIDTH)) {
+            Text(
+                text = row.label,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            val fileCount = row.files.size
+            Text(
+                text = if (fileCount == 1) "1 file" else "$fileCount files",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        TimelineRowBar(
+            row = row,
+            minDay = minDay,
+            maxDay = maxDay,
+            onOpenFile = onOpenFile,
+            modifier = Modifier.weight(1f).height(ROW_BAR_HEIGHT),
+        )
+    }
+}
+
+@Composable
+private fun TimelineRowBar(
+    row: TimelineRow,
+    minDay: Long,
+    maxDay: Long,
+    onOpenFile: (ImportFileDateRange) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val spanDays = (maxDay - minDay + 1).coerceAtLeast(1)
+    var barSizePx by remember { mutableStateOf(IntSize.Zero) }
+    var pointer by remember { mutableStateOf(Offset.Zero) }
+    var hovered by remember(row) { mutableStateOf<TimelineHover?>(null) }
+    var chooser by remember(row) { mutableStateOf<List<TimelineFile>>(emptyList()) }
+    var chooserAt by remember { mutableStateOf(Offset.Zero) }
+
+    fun dayAt(x: Float): Long = minDay + ((x / barSizePx.width) * spanDays).toLong().coerceIn(0, spanDays - 1)
+
+    fun hoverAt(x: Float): TimelineHover? {
+        if (barSizePx.width <= 0) return null
+        val day = dayAt(x)
+        val files = filesAt(row, day)
+        if (files.isNotEmpty()) return TimelineHover.Files(files)
+        return gapAt(row, day)?.let { TimelineHover.Gap(it) }
+    }
+
+    val baseColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.45f)
+    val overlapColor = MaterialTheme.colorScheme.primary
+    val gapColor = MaterialTheme.colorScheme.error.copy(alpha = 0.5f)
+    val trackColor = MaterialTheme.colorScheme.surfaceVariant
+
+    Box(
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(4.dp))
+                .background(trackColor)
+                .onSizeChanged { barSizePx = it }
+                .pointerInput(row, minDay, maxDay) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            val event = awaitPointerEvent()
+                            when (event.type) {
+                                PointerEventType.Move, PointerEventType.Enter, PointerEventType.Press -> {
+                                    val position = event.changes.first().position
+                                    pointer = position
+                                    hovered = hoverAt(position.x)
+                                }
+                                PointerEventType.Release -> {
+                                    val position = event.changes.first().position
+                                    if (barSizePx.width > 0) {
+                                        val clickable =
+                                            filesAt(row, dayAt(position.x))
+                                                .filter { it.kind != TimelineSourceKind.MANUAL }
+                                        when {
+                                            clickable.size == 1 -> onOpenFile(clickable.single().range)
+                                            clickable.size > 1 -> {
+                                                chooserAt = position
+                                                chooser = clickable
+                                            }
+                                        }
+                                    }
+                                }
+                                PointerEventType.Exit -> hovered = null
+                            }
+                        }
+                    }
+                },
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val pxPerDay = size.width / spanDays
+
+            fun drawSpan(
+                startDay: Long,
+                endDay: Long,
+                color: Color,
+            ) {
+                val left = (startDay - minDay) * pxPerDay
+                val right = (endDay - minDay + 1) * pxPerDay
+                drawRect(
+                    color = color,
+                    topLeft = Offset(left, 0f),
+                    size =
+                        Size(
+                            width = (right - left).coerceAtLeast(2f),
+                            height = size.height,
+                        ),
+                )
+            }
+            row.gaps.forEach { gap -> drawSpan(gap.startDay, gap.endDay, gapColor) }
+            row.segments.forEach { segment ->
+                drawSpan(segment.startDay, segment.endDay, if (segment.depth >= 2) overlapColor else baseColor)
+            }
+        }
+        hovered?.let { TimelineTooltip(hover = it, anchor = pointer) }
+        if (chooser.isNotEmpty()) {
+            val density = LocalDensity.current
+            DropdownMenu(
+                expanded = true,
+                onDismissRequest = { chooser = emptyList() },
+                offset =
+                    with(density) {
+                        DpOffset(x = chooserAt.x.toDp(), y = chooserAt.y.toDp() - ROW_BAR_HEIGHT)
+                    },
+            ) {
+                chooser.forEach { file ->
+                    DropdownMenuItem(
+                        text = { Text(file.label, style = MaterialTheme.typography.bodySmall) },
+                        onClick = {
+                            chooser = emptyList()
+                            onOpenFile(file.range)
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** What the cursor is over inside a timeline row: covered files, or a gap between them. */
+private sealed interface TimelineHover {
+    data class Files(
+        val files: List<TimelineFile>,
+    ) : TimelineHover
+
+    data class Gap(
+        val gap: TimelineGap,
+    ) : TimelineHover
+}
+
+/**
+ * Floating tooltip for the hovered files or gap. Rendered in a [Popup] so it escapes the
+ * clipped 24dp bar and draws above the neighbouring rows.
+ */
+@Composable
+private fun TimelineTooltip(
+    hover: TimelineHover,
+    anchor: Offset,
+) {
+    val offsetPx = with(LocalDensity.current) { TOOLTIP_OFFSET.roundToPx() }
+    Popup(
+        offset =
+            IntOffset(
+                x = anchor.x.roundToInt() + offsetPx,
+                y = anchor.y.roundToInt() + offsetPx,
+            ),
+    ) {
+        TimelineTooltipContent(hover)
+    }
+}
+
+@Composable
+private fun TimelineTooltipContent(hover: TimelineHover) {
+    Surface(
+        shape = RoundedCornerShape(6.dp),
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+        shadowElevation = 4.dp,
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
+            when (hover) {
+                is TimelineHover.Files ->
+                    hover.files.forEach { file ->
+                        val range = file.range
+                        Text(
+                            text =
+                                "${file.label} — ${range.earliest.displayDate()} → ${range.latest.displayDate()} " +
+                                    "(${range.transactionCount} tx)",
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                is TimelineHover.Gap -> {
+                    val gap = hover.gap
+                    val days = gap.endDay - gap.startDay + 1
+                    Text(
+                        text =
+                            "Gap: ${LocalDate.fromEpochDays(gap.startDay)} → ${LocalDate.fromEpochDays(gap.endDay)} " +
+                                "($days day${if (days == 1L) "" else "s"})",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineAxis(
+    minDay: Long,
+    maxDay: Long,
+) {
+    val ticks = remember(minDay, maxDay) { axisTicks(minDay, maxDay) }
+    val spanDays = (maxDay - minDay + 1).coerceAtLeast(1)
+    Row {
+        Spacer(modifier = Modifier.width(ROW_LABEL_WIDTH))
+        BoxWithConstraints(modifier = Modifier.weight(1f).height(24.dp)) {
+            val widthPx = constraints.maxWidth
+            ticks.forEach { (day, label) ->
+                val fraction = (day - minDay).toFloat() / spanDays
+                Column(
+                    modifier = Modifier.offset { IntOffset(x = (fraction * widthPx).roundToInt(), y = 0) },
+                    horizontalAlignment = Alignment.Start,
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .width(1.dp)
+                                .height(6.dp)
+                                .background(MaterialTheme.colorScheme.outline),
+                    )
+                    Text(
+                        text = label,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/ui/imports/timeline/src/commonMain/kotlin/com/moneymanager/ui/screens/timeline/TimelineModel.kt
+++ b/app/ui/imports/timeline/src/commonMain/kotlin/com/moneymanager/ui/screens/timeline/TimelineModel.kt
@@ -1,0 +1,247 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.ui.screens.timeline
+
+import com.moneymanager.domain.model.ApiSessionType
+import com.moneymanager.domain.model.timeline.ImportFileDateRange
+import com.moneymanager.domain.model.timeline.TimelineSourceKind
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.number
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Instant
+
+/** One file/session bar inside a timeline row, in local epoch days (inclusive on both ends). */
+data class TimelineFile(
+    val label: String,
+    val kind: TimelineSourceKind,
+    val startDay: Long,
+    val endDay: Long,
+    val range: ImportFileDateRange,
+)
+
+/** A stretch of days covered by [depth] files; depth >= 2 marks overlapping coverage. */
+data class TimelineSegment(
+    val startDay: Long,
+    val endDay: Long,
+    val depth: Int,
+)
+
+/** An uncovered stretch of days between a row's covered segments (both ends inclusive). */
+data class TimelineGap(
+    val startDay: Long,
+    val endDay: Long,
+)
+
+data class TimelineRow(
+    val label: String,
+    val files: List<TimelineFile>,
+    val segments: List<TimelineSegment>,
+    val gaps: List<TimelineGap>,
+)
+
+data class TimelineMatrix(
+    val minDay: Long,
+    val maxDay: Long,
+    val rows: List<TimelineRow>,
+)
+
+private const val MANUAL_ROW_LABEL = "Manual entries"
+private const val UNKNOWN_STRATEGY_LABEL = "Unknown strategy"
+
+/**
+ * Groups per-file date ranges into timeline rows keyed by strategy name. CSV and QIF files that
+ * share a strategy land in the same row (QIF reuses CSV strategies — one strategy is one logical
+ * source, and a CSV+QIF export of the same period should show up as overlap, not as two rows).
+ * Strategy names are per-application snapshots, so files imported before and after a strategy
+ * rename split into separate rows. API sessions group by API strategy name, falling back to the
+ * session type for legacy strategy-less sessions. The manual aggregate gets its own last row.
+ *
+ * The axis spans the earliest transaction anywhere up to [todayDay]. A row whose coverage starts
+ * later than the axis gets a leading gap, and one whose coverage stops before today gets a
+ * trailing gap, so missing data at either end is as visible as holes in the middle.
+ */
+fun buildTimelineMatrix(
+    ranges: List<ImportFileDateRange>,
+    timeZone: TimeZone,
+    todayDay: Long,
+): TimelineMatrix? {
+    if (ranges.isEmpty()) return null
+    val files =
+        ranges.map { range ->
+            TimelineFile(
+                label = fileLabel(range, timeZone),
+                kind = range.kind,
+                startDay = range.earliest.toEpochDay(timeZone),
+                endDay = range.latest.toEpochDay(timeZone),
+                range = range,
+            )
+        }
+    val minDay = files.minOf { it.startDay }
+    val maxDay = maxOf(files.maxOf { it.endDay }, todayDay)
+    val rows =
+        files
+            .groupBy { rowLabel(it.range) }
+            .map { (label, rowFiles) ->
+                val segments = mergeIntervals(rowFiles)
+                TimelineRow(
+                    label = label,
+                    files = rowFiles.sortedBy { it.startDay },
+                    segments = segments,
+                    gaps = leadingGap(segments, minDay) + gapsBetween(segments) + trailingGap(segments, maxDay),
+                )
+            }.sortedWith(
+                compareBy({ it.files.first().kind == TimelineSourceKind.MANUAL }, { it.label.lowercase() }),
+            )
+    return TimelineMatrix(
+        minDay = minDay,
+        maxDay = maxDay,
+        rows = rows,
+    )
+}
+
+/** A gap from the start of the axis up to the day before the row's first coverage. */
+private fun leadingGap(
+    segments: List<TimelineSegment>,
+    axisStartDay: Long,
+): List<TimelineGap> {
+    val firstCoveredDay = segments.firstOrNull()?.startDay ?: return emptyList()
+    return if (firstCoveredDay > axisStartDay) {
+        listOf(TimelineGap(startDay = axisStartDay, endDay = firstCoveredDay - 1))
+    } else {
+        emptyList()
+    }
+}
+
+/** A gap from the day after the row's last coverage up to the end of the axis (today). */
+private fun trailingGap(
+    segments: List<TimelineSegment>,
+    axisEndDay: Long,
+): List<TimelineGap> {
+    val lastCoveredDay = segments.lastOrNull()?.endDay ?: return emptyList()
+    return if (lastCoveredDay < axisEndDay) {
+        listOf(TimelineGap(startDay = lastCoveredDay + 1, endDay = axisEndDay))
+    } else {
+        emptyList()
+    }
+}
+
+private fun rowLabel(range: ImportFileDateRange): String =
+    when (range.kind) {
+        TimelineSourceKind.MANUAL -> MANUAL_ROW_LABEL
+        TimelineSourceKind.API -> range.strategyName ?: range.apiSessionType?.displayName() ?: UNKNOWN_STRATEGY_LABEL
+        TimelineSourceKind.CSV, TimelineSourceKind.QIF -> range.strategyName ?: UNKNOWN_STRATEGY_LABEL
+    }
+
+private fun fileLabel(
+    range: ImportFileDateRange,
+    timeZone: TimeZone,
+): String =
+    when (range.kind) {
+        TimelineSourceKind.MANUAL -> range.fileName
+        TimelineSourceKind.API -> "[API] ${range.fileName} (${range.earliest.toLocalDate(timeZone)})"
+        TimelineSourceKind.CSV -> "[CSV] ${range.fileName}" + if (range.ignored) " (ignored)" else ""
+        TimelineSourceKind.QIF -> "[QIF] ${range.fileName}" + if (range.ignored) " (ignored)" else ""
+    }
+
+private fun ApiSessionType.displayName(): String =
+    when (this) {
+        ApiSessionType.MONZO -> "Monzo"
+        ApiSessionType.CRYPTO_COM_EXCHANGE -> "Crypto.com Exchange"
+    }
+
+/**
+ * Sweep-line merge of the row's file intervals into contiguous covered segments annotated with
+ * coverage depth. Boundaries are +1/-1 events at startDay and endDay + 1; a stretch with depth 0
+ * is a gap and produces no segment.
+ */
+fun mergeIntervals(files: List<TimelineFile>): List<TimelineSegment> {
+    val deltas = mutableMapOf<Long, Int>()
+    for (file in files) {
+        deltas[file.startDay] = (deltas[file.startDay] ?: 0) + 1
+        deltas[file.endDay + 1] = (deltas[file.endDay + 1] ?: 0) - 1
+    }
+    val segments = mutableListOf<TimelineSegment>()
+    var depth = 0
+    var previousDay = 0L
+    for ((day, delta) in deltas.entries.sortedBy { it.key }) {
+        if (depth > 0 && previousDay < day) {
+            segments += TimelineSegment(previousDay, day - 1, depth)
+        }
+        depth += delta
+        previousDay = day
+    }
+    return segments
+}
+
+/**
+ * The uncovered stretches between consecutive covered segments. Days before the first and after
+ * the last segment are not gaps — the source simply doesn't span them.
+ */
+fun gapsBetween(segments: List<TimelineSegment>): List<TimelineGap> =
+    segments.zipWithNext().mapNotNull { (previous, next) ->
+        if (previous.endDay + 1 < next.startDay) {
+            TimelineGap(startDay = previous.endDay + 1, endDay = next.startDay - 1)
+        } else {
+            null
+        }
+    }
+
+/** Files whose range covers the given local epoch day — the hover tooltip's content. */
+fun filesAt(
+    row: TimelineRow,
+    day: Long,
+): List<TimelineFile> = row.files.filter { day in it.startDay..it.endDay }
+
+/** The gap containing the given local epoch day, if the cursor is over one. */
+fun gapAt(
+    row: TimelineRow,
+    day: Long,
+): TimelineGap? = row.gaps.firstOrNull { day in it.startDay..it.endDay }
+
+private const val YEAR_TICKS_MIN_SPAN_DAYS = 4 * 365L
+private const val QUARTER_TICKS_MIN_SPAN_DAYS = 365L
+private const val MONTHS_PER_QUARTER = 3
+
+/**
+ * Axis tick positions (local epoch day) with labels, adapted to the span: January firsts labelled
+ * with the year for long spans, month firsts (every month or every quarter) for shorter ones.
+ */
+fun axisTicks(
+    minDay: Long,
+    maxDay: Long,
+): List<Pair<Long, String>> {
+    val span = maxDay - minDay
+    val start = LocalDate.fromEpochDays(minDay)
+    val ticks = mutableListOf<Pair<Long, String>>()
+    when {
+        span >= YEAR_TICKS_MIN_SPAN_DAYS -> {
+            for (year in start.year + 1..LocalDate.fromEpochDays(maxDay).year) {
+                ticks += LocalDate(year, 1, 1).toEpochDays() to year.toString()
+            }
+        }
+        else -> {
+            val everyMonths = if (span >= QUARTER_TICKS_MIN_SPAN_DAYS) MONTHS_PER_QUARTER else 1
+            var year = start.year
+            var month = start.month.number
+            while (true) {
+                month += 1
+                if (month > 12) {
+                    month = 1
+                    year += 1
+                }
+                val tick = LocalDate(year, month, 1)
+                if (tick.toEpochDays() > maxDay) break
+                if ((month - 1) % everyMonths == 0) {
+                    val label = if (month == 1) year.toString() else "${tick.year}-${month.toString().padStart(2, '0')}"
+                    ticks += tick.toEpochDays() to label
+                }
+            }
+        }
+    }
+    return ticks
+}
+
+private fun Instant.toEpochDay(timeZone: TimeZone): Long = toLocalDateTime(timeZone).date.toEpochDays()
+
+private fun Instant.toLocalDate(timeZone: TimeZone): LocalDate = toLocalDateTime(timeZone).date

--- a/app/ui/imports/timeline/src/commonTest/kotlin/com/moneymanager/ui/screens/timeline/ImportTimelineScreenTest.kt
+++ b/app/ui/imports/timeline/src/commonTest/kotlin/com/moneymanager/ui/screens/timeline/ImportTimelineScreenTest.kt
@@ -1,0 +1,88 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.ui.screens.timeline
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import com.moneymanager.domain.model.timeline.ImportFileDateRange
+import com.moneymanager.domain.model.timeline.TimelineSourceKind
+import com.moneymanager.domain.repository.ImportTimelineReadRepository
+import com.moneymanager.ui.error.ProvideSchemaAwareScope
+import com.moneymanager.ui.test.runMoneyManagerComposeUiTest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlin.test.Test
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTestApi::class)
+class ImportTimelineScreenTest {
+    private fun createRepository(ranges: List<ImportFileDateRange>): ImportTimelineReadRepository =
+        object : ImportTimelineReadRepository {
+            override fun getCsvImportDateRanges(): Flow<List<ImportFileDateRange>> = flowOf(emptyList())
+
+            override fun getQifImportDateRanges(): Flow<List<ImportFileDateRange>> = flowOf(emptyList())
+
+            override fun getApiSessionDateRanges(): Flow<List<ImportFileDateRange>> = flowOf(emptyList())
+
+            override fun getManualDateRange(): Flow<ImportFileDateRange?> = flowOf(null)
+
+            override fun getAllDateRanges(): Flow<List<ImportFileDateRange>> = flowOf(ranges)
+        }
+
+    private fun range(
+        strategyName: String?,
+        kind: TimelineSourceKind = TimelineSourceKind.CSV,
+        fileName: String = "file.csv",
+    ): ImportFileDateRange =
+        ImportFileDateRange(
+            kind = kind,
+            fileId = "$kind-$fileName",
+            fileName = fileName,
+            strategyName = strategyName,
+            earliest = Instant.parse("2024-01-01T00:00:00Z"),
+            latest = Instant.parse("2024-03-01T00:00:00Z"),
+            transactionCount = 42,
+        )
+
+    @Test
+    fun timelineScreen_displaysEmptyState_whenNoRanges() =
+        runMoneyManagerComposeUiTest {
+            setContent {
+                ProvideSchemaAwareScope {
+                    ImportTimelineScreen(importTimelineRepository = createRepository(emptyList()))
+                }
+            }
+
+            onNodeWithText("No imported transactions yet").assertIsDisplayed()
+        }
+
+    @Test
+    fun timelineScreen_displaysStrategyRowsAndManualRow() =
+        runMoneyManagerComposeUiTest {
+            val ranges =
+                listOf(
+                    range(strategyName = "Monzo", kind = TimelineSourceKind.CSV, fileName = "monzo.csv"),
+                    range(strategyName = "Monzo", kind = TimelineSourceKind.QIF, fileName = "monzo.qif"),
+                    range(strategyName = "Crypto.com Card", kind = TimelineSourceKind.CSV, fileName = "card.csv"),
+                    range(strategyName = null, kind = TimelineSourceKind.MANUAL, fileName = "Manual entries"),
+                )
+
+            setContent {
+                ProvideSchemaAwareScope {
+                    ImportTimelineScreen(importTimelineRepository = createRepository(ranges))
+                }
+            }
+
+            // Labels can appear both as a timeline row and in the gaps table below it.
+            onAllNodesWithText("Monzo").onFirst().assertIsDisplayed()
+            onAllNodesWithText("Crypto.com Card").onFirst().assertIsDisplayed()
+            onAllNodesWithText("Manual entries").onFirst().assertIsDisplayed()
+            // Monzo groups the CSV and QIF files into one row.
+            onNodeWithText("2 files").assertIsDisplayed()
+            // Every row's data stops before today, so the gaps table lists them.
+            onNodeWithText("Gaps").assertIsDisplayed()
+        }
+}

--- a/app/ui/imports/timeline/src/commonTest/kotlin/com/moneymanager/ui/screens/timeline/TimelineModelTest.kt
+++ b/app/ui/imports/timeline/src/commonTest/kotlin/com/moneymanager/ui/screens/timeline/TimelineModelTest.kt
@@ -1,0 +1,296 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.ui.screens.timeline
+
+import com.moneymanager.domain.model.ApiSessionType
+import com.moneymanager.domain.model.timeline.ImportFileDateRange
+import com.moneymanager.domain.model.timeline.TimelineSourceKind
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+class TimelineModelTest {
+    private val timeZone = TimeZone.UTC
+
+    private fun day(isoDate: String): Long = LocalDate.parse(isoDate).toEpochDays()
+
+    private fun instant(isoDate: String): Instant = LocalDate.parse(isoDate).atStartOfDayIn(timeZone)
+
+    private fun range(
+        start: String,
+        end: String,
+        kind: TimelineSourceKind = TimelineSourceKind.CSV,
+        fileId: String = "id-$start",
+        fileName: String = "file-$start.csv",
+        strategyName: String? = "Strategy A",
+        apiSessionType: ApiSessionType? = null,
+        ignored: Boolean = false,
+        count: Long = 10,
+    ): ImportFileDateRange =
+        ImportFileDateRange(
+            kind = kind,
+            fileId = fileId,
+            fileName = fileName,
+            strategyName = strategyName,
+            apiSessionType = apiSessionType,
+            ignored = ignored,
+            earliest = instant(start),
+            latest = instant(end),
+            transactionCount = count,
+        )
+
+    private fun file(
+        start: String,
+        end: String,
+    ): TimelineFile {
+        val r = range(start, end)
+        return TimelineFile("f", r.kind, day(start), day(end), r)
+    }
+
+    @Test
+    fun emptyInputProducesNoMatrix() {
+        assertNull(buildTimelineMatrix(emptyList(), timeZone, todayDay = day("2024-01-01")))
+    }
+
+    @Test
+    fun disjointIntervalsKeepAGap() {
+        val segments = mergeIntervals(listOf(file("2024-01-01", "2024-01-10"), file("2024-02-01", "2024-02-10")))
+        assertEquals(
+            listOf(
+                TimelineSegment(day("2024-01-01"), day("2024-01-10"), 1),
+                TimelineSegment(day("2024-02-01"), day("2024-02-10"), 1),
+            ),
+            segments,
+        )
+    }
+
+    @Test
+    fun adjacentIntervalsProduceContiguousCoverage() {
+        val segments = mergeIntervals(listOf(file("2024-01-01", "2024-01-10"), file("2024-01-11", "2024-01-20")))
+        assertEquals(
+            listOf(
+                TimelineSegment(day("2024-01-01"), day("2024-01-10"), 1),
+                TimelineSegment(day("2024-01-11"), day("2024-01-20"), 1),
+            ),
+            segments,
+        )
+        assertTrue(segments.zipWithNext().all { (a, b) -> a.endDay + 1 == b.startDay })
+    }
+
+    @Test
+    fun overlappingIntervalsGetDepthTwoSegment() {
+        val segments = mergeIntervals(listOf(file("2024-01-01", "2024-01-15"), file("2024-01-10", "2024-01-20")))
+        assertEquals(
+            listOf(
+                TimelineSegment(day("2024-01-01"), day("2024-01-09"), 1),
+                TimelineSegment(day("2024-01-10"), day("2024-01-15"), 2),
+                TimelineSegment(day("2024-01-16"), day("2024-01-20"), 1),
+            ),
+            segments,
+        )
+    }
+
+    @Test
+    fun nestedIntervalSplitsIntoThreeSegments() {
+        val segments = mergeIntervals(listOf(file("2024-01-01", "2024-01-31"), file("2024-01-10", "2024-01-20")))
+        assertEquals(
+            listOf(
+                TimelineSegment(day("2024-01-01"), day("2024-01-09"), 1),
+                TimelineSegment(day("2024-01-10"), day("2024-01-20"), 2),
+                TimelineSegment(day("2024-01-21"), day("2024-01-31"), 1),
+            ),
+            segments,
+        )
+    }
+
+    @Test
+    fun identicalIntervalsStackDepth() {
+        val segments = mergeIntervals(listOf(file("2024-01-01", "2024-01-10"), file("2024-01-01", "2024-01-10")))
+        assertEquals(listOf(TimelineSegment(day("2024-01-01"), day("2024-01-10"), 2)), segments)
+    }
+
+    @Test
+    fun singleDayFileIsASegment() {
+        val segments = mergeIntervals(listOf(file("2024-01-05", "2024-01-05")))
+        assertEquals(listOf(TimelineSegment(day("2024-01-05"), day("2024-01-05"), 1)), segments)
+    }
+
+    @Test
+    fun csvAndQifWithSameStrategyShareARow() {
+        val matrix =
+            buildTimelineMatrix(
+                listOf(
+                    range("2024-01-01", "2024-01-31", kind = TimelineSourceKind.CSV, strategyName = "Monzo"),
+                    range("2024-02-01", "2024-02-28", kind = TimelineSourceKind.QIF, strategyName = "Monzo"),
+                    range("2024-01-01", "2024-03-31", kind = TimelineSourceKind.CSV, strategyName = "Barclays"),
+                ),
+                timeZone,
+                todayDay = day("2024-03-31"),
+            )!!
+        assertEquals(listOf("Barclays", "Monzo"), matrix.rows.map { it.label })
+        val monzoRow = matrix.rows.single { it.label == "Monzo" }
+        assertEquals(2, monzoRow.files.size)
+        assertEquals(day("2024-01-01"), matrix.minDay)
+        assertEquals(day("2024-03-31"), matrix.maxDay)
+    }
+
+    @Test
+    fun apiRowsUseStrategyNameWithSessionTypeFallback() {
+        val matrix =
+            buildTimelineMatrix(
+                listOf(
+                    range(
+                        "2024-01-01",
+                        "2024-01-31",
+                        kind = TimelineSourceKind.API,
+                        strategyName = "Crypto.com REST",
+                        apiSessionType = ApiSessionType.CRYPTO_COM_EXCHANGE,
+                    ),
+                    range(
+                        "2024-01-01",
+                        "2024-01-31",
+                        kind = TimelineSourceKind.API,
+                        strategyName = null,
+                        apiSessionType = ApiSessionType.MONZO,
+                    ),
+                ),
+                timeZone,
+                todayDay = day("2024-01-31"),
+            )!!
+        assertEquals(listOf("Crypto.com REST", "Monzo"), matrix.rows.map { it.label })
+    }
+
+    @Test
+    fun manualRowIsAlwaysLast() {
+        val matrix =
+            buildTimelineMatrix(
+                listOf(
+                    range("2024-01-01", "2024-01-31", kind = TimelineSourceKind.MANUAL, strategyName = null, fileName = "Manual entries"),
+                    range("2024-01-01", "2024-01-31", strategyName = "Zebra Bank"),
+                ),
+                timeZone,
+                todayDay = day("2024-01-31"),
+            )!!
+        assertEquals(listOf("Zebra Bank", "Manual entries"), matrix.rows.map { it.label })
+    }
+
+    @Test
+    fun gapsBetweenReturnsUncoveredStretchesBetweenSegments() {
+        val segments =
+            listOf(
+                TimelineSegment(day("2024-01-01"), day("2024-01-10"), 1),
+                TimelineSegment(day("2024-02-01"), day("2024-02-10"), 1),
+                TimelineSegment(day("2024-02-11"), day("2024-02-20"), 2),
+            )
+        assertEquals(
+            listOf(TimelineGap(day("2024-01-11"), day("2024-01-31"))),
+            gapsBetween(segments),
+        )
+    }
+
+    @Test
+    fun gapsBetweenIsEmptyForContiguousCoverage() {
+        val segments =
+            listOf(
+                TimelineSegment(day("2024-01-01"), day("2024-01-10"), 1),
+                TimelineSegment(day("2024-01-11"), day("2024-01-20"), 1),
+            )
+        assertEquals(emptyList(), gapsBetween(segments))
+    }
+
+    @Test
+    fun buildTimelineMatrixExposesRowGaps() {
+        val matrix =
+            buildTimelineMatrix(
+                listOf(
+                    range("2024-01-01", "2024-01-10"),
+                    range("2024-03-01", "2024-03-10"),
+                ),
+                timeZone,
+                todayDay = day("2024-03-10"),
+            )!!
+        val row = matrix.rows.single()
+        assertEquals(listOf(TimelineGap(day("2024-01-11"), day("2024-02-29"))), row.gaps)
+        assertEquals(TimelineGap(day("2024-01-11"), day("2024-02-29")), gapAt(row, day("2024-02-01")))
+        assertNull(gapAt(row, day("2024-01-05")))
+        assertNull(gapAt(row, day("2024-04-01")))
+    }
+
+    @Test
+    fun axisExtendsToTodayAndRowsGetLeadingAndTrailingGaps() {
+        val matrix =
+            buildTimelineMatrix(
+                listOf(
+                    range("2024-01-01", "2024-01-31", strategyName = "Alpha"),
+                    range("2024-02-01", "2024-02-29", strategyName = "Beta"),
+                ),
+                timeZone,
+                todayDay = day("2024-03-15"),
+            )!!
+
+        assertEquals(day("2024-01-01"), matrix.minDay)
+        assertEquals(day("2024-03-15"), matrix.maxDay)
+
+        val alpha = matrix.rows.single { it.label == "Alpha" }
+        assertEquals(listOf(TimelineGap(day("2024-02-01"), day("2024-03-15"))), alpha.gaps)
+
+        val beta = matrix.rows.single { it.label == "Beta" }
+        assertEquals(
+            listOf(
+                TimelineGap(day("2024-01-01"), day("2024-01-31")),
+                TimelineGap(day("2024-03-01"), day("2024-03-15")),
+            ),
+            beta.gaps,
+        )
+    }
+
+    @Test
+    fun rowCoveringTheWholeAxisHasNoGaps() {
+        val matrix =
+            buildTimelineMatrix(
+                listOf(range("2024-01-01", "2024-03-15", strategyName = "Alpha")),
+                timeZone,
+                todayDay = day("2024-03-15"),
+            )!!
+        assertEquals(emptyList(), matrix.rows.single().gaps)
+    }
+
+    @Test
+    fun filesAtReturnsOnlyFilesCoveringTheDay() {
+        val row =
+            TimelineRow(
+                label = "r",
+                files = listOf(file("2024-01-01", "2024-01-10"), file("2024-01-05", "2024-01-20")),
+                segments = emptyList(),
+                gaps = emptyList(),
+            )
+        assertEquals(1, filesAt(row, day("2024-01-02")).size)
+        assertEquals(2, filesAt(row, day("2024-01-07")).size)
+        assertEquals(1, filesAt(row, day("2024-01-15")).size)
+        assertEquals(0, filesAt(row, day("2024-02-01")).size)
+    }
+
+    @Test
+    fun longSpanUsesYearTicks() {
+        val ticks = axisTicks(day("2018-06-15"), day("2024-03-01"))
+        assertEquals(listOf("2019", "2020", "2021", "2022", "2023", "2024"), ticks.map { it.second })
+        assertEquals(day("2019-01-01"), ticks.first().first)
+    }
+
+    @Test
+    fun mediumSpanUsesQuarterTicks() {
+        val ticks = axisTicks(day("2023-01-15"), day("2024-02-15"))
+        assertEquals(listOf("2023-04", "2023-07", "2023-10", "2024"), ticks.map { it.second })
+    }
+
+    @Test
+    fun shortSpanUsesMonthTicks() {
+        val ticks = axisTicks(day("2024-01-10"), day("2024-04-20"))
+        assertEquals(listOf("2024-02", "2024-03", "2024-04"), ticks.map { it.second })
+    }
+}

--- a/app/ui/transactions/build.gradle.kts
+++ b/app/ui/transactions/build.gradle.kts
@@ -35,11 +35,12 @@ kotlin {
             dependencies {
                 api(libs.androidx.compose.foundation)
                 api(libs.androidx.compose.foundation.layout)
+                api(libs.androidx.compose.material3)
                 api(libs.androidx.compose.runtime)
                 api(libs.androidx.compose.ui)
 
                 implementation(libs.androidx.compose.animation.core)
-                implementation(libs.androidx.compose.material3)
+                implementation(libs.androidx.compose.material.icons.core)
                 implementation(libs.androidx.compose.ui.graphics)
                 implementation(libs.androidx.compose.ui.text)
                 implementation(libs.androidx.compose.ui.unit)
@@ -52,11 +53,12 @@ kotlin {
                 api(libs.androidx.compose.runtime.desktop)
                 api(libs.compose.foundation.desktop)
                 api(libs.compose.foundation.layout.desktop)
+                api(libs.compose.material3.desktop)
                 api(projects.app.model.core)
                 api(projects.app.ui.foundation)
 
                 implementation(libs.compose.animation.core.desktop)
-                implementation(libs.compose.material3.desktop)
+                implementation(libs.compose.material.icons.core.desktop)
                 implementation(libs.compose.ui.desktop)
                 implementation(libs.compose.ui.graphics.desktop)
                 implementation(libs.compose.ui.text.desktop)

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/ManualEntriesScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/ManualEntriesScreen.kt
@@ -200,7 +200,7 @@ private suspend fun createCompanionTransfers(
                 toAccount = AccountRef.Existing(matched.sourceAccountId),
                 timestamp = matched.timestamp,
                 description = rule.companionDescription,
-                amount = Money.fromDisplayValue(amount, matched.amount.currency),
+                amount = Money.fromDisplayValue(amount, matched.amount.asset),
                 attributes = listOf(NewAttribute(linkTypeId, matched.matchValue)),
             )
         }
@@ -290,7 +290,7 @@ private fun PendingCompanionCard(
             OutlinedTextField(
                 value = amountText,
                 onValueChange = onAmountChange,
-                label = { Text("Amount (${matched.amount.currency.code})") },
+                label = { Text("Amount (${matched.amount.asset.code})") },
                 isError = amountText.isNotBlank() && parseAmount(amountText) == null,
                 singleLine = true,
                 modifier = Modifier.width(180.dp),

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionAuditScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionAuditScreen.kt
@@ -30,6 +30,8 @@ import com.moneymanager.domain.model.DeviceId
 import com.moneymanager.domain.model.DeviceInfo
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.SourceRecord
+import com.moneymanager.domain.model.TradeAuditEntry
+import com.moneymanager.domain.model.TradeId
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.CsvImportId
 import com.moneymanager.domain.model.qif.QifImportId
@@ -97,7 +99,7 @@ fun TransactionAuditScreen(
                 currentAttrs = reverseAttributeChanges(currentAttrs, entry)
             }
 
-            val diffs =
+            val transferDiffs =
                 auditEntries.mapIndexed { index, entry ->
                     val newValuesForUpdate =
                         when {
@@ -111,28 +113,216 @@ fun TransactionAuditScreen(
                                 )
                             else -> null
                         }
-                    computeAuditDiff(entry, newValuesForUpdate)
+                    TransferAuditRow(computeAuditDiff(entry, newValuesForUpdate))
+                }
+
+            // A transaction id with no transfer history is a trade (same id space); show its
+            // trade_audit trail instead. Each row carries the next-older entry for update diffs.
+            val diffs: List<TransactionAuditRow> =
+                transferDiffs.ifEmpty {
+                    val tradeEntries = auditRepository.getAuditHistoryForTrade(TradeId(transferId.id))
+                    tradeEntries.mapIndexed { index, entry ->
+                        TradeAuditRow(entry = entry, previous = tradeEntries.getOrNull(index + 1))
+                    }
                 }
             AuditScreenData(
                 title = "Audit History: $transferId",
                 diffs = diffs,
             )
         },
-        diffKey = { it.id },
+        // Only one of the two lists is ever shown (a transaction is a transfer or a trade), so the
+        // per-table audit ids cannot collide within one screen.
+        diffKey = { row ->
+            when (row) {
+                is TransferAuditRow -> row.diff.id
+                is TradeAuditRow -> row.entry.id
+            }
+        },
         onBack = onBack,
-        diffCard = { diff ->
-            TransactionAuditDiffCard(
-                diff = diff,
-                accounts = accounts,
-                auditedAccountNames = auditedAccountNames,
+        diffCard = { row ->
+            when (row) {
+                is TransferAuditRow ->
+                    TransactionAuditDiffCard(
+                        diff = row.diff,
+                        accounts = accounts,
+                        auditedAccountNames = auditedAccountNames,
+                        currentDeviceId = currentDeviceId,
+                        onCsvSourceClick = onCsvSourceClick,
+                        onQifSourceClick = onQifSourceClick,
+                        onApiSourceClick = onApiSourceClick,
+                        onAccountClick = onAccountClick,
+                    )
+                is TradeAuditRow ->
+                    TradeAuditDiffCard(
+                        entry = row.entry,
+                        previous = row.previous,
+                        accounts = accounts,
+                        auditedAccountNames = auditedAccountNames,
+                        currentDeviceId = currentDeviceId,
+                        onCsvSourceClick = onCsvSourceClick,
+                        onQifSourceClick = onQifSourceClick,
+                        onApiSourceClick = onApiSourceClick,
+                        onAccountClick = onAccountClick,
+                    )
+            }
+        },
+    )
+}
+
+/** One row of a transaction's audit trail: a transfer revision diff or a trade revision. */
+private sealed interface TransactionAuditRow
+
+private data class TransferAuditRow(
+    val diff: AuditEntryDiff,
+) : TransactionAuditRow
+
+private data class TradeAuditRow(
+    val entry: TradeAuditEntry,
+    val previous: TradeAuditEntry?,
+) : TransactionAuditRow
+
+@Suppress("LongParameterList")
+@Composable
+private fun TradeAuditDiffCard(
+    entry: TradeAuditEntry,
+    previous: TradeAuditEntry?,
+    accounts: List<Account>,
+    auditedAccountNames: Map<Long, String>,
+    currentDeviceId: DeviceId? = null,
+    onCsvSourceClick: (CsvImportId, Long) -> Unit = { _, _ -> },
+    onQifSourceClick: (QifImportId, Long?) -> Unit = { _, _ -> },
+    onApiSourceClick: (ApiSessionId, ApiRequestId, String) -> Unit = { _, _, _ -> },
+    onAccountClick: (AccountId) -> Unit = {},
+) {
+    AuditDiffCard(
+        auditType = entry.auditType,
+        auditTimestamp = entry.auditTimestamp,
+        revisionId = entry.revisionId,
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            when (entry.auditType) {
+                AuditType.INSERT ->
+                    TradeSnapshotContent("Created with:", entry, accounts, auditedAccountNames, onAccountClick)
+                AuditType.UPDATE ->
+                    TradeUpdateContent(entry, previous, accounts, auditedAccountNames, onAccountClick)
+                AuditType.DELETE ->
+                    TradeSnapshotContent(
+                        header = "Deleted (final values):",
+                        entry = entry,
+                        accounts = accounts,
+                        auditedAccountNames = auditedAccountNames,
+                        onAccountClick = onAccountClick,
+                        valueColor = MaterialTheme.colorScheme.error,
+                    )
+            }
+            SourceInfoSection(
+                entry.source,
                 currentDeviceId = currentDeviceId,
                 onCsvSourceClick = onCsvSourceClick,
                 onQifSourceClick = onQifSourceClick,
                 onApiSourceClick = onApiSourceClick,
-                onAccountClick = onAccountClick,
             )
-        },
+        }
+    }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun TradeSnapshotContent(
+    header: String,
+    entry: TradeAuditEntry,
+    accounts: List<Account>,
+    auditedAccountNames: Map<Long, String>,
+    onAccountClick: (AccountId) -> Unit,
+    valueColor: Color = MaterialTheme.colorScheme.onSurface,
+) {
+    val tradeDateTime = entry.timestamp.toLocalDateTime(TimeZone.currentSystemDefault())
+    Text(
+        text = header,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
+    FieldValueRow("Date", "${tradeDateTime.date} ${tradeDateTime.time}", valueColor, labelWidth = LABEL_WIDTH)
+    AccountLinkRow("From", entry.fromAccountId, accounts, auditedAccountNames, onAccountClick)
+    FieldValueRow("Sold", formatAmount(entry.fromAmount), valueColor, labelWidth = LABEL_WIDTH)
+    AccountLinkRow("To", entry.toAccountId, accounts, auditedAccountNames, onAccountClick)
+    FieldValueRow("Bought", formatAmount(entry.toAmount), valueColor, labelWidth = LABEL_WIDTH)
+    FieldValueRow("Description", entry.description.ifBlank { "(none)" }, valueColor, labelWidth = LABEL_WIDTH)
+}
+
+@Composable
+private fun TradeUpdateContent(
+    entry: TradeAuditEntry,
+    previous: TradeAuditEntry?,
+    accounts: List<Account>,
+    auditedAccountNames: Map<Long, String>,
+    onAccountClick: (AccountId) -> Unit,
+) {
+    // Trade audit rows carry full snapshots, so an update diff is a field-by-field comparison
+    // against the next-older revision; without one, show the full updated snapshot.
+    if (previous == null) {
+        TradeSnapshotContent("Updated to:", entry, accounts, auditedAccountNames, onAccountClick)
+        return
+    }
+    var anyChanges = false
+    Text(
+        text = "Changed:",
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    if (entry.timestamp != previous.timestamp) {
+        anyChanges = true
+        val oldDateTime = previous.timestamp.toLocalDateTime(TimeZone.currentSystemDefault())
+        val newDateTime = entry.timestamp.toLocalDateTime(TimeZone.currentSystemDefault())
+        FieldChangeRow(
+            label = "Date",
+            oldValue = "${oldDateTime.date} ${oldDateTime.time}",
+            newValue = "${newDateTime.date} ${newDateTime.time}",
+            labelWidth = LABEL_WIDTH,
+        )
+    }
+    if (entry.fromAccountId != previous.fromAccountId) {
+        anyChanges = true
+        AccountChangeRow("From", previous.fromAccountId, entry.fromAccountId, accounts, auditedAccountNames, onAccountClick)
+    }
+    if (entry.fromAmount != previous.fromAmount) {
+        anyChanges = true
+        FieldChangeRow(
+            label = "Sold",
+            oldValue = formatAmount(previous.fromAmount),
+            newValue = formatAmount(entry.fromAmount),
+            labelWidth = LABEL_WIDTH,
+        )
+    }
+    if (entry.toAccountId != previous.toAccountId) {
+        anyChanges = true
+        AccountChangeRow("To", previous.toAccountId, entry.toAccountId, accounts, auditedAccountNames, onAccountClick)
+    }
+    if (entry.toAmount != previous.toAmount) {
+        anyChanges = true
+        FieldChangeRow(
+            label = "Bought",
+            oldValue = formatAmount(previous.toAmount),
+            newValue = formatAmount(entry.toAmount),
+            labelWidth = LABEL_WIDTH,
+        )
+    }
+    if (entry.description != previous.description) {
+        anyChanges = true
+        FieldChangeRow(
+            label = "Description",
+            oldValue = previous.description.ifBlank { "(none)" },
+            newValue = entry.description.ifBlank { "(none)" },
+            labelWidth = LABEL_WIDTH,
+        )
+    }
+    if (!anyChanges) {
+        Text(
+            text = "No visible changes recorded",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
 }
 
 @Composable

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionCard.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionCard.kt
@@ -1,3 +1,5 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
 package com.moneymanager.ui.screens.transactions
 
 import androidx.compose.foundation.background
@@ -10,17 +12,29 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.TextAutoSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipAnchorPosition
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -28,12 +42,31 @@ import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AccountRow
 import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.TransactionKind
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.ui.util.ScreenSizeClass
 import com.moneymanager.ui.util.formatAmount
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+
+/** Reconciled tick color; the Material color scheme has no "success" green, so a fixed one. */
+private val RECONCILED_GREEN = Color(0xFF4CAF50)
+
+/** The icon a [TransactionKind] renders as in the type column (and its header legend). */
+internal fun TransactionKind.icon(): ImageVector =
+    when (this) {
+        TransactionKind.TRANSFER -> Icons.AutoMirrored.Filled.ArrowForward
+        TransactionKind.TRADE -> Icons.Filled.Refresh
+        TransactionKind.ORDER -> Icons.Filled.ShoppingCart
+    }
+
+internal fun TransactionKind.displayLabel(): String =
+    when (this) {
+        TransactionKind.TRANSFER -> "Transfer"
+        TransactionKind.TRADE -> "Trade"
+        TransactionKind.ORDER -> "Order"
+    }
 
 @Composable
 fun AccountTransactionCard(
@@ -87,9 +120,42 @@ fun AccountTransactionCard(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // Reconciled column: read-only tick when this transfer is part of a reconciliation
-            Box(modifier = Modifier.width(40.dp), contentAlignment = Alignment.Center) {
-                Checkbox(checked = runningBalance.isReconciled, onCheckedChange = null)
+            // Reconciled column: green tick when this transfer is part of a reconciliation, red cross otherwise.
+            Box(modifier = Modifier.width(24.dp), contentAlignment = Alignment.Center) {
+                val reconciledLabel = if (runningBalance.isReconciled) "Reconciled" else "Not reconciled"
+                TooltipBox(
+                    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
+                    tooltip = { PlainTooltip { Text(reconciledLabel) } },
+                    state = rememberTooltipState(),
+                ) {
+                    Icon(
+                        imageVector = if (runningBalance.isReconciled) Icons.Filled.Check else Icons.Filled.Close,
+                        contentDescription = reconciledLabel,
+                        tint =
+                            if (runningBalance.isReconciled) {
+                                RECONCILED_GREEN.copy(alpha = mutedAlpha)
+                            } else {
+                                MaterialTheme.colorScheme.error.copy(alpha = mutedAlpha)
+                            },
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            }
+
+            // Transaction type column: transfer / trade / order as an icon with a hover tooltip.
+            Box(modifier = Modifier.width(24.dp), contentAlignment = Alignment.Center) {
+                TooltipBox(
+                    positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
+                    tooltip = { PlainTooltip { Text(runningBalance.kind.displayLabel()) } },
+                    state = rememberTooltipState(),
+                ) {
+                    Icon(
+                        imageVector = runningBalance.kind.icon(),
+                        contentDescription = runningBalance.kind.displayLabel(),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = mutedAlpha),
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
             }
 
             // Date column
@@ -232,46 +298,58 @@ fun AccountTransactionCard(
             )
 
             // Edit button - reconstruct Transfer from AccountRow
-            IconButton(
-                onClick = {
-                    // Reconstruct Transfer object from AccountRow fields
-                    // Note: Amount needs to be positive value from the materialized view
-                    val amount =
-                        if (runningBalance.transactionAmount.isNegative()) {
-                            Money(-runningBalance.transactionAmount.amount, runningBalance.transactionAmount.currency)
-                        } else {
-                            runningBalance.transactionAmount
-                        }
-                    val transfer =
-                        Transfer(
-                            id = runningBalance.transactionId as TransferId,
-                            timestamp = runningBalance.timestamp,
-                            description = runningBalance.description,
-                            sourceAccountId = runningBalance.sourceAccountId,
-                            targetAccountId = runningBalance.targetAccountId,
-                            amount = amount,
-                        )
-                    onEditClick(transfer)
-                },
-                modifier = Modifier.size(32.dp),
+            TooltipBox(
+                positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
+                tooltip = { PlainTooltip { Text("Edit transaction") } },
+                state = rememberTooltipState(),
             ) {
-                Text(
-                    text = "\u270F\uFE0F",
-                    style = MaterialTheme.typography.bodyLarge,
-                )
+                IconButton(
+                    onClick = {
+                        // Reconstruct Transfer object from AccountRow fields
+                        // Note: Amount needs to be positive value from the materialized view
+                        val amount =
+                            if (runningBalance.transactionAmount.isNegative()) {
+                                Money(-runningBalance.transactionAmount.amount, runningBalance.transactionAmount.asset)
+                            } else {
+                                runningBalance.transactionAmount
+                            }
+                        val transfer =
+                            Transfer(
+                                id = runningBalance.transactionId as TransferId,
+                                timestamp = runningBalance.timestamp,
+                                description = runningBalance.description,
+                                sourceAccountId = runningBalance.sourceAccountId,
+                                targetAccountId = runningBalance.targetAccountId,
+                                amount = amount,
+                            )
+                        onEditClick(transfer)
+                    },
+                    modifier = Modifier.size(24.dp),
+                ) {
+                    Text(
+                        text = "\u270F\uFE0F",
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                }
             }
 
             // Audit button - show audit history for this transaction
-            IconButton(
-                onClick = {
-                    onAuditClick(runningBalance.transactionId as TransferId)
-                },
-                modifier = Modifier.size(32.dp),
+            TooltipBox(
+                positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
+                tooltip = { PlainTooltip { Text("Audit history") } },
+                state = rememberTooltipState(),
             ) {
-                Text(
-                    text = "\uD83D\uDCDC",
-                    style = MaterialTheme.typography.bodyLarge,
-                )
+                IconButton(
+                    onClick = {
+                        onAuditClick(runningBalance.transactionId as TransferId)
+                    },
+                    modifier = Modifier.size(24.dp),
+                ) {
+                    Text(
+                        text = "\uD83D\uDCDC",
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                }
             }
         }
     }

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
@@ -95,7 +95,7 @@ fun TransactionEditDialog(
         mutableStateOf(
             transaction
                 ?.amount
-                ?.currency
+                ?.asset
                 ?.id
                 ?.let { CurrencyId(it.id) } ?: preSelectedCurrencyId,
         )
@@ -207,7 +207,7 @@ fun TransactionEditDialog(
             } else {
                 sourceAccountId != transaction.sourceAccountId ||
                     targetAccountId != transaction.targetAccountId ||
-                    currencyId != transaction.amount.currency.id ||
+                    currencyId != transaction.amount.asset.id ||
                     parsedAmount != transaction.amount.toDisplayValue() ||
                     description != transaction.description ||
                     selectedDate != transactionDateTime!!.date ||
@@ -288,7 +288,7 @@ fun TransactionEditDialog(
                             val transferFieldsChanged =
                                 sourceAccountId != transaction.sourceAccountId ||
                                     targetAccountId != transaction.targetAccountId ||
-                                    currencyId != transaction.amount.currency.id ||
+                                    currencyId != transaction.amount.asset.id ||
                                     parsedAmount != transaction.amount.toDisplayValue() ||
                                     description.trim() != transaction.description ||
                                     timestamp != transaction.timestamp

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class)
+@file:OptIn(kotlin.time.ExperimentalTime::class, androidx.compose.material3.ExperimentalMaterial3Api::class)
 
 package com.moneymanager.ui.screens.transactions
 
@@ -23,10 +23,18 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipAnchorPosition
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -54,6 +62,7 @@ import com.moneymanager.domain.model.Asset
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.TransactionId
+import com.moneymanager.domain.model.TransactionKind
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
@@ -264,7 +273,7 @@ fun AccountTransactionsScreen(
     val accountCurrencyIds =
         accountBalances
             .filter { it.accountId == selectedAccountId }
-            .map { it.balance.currency.id }
+            .map { it.balance.asset.id }
             .distinct()
     val accountCurrencies = currencies.filter { it.id in accountCurrencyIds }
 
@@ -311,7 +320,7 @@ fun AccountTransactionsScreen(
                 .groupBy { it.accountId.id }
                 .mapValues { (_, list) ->
                     list.associate { ab ->
-                        ab.balance.currency.id.id to MatrixCell(formatAmount(ab.balance), ab.balance.isNegative())
+                        ab.balance.asset.id.id to MatrixCell(formatAmount(ab.balance), ab.balance.isNegative())
                     }
                 }
         }
@@ -320,7 +329,7 @@ fun AccountTransactionsScreen(
     // Sorted by code for a deterministic row order independent of balance emission order.
     val uniqueAssets =
         remember(accountBalances) {
-            accountBalances.map { it.balance.currency }.distinctBy { it.id.id }.sortedBy { it.code }
+            accountBalances.map { it.balance.asset }.distinctBy { it.id.id }.sortedBy { it.code }
         }
 
     // Calculate column widths for each account based on account name and balance amounts,
@@ -832,15 +841,49 @@ fun AccountTransactionsScreen(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(
-                        text = "Rec.",
-                        style = headerStyle,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        textAlign = TextAlign.Center,
-                        maxLines = 1,
-                        softWrap = false,
-                        modifier = Modifier.width(40.dp),
-                    )
+                    // Reconciliation column heading: blank; the per-row tick/cross icons are
+                    // self-explanatory via their tooltips.
+                    Spacer(modifier = Modifier.width(24.dp))
+                    // Transaction type column heading: an icon whose tooltip legends the per-row icons.
+                    Box(modifier = Modifier.width(24.dp), contentAlignment = Alignment.Center) {
+                        TooltipBox(
+                            positionProvider = TooltipDefaults.rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
+                            tooltip = {
+                                PlainTooltip {
+                                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                        Text(
+                                            text = "Transaction type",
+                                            style = MaterialTheme.typography.labelMedium,
+                                        )
+                                        TransactionKind.entries.forEach { kind ->
+                                            Row(
+                                                verticalAlignment = Alignment.CenterVertically,
+                                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                            ) {
+                                                Icon(
+                                                    imageVector = kind.icon(),
+                                                    contentDescription = null,
+                                                    modifier = Modifier.size(14.dp),
+                                                )
+                                                Text(
+                                                    text = kind.displayLabel(),
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            state = rememberTooltipState(),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Info,
+                                contentDescription = "Transaction type",
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        }
+                    }
                     Text(
                         text = "Date",
                         style = headerStyle,
@@ -894,7 +937,7 @@ fun AccountTransactionsScreen(
                         modifier = Modifier.weight(0.15f).padding(start = 8.dp),
                     )
                     // Spacer for edit and audit button columns
-                    Spacer(modifier = Modifier.width(64.dp))
+                    Spacer(modifier = Modifier.width(48.dp))
                 }
 
                 val listState = rememberLazyListState()
@@ -924,7 +967,7 @@ fun AccountTransactionsScreen(
 
                         // Set currency filter to match the transaction; that reloads the page, so the
                         // centering scroll happens on the next pass over the filtered list
-                        val targetCurrencyId = CurrencyId(transaction.transactionAmount.currency.id.id)
+                        val targetCurrencyId = CurrencyId(transaction.transactionAmount.asset.id.id)
                         if (selectedCurrencyId != targetCurrencyId) {
                             selectedCurrencyId = targetCurrencyId
                             return@let
@@ -935,7 +978,7 @@ fun AccountTransactionsScreen(
                         val index =
                             displayedRunningBalances
                                 .filter {
-                                    it.transactionAmount.currency.id == transaction.transactionAmount.currency.id
+                                    it.transactionAmount.asset.id == transaction.transactionAmount.asset.id
                                 }.indexOfFirst { it.transactionId.id == targetTransferId.id }
 
                         if (index < 0) {
@@ -965,7 +1008,7 @@ fun AccountTransactionsScreen(
 
                         // Scroll matrix to show the account and currency
                         val accountIndex = allAccounts.indexOfFirst { it.id == accountId }
-                        val currencyIndex = uniqueAssets.indexOfAsset(transaction.transactionAmount.currency.id.id)
+                        val currencyIndex = uniqueAssets.indexOfAsset(transaction.transactionAmount.asset.id.id)
 
                         if (accountIndex >= 0 && currencyIndex >= 0) {
                             val targetScrollX =
@@ -1045,7 +1088,10 @@ fun AccountTransactionsScreen(
                     ) {
                         items(
                             items = displayedRunningBalances,
-                            key = { "${it.transactionId}-${it.accountId}" },
+                            // A same-account trade (e.g. BTC→ETH inside one exchange account) yields two
+                            // rows with the same transaction and account, one per asset leg — the asset
+                            // code keeps their keys unique.
+                            key = { "${it.transactionId}-${it.accountId}-${it.transactionAmount.asset.code}" },
                         ) { runningBalance ->
                             AccountTransactionCard(
                                 runningBalance = runningBalance,
@@ -1056,7 +1102,7 @@ fun AccountTransactionsScreen(
                                     // TransactionEditDialog is fiat-only (CurrencyPicker + currencyRepository
                                     // save path); opening it on a crypto-denominated transfer would corrupt
                                     // its asset. Only fiat transfers are editable here for now.
-                                    if (transfer.amount.currency is Currency) {
+                                    if (transfer.amount.asset is Currency) {
                                         transactionIdToEdit = transfer.id
                                     }
                                 },
@@ -1088,7 +1134,7 @@ fun AccountTransactionsScreen(
                                 },
                                 onAccountClick = { clickedAccountId ->
                                     highlightedTransactionId = runningBalance.transactionId
-                                    selectedCurrencyId = CurrencyId(runningBalance.transactionAmount.currency.id.id)
+                                    selectedCurrencyId = CurrencyId(runningBalance.transactionAmount.asset.id.id)
 
                                     // Notify parent to switch to the clicked account
                                     onAccountIdChange(clickedAccountId)
@@ -1108,7 +1154,7 @@ fun AccountTransactionsScreen(
                                                 )
                                             // Calculate vertical scroll position for the currency
                                             val currencyIndex =
-                                                uniqueAssets.indexOfAsset(runningBalance.transactionAmount.currency.id.id)
+                                                uniqueAssets.indexOfAsset(runningBalance.transactionAmount.asset.id.id)
                                             if (currencyIndex >= 0) {
                                                 // Each currency row: text + padding + spacing ≈ 28.dp
                                                 val targetScrollY =
@@ -1132,7 +1178,7 @@ fun AccountTransactionsScreen(
                                         onAccountClick(
                                             clickedAccountId,
                                             clickedAccount.name,
-                                            CurrencyId(runningBalance.transactionAmount.currency.id.id),
+                                            CurrencyId(runningBalance.transactionAmount.asset.id.id),
                                             TransferId(runningBalance.transactionId.id),
                                         )
                                     }

--- a/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -40,6 +41,7 @@ import com.moneymanager.domain.model.PagingResult
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.TransactionId
+import com.moneymanager.domain.model.TransactionKind
 import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.repository.AccountAttributeWriteRepository
@@ -546,6 +548,80 @@ class AccountTransactionsScreenTest {
             onNodeWithText("Fee").performClick()
             waitForIdle()
             assertEquals(mainId, linkClicked)
+        }
+
+    @Test
+    fun sameAccountTrade_rendersBothAssetLegs_withoutDuplicateListKeys() =
+        runMoneyManagerComposeUiTest {
+            // A trade inside one account (e.g. BTC→USD on an exchange) produces two running-balance
+            // rows with the same transaction AND account ids, differing only in asset. The list key
+            // must include the asset or LazyColumn throws "Key ... was already used".
+            val now = Clock.System.now()
+            val usd = Currency(id = CurrencyId(1L), code = "USD", name = "US Dollar")
+            val btc = Currency(id = CurrencyId(2L), code = "BTC", name = "Bitcoin")
+            val exchange = Account(id = AccountId(10L), name = "Exchange", openingDate = now)
+            val tradeId = TransferId(19157L)
+            val legs =
+                listOf(
+                    AccountRow(
+                        transactionId = tradeId,
+                        timestamp = now,
+                        description = "BTC to USD trade",
+                        accountId = exchange.id,
+                        transactionAmount = Money(-100, btc),
+                        runningBalance = Money(0, btc),
+                        sourceAccountId = exchange.id,
+                        targetAccountId = exchange.id,
+                        kind = TransactionKind.TRADE,
+                    ),
+                    AccountRow(
+                        transactionId = tradeId,
+                        timestamp = now,
+                        description = "BTC to USD trade",
+                        accountId = exchange.id,
+                        transactionAmount = Money(500, usd),
+                        runningBalance = Money(500, usd),
+                        sourceAccountId = exchange.id,
+                        targetAccountId = exchange.id,
+                        kind = TransactionKind.TRADE,
+                    ),
+                )
+            val transactionRepository =
+                mock<TransactionWriteRepository>(MockMode.autoUnit) {
+                    every { getTransactionById(any()) } returns flowOf(null)
+                    every { getTransactionsByAccount(any()) } returns flowOf(emptyList())
+                    every { getTransactionsByDateRange(any(), any()) } returns flowOf(emptyList())
+                    every { getTransactionsByAccountAndDateRange(any(), any(), any()) } returns flowOf(emptyList())
+                    every { getAccountBalances() } returns flowOf(emptyList())
+                    everySuspend { getRunningBalanceByAccountPaginated(any(), any(), any(), any()) } returns
+                        PagingResult(items = legs, pagingInfo = PagingInfo(null, null, hasMore = false))
+                    everySuspend { getRunningBalanceByAccountPaginatedBackward(any(), any(), any(), any(), any()) } returns
+                        PagingResult(emptyList(), PagingInfo(null, null, false))
+                }
+
+            setContent {
+                ProvideSchemaAwareScope {
+                    AccountTransactionsScreen(
+                        accountId = exchange.id,
+                        transactionRepository = transactionRepository,
+                        accountRepository = createAccountRepository(listOf(exchange)),
+                        accountAttributeRepository = createAccountAttributeRepository(),
+                        categoryRepository = createCategoryRepository(),
+                        currencyRepository = createCurrencyRepository(listOf(usd, btc)),
+                        attributeTypeRepository = createAttributeTypeRepository(),
+                        personRepository = createPersonRepository(),
+                        personAccountOwnershipRepository = createPersonAccountOwnershipRepository(),
+                        maintenance = createMaintenance(),
+                        onAccountIdChange = {},
+                        onCurrencyIdChange = {},
+                    )
+                }
+            }
+            waitForIdle()
+
+            onAllNodesWithText("BTC to USD trade").assertCountEquals(2)
+            // Both legs carry the trade type icon in the type column.
+            onAllNodesWithContentDescription("Trade").assertCountEquals(2)
         }
 
     @Test
@@ -1326,7 +1402,7 @@ class AccountTransactionsScreenTest {
 
     /** Mirrors the repository's SQL currency filter so the test double matches production semantics. */
     private fun List<AccountRow>.filterByCurrency(currencyId: CurrencyId?): List<AccountRow> =
-        if (currencyId == null) this else filter { it.transactionAmount.currency.id == currencyId }
+        if (currencyId == null) this else filter { it.transactionAmount.asset.id == currencyId }
 
     private fun buildAccountRows(
         transfers: List<Transfer>,
@@ -1344,7 +1420,7 @@ class AccountTransactionsScreenTest {
                         timestamp = transfer.timestamp,
                         description = transfer.description,
                         accountId = transfer.sourceAccountId,
-                        transactionAmount = Money(-transfer.amount.amount, transfer.amount.currency),
+                        transactionAmount = Money(-transfer.amount.amount, transfer.amount.asset),
                         runningBalance = transfer.amount,
                         sourceAccountId = transfer.sourceAccountId,
                         targetAccountId = transfer.targetAccountId,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,6 +126,7 @@ dependencyAnalysis {
             ":app:ui:imports:api",
             ":app:ui:imports:importDirectory",
             ":app:ui:imports:qif",
+            ":app:ui:imports:timeline",
             ":test:app:ui",
         ).forEach { p -> project(p) { ignoreSourceSet("jvmDev") } }
 


### PR DESCRIPTION
## What

### Import Timeline (new tab under Imports)
- New `app/ui/imports/timeline` module with a coverage matrix: one row per import strategy (CSV+QIF strategies share a row, API strategies, plus manual entries), time axis from the earliest imported transaction to **today**.
- Red gaps wherever a row's coverage is missing — between files, before the first file, and after the last file up to today — each with a hover tooltip showing the exact range; darker fill where files overlap; a gaps table (Strategy / From / To / Days) under the axis.
- Clicking a covered spot opens the underlying CSV/QIF import or API session; overlaps open a chooser.
- New `TimelineSelect.sq` queries derive per-file MIN/MAX transaction dates from `entity_source` provenance (no schema change); the CSV/QIF/API import screens now show each file's transaction date range on its card.

### Trade audit history
- `TransactionAuditScreen` only queried `transfer_audit`, so trades (e.g. "Sell CRO/BTC") appeared to have no audit history even though DB triggers had recorded it. It now falls back to the `trade_audit` trail with full created-with/update/delete cards and source links; `selectAuditHistoryForTrade` returns the audited field values.
- `TradeAuditHistoryTest` pins that engine-created trades round-trip their audit field values.

### Transaction list
- Type column (transfer → arrow, trade → cycle, order → cart) after the reconciliation column; header shows an info icon whose tooltip legends the icons.
- Reconciliation column is now a green tick / red cross with tooltips (header blank); edit/audit buttons have tooltips; icon/button columns narrowed to give text columns more space.

### Fixes
- **Crash**: same-account trades (crypto exchange BTC→ETH etc.) produced two running-balance rows with identical `(transactionId, accountId)` LazyColumn keys — key now includes the asset code (regression test included).
- **Rename**: `Money.currency` → `Money.asset` (it has been typed `Asset` since crypto support landed); all ~112 call sites updated via compiler-reported positions, so genuine currency concepts are untouched.

## Why
Imported data comes from many files/sessions and it was hard to see coverage gaps (e.g. crypto.com's three file types); trades looked unauditable; trades and transfers were indistinguishable in the transaction list.

## Testing
`./gradlew build buildHealth` green: 15 timeline model tests, 2 timeline screen tests, 8 timeline repository tests (DbTest), trade audit round-trip test, same-account-trade regression test, plus updated existing screen tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Imports Timeline showing transaction coverage, gaps, and overlapping import sources.
  * Added transaction date-range summaries to CSV, QIF, and API import entries.
  * Added navigation from timeline items to their related import details.
  * Added transaction-type indicators and tooltips for transfers and trades.
  * Expanded trade audit history to display field values and changes.

* **Bug Fixes**
  * Improved handling and display of multiple asset types, including crypto assets.
  * Corrected fee calculations and internal-transfer matching across different assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->