### PR TITLE
Model exchange orders as a first-class entity linked to fill trades

### DIFF
--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ExchangeApiImportService.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ExchangeApiImportService.kt
@@ -35,10 +35,12 @@ import com.moneymanager.importengineapi.ExistingApiIdExtractor
 import com.moneymanager.importengineapi.ImportAccountIntent
 import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.ImportOrderIntent
 import com.moneymanager.importengineapi.ImportRowKey
 import com.moneymanager.importengineapi.ImportTradeIntent
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
+import com.moneymanager.importengineapi.LocalOrderKey
 import com.moneymanager.importengineapi.LocalTradeKey
 import com.moneymanager.importengineapi.createCrypto
 import com.moneymanager.importengineapi.getOrCreateAttributeType
@@ -230,6 +232,8 @@ data class ExchangeImportResult(
     val tradesImported: Int,
     val transfersImported: Int,
     val duplicatesSkipped: Int,
+    val ordersImported: Int = 0,
+    val ordersUpdated: Int = 0,
 )
 
 private data class ParsedTrade(
@@ -265,16 +269,27 @@ private data class ParsedExchangeTransfer(
     val aliasAccount: String?,
 )
 
-private data class OrderMeta(
-    val type: String?,
+private data class ParsedOrder(
+    val orderRef: String,
+    val clientOid: String?,
+    val side: String,
+    val orderType: String?,
+    val timeInForce: String?,
     val status: String?,
+    val limitPrice: String?,
+    val quantity: String?,
+    val avgPrice: String?,
+    val createdAt: Instant,
+    val updatedAt: Instant?,
+    val requestId: ApiRequestId,
+    val jsonPath: String,
 )
 
 /** Accumulator for parsed items across all of a session's responses. */
 private class ParsedExchangeData {
     val trades = mutableListOf<ParsedTrade>()
     val transfers = mutableListOf<ParsedExchangeTransfer>()
-    val orderMeta = mutableMapOf<String, OrderMeta>()
+    val orders = mutableListOf<ParsedOrder>()
 }
 
 /** Parses one response item into [into] according to its endpoint kind. */
@@ -289,13 +304,7 @@ private fun parseExchangeItem(
         ApiEndpointKind.TRADES ->
             dataEndpoint.tradeMappings?.let { parseTrade(obj, it, requestId, jsonPath) }?.let(into.trades::add)
         ApiEndpointKind.ORDERS ->
-            dataEndpoint.tradeMappings?.let { tm ->
-                val orderId = tm.orderIdField?.let { obj.str(it) } ?: obj.str(tm.idField)
-                orderId?.let {
-                    into.orderMeta[it] =
-                        OrderMeta(type = tm.orderTypeField?.let { f -> obj.str(f) }, status = tm.orderStatusField?.let { f -> obj.str(f) })
-                }
-            }
+            dataEndpoint.tradeMappings?.let { parseOrder(obj, it, requestId, jsonPath) }?.let(into.orders::add)
         ApiEndpointKind.DEPOSITS ->
             dataEndpoint.transactionMappings
                 ?.let { parseExchangeTransfer(obj, it, TransferDirection.IN, requestId, jsonPath) }
@@ -343,7 +352,13 @@ suspend fun importApiSessionExchange(
     }
     val trades = parsed.trades
     val transfers = parsed.transfers
-    val orderMeta = parsed.orderMeta
+    // An order can surface in several download windows (created in one, updated in another); keep the
+    // freshest snapshot per order id.
+    val orders =
+        parsed.orders
+            .groupBy { it.orderRef }
+            .values
+            .map { snapshots -> snapshots.maxBy { it.updatedAt ?: it.createdAt } }
 
     // Resolve assets: any code that isn't a known fiat currency is treated as a crypto asset and
     // auto-created (the same rule as the CSV importer), sized to the precision the data actually uses.
@@ -420,6 +435,9 @@ suspend fun importApiSessionExchange(
 
     val tradeIntents = mutableListOf<ImportTradeIntent>()
     val transferIntents = mutableListOf<ImportTransfer>()
+    // Fill-trade keys per order id, collected only for trades that actually became intents (a trade
+    // skipped for an unresolvable asset must not surface as a dangling link key).
+    val tradeKeysByOrderRef = mutableMapOf<String, MutableList<LocalTradeKey>>()
 
     trades.forEach forEachTrade@{ t ->
         val baseAsset = asset(t.baseCode)
@@ -427,14 +445,14 @@ suspend fun importApiSessionExchange(
         if (baseAsset == null || quoteAsset == null) return@forEachTrade
         val baseMoney = Money.fromDisplayValue(t.baseQuantity, baseAsset)
         val quoteMoney = moneyExact(t.quoteAmount, quoteAsset, "Trade ${t.id} quote leg")
-        val orderInfo = t.orderId?.let { orderMeta[it] }
-        val description = tradeDescription(t, orderInfo)
+        val description = tradeDescription(t)
         // BUY: quote leaves, base arrives. SELL: base leaves, quote arrives. Both on the one account.
         val fromAmount = if (t.isBuy) quoteMoney else baseMoney
         val toAmount = if (t.isBuy) baseMoney else quoteMoney
+        val tradeKey = LocalTradeKey("api-$sessionId-trade-${t.id}")
         tradeIntents +=
             ImportTradeIntent(
-                key = LocalTradeKey("api-$sessionId-trade-${t.id}"),
+                key = tradeKey,
                 source = Source.Api(sessionId, t.requestId, JsonPath(t.jsonPath)),
                 timestamp = t.timestamp,
                 description = description,
@@ -443,6 +461,7 @@ suspend fun importApiSessionExchange(
                 toAccountId = syntheticId,
                 toAmount = toAmount,
             )
+        t.orderId?.let { tradeKeysByOrderRef.getOrPut(it, ::mutableListOf).add(tradeKey) }
         // A trade carries no fee slot, so emit any fee as its own movement to the fee account.
         val feeCode = t.feeCode
         val feeAmount = t.feeAmount
@@ -534,11 +553,33 @@ suspend fun importApiSessionExchange(
                     ?.let { AccountBridge(exchangeAccountId = syntheticId, appAccountId = it.id) }
             }.orEmpty()
 
+    val orderIntents =
+        orders.map { o ->
+            ImportOrderIntent(
+                key = LocalOrderKey("api-$sessionId-order-${o.orderRef}"),
+                source = Source.Api(sessionId, o.requestId, JsonPath(o.jsonPath)),
+                accountId = syntheticId,
+                orderRef = o.orderRef,
+                clientOid = o.clientOid,
+                side = o.side,
+                orderType = o.orderType,
+                timeInForce = o.timeInForce,
+                status = o.status,
+                limitPrice = o.limitPrice,
+                quantity = o.quantity,
+                avgPrice = o.avgPrice,
+                createdAt = o.createdAt,
+                updatedAt = o.updatedAt,
+                tradeKeys = tradeKeysByOrderRef[o.orderRef].orEmpty(),
+            )
+        }
+
     val result =
         importEngine.import(
             ImportBatch(
                 transfers = transferIntents,
                 trades = tradeIntents,
+                orders = orderIntents,
                 accountsToCreate = counterpartyIntents,
                 dedupePolicy =
                     DedupePolicy.ApiMultiKey(
@@ -565,6 +606,8 @@ suspend fun importApiSessionExchange(
         tradesImported = tradeIntents.size,
         transfersImported = result.transfersImported,
         duplicatesSkipped = result.duplicates,
+        ordersImported = orderIntents.size - result.updatedOrderKeys.size - result.dedupedOrderKeys.size,
+        ordersUpdated = result.updatedOrderKeys.size,
     )
 }
 
@@ -599,14 +642,38 @@ private fun exchangeTransfer(
     )
 }
 
-private fun tradeDescription(
-    trade: ParsedTrade,
-    order: OrderMeta?,
-): String {
+// No order-derived suffix: existing databases were imported with plain "<verb> BASE/QUOTE"
+// descriptions, and trade dedupe is a full-tuple match including description — changing this format
+// would duplicate every trade on re-import. Order type/status live on the linked exchange_order.
+private fun tradeDescription(trade: ParsedTrade): String {
     val verb = if (trade.isBuy) "Buy" else "Sell"
-    val base = "$verb ${trade.baseCode}/${trade.quoteCode}"
-    val suffix = order?.type?.let { " ($it)" } ?: ""
-    return base + suffix
+    return "$verb ${trade.baseCode}/${trade.quoteCode}"
+}
+
+private fun parseOrder(
+    obj: JsonObject,
+    tm: ApiTradeMappings,
+    requestId: ApiRequestId,
+    jsonPath: String,
+): ParsedOrder? {
+    val orderRef = (tm.orderIdField?.let { obj.str(it) } ?: obj.str(tm.idField)) ?: return null
+    val side = obj.str(tm.sideField) ?: return null
+    val createdAt = obj.str(tm.timestampField)?.let { parseApiTimestamp(it, tm.timestampFormat) } ?: return null
+    return ParsedOrder(
+        orderRef = orderRef,
+        clientOid = tm.clientOidField?.let { obj.str(it) },
+        side = side,
+        orderType = tm.orderTypeField?.let { obj.str(it) },
+        timeInForce = tm.timeInForceField?.let { obj.str(it) },
+        status = tm.orderStatusField?.let { obj.str(it) },
+        limitPrice = tm.limitPriceField?.let { obj.str(it) },
+        quantity = obj.str(tm.baseQuantityField),
+        avgPrice = tm.avgPriceField?.let { obj.str(it) },
+        createdAt = createdAt,
+        updatedAt = tm.updateTimestampField?.let { obj.str(it) }?.let { parseApiTimestamp(it, tm.timestampFormat) },
+        requestId = requestId,
+        jsonPath = jsonPath,
+    )
 }
 
 private fun parseTrade(

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/Application.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/Application.kt
@@ -19,6 +19,7 @@ import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
 import com.moneymanager.domain.repository.CsvImportWriteRepository
 import com.moneymanager.domain.repository.CurrencyWriteRepository
 import com.moneymanager.domain.repository.DeviceReadRepository
+import com.moneymanager.domain.repository.ExchangeOrderWriteRepository
 import com.moneymanager.domain.repository.ImportDirectoryReadRepository
 import com.moneymanager.domain.repository.ImportTimelineReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
@@ -75,6 +76,7 @@ data class Transactions(
     val relationshipTypeRepository: RelationshipTypeWriteRepository,
     val transferRelationshipRepository: TransferRelationshipReadRepository,
     val tradeRepository: TradeWriteRepository,
+    val exchangeOrderRepository: ExchangeOrderWriteRepository,
 )
 
 data class People(

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/api/CryptoComExchangeApiE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/api/CryptoComExchangeApiE2ETest.kt
@@ -42,11 +42,19 @@ class CryptoComExchangeApiE2ETest : DbTest() {
         ]}}
         """.trimIndent()
 
+    // Field names mirror the live get-order-history payload ("order_type", not "type"). o1/o2 are the
+    // filled orders behind trades t1/t2; o3 is a still-open limit order with no fills.
     private val ordersJson =
         """
         {"code":0,"result":{"data":[
           {"instrument_name":"BTC_USD","side":"BUY","quantity":"0.5","create_time":1700000000000,
-           "order_id":"o1","type":"LIMIT","status":"FILLED"}
+           "order_id":"o1","client_oid":"co-1","order_type":"LIMIT","time_in_force":"GOOD_TILL_CANCEL",
+           "status":"FILLED","limit_price":"40000.54","avg_price":"40000.54","update_time":1700000000050},
+          {"instrument_name":"BTC_USD","side":"SELL","quantity":"0.1","create_time":1700000000100,
+           "order_id":"o2","order_type":"MARKET","status":"FILLED","avg_price":"41000.00"},
+          {"instrument_name":"BTC_USD","side":"BUY","quantity":"2","create_time":1700000000200,
+           "order_id":"o3","order_type":"LIMIT","time_in_force":"GOOD_TILL_CANCEL",
+           "status":"ACTIVE","limit_price":"30000.00"}
         ]}}
         """.trimIndent()
 
@@ -61,6 +69,7 @@ class CryptoComExchangeApiE2ETest : DbTest() {
     private suspend fun stageSessionAndImport(
         deposits: String = depositsJson,
         trades: String = tradesJson,
+        orders: String = ordersJson,
     ): Int {
         val strategy = repositories.apiImportStrategyRepository.getStrategyByName("Crypto.com Exchange").first()
         assertNotNull(strategy, "built-in Crypto.com Exchange strategy should be installed")
@@ -81,7 +90,7 @@ class CryptoComExchangeApiE2ETest : DbTest() {
             repositories.apiSessionRepository.insertResponse(requestId, sessionId, json)
         }
         stage("private/get-trades", trades)
-        stage("private/get-order-history", ordersJson)
+        stage("private/get-order-history", orders)
         stage("private/get-deposit-history", deposits)
 
         importApiSessionExchange(
@@ -123,8 +132,34 @@ class CryptoComExchangeApiE2ETest : DbTest() {
             assertEquals("0.5", trade.to.toDisplayValue().toString())
             // quote = 0.5 * 40000.54 = 20000.27, exactly representable at USD's 2-decimal scale.
             assertEquals("20000.27", trade.from.toDisplayValue().toString())
-            // Order type folded into the description as reference.
-            assertTrue(trade.description.contains("LIMIT"), "order type recorded: ${trade.description}")
+            // The description stays the stable "<verb> BASE/QUOTE" (dedupe keys on it); order metadata
+            // lives on the linked exchange order instead.
+            assertEquals("Buy BTC/USD", trade.description)
+
+            // All three orders imported (o3 has no fills but is still persisted, status ACTIVE).
+            val orders = repositories.exchangeOrderRepository.getOrdersByAccount(exchange.id).first()
+            assertEquals(3, orders.size, "all orders imported: $orders")
+            val o1 = orders.first { it.orderRef == "o1" }
+            assertEquals("LIMIT", o1.orderType)
+            assertEquals("FILLED", o1.status)
+            assertEquals("GOOD_TILL_CANCEL", o1.timeInForce)
+            assertEquals("40000.54", o1.limitPrice)
+            assertEquals("40000.54", o1.avgPrice)
+            assertEquals("co-1", o1.clientOid)
+            assertEquals(1_700_000_000_050L, o1.updatedAt?.toEpochMilliseconds())
+            val o3 = orders.first { it.orderRef == "o3" }
+            assertEquals("ACTIVE", o3.status)
+
+            // o1 is linked to its BUY fill trade, bidirectionally queryable.
+            val o1Fills = repositories.exchangeOrderRepository.getFillTradesForOrder(o1.id).first()
+            assertEquals(listOf(trade.id), o1Fills.map { it.id }, "o1 linked to the BUY fill")
+            assertTrue(
+                repositories.exchangeOrderRepository
+                    .getFillTradesForOrder(o3.id)
+                    .first()
+                    .isEmpty(),
+                "the unfilled order has no fill links",
+            )
 
             // The SELL's fiat fee books as its own movement to the Fees account.
             val feesAccount =
@@ -198,6 +233,50 @@ class CryptoComExchangeApiE2ETest : DbTest() {
                 "re-import must not double-book trades",
             )
             assertEquals(depositsBefore, depositCount(), "re-import must not double-book deposits")
+            val ordersAfter = repositories.exchangeOrderRepository.getOrdersByAccount(exchange.id).first()
+            assertEquals(3, ordersAfter.size, "re-import must not duplicate orders")
+            val o1After = ordersAfter.first { it.orderRef == "o1" }
+            assertEquals(1L, o1After.revisionId, "an unchanged order keeps its revision")
+            assertEquals(
+                1,
+                repositories.exchangeOrderRepository
+                    .getFillTradesForOrder(o1After.id)
+                    .first()
+                    .size,
+                "re-import must not duplicate order-trade links",
+            )
+        }
+
+    @Test
+    fun `re-importing an order whose status changed updates it in place and bumps the revision`() =
+        runTest {
+            stageSessionAndImport()
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Crypto.com Exchange" }
+            val o3Before =
+                repositories.exchangeOrderRepository
+                    .getOrdersByAccount(exchange.id)
+                    .first()
+                    .first { it.orderRef == "o3" }
+            assertEquals("ACTIVE", o3Before.status)
+            assertEquals(1L, o3Before.revisionId)
+
+            // The exchange later reports the same order as cancelled.
+            val cancelledOrders =
+                ordersJson.replace(""""status":"ACTIVE"""", """"status":"CANCELED"""")
+            stageSessionAndImport(orders = cancelledOrders)
+
+            val o3After =
+                repositories.exchangeOrderRepository
+                    .getOrdersByAccount(exchange.id)
+                    .first()
+                    .first { it.orderRef == "o3" }
+            assertEquals(o3Before.id, o3After.id, "the order is updated in place, not duplicated")
+            assertEquals("CANCELED", o3After.status)
+            assertEquals(2L, o3After.revisionId, "a content change bumps the revision")
         }
 
     @Test

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/audit/AuditSourceCoverageTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/audit/AuditSourceCoverageTest.kt
@@ -208,6 +208,45 @@ class AuditSourceCoverageTest : DbTest() {
             ) { it.source }
             coveredTables.add("trade_audit")
 
+            // Exchange order — upserted directly (the engine's ImportOrderIntent path uses the same
+            // repository call), recording EntityType.EXCHANGE_ORDER provenance on create AND update.
+            val orderResult =
+                repositories.exchangeOrderRepository.upsertOrder(
+                    accountId = sourceAccountId,
+                    orderRef = "coverage-o1",
+                    clientOid = null,
+                    side = "BUY",
+                    orderType = "LIMIT",
+                    timeInForce = "GOOD_TILL_CANCEL",
+                    status = "ACTIVE",
+                    limitPrice = "1.00",
+                    quantity = "10",
+                    avgPrice = null,
+                    createdAt = now,
+                    updatedAt = null,
+                    source = Source.Manual,
+                )
+            repositories.exchangeOrderRepository.upsertOrder(
+                accountId = sourceAccountId,
+                orderRef = "coverage-o1",
+                clientOid = null,
+                side = "BUY",
+                orderType = "LIMIT",
+                timeInForce = "GOOD_TILL_CANCEL",
+                status = "FILLED",
+                limitPrice = "1.00",
+                quantity = "10",
+                avgPrice = "1.00",
+                createdAt = now,
+                updatedAt = now,
+                source = Source.Manual,
+            )
+            assertAllHaveSource(
+                "exchange order",
+                repositories.auditRepository.getAuditHistoryForExchangeOrder(orderResult.id),
+            ) { it.source }
+            coveredTables.add("exchange_order_audit")
+
             // CSV import strategy (dedicated source table, like the API strategy)
             val csvStrategyId =
                 repositories.csvImportStrategyRepository.createStrategy(

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/ImportDirectoryScannerTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/ImportDirectoryScannerTest.kt
@@ -74,6 +74,7 @@ class ImportDirectoryScannerTest : DbTest() {
             currencyRepository = repositories.currencyRepository,
             cryptoRepository = repositories.cryptoRepository,
             tradeRepository = repositories.tradeRepository,
+            exchangeOrderRepository = repositories.exchangeOrderRepository,
             attributeTypeRepository = repositories.attributeTypeRepository,
             relationshipTypeRepository = repositories.relationshipTypeRepository,
             csvImportStrategyRepository = repositories.csvImportStrategyRepository,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -21,14 +21,18 @@ import com.moneymanager.importengineapi.ImportAccountIntent
 import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportCategoryIntent
 import com.moneymanager.importengineapi.ImportOperation
+import com.moneymanager.importengineapi.ImportOrderIntent
 import com.moneymanager.importengineapi.ImportOwnershipIntent
 import com.moneymanager.importengineapi.ImportPassThrough
 import com.moneymanager.importengineapi.ImportPersonIntent
 import com.moneymanager.importengineapi.ImportRowKey
+import com.moneymanager.importengineapi.ImportTradeIntent
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.importengineapi.LocalCategoryKey
+import com.moneymanager.importengineapi.LocalOrderKey
 import com.moneymanager.importengineapi.LocalPersonKey
+import com.moneymanager.importengineapi.LocalTradeKey
 import com.moneymanager.importengineapi.PersonMatchKey
 import com.moneymanager.importengineapi.createCrypto
 import com.moneymanager.importengineapi.createTrade
@@ -61,6 +65,7 @@ class ImportEngineDbTest : DbTest() {
             currencyRepository = repositories.currencyRepository,
             cryptoRepository = repositories.cryptoRepository,
             tradeRepository = repositories.tradeRepository,
+            exchangeOrderRepository = repositories.exchangeOrderRepository,
             attributeTypeRepository = repositories.attributeTypeRepository,
             relationshipTypeRepository = repositories.relationshipTypeRepository,
             csvImportStrategyRepository = repositories.csvImportStrategyRepository,
@@ -1311,5 +1316,91 @@ class ImportEngineDbTest : DbTest() {
             assertEquals(BigInteger("100000000000000000000"), tradeRow.transactionAmount.amount)
             assertEquals(bank, tradeRow.sourceAccountId)
             assertEquals(wallet, tradeRow.targetAccountId)
+        }
+
+    @Test
+    fun orderIntents_upsertOrdersAndLinkFills_andStandaloneOrdersImport() =
+        runTest {
+            val e = engine()
+            val exchange =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Exchange", openingDate = baseTime),
+                )
+            val gbp = repositories.currencyRepository.getCurrencyByCode("GBP").first()!!
+            val eth = repositories.cryptoRepository.getCryptoAssetById(e.createCrypto("ETH")).first()!!
+
+            val tradeKey = LocalTradeKey("t1")
+            val result =
+                e.import(
+                    ImportBatch(
+                        trades =
+                            listOf(
+                                ImportTradeIntent(
+                                    key = tradeKey,
+                                    source = Source.Manual,
+                                    timestamp = baseTime,
+                                    description = "Buy ETH/GBP",
+                                    fromAccountId = exchange,
+                                    fromAmount = Money.fromDisplayValue("100", gbp),
+                                    toAccountId = exchange,
+                                    toAmount = Money.fromDisplayValue("0.05", eth),
+                                ),
+                            ),
+                        orders =
+                            listOf(
+                                ImportOrderIntent(
+                                    key = LocalOrderKey("o1"),
+                                    source = Source.Manual,
+                                    accountId = exchange,
+                                    orderRef = "ref-1",
+                                    side = "BUY",
+                                    status = "FILLED",
+                                    createdAt = baseTime,
+                                    tradeKeys = listOf(tradeKey),
+                                ),
+                                // An order with no fills in the batch (open limit order) imports standalone.
+                                ImportOrderIntent(
+                                    key = LocalOrderKey("o2"),
+                                    source = Source.Manual,
+                                    accountId = exchange,
+                                    orderRef = "ref-2",
+                                    side = "SELL",
+                                    status = "ACTIVE",
+                                    createdAt = baseTime,
+                                ),
+                            ),
+                    ),
+                )
+
+            val o1 = result.orderIds.getValue(LocalOrderKey("o1"))
+            val fills = repositories.exchangeOrderRepository.getFillTradesForOrder(o1).first()
+            assertEquals(listOf(result.createdTradeIds.getValue(tradeKey)), fills.map { it.id })
+            assertEquals(
+                2,
+                repositories.exchangeOrderRepository
+                    .getOrdersByAccount(exchange)
+                    .first()
+                    .size,
+            )
+
+            // A tradeKey that resolves to nothing in the batch must fail loudly, not drop the link.
+            assertFailsWith<IllegalArgumentException> {
+                e.import(
+                    ImportBatch(
+                        orders =
+                            listOf(
+                                ImportOrderIntent(
+                                    key = LocalOrderKey("o3"),
+                                    source = Source.Manual,
+                                    accountId = exchange,
+                                    orderRef = "ref-3",
+                                    side = "BUY",
+                                    createdAt = baseTime,
+                                    tradeKeys = listOf(LocalTradeKey("missing")),
+                                ),
+                            ),
+                    ),
+                )
+            }
         }
 }

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/ExchangeOrderRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/ExchangeOrderRepositoryImplTest.kt
@@ -1,0 +1,135 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.database.repository
+
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.repository.OrderUpsertResult
+import com.moneymanager.importengineapi.createCrypto
+import com.moneymanager.importengineapi.createTrade
+import com.moneymanager.test.database.DbTest
+import com.moneymanager.test.database.createAccount
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+class ExchangeOrderRepositoryImplTest : DbTest() {
+    private val now = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+
+    private suspend fun account(name: String = "Exchange"): AccountId =
+        repositories.accountRepository.createAccount(Account(id = AccountId(0), name = name, openingDate = now))
+
+    private suspend fun upsert(
+        accountId: AccountId,
+        orderRef: String = "o1",
+        status: String? = "ACTIVE",
+        avgPrice: String? = null,
+    ): OrderUpsertResult =
+        repositories.exchangeOrderRepository.upsertOrder(
+            accountId = accountId,
+            orderRef = orderRef,
+            clientOid = "co-1",
+            side = "BUY",
+            orderType = "LIMIT",
+            timeInForce = "GOOD_TILL_CANCEL",
+            status = status,
+            limitPrice = "100.00",
+            quantity = "5",
+            avgPrice = avgPrice,
+            createdAt = now,
+            updatedAt = null,
+            source = Source.Manual,
+        )
+
+    @Test
+    fun `upsert creates, dedupes identical, and revises changed orders`() =
+        runTest {
+            val accountId = account()
+
+            val created = upsert(accountId)
+            assertEquals(OrderUpsertResult.Outcome.CREATED, created.outcome)
+
+            val unchanged = upsert(accountId)
+            assertEquals(OrderUpsertResult.Outcome.UNCHANGED, unchanged.outcome)
+            assertEquals(created.id, unchanged.id)
+
+            val updated = upsert(accountId, status = "FILLED", avgPrice = "99.98")
+            assertEquals(OrderUpsertResult.Outcome.UPDATED, updated.outcome)
+            assertEquals(created.id, updated.id)
+
+            val order = repositories.exchangeOrderRepository.getOrderById(created.id).first()!!
+            assertEquals("FILLED", order.status)
+            assertEquals("99.98", order.avgPrice)
+            assertEquals(2L, order.revisionId, "content change bumps the revision")
+            assertEquals(
+                1,
+                repositories.exchangeOrderRepository
+                    .getOrdersByAccount(accountId)
+                    .first()
+                    .size,
+                "upsert never duplicates",
+            )
+        }
+
+    @Test
+    fun `the same order ref on different accounts is two distinct orders`() =
+        runTest {
+            val a = account("Exchange A")
+            val b = account("Exchange B")
+            val first = upsert(a)
+            val second = upsert(b)
+            assertEquals(OrderUpsertResult.Outcome.CREATED, second.outcome)
+            assertTrue(first.id != second.id)
+        }
+
+    @Test
+    fun `linkTrade is idempotent and drives both fill queries`() =
+        runTest {
+            val accountId = account()
+            val gbp =
+                repositories.currencyRepository
+                    .getAllCurrencies()
+                    .first()
+                    .first { it.code == "GBP" }
+            val btcId = repositories.importEngine.createCrypto("BTC")
+            val btc = repositories.cryptoRepository.getCryptoAssetById(btcId).first()!!
+            val tradeId =
+                repositories.importEngine.createTrade(
+                    timestamp = now,
+                    description = "Buy BTC/GBP",
+                    fromAccountId = accountId,
+                    fromAmount = Money.fromDisplayValue("100.00", gbp),
+                    toAccountId = accountId,
+                    toAmount = Money.fromDisplayValue("0.001", btc),
+                )
+            val order = upsert(accountId)
+
+            repositories.exchangeOrderRepository.linkTrade(order.id, tradeId)
+            repositories.exchangeOrderRepository.linkTrade(order.id, tradeId)
+
+            val fills = repositories.exchangeOrderRepository.getFillTradesForOrder(order.id).first()
+            assertEquals(listOf(tradeId), fills.map { it.id }, "re-linking must not duplicate")
+            assertEquals(
+                mapOf(order.id to 1L),
+                repositories.exchangeOrderRepository.getFillCountsByAccount(accountId).first(),
+            )
+        }
+
+    @Test
+    fun `deleting the account cascades to its orders and links`() =
+        runTest {
+            val accountId = account()
+            val order = upsert(accountId)
+            assertEquals(1L, repositories.exchangeOrderRepository.countOrdersByAccount(accountId).first())
+
+            repositories.accountRepository.deleteAccount(accountId)
+
+            assertEquals(0L, repositories.exchangeOrderRepository.countOrdersByAccount(accountId).first())
+            assertEquals(null, repositories.exchangeOrderRepository.getOrderById(order.id).first())
+        }
+}

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/ExchangeOrderRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/ExchangeOrderRepositoryImplTest.kt
@@ -46,9 +46,9 @@ class ExchangeOrderRepositoryImplTest : DbTest() {
             source = Source.Manual,
         )
 
-    @Test
     // Test names in this package are dexed for the Android device test run, whose SimpleName grammar
     // allows spaces but not commas — keep punctuation out of the backticked names here.
+    @Test
     fun `upsert creates then dedupes an identical order and revises a changed one`() =
         runTest {
             val accountId = account()

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/ExchangeOrderRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/ExchangeOrderRepositoryImplTest.kt
@@ -47,7 +47,9 @@ class ExchangeOrderRepositoryImplTest : DbTest() {
         )
 
     @Test
-    fun `upsert creates, dedupes identical, and revises changed orders`() =
+    // Test names in this package are dexed for the Android device test run, whose SimpleName grammar
+    // allows spaces but not commas — keep punctuation out of the backticked names here.
+    fun `upsert creates then dedupes an identical order and revises a changed one`() =
         runTest {
             val accountId = account()
 

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountRowMapper.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/mapper/AccountRowMapper.kt
@@ -5,6 +5,7 @@ package com.moneymanager.database.mapper
 import com.moneymanager.bigdecimal.BigInteger
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AccountRow
+import com.moneymanager.domain.model.ExchangeOrderId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.TransactionKind
 import com.moneymanager.domain.model.TransferId
@@ -34,6 +35,7 @@ object AccountRowMapper {
         feeParentTransferId: Long?,
         passThroughSpendId: Long?,
         passThroughFundingId: Long?,
+        exchangeOrderId: Long?,
         transactionKind: String,
     ): AccountRow {
         val asset = AssetRowMapper.buildAsset(assetId, assetCode, assetName, assetScaleFactor, assetKind)
@@ -52,6 +54,7 @@ object AccountRowMapper {
             feeParentTransferId = feeParentTransferId?.let { TransferId(it) },
             passThroughSpendId = passThroughSpendId?.let { TransferId(it) },
             passThroughFundingId = passThroughFundingId?.let { TransferId(it) },
+            exchangeOrderId = exchangeOrderId?.let { ExchangeOrderId(it) },
             kind = TransactionKind.valueOf(transactionKind),
         )
     }

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/mapper/ExchangeOrderAuditEntryMapper.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/mapper/ExchangeOrderAuditEntryMapper.kt
@@ -1,0 +1,66 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.database.mapper
+
+import com.moneymanager.database.sql.audit.SelectAuditHistoryForExchangeOrder
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AuditType
+import com.moneymanager.domain.model.EntityType
+import com.moneymanager.domain.model.ExchangeOrderAuditEntry
+import com.moneymanager.domain.model.ExchangeOrderId
+import com.moneymanager.domain.model.SourceRecord
+import kotlin.time.Instant.Companion.fromEpochMilliseconds
+
+object ExchangeOrderAuditEntryMapper {
+    fun map(from: SelectAuditHistoryForExchangeOrder): ExchangeOrderAuditEntry =
+        ExchangeOrderAuditEntry(
+            id = from.id,
+            auditTimestamp = fromEpochMilliseconds(from.audit_timestamp),
+            auditType = AuditType.valueOf(from.audit_type.uppercase()),
+            orderId = ExchangeOrderId(from.exchange_order_id),
+            revisionId = from.revision_id,
+            accountId = AccountId(from.account_id),
+            orderRef = from.order_ref,
+            clientOid = from.client_oid,
+            side = from.side,
+            orderType = from.order_type,
+            timeInForce = from.time_in_force,
+            status = from.status,
+            limitPrice = from.limit_price,
+            quantity = from.quantity,
+            avgPrice = from.avg_price,
+            createdAt = fromEpochMilliseconds(from.created_at),
+            updatedAt = from.updated_at?.let(::fromEpochMilliseconds),
+            source = from.toSourceRecord(),
+        )
+}
+
+private fun SelectAuditHistoryForExchangeOrder.toSourceRecord(): SourceRecord? =
+    buildSourceRecord(
+        SourceColumns(
+            sourceId = source_id,
+            sourceTypeName = source_type_name,
+            deviceId = source_device_id,
+            createdAt = source_created_at,
+            entityType = EntityType.EXCHANGE_ORDER,
+            entityId = exchange_order_id,
+            revisionId = revision_id,
+            detail =
+                SourceDetailColumns(
+                    platformName = source_platform_name,
+                    osName = source_os_name,
+                    machineName = source_machine_name,
+                    deviceMake = source_device_make,
+                    deviceModel = source_device_model,
+                    csvImportId = source_csv_import_id,
+                    csvRowIndex = source_csv_row_index,
+                    csvFileName = source_csv_file_name,
+                    qifImportId = source_qif_import_id,
+                    qifRecordIndex = source_qif_record_index,
+                    qifFileName = source_qif_file_name,
+                    apiSessionId = source_api_session_id,
+                    apiRequestId = source_api_request_id,
+                    apiJsonPath = source_api_json_path,
+                ),
+        ),
+    )

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/mapper/ExchangeOrderMapper.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/mapper/ExchangeOrderMapper.kt
@@ -1,0 +1,44 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.database.mapper
+
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.ExchangeOrder
+import com.moneymanager.domain.model.ExchangeOrderId
+import kotlin.time.Instant.Companion.fromEpochMilliseconds
+
+object ExchangeOrderMapper {
+    @Suppress("LongParameterList")
+    fun mapRaw(
+        id: Long,
+        revisionId: Long,
+        accountId: Long,
+        orderRef: String,
+        clientOid: String?,
+        side: String,
+        orderType: String?,
+        timeInForce: String?,
+        status: String?,
+        limitPrice: String?,
+        quantity: String?,
+        avgPrice: String?,
+        createdAt: Long,
+        updatedAt: Long?,
+    ): ExchangeOrder =
+        ExchangeOrder(
+            id = ExchangeOrderId(id),
+            revisionId = revisionId,
+            accountId = AccountId(accountId),
+            orderRef = orderRef,
+            clientOid = clientOid,
+            side = side,
+            orderType = orderType,
+            timeInForce = timeInForce,
+            status = status,
+            limitPrice = limitPrice,
+            quantity = quantity,
+            avgPrice = avgPrice,
+            createdAt = fromEpochMilliseconds(createdAt),
+            updatedAt = updatedAt?.let(::fromEpochMilliseconds),
+        )
+}

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/AuditReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/AuditReadRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.moneymanager.database.mapper.CategoryAuditEntryMapper
 import com.moneymanager.database.mapper.CryptoAuditEntryMapper
 import com.moneymanager.database.mapper.CsvImportStrategyAuditEntryMapper
 import com.moneymanager.database.mapper.CurrencyAuditEntryMapper
+import com.moneymanager.database.mapper.ExchangeOrderAuditEntryMapper
 import com.moneymanager.database.mapper.ImportDirectoryAuditEntryMapper
 import com.moneymanager.database.mapper.OwnershipAuditHistoryForAccountMapper
 import com.moneymanager.database.mapper.PersonAccountOwnershipAuditEntryMapper
@@ -29,6 +30,8 @@ import com.moneymanager.domain.model.CryptoId
 import com.moneymanager.domain.model.CsvImportStrategyAuditEntry
 import com.moneymanager.domain.model.CurrencyAuditEntry
 import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.ExchangeOrderAuditEntry
+import com.moneymanager.domain.model.ExchangeOrderId
 import com.moneymanager.domain.model.ImportDirectoryAuditEntry
 import com.moneymanager.domain.model.PersonAccountOwnershipAuditEntry
 import com.moneymanager.domain.model.PersonAttributeAuditEntry
@@ -130,6 +133,14 @@ class AuditReadRepositoryImpl(
                 .selectAuditHistoryForTrade(tradeId.id)
                 .executeAsList()
                 .map(TradeAuditEntryMapper::map)
+        }
+
+    override suspend fun getAuditHistoryForExchangeOrder(orderId: ExchangeOrderId): List<ExchangeOrderAuditEntry> =
+        withContext(Dispatchers.Default) {
+            auditSelectQueries
+                .selectAuditHistoryForExchangeOrder(orderId.id)
+                .executeAsList()
+                .map(ExchangeOrderAuditEntryMapper::map)
         }
 
     override suspend fun getAuditHistoryForCategory(categoryId: Long): List<CategoryAuditEntry> =

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/ExchangeOrderReadRepositoryImpl.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/repository/ExchangeOrderReadRepositoryImpl.kt
@@ -1,0 +1,54 @@
+package com.moneymanager.database.repository
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.coroutines.mapToOne
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import com.moneymanager.database.mapper.ExchangeOrderMapper
+import com.moneymanager.database.mapper.TradeMapper
+import com.moneymanager.database.sql.read.MoneyManagerDatabase
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.ExchangeOrder
+import com.moneymanager.domain.model.ExchangeOrderId
+import com.moneymanager.domain.model.Trade
+import com.moneymanager.domain.repository.ExchangeOrderReadRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class ExchangeOrderReadRepositoryImpl(
+    database: MoneyManagerDatabase,
+) : ExchangeOrderReadRepository {
+    private val selectQueries = database.exchangeOrderSelectQueries
+
+    override fun getOrderById(id: ExchangeOrderId): Flow<ExchangeOrder?> =
+        selectQueries
+            .selectById(id.id, ExchangeOrderMapper::mapRaw)
+            .asFlow()
+            .mapToOneOrNull(Dispatchers.Default)
+
+    override fun getOrdersByAccount(accountId: AccountId): Flow<List<ExchangeOrder>> =
+        selectQueries
+            .selectByAccount(accountId.id, ExchangeOrderMapper::mapRaw)
+            .asFlow()
+            .mapToList(Dispatchers.Default)
+
+    override fun countOrdersByAccount(accountId: AccountId): Flow<Long> =
+        selectQueries
+            .countByAccount(accountId.id)
+            .asFlow()
+            .mapToOne(Dispatchers.Default)
+
+    override fun getFillTradesForOrder(id: ExchangeOrderId): Flow<List<Trade>> =
+        selectQueries
+            .selectFillTradesForOrder(id.id, TradeMapper::mapRaw)
+            .asFlow()
+            .mapToList(Dispatchers.Default)
+
+    override fun getFillCountsByAccount(accountId: AccountId): Flow<Map<ExchangeOrderId, Long>> =
+        selectQueries
+            .selectFillCountsByAccount(accountId.id)
+            .asFlow()
+            .mapToList(Dispatchers.Default)
+            .map { rows -> rows.associate { ExchangeOrderId(it.order_id) to it.fill_count } }
+}

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/AuditSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/AuditSelect.sq
@@ -651,3 +651,57 @@ LEFT JOIN qif_entity_source ON entity_source.id = qif_entity_source.id
 LEFT JOIN qif_import_metadata ON qif_entity_source.qif_import_id = qif_import_metadata.id
 WHERE trade_audit.trade_id = ?
 ORDER BY trade_audit.audit_timestamp DESC, trade_audit.id DESC;
+
+selectAuditHistoryForExchangeOrder:
+SELECT
+    exchange_order_audit.id,
+    exchange_order_audit.audit_timestamp,
+    audit_type.name AS audit_type,
+    exchange_order_audit.exchange_order_id,
+    exchange_order_audit.revision_id,
+    exchange_order_audit.account_id,
+    exchange_order_audit.order_ref,
+    exchange_order_audit.client_oid,
+    exchange_order_audit.side,
+    exchange_order_audit.order_type,
+    exchange_order_audit.time_in_force,
+    exchange_order_audit.status,
+    exchange_order_audit.limit_price,
+    exchange_order_audit.quantity,
+    exchange_order_audit.avg_price,
+    exchange_order_audit.created_at,
+    exchange_order_audit.updated_at,
+    -- Source information
+    entity_source.id AS source_id,
+    entity_source.device_id AS source_device_id,
+    source_type.id AS source_type_id,
+    source_type.name AS source_type_name,
+    device_view.platform_name AS source_platform_name,
+    device_view.os_name AS source_os_name,
+    device_view.machine_name AS source_machine_name,
+    device_view.device_make AS source_device_make,
+    device_view.device_model AS source_device_model,
+    entity_source.created_at AS source_created_at,
+    api_entity_source.api_session_id AS source_api_session_id,
+    api_entity_source.api_request_id AS source_api_request_id,
+    api_entity_source.json_path AS source_api_json_path,
+    csv_entity_source.csv_import_id AS source_csv_import_id,
+    csv_entity_source.csv_row_index AS source_csv_row_index,
+    csv_import_metadata.original_file_name AS source_csv_file_name,
+    qif_entity_source.qif_import_id AS source_qif_import_id,
+    qif_entity_source.qif_record_index AS source_qif_record_index,
+    qif_import_metadata.original_file_name AS source_qif_file_name
+FROM exchange_order_audit
+JOIN audit_type ON exchange_order_audit.audit_type_id = audit_type.id
+LEFT JOIN entity_source ON exchange_order_audit.exchange_order_id = entity_source.entity_id
+    AND exchange_order_audit.revision_id = entity_source.revision_id
+    AND entity_source.entity_type_id = 12
+LEFT JOIN source_type ON entity_source.source_type_id = source_type.id
+LEFT JOIN device_view ON entity_source.device_id = device_view.id
+LEFT JOIN api_entity_source ON entity_source.id = api_entity_source.id
+LEFT JOIN csv_entity_source ON entity_source.id = csv_entity_source.id
+LEFT JOIN csv_import_metadata ON csv_entity_source.csv_import_id = csv_import_metadata.id
+LEFT JOIN qif_entity_source ON entity_source.id = qif_entity_source.id
+LEFT JOIN qif_import_metadata ON qif_entity_source.qif_import_id = qif_import_metadata.id
+WHERE exchange_order_audit.exchange_order_id = ?
+ORDER BY exchange_order_audit.audit_timestamp DESC, exchange_order_audit.id DESC;

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/exchangeOrder/ExchangeOrderSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/exchangeOrder/ExchangeOrderSelect.sq
@@ -1,0 +1,57 @@
+selectById:
+SELECT id, revision_id, account_id, order_ref, client_oid, side, order_type, time_in_force, status, limit_price, quantity, avg_price, created_at, updated_at
+FROM exchange_order
+WHERE id = ?;
+
+selectByAccount:
+SELECT id, revision_id, account_id, order_ref, client_oid, side, order_type, time_in_force, status, limit_price, quantity, avg_price, created_at, updated_at
+FROM exchange_order
+WHERE account_id = ?
+ORDER BY created_at DESC, id DESC;
+
+countByAccount:
+SELECT COUNT(*)
+FROM exchange_order
+WHERE account_id = ?;
+
+-- Upsert probe: an order is identified by (account, exchange order id) across imports.
+selectByAccountAndOrderRef:
+SELECT id, revision_id, account_id, order_ref, client_oid, side, order_type, time_in_force, status, limit_price, quantity, avg_price, created_at, updated_at
+FROM exchange_order
+WHERE account_id = ? AND order_ref = ?;
+
+-- The fill trades linked to an order, with both legs' assets resolved (mirrors trade/TradeSelect.sq).
+selectFillTradesForOrder:
+SELECT
+    trade.id,
+    trade.revision_id,
+    trade.timestamp,
+    trade.description,
+    trade.from_account_id,
+    trade.from_asset_id,
+    trade.from_amount,
+    fa.code AS from_asset_code,
+    fa.name AS from_asset_name,
+    fa.scale_factor AS from_asset_scale_factor,
+    fa.kind AS from_asset_kind,
+    trade.to_account_id,
+    trade.to_asset_id,
+    trade.to_amount,
+    ta.code AS to_asset_code,
+    ta.name AS to_asset_name,
+    ta.scale_factor AS to_asset_scale_factor,
+    ta.kind AS to_asset_kind
+FROM exchange_order_trade
+JOIN trade ON trade.id = exchange_order_trade.trade_id
+JOIN asset_details fa ON trade.from_asset_id = fa.id
+JOIN asset_details ta ON trade.to_asset_id = ta.id
+WHERE exchange_order_trade.order_id = ?
+ORDER BY trade.timestamp ASC, trade.id ASC;
+
+-- Fill counts per order for a whole account's order list (single query, no N+1).
+selectFillCountsByAccount:
+SELECT exchange_order_trade.order_id, COUNT(*) AS fill_count
+FROM exchange_order_trade
+JOIN exchange_order ON exchange_order.id = exchange_order_trade.order_id
+WHERE exchange_order.account_id = ?
+GROUP BY exchange_order_trade.order_id;

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
@@ -139,6 +139,9 @@ SELECT
     -- and the funding leg when this row is the spend leg (id2). PASS_THROUGH_RELATIONSHIP_TYPE_ID = 3.
     pass_through_as_funding.id2 AS pass_through_spend_id,
     pass_through_as_spend.id1 AS pass_through_funding_id,
+    -- The exchange order this trade fills, when any (exchange_order_trade.trade_id is UNIQUE, so
+    -- the join never multiplies rows and is a point index lookup).
+    order_link.order_id AS exchange_order_id,
     -- Whether this row is a trade (same-transaction asset conversion) or a plain transfer.
     CASE WHEN trade.id IS NOT NULL THEN 'TRADE' ELSE 'TRANSFER' END AS transaction_kind
 FROM running_balance_materialized_view
@@ -153,6 +156,7 @@ LEFT JOIN transfer_relationship pass_through_as_funding
     ON pass_through_as_funding.id1 = running_balance_materialized_view.id AND pass_through_as_funding.relationship_type_id = 3
 LEFT JOIN transfer_relationship pass_through_as_spend
     ON pass_through_as_spend.id2 = running_balance_materialized_view.id AND pass_through_as_spend.relationship_type_id = 3
+LEFT JOIN exchange_order_trade order_link ON order_link.trade_id = running_balance_materialized_view.id
 WHERE running_balance_materialized_view.account_id = :accountId
   AND (:currencyId IS NULL OR running_balance_materialized_view.asset_id = :currencyId)
   AND ((:lastTimestamp IS NULL AND :lastId IS NULL)
@@ -197,6 +201,9 @@ SELECT
     -- and the funding leg when this row is the spend leg (id2). PASS_THROUGH_RELATIONSHIP_TYPE_ID = 3.
     pass_through_as_funding.id2 AS pass_through_spend_id,
     pass_through_as_spend.id1 AS pass_through_funding_id,
+    -- The exchange order this trade fills, when any (exchange_order_trade.trade_id is UNIQUE, so
+    -- the join never multiplies rows and is a point index lookup).
+    order_link.order_id AS exchange_order_id,
     -- Whether this row is a trade (same-transaction asset conversion) or a plain transfer.
     CASE WHEN trade.id IS NOT NULL THEN 'TRADE' ELSE 'TRANSFER' END AS transaction_kind
 FROM running_balance_materialized_view
@@ -211,6 +218,7 @@ LEFT JOIN transfer_relationship pass_through_as_funding
     ON pass_through_as_funding.id1 = running_balance_materialized_view.id AND pass_through_as_funding.relationship_type_id = 3
 LEFT JOIN transfer_relationship pass_through_as_spend
     ON pass_through_as_spend.id2 = running_balance_materialized_view.id AND pass_through_as_spend.relationship_type_id = 3
+LEFT JOIN exchange_order_trade order_link ON order_link.trade_id = running_balance_materialized_view.id
 WHERE running_balance_materialized_view.account_id = :accountId
   AND (:currencyId IS NULL OR running_balance_materialized_view.asset_id = :currencyId)
   AND (running_balance_materialized_view.timestamp > :firstTimestamp
@@ -263,6 +271,9 @@ SELECT
     -- and the funding leg when this row is the spend leg (id2). PASS_THROUGH_RELATIONSHIP_TYPE_ID = 3.
     pass_through_as_funding.id2 AS pass_through_spend_id,
     pass_through_as_spend.id1 AS pass_through_funding_id,
+    -- The exchange order this trade fills, when any (exchange_order_trade.trade_id is UNIQUE, so
+    -- the join never multiplies rows and is a point index lookup).
+    order_link.order_id AS exchange_order_id,
     -- Whether this row is a trade (same-transaction asset conversion) or a plain transfer.
     CASE WHEN trade.id IS NOT NULL THEN 'TRADE' ELSE 'TRANSFER' END AS transaction_kind
 FROM running_balance_materialized_view
@@ -277,6 +288,7 @@ LEFT JOIN transfer_relationship pass_through_as_funding
     ON pass_through_as_funding.id1 = running_balance_materialized_view.id AND pass_through_as_funding.relationship_type_id = 3
 LEFT JOIN transfer_relationship pass_through_as_spend
     ON pass_through_as_spend.id2 = running_balance_materialized_view.id AND pass_through_as_spend.relationship_type_id = 3
+LEFT JOIN exchange_order_trade order_link ON order_link.trade_id = running_balance_materialized_view.id
 WHERE running_balance_materialized_view.account_id = :accountId
   AND (:currencyId IS NULL OR running_balance_materialized_view.asset_id = :currencyId)
 ORDER BY running_balance_materialized_view.timestamp DESC, running_balance_materialized_view.id DESC

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/Audit.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/Audit.sq
@@ -293,3 +293,30 @@ CREATE INDEX IF NOT EXISTS idx_pass_through_account_audit_account_id ON pass_thr
 CREATE INDEX IF NOT EXISTS idx_pass_through_account_audit_timestamp ON pass_through_account_audit(audit_timestamp);
 CREATE INDEX IF NOT EXISTS idx_pass_through_account_audit_type ON pass_through_account_audit(audit_type_id);
 CREATE INDEX IF NOT EXISTS idx_pass_through_account_audit_account_id_timestamp ON pass_through_account_audit(pass_through_account_id, audit_timestamp DESC);
+
+-- exchange_order_audit: Audit trail for exchange_order table
+CREATE TABLE exchange_order_audit (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    audit_timestamp INTEGER NOT NULL,
+    audit_type_id INTEGER NOT NULL,
+    exchange_order_id INTEGER NOT NULL,
+    revision_id INTEGER NOT NULL,
+    account_id INTEGER NOT NULL,
+    order_ref TEXT NOT NULL,
+    client_oid TEXT,
+    side TEXT NOT NULL,
+    order_type TEXT,
+    time_in_force TEXT,
+    status TEXT,
+    limit_price TEXT,
+    quantity TEXT,
+    avg_price TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER,
+    FOREIGN KEY (audit_type_id) REFERENCES audit_type(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_exchange_order_audit_order_id ON exchange_order_audit(exchange_order_id);
+CREATE INDEX IF NOT EXISTS idx_exchange_order_audit_timestamp ON exchange_order_audit(audit_timestamp);
+CREATE INDEX IF NOT EXISTS idx_exchange_order_audit_type ON exchange_order_audit(audit_type_id);
+CREATE INDEX IF NOT EXISTS idx_exchange_order_audit_order_id_timestamp ON exchange_order_audit(exchange_order_id, audit_timestamp DESC);

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/AuditTriggers.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/AuditTriggers.sq
@@ -569,3 +569,30 @@ BEGIN
     VALUES (CAST(strftime('%s', 'now') AS INTEGER) * 1000, 2, old.id, new.revision_id, old.timestamp, old.description, old.source_account_id, old.target_account_id, old.asset_id, old.amount);
 END;
 
+
+-- trigger_exchange_order_delete_audit
+CREATE TRIGGER trigger_exchange_order_delete_audit
+AFTER DELETE ON exchange_order
+FOR EACH ROW
+BEGIN
+    INSERT INTO exchange_order_audit (audit_timestamp, audit_type_id, exchange_order_id, revision_id, account_id, order_ref, client_oid, side, order_type, time_in_force, status, limit_price, quantity, avg_price, created_at, updated_at)
+    VALUES (CAST(strftime('%s', 'now') AS INTEGER) * 1000, 3, old.id, old.revision_id, old.account_id, old.order_ref, old.client_oid, old.side, old.order_type, old.time_in_force, old.status, old.limit_price, old.quantity, old.avg_price, old.created_at, old.updated_at);
+END;
+
+-- trigger_exchange_order_insert_audit
+CREATE TRIGGER trigger_exchange_order_insert_audit
+AFTER INSERT ON exchange_order
+FOR EACH ROW
+BEGIN
+    INSERT INTO exchange_order_audit (audit_timestamp, audit_type_id, exchange_order_id, revision_id, account_id, order_ref, client_oid, side, order_type, time_in_force, status, limit_price, quantity, avg_price, created_at, updated_at)
+    VALUES (CAST(strftime('%s', 'now') AS INTEGER) * 1000, 1, new.id, new.revision_id, new.account_id, new.order_ref, new.client_oid, new.side, new.order_type, new.time_in_force, new.status, new.limit_price, new.quantity, new.avg_price, new.created_at, new.updated_at);
+END;
+
+-- trigger_exchange_order_update_audit
+CREATE TRIGGER trigger_exchange_order_update_audit
+AFTER UPDATE ON exchange_order
+FOR EACH ROW
+BEGIN
+    INSERT INTO exchange_order_audit (audit_timestamp, audit_type_id, exchange_order_id, revision_id, account_id, order_ref, client_oid, side, order_type, time_in_force, status, limit_price, quantity, avg_price, created_at, updated_at)
+    VALUES (CAST(strftime('%s', 'now') AS INTEGER) * 1000, 2, old.id, new.revision_id, old.account_id, old.order_ref, old.client_oid, old.side, old.order_type, old.time_in_force, old.status, old.limit_price, old.quantity, old.avg_price, old.created_at, old.updated_at);
+END;

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/entitySource/EntitySource.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/entitySource/EntitySource.sq
@@ -27,6 +27,7 @@ INSERT OR IGNORE INTO entity_type (id, name) VALUES (7, 'TRANSFER');
 INSERT OR IGNORE INTO entity_type (id, name) VALUES (8, 'CSV_IMPORT_STRATEGY');
 INSERT OR IGNORE INTO entity_type (id, name) VALUES (10, 'CRYPTO');
 INSERT OR IGNORE INTO entity_type (id, name) VALUES (11, 'TRADE');
+INSERT OR IGNORE INTO entity_type (id, name) VALUES (12, 'EXCHANGE_ORDER');
 
 CREATE TABLE entity_source (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/exchangeOrder/ExchangeOrder.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/exchangeOrder/ExchangeOrder.sq
@@ -1,0 +1,38 @@
+-- exchange_order: an order placed on a crypto exchange (from e.g. Crypto.com's
+-- private/get-order-history). Orders are metadata, not transactions: the economics of a filled
+-- order are already fully represented by its fill trades, so an order row deliberately has no
+-- transaction_id and never participates in balances. Status/avg_price/quantity legitimately change
+-- between imports (ACTIVE -> FILLED/CANCELED), so re-import upserts by (account_id, order_ref) and
+-- bumps revision_id.
+--
+-- Prices/quantities are exchange-reported decimal strings, display-only (never aggregated in SQL).
+CREATE TABLE exchange_order (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    revision_id INTEGER NOT NULL DEFAULT 1,
+    account_id INTEGER NOT NULL,
+    order_ref TEXT NOT NULL,
+    client_oid TEXT,
+    side TEXT NOT NULL,
+    order_type TEXT,
+    time_in_force TEXT,
+    status TEXT,
+    limit_price TEXT,
+    quantity TEXT,
+    avg_price TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER,
+    UNIQUE (account_id, order_ref),
+    FOREIGN KEY (account_id) REFERENCES account(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_exchange_order_account ON exchange_order(account_id);
+
+-- exchange_order_trade: links an order to its fill trades. A fill belongs to at most one order
+-- (trade_id UNIQUE); an order can have many fills. Un-audited join table, like transfer_relationship.
+CREATE TABLE exchange_order_trade (
+    order_id INTEGER NOT NULL,
+    trade_id INTEGER NOT NULL UNIQUE,
+    PRIMARY KEY (order_id, trade_id),
+    FOREIGN KEY (order_id) REFERENCES exchange_order(id) ON DELETE CASCADE,
+    FOREIGN KEY (trade_id) REFERENCES trade(id) ON DELETE CASCADE
+);

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/MoneyManagerDatabaseWrapper.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/MoneyManagerDatabaseWrapper.kt
@@ -36,6 +36,7 @@ class MoneyManagerDatabaseWrapper(
     val currencyWriteQueries get() = writeDb.currencyWriteQueries
     val deviceWriteQueries get() = writeDb.deviceWriteQueries
     val entitySourceWriteQueries get() = writeDb.entitySourceWriteQueries
+    val exchangeOrderWriteQueries get() = writeDb.exchangeOrderWriteQueries
     val importDirectoryWriteQueries get() = writeDb.importDirectoryWriteQueries
     val maintenanceWriteQueries get() = writeDb.maintenanceWriteQueries
     val personAttributeWriteQueries get() = writeDb.personAttributeWriteQueries
@@ -337,6 +338,8 @@ class MoneyManagerDatabaseWrapper(
             "currency_audit",
             "crypto_audit",
             "trade_audit",
+            "exchange_order_audit",
+            "exchange_order_trade",
             "asset",
             "category_audit",
             "transfer_audit",

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/ExchangeOrderWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/ExchangeOrderWriteRepositoryImpl.kt
@@ -1,0 +1,108 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.database.repository
+
+import com.moneymanager.database.MoneyManagerDatabaseWrapper
+import com.moneymanager.database.recordSource
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.DeviceId
+import com.moneymanager.domain.model.EntityType
+import com.moneymanager.domain.model.ExchangeOrderId
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.TradeId
+import com.moneymanager.domain.repository.ExchangeOrderReadRepository
+import com.moneymanager.domain.repository.ExchangeOrderWriteRepository
+import com.moneymanager.domain.repository.OrderUpsertResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.time.Instant
+
+class ExchangeOrderWriteRepositoryImpl(
+    private val database: MoneyManagerDatabaseWrapper,
+    private val deviceId: DeviceId,
+    reader: ExchangeOrderReadRepository,
+) : ExchangeOrderWriteRepository,
+    ExchangeOrderReadRepository by reader {
+    private val writeQueries = database.exchangeOrderWriteQueries
+    private val selectQueries = database.exchangeOrderSelectQueries
+
+    override suspend fun upsertOrder(
+        accountId: AccountId,
+        orderRef: String,
+        clientOid: String?,
+        side: String,
+        orderType: String?,
+        timeInForce: String?,
+        status: String?,
+        limitPrice: String?,
+        quantity: String?,
+        avgPrice: String?,
+        createdAt: Instant,
+        updatedAt: Instant?,
+        source: Source,
+    ): OrderUpsertResult =
+        withContext(Dispatchers.Default) {
+            writeQueries.transactionWithResult {
+                val existing = selectQueries.selectByAccountAndOrderRef(accountId.id, orderRef).executeAsOneOrNull()
+                when {
+                    existing == null -> {
+                        writeQueries.insert(
+                            account_id = accountId.id,
+                            order_ref = orderRef,
+                            client_oid = clientOid,
+                            side = side,
+                            order_type = orderType,
+                            time_in_force = timeInForce,
+                            status = status,
+                            limit_price = limitPrice,
+                            quantity = quantity,
+                            avg_price = avgPrice,
+                            created_at = createdAt.toEpochMilliseconds(),
+                            updated_at = updatedAt?.toEpochMilliseconds(),
+                        )
+                        val id = writeQueries.lastInsertedId().executeAsOne()
+                        database.recordSource(deviceId, EntityType.EXCHANGE_ORDER, id, 1L, source)
+                        OrderUpsertResult(ExchangeOrderId(id), OrderUpsertResult.Outcome.CREATED)
+                    }
+                    existing.client_oid == clientOid &&
+                        existing.side == side &&
+                        existing.order_type == orderType &&
+                        existing.time_in_force == timeInForce &&
+                        existing.status == status &&
+                        existing.limit_price == limitPrice &&
+                        existing.quantity == quantity &&
+                        existing.avg_price == avgPrice &&
+                        existing.created_at == createdAt.toEpochMilliseconds() &&
+                        existing.updated_at == updatedAt?.toEpochMilliseconds() -> {
+                        OrderUpsertResult(ExchangeOrderId(existing.id), OrderUpsertResult.Outcome.UNCHANGED)
+                    }
+                    else -> {
+                        writeQueries.updateByUniqueKey(
+                            client_oid = clientOid,
+                            side = side,
+                            order_type = orderType,
+                            time_in_force = timeInForce,
+                            status = status,
+                            limit_price = limitPrice,
+                            quantity = quantity,
+                            avg_price = avgPrice,
+                            created_at = createdAt.toEpochMilliseconds(),
+                            updated_at = updatedAt?.toEpochMilliseconds(),
+                            account_id = accountId.id,
+                            order_ref = orderRef,
+                        )
+                        database.recordSource(deviceId, EntityType.EXCHANGE_ORDER, existing.id, existing.revision_id + 1, source)
+                        OrderUpsertResult(ExchangeOrderId(existing.id), OrderUpsertResult.Outcome.UPDATED)
+                    }
+                }
+            }
+        }
+
+    override suspend fun linkTrade(
+        orderId: ExchangeOrderId,
+        tradeId: TradeId,
+    ): Unit =
+        withContext(Dispatchers.Default) {
+            writeQueries.linkTrade(orderId.id, tradeId.id)
+        }
+}

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/exchangeOrder/ExchangeOrderWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/exchangeOrder/ExchangeOrderWrite.sq
@@ -1,0 +1,23 @@
+insert:
+INSERT INTO exchange_order(revision_id, account_id, order_ref, client_oid, side, order_type, time_in_force, status, limit_price, quantity, avg_price, created_at, updated_at)
+VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+lastInsertedId:
+SELECT last_insert_rowid();
+
+-- Revises an existing order in place: order status/prices legitimately change between imports
+-- (ACTIVE -> FILLED/CANCELED), so the row is updated and revision bumped instead of duplicated.
+updateByUniqueKey:
+UPDATE exchange_order
+SET revision_id = revision_id + 1,
+    client_oid = ?, side = ?, order_type = ?, time_in_force = ?, status = ?,
+    limit_price = ?, quantity = ?, avg_price = ?, created_at = ?, updated_at = ?
+WHERE account_id = ? AND order_ref = ?;
+
+delete:
+DELETE FROM exchange_order WHERE id = ?;
+
+-- Idempotent: re-importing the same session re-links the same fills.
+linkTrade:
+INSERT OR IGNORE INTO exchange_order_trade(order_id, trade_id)
+VALUES (?, ?);

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/ApplicationMapper.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/ApplicationMapper.kt
@@ -45,6 +45,7 @@ fun DatabaseComponent.toApplication() =
                 relationshipTypeRepository = relationshipTypeRepository,
                 transferRelationshipRepository = transferRelationshipRepository,
                 tradeRepository = tradeRepository,
+                exchangeOrderRepository = exchangeOrderRepository,
             ),
         people =
             People(

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/DatabaseComponent.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/DatabaseComponent.kt
@@ -20,6 +20,7 @@ import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
 import com.moneymanager.domain.repository.CsvImportWriteRepository
 import com.moneymanager.domain.repository.CurrencyWriteRepository
 import com.moneymanager.domain.repository.DeviceWriteRepository
+import com.moneymanager.domain.repository.ExchangeOrderWriteRepository
 import com.moneymanager.domain.repository.ImportDirectoryWriteRepository
 import com.moneymanager.domain.repository.ImportTimelineReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountWriteRepository
@@ -67,6 +68,7 @@ interface DatabaseComponent {
     val cryptoRepository: CryptoWriteRepository
 
     val tradeRepository: TradeWriteRepository
+    val exchangeOrderRepository: ExchangeOrderWriteRepository
     val deviceRepository: DeviceWriteRepository
     val importDirectoryRepository: ImportDirectoryWriteRepository
     val importTimelineRepository: ImportTimelineReadRepository

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/ImportEngineFactory.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/ImportEngineFactory.kt
@@ -22,6 +22,7 @@ fun DatabaseComponent.createImportEngine(editGate: EditGate): ImportEngine =
         currencyRepository = currencyRepository,
         cryptoRepository = cryptoRepository,
         tradeRepository = tradeRepository,
+        exchangeOrderRepository = exchangeOrderRepository,
         attributeTypeRepository = attributeTypeRepository,
         relationshipTypeRepository = relationshipTypeRepository,
         csvImportStrategyRepository = csvImportStrategyRepository,

--- a/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/RepositoryModule.kt
+++ b/app/di/core/src/commonMain/kotlin/com/moneymanager/di/database/RepositoryModule.kt
@@ -28,6 +28,8 @@ import com.moneymanager.database.repository.CurrencyReadRepositoryImpl
 import com.moneymanager.database.repository.CurrencyWriteRepositoryImpl
 import com.moneymanager.database.repository.DeviceReadRepositoryImpl
 import com.moneymanager.database.repository.DeviceWriteRepositoryImpl
+import com.moneymanager.database.repository.ExchangeOrderReadRepositoryImpl
+import com.moneymanager.database.repository.ExchangeOrderWriteRepositoryImpl
 import com.moneymanager.database.repository.ImportDirectoryReadRepositoryImpl
 import com.moneymanager.database.repository.ImportDirectoryWriteRepositoryImpl
 import com.moneymanager.database.repository.ImportTimelineReadRepositoryImpl
@@ -87,6 +89,8 @@ import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.CurrencyWriteRepository
 import com.moneymanager.domain.repository.DeviceReadRepository
 import com.moneymanager.domain.repository.DeviceWriteRepository
+import com.moneymanager.domain.repository.ExchangeOrderReadRepository
+import com.moneymanager.domain.repository.ExchangeOrderWriteRepository
 import com.moneymanager.domain.repository.ImportDirectoryReadRepository
 import com.moneymanager.domain.repository.ImportDirectoryWriteRepository
 import com.moneymanager.domain.repository.ImportTimelineReadRepository
@@ -309,6 +313,19 @@ interface RepositoryModule {
 
     @Provides
     @SingleIn(DatabaseScope::class)
+    fun provideExchangeOrderReadRepository(database: MoneyManagerDatabaseWrapper): ExchangeOrderReadRepository =
+        ExchangeOrderReadRepositoryImpl(database)
+
+    @Provides
+    @SingleIn(DatabaseScope::class)
+    fun provideExchangeOrderWriteRepository(
+        database: MoneyManagerDatabaseWrapper,
+        deviceId: DeviceId,
+        reader: ExchangeOrderReadRepository,
+    ): ExchangeOrderWriteRepository = ExchangeOrderWriteRepositoryImpl(database, deviceId, reader)
+
+    @Provides
+    @SingleIn(DatabaseScope::class)
     fun provideDeviceReadRepository(database: MoneyManagerDatabaseWrapper): DeviceReadRepository = DeviceReadRepositoryImpl(database)
 
     @Provides
@@ -504,6 +521,7 @@ interface RepositoryModule {
         currencyRepository: CurrencyWriteRepository,
         cryptoRepository: CryptoWriteRepository,
         tradeRepository: TradeWriteRepository,
+        exchangeOrderRepository: ExchangeOrderWriteRepository,
         attributeTypeRepository: AttributeTypeWriteRepository,
         relationshipTypeRepository: RelationshipTypeWriteRepository,
         csvImportStrategyRepository: CsvImportStrategyWriteRepository,
@@ -527,6 +545,7 @@ interface RepositoryModule {
             currencyRepository = currencyRepository,
             cryptoRepository = cryptoRepository,
             tradeRepository = tradeRepository,
+            exchangeOrderRepository = exchangeOrderRepository,
             attributeTypeRepository = attributeTypeRepository,
             relationshipTypeRepository = relationshipTypeRepository,
             csvImportStrategyRepository = csvImportStrategyRepository,

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
@@ -289,6 +289,37 @@ data class ImportTradeIntent(
     val toAmount: Money,
 )
 
+/** Builder-chosen placeholder identity for an exchange order upserted in this batch. */
+@JvmInline
+value class LocalOrderKey(
+    val value: String,
+)
+
+/**
+ * An exchange order to upsert, keyed by ([accountId], [orderRef]). Orders are metadata, not
+ * transactions: they never move money (their fills — trades — do), but their status/prices change
+ * between imports, so the engine creates-or-revises rather than create-only. [tradeKeys] name the
+ * fill trades in the same batch to link via `exchange_order_trade`; every key must resolve in
+ * [ImportResult.createdTradeIds]. Orders without fills (ACTIVE/CANCELED) import standalone.
+ */
+data class ImportOrderIntent(
+    val key: LocalOrderKey,
+    val source: Source,
+    val accountId: AccountId,
+    val orderRef: String,
+    val clientOid: String? = null,
+    val side: String,
+    val orderType: String? = null,
+    val timeInForce: String? = null,
+    val status: String? = null,
+    val limitPrice: String? = null,
+    val quantity: String? = null,
+    val avgPrice: String? = null,
+    val createdAt: Instant,
+    val updatedAt: Instant? = null,
+    val tradeKeys: List<LocalTradeKey> = emptyList(),
+)
+
 /** A request to merge [deletedId] into [survivingId] (reassign its transfers, then delete it). */
 data class AccountMergeRequest(
     val deletedId: AccountId,
@@ -470,6 +501,7 @@ data class ImportBatch(
     val currencies: List<ImportCurrencyIntent> = emptyList(),
     val cryptoAssets: List<ImportCryptoIntent> = emptyList(),
     val trades: List<ImportTradeIntent> = emptyList(),
+    val orders: List<ImportOrderIntent> = emptyList(),
     val csvStrategyMutations: List<CsvStrategyMutation> = emptyList(),
     val apiStrategyMutations: List<ApiStrategyMutation> = emptyList(),
     val passThroughMutations: List<PassThroughMutation> = emptyList(),

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportResult.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportResult.kt
@@ -8,6 +8,7 @@ import com.moneymanager.domain.model.ApiSessionId
 import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.CryptoId
 import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.ExchangeOrderId
 import com.moneymanager.domain.model.MonzoCredentialId
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.RelationshipTypeId
@@ -67,6 +68,12 @@ data class ImportResult(
      * (createTrade is idempotent). [createdTradeIds] still maps these keys to the existing trade's id.
      */
     val dedupedTradeKeys: Set<LocalTradeKey> = emptySet(),
+    /** Ids of exchange orders upserted for each [LocalOrderKey] in [ImportBatch.orders] (all outcomes). */
+    val orderIds: Map<LocalOrderKey, ExchangeOrderId> = emptyMap(),
+    /** Keys of order intents that revised an existing order (status/price change since last import). */
+    val updatedOrderKeys: Set<LocalOrderKey> = emptySet(),
+    /** Keys of order intents that matched an identical existing order (idempotent re-import). */
+    val dedupedOrderKeys: Set<LocalOrderKey> = emptySet(),
     /** Resolved (get-or-create) attribute-type ids for each name in [ImportBatch.attributeTypeNames]. */
     val attributeTypeIds: Map<String, AttributeTypeId> = emptyMap(),
     /** Resolved (get-or-create) relationship-type ids for each name in [ImportBatch.relationshipTypeNames]. */

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -12,6 +12,7 @@ import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.Category
 import com.moneymanager.domain.model.CryptoId
 import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.ExchangeOrderId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.MonzoCredentialId
 import com.moneymanager.domain.model.NewAttribute
@@ -41,7 +42,9 @@ import com.moneymanager.domain.repository.CryptoWriteRepository
 import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
 import com.moneymanager.domain.repository.CsvImportWriteRepository
 import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.ExchangeOrderWriteRepository
 import com.moneymanager.domain.repository.ImportDirectoryWriteRepository
+import com.moneymanager.domain.repository.OrderUpsertResult
 import com.moneymanager.domain.repository.PassThroughAccountWriteRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipWriteRepository
 import com.moneymanager.domain.repository.PersonAttributeWriteRepository
@@ -75,6 +78,7 @@ import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.importengineapi.LocalCategoryKey
 import com.moneymanager.importengineapi.LocalCryptoKey
 import com.moneymanager.importengineapi.LocalCurrencyKey
+import com.moneymanager.importengineapi.LocalOrderKey
 import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.importengineapi.LocalTradeKey
 import com.moneymanager.importengineapi.PassThroughMutation
@@ -109,6 +113,7 @@ class ImportEngineImpl(
     private val currencyRepository: CurrencyWriteRepository,
     private val cryptoRepository: CryptoWriteRepository,
     private val tradeRepository: TradeWriteRepository,
+    private val exchangeOrderRepository: ExchangeOrderWriteRepository,
     private val attributeTypeRepository: AttributeTypeWriteRepository,
     private val relationshipTypeRepository: RelationshipTypeWriteRepository,
     private val csvImportStrategyRepository: CsvImportStrategyWriteRepository,
@@ -167,6 +172,42 @@ class ImportEngineImpl(
                 )
             createdTradeIds[intent.key] = tradeResult.id
             if (!tradeResult.created) dedupedTradeKeys += intent.key
+        }
+        val orderIds = mutableMapOf<LocalOrderKey, ExchangeOrderId>()
+        val updatedOrderKeys = mutableSetOf<LocalOrderKey>()
+        val dedupedOrderKeys = mutableSetOf<LocalOrderKey>()
+        for (intent in batch.orders) {
+            val orderResult =
+                exchangeOrderRepository.upsertOrder(
+                    accountId = intent.accountId,
+                    orderRef = intent.orderRef,
+                    clientOid = intent.clientOid,
+                    side = intent.side,
+                    orderType = intent.orderType,
+                    timeInForce = intent.timeInForce,
+                    status = intent.status,
+                    limitPrice = intent.limitPrice,
+                    quantity = intent.quantity,
+                    avgPrice = intent.avgPrice,
+                    createdAt = intent.createdAt,
+                    updatedAt = intent.updatedAt,
+                    source = intent.source,
+                )
+            orderIds[intent.key] = orderResult.id
+            when (orderResult.outcome) {
+                OrderUpsertResult.Outcome.UPDATED -> updatedOrderKeys += intent.key
+                OrderUpsertResult.Outcome.UNCHANGED -> dedupedOrderKeys += intent.key
+                OrderUpsertResult.Outcome.CREATED -> Unit
+            }
+            for (tradeKey in intent.tradeKeys) {
+                // A dangling key means the producer's trade/order keys diverged — losing the link
+                // silently would be far worse than failing the import.
+                val tradeId =
+                    requireNotNull(createdTradeIds[tradeKey]) {
+                        "Order ${intent.orderRef} references trade key '${tradeKey.value}' absent from this batch"
+                    }
+                exchangeOrderRepository.linkTrade(orderResult.id, tradeId)
+            }
         }
         val createdCategoryIds = mutableMapOf<LocalCategoryKey, Long>()
         for (intent in batch.categories.creates()) {
@@ -265,6 +306,9 @@ class ImportEngineImpl(
             createdCryptoIds = createdCryptoIds,
             createdTradeIds = createdTradeIds,
             dedupedTradeKeys = dedupedTradeKeys,
+            orderIds = orderIds,
+            updatedOrderKeys = updatedOrderKeys,
+            dedupedOrderKeys = dedupedOrderKeys,
             attributeTypeIds = attributeTypeIds,
             relationshipTypeIds = relationshipTypeIds,
             createdCsvStrategyIds = config.csvStrategyIds,

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AccountRow.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AccountRow.kt
@@ -26,5 +26,7 @@ data class AccountRow(
     val passThroughSpendId: TransferId? = null,
     /** When this row IS the spend leg of a pass-through charge, the id of its funding leg. */
     val passThroughFundingId: TransferId? = null,
+    /** When this row is a trade filling an exchange order, the id of that order. */
+    val exchangeOrderId: ExchangeOrderId? = null,
     val kind: TransactionKind = TransactionKind.TRANSFER,
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/EntityType.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/EntityType.kt
@@ -41,4 +41,10 @@ enum class EntityType(
      * [TRANSFER]: a trade's provenance is an `entity_source` row with `entity_type_id = 11`.
      */
     TRADE(11),
+
+    /**
+     * An exchange order (metadata for a set of fill trades). Shares the unified `entity_source`
+     * store, like [TRADE]: provenance is an `entity_source` row with `entity_type_id = 12`.
+     */
+    EXCHANGE_ORDER(12),
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ExchangeOrder.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ExchangeOrder.kt
@@ -1,0 +1,41 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.domain.model
+
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+
+/**
+ * An order placed on a crypto exchange (e.g. Crypto.com's `private/get-order-history`). Orders are
+ * metadata, not transactions: a filled order's economics are fully represented by its fill [Trade]s
+ * (linked via `exchange_order_trade`), so an order never participates in balances. Unlike trades,
+ * an order's [status]/[avgPrice]/[quantity] legitimately change between imports (ACTIVE → FILLED /
+ * CANCELED), so re-import upserts by ([accountId], [orderRef]) and bumps [revisionId].
+ *
+ * Price/quantity fields are exchange-reported decimal strings, display-only — they are never used
+ * in arithmetic, so they stay in whatever scale the exchange reported.
+ */
+data class ExchangeOrder(
+    val id: ExchangeOrderId,
+    val revisionId: Long = 1,
+    val accountId: AccountId,
+    val orderRef: String,
+    val clientOid: String? = null,
+    val side: String,
+    val orderType: String? = null,
+    val timeInForce: String? = null,
+    val status: String? = null,
+    val limitPrice: String? = null,
+    val quantity: String? = null,
+    val avgPrice: String? = null,
+    val createdAt: Instant,
+    val updatedAt: Instant? = null,
+)
+
+@Serializable
+@JvmInline
+value class ExchangeOrderId(
+    val id: Long,
+) {
+    override fun toString() = id.toString()
+}

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ExchangeOrderAuditEntry.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/ExchangeOrderAuditEntry.kt
@@ -1,0 +1,27 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.domain.model
+
+import kotlin.time.Instant
+
+/** One historical revision of an exchange order, with its audited field values and provenance. */
+data class ExchangeOrderAuditEntry(
+    val id: Long,
+    val auditTimestamp: Instant,
+    val auditType: AuditType,
+    val orderId: ExchangeOrderId,
+    val revisionId: Long,
+    val accountId: AccountId,
+    val orderRef: String,
+    val clientOid: String?,
+    val side: String,
+    val orderType: String?,
+    val timeInForce: String?,
+    val status: String?,
+    val limitPrice: String?,
+    val quantity: String?,
+    val avgPrice: String?,
+    val createdAt: Instant,
+    val updatedAt: Instant?,
+    val source: SourceRecord? = null,
+)

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TransactionKind.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TransactionKind.kt
@@ -1,11 +1,11 @@
 package com.moneymanager.domain.model
 
 /**
- * What kind of transaction a row represents: a [Transfer] between accounts, a [Trade] converting
- * one asset to another, or an order (declared ahead of the order entity landing).
+ * What kind of transaction a row represents: a [Transfer] between accounts or a [Trade] converting
+ * one asset to another. (Orders are not transactions — they are a separate metadata entity linked to
+ * their fill trades, so they never appear as a transaction row.)
  */
 enum class TransactionKind {
     TRANSFER,
     TRADE,
-    ORDER,
 }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
@@ -716,6 +716,12 @@ data class ApiTradeMappings(
     /** Order-only fields surfaced as trade attributes when ORDERS metadata is joined in. */
     val orderTypeField: String? = null,
     val orderStatusField: String? = null,
+    // Order-only fields for persisting the order itself (ORDERS endpoints; ignored for TRADES).
+    val limitPriceField: String? = null,
+    val avgPriceField: String? = null,
+    val updateTimestampField: String? = null,
+    val clientOidField: String? = null,
+    val timeInForceField: String? = null,
 )
 
 /**

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/AuditReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/AuditReadRepository.kt
@@ -12,6 +12,8 @@ import com.moneymanager.domain.model.CryptoId
 import com.moneymanager.domain.model.CsvImportStrategyAuditEntry
 import com.moneymanager.domain.model.CurrencyAuditEntry
 import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.ExchangeOrderAuditEntry
+import com.moneymanager.domain.model.ExchangeOrderId
 import com.moneymanager.domain.model.ImportDirectoryAuditEntry
 import com.moneymanager.domain.model.PersonAccountOwnershipAuditEntry
 import com.moneymanager.domain.model.PersonAttributeAuditEntry
@@ -107,6 +109,8 @@ interface AuditReadRepository {
 
     /** Audit history for a trade. */
     suspend fun getAuditHistoryForTrade(tradeId: TradeId): List<TradeAuditEntry>
+
+    suspend fun getAuditHistoryForExchangeOrder(orderId: ExchangeOrderId): List<ExchangeOrderAuditEntry>
 
     /**
      * Gets the audit history for a specific category.

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ExchangeOrderReadRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ExchangeOrderReadRepository.kt
@@ -1,0 +1,23 @@
+package com.moneymanager.domain.repository
+
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.ExchangeOrder
+import com.moneymanager.domain.model.ExchangeOrderId
+import com.moneymanager.domain.model.Trade
+import kotlinx.coroutines.flow.Flow
+
+interface ExchangeOrderReadRepository {
+    fun getOrderById(id: ExchangeOrderId): Flow<ExchangeOrder?>
+
+    /** Orders placed on [accountId], newest first. */
+    fun getOrdersByAccount(accountId: AccountId): Flow<List<ExchangeOrder>>
+
+    /** Number of orders on [accountId] (drives visibility of the Orders UI entry point). */
+    fun countOrdersByAccount(accountId: AccountId): Flow<Long>
+
+    /** The fill trades linked to [id] via `exchange_order_trade`, oldest first. */
+    fun getFillTradesForOrder(id: ExchangeOrderId): Flow<List<Trade>>
+
+    /** Fill-trade counts per order across [accountId]'s orders (single query for list rendering). */
+    fun getFillCountsByAccount(accountId: AccountId): Flow<Map<ExchangeOrderId, Long>>
+}

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ExchangeOrderWriteRepository.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/repository/ExchangeOrderWriteRepository.kt
@@ -1,0 +1,52 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.domain.repository
+
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.ExchangeOrderId
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.TradeId
+import kotlin.time.Instant
+
+/**
+ * Outcome of [ExchangeOrderWriteRepository.upsertOrder]: CREATED inserted a new order, UPDATED
+ * revised an existing one (status/price fields changed since the last import), UNCHANGED matched an
+ * identical existing row (the idempotent re-import path).
+ */
+data class OrderUpsertResult(
+    val id: ExchangeOrderId,
+    val outcome: Outcome,
+) {
+    enum class Outcome { CREATED, UPDATED, UNCHANGED }
+}
+
+interface ExchangeOrderWriteRepository : ExchangeOrderReadRepository {
+    /**
+     * Creates or revises the order identified by ([accountId], [orderRef]). An existing order with
+     * different content is updated in place with a bumped revision (orders legitimately change
+     * status between imports); an identical one is left untouched. Provenance is recorded for every
+     * created/updated revision.
+     */
+    @Suppress("LongParameterList")
+    suspend fun upsertOrder(
+        accountId: AccountId,
+        orderRef: String,
+        clientOid: String?,
+        side: String,
+        orderType: String?,
+        timeInForce: String?,
+        status: String?,
+        limitPrice: String?,
+        quantity: String?,
+        avgPrice: String?,
+        createdAt: Instant,
+        updatedAt: Instant?,
+        source: Source,
+    ): OrderUpsertResult
+
+    /** Links a fill trade to its order. Idempotent (INSERT OR IGNORE). */
+    suspend fun linkTrade(
+        orderId: ExchangeOrderId,
+        tradeId: TradeId,
+    )
+}

--- a/app/remotestorage/googledrive/src/jvmAndroidMain/kotlin/com/moneymanager/remotestorage/googledrive/GoogleDriveProviderFactory.kt
+++ b/app/remotestorage/googledrive/src/jvmAndroidMain/kotlin/com/moneymanager/remotestorage/googledrive/GoogleDriveProviderFactory.kt
@@ -1,6 +1,7 @@
 package com.moneymanager.remotestorage.googledrive
 
 import com.moneymanager.localsettings.LocalSettings
+import com.moneymanager.remotestorage.RemoteAuthException
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.auth.Auth
@@ -62,7 +63,9 @@ fun googleDriveProvider(
     val oauth = GoogleOAuth(tokenHttpClient)
     val driveClient =
         synchronized(driveClients) {
-            driveClients.getOrPut(credentials.clientId) { buildDriveClient(credentials, accountStore, oauth) }
+            driveClients.getOrPut(credentials.clientId) {
+                buildDriveClient(credentials, accountStore, oauth, browser, listOf(DRIVE_FILE_SCOPE))
+            }
         }
     return GoogleDriveProvider(
         JvmGoogleAccessTokenSource(credentials, accountStore, browser, oauth, driveClient),
@@ -93,7 +96,7 @@ fun googleDriveTokenSource(
         )
     val accountStore = GoogleDriveAccountStore(localSettings)
     val oauth = GoogleOAuth(tokenHttpClient)
-    val driveClient = buildDriveClient(credentials, accountStore, oauth)
+    val driveClient = buildDriveClient(credentials, accountStore, oauth, browser, scopes)
     return JvmGoogleAccessTokenSource(credentials, accountStore, browser, oauth, driveClient, scopes)
 }
 
@@ -107,6 +110,8 @@ private fun buildDriveClient(
     credentials: GoogleDriveCredentials,
     accountStore: GoogleDriveAccountStore,
     oauth: GoogleOAuth,
+    browser: BrowserLauncher,
+    scopes: List<String>,
 ): HttpClient =
     HttpClient(CIO) {
         install(Auth) {
@@ -118,13 +123,23 @@ private fun buildDriveClient(
                 }
                 refreshTokens {
                     accountStore.refreshToken(credentials.clientId)?.let { refresh ->
-                        val tokens = oauth.refresh(credentials, refresh)
+                        val tokens =
+                            try {
+                                oauth.refresh(credentials, refresh).copy(refreshToken = refresh)
+                            } catch (expired: RemoteAuthException) {
+                                // A revoked/expired refresh token comes back as `invalid_grant`. The stored
+                                // token is dead, so clear it and re-run the browser consent flow (the same
+                                // one used to connect originally) instead of surfacing the error.
+                                if ("invalid_grant" !in expired.message.orEmpty()) throw expired
+                                accountStore.clear(credentials.clientId)
+                                performLoopbackSignIn(credentials, accountStore, browser, oauth, scopes)
+                            }
                         accountStore.saveAccessToken(
                             credentials.clientId,
                             tokens.accessToken,
                             accessTokenExpiry(tokens.expiresInSeconds),
                         )
-                        BearerTokens(tokens.accessToken, refresh)
+                        BearerTokens(tokens.accessToken, tokens.refreshToken ?: refresh)
                     }
                 }
                 // Attach the token up front for Drive API hosts instead of waiting for a 401 challenge.

--- a/app/remotestorage/googledrive/src/jvmAndroidMain/kotlin/com/moneymanager/remotestorage/googledrive/JvmGoogleAccessTokenSource.kt
+++ b/app/remotestorage/googledrive/src/jvmAndroidMain/kotlin/com/moneymanager/remotestorage/googledrive/JvmGoogleAccessTokenSource.kt
@@ -28,23 +28,7 @@ class JvmGoogleAccessTokenSource(
         isSignedIn() && accountStore.grantedScopes(credentials.clientId).containsAll(scopes)
 
     override suspend fun signIn() {
-        withContext(Dispatchers.IO) {
-            LoopbackRedirectReceiver().use { receiver ->
-                val state = oauth.newState()
-                browser.open(oauth.consentUrl(credentials.clientId, receiver.redirectUri, state, scopes))
-                val code = receiver.awaitCode(state)
-                val tokens = oauth.exchangeCode(credentials, code, receiver.redirectUri)
-                val refreshToken =
-                    tokens.refreshToken
-                        ?: throw RemoteAuthException(
-                            "Google did not return a refresh token. Remove Money Manager from your Google " +
-                                "account's third-party access and connect again.",
-                        )
-                accountStore.saveRefreshToken(credentials.clientId, refreshToken)
-                accountStore.saveAccessToken(credentials.clientId, tokens.accessToken, accessTokenExpiry(tokens.expiresInSeconds))
-                accountStore.saveGrantedScopes(credentials.clientId, scopes.toSet())
-            }
-        }
+        performLoopbackSignIn(credentials, accountStore, browser, oauth, scopes)
     }
 
     override suspend fun signOut() {
@@ -55,3 +39,35 @@ class JvmGoogleAccessTokenSource(
 
     override suspend fun accessTokenExpiresAtEpochMs(): Long? = accountStore.accessToken(credentials.clientId)?.expiresAtMillis
 }
+
+/**
+ * The installed-app loopback consent flow: opens the browser, waits for the redirect, exchanges the
+ * code, and persists the refresh/access tokens and granted scopes. Shared between the explicit
+ * [JvmGoogleAccessTokenSource.signIn] and the Bearer client's expired-refresh-token fallback, so a
+ * dead refresh token re-runs the same consent instead of surfacing an error. Returns the new tokens.
+ */
+internal suspend fun performLoopbackSignIn(
+    credentials: GoogleDriveCredentials,
+    accountStore: GoogleDriveAccountStore,
+    browser: BrowserLauncher,
+    oauth: GoogleOAuth,
+    scopes: List<String>,
+): GoogleTokens =
+    withContext(Dispatchers.IO) {
+        LoopbackRedirectReceiver().use { receiver ->
+            val state = oauth.newState()
+            browser.open(oauth.consentUrl(credentials.clientId, receiver.redirectUri, state, scopes))
+            val code = receiver.awaitCode(state)
+            val tokens = oauth.exchangeCode(credentials, code, receiver.redirectUri)
+            val refreshToken =
+                tokens.refreshToken
+                    ?: throw RemoteAuthException(
+                        "Google did not return a refresh token. Remove Money Manager from your Google " +
+                            "account's third-party access and connect again.",
+                    )
+            accountStore.saveRefreshToken(credentials.clientId, refreshToken)
+            accountStore.saveAccessToken(credentials.clientId, tokens.accessToken, accessTokenExpiry(tokens.expiresInSeconds))
+            accountStore.saveGrantedScopes(credentials.clientId, scopes.toSet())
+            tokens
+        }
+    }

--- a/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInApiStrategies.kt
+++ b/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInApiStrategies.kt
@@ -392,8 +392,14 @@ object BuiltInApiStrategies {
                 timestampFormat = TimestampFormat.EPOCH_MS,
                 idField = "order_id",
                 orderIdField = "order_id",
-                orderTypeField = "type",
+                // The live get-order-history payload calls this "order_type" (not "type").
+                orderTypeField = "order_type",
                 orderStatusField = "status",
+                limitPriceField = "limit_price",
+                avgPriceField = "avg_price",
+                updateTimestampField = "update_time",
+                clientOidField = "client_oid",
+                timeInForceField = "time_in_force",
             )
 
         fun transferMappings(addressField: String) =

--- a/app/ui/categories/src/commonTest/kotlin/com/moneymanager/ui/screens/CategoriesScreenTest.kt
+++ b/app/ui/categories/src/commonTest/kotlin/com/moneymanager/ui/screens/CategoriesScreenTest.kt
@@ -25,6 +25,7 @@ import com.moneymanager.domain.repository.CryptoWriteRepository
 import com.moneymanager.domain.repository.CsvImportStrategyWriteRepository
 import com.moneymanager.domain.repository.CsvImportWriteRepository
 import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.ExchangeOrderWriteRepository
 import com.moneymanager.domain.repository.ImportDirectoryWriteRepository
 import com.moneymanager.domain.repository.PassThroughAccountWriteRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipWriteRepository
@@ -71,6 +72,7 @@ class CategoriesScreenTest {
             currencyRepository = mock<CurrencyWriteRepository>(MockMode.autoUnit),
             cryptoRepository = mock<CryptoWriteRepository>(MockMode.autoUnit),
             tradeRepository = mock<TradeWriteRepository>(MockMode.autoUnit),
+            exchangeOrderRepository = mock<ExchangeOrderWriteRepository>(MockMode.autoUnit),
             attributeTypeRepository = mock<AttributeTypeWriteRepository>(MockMode.autoUnit),
             relationshipTypeRepository = mock<RelationshipTypeWriteRepository>(MockMode.autoUnit),
             csvImportStrategyRepository = mock<CsvImportStrategyWriteRepository>(MockMode.autoUnit),

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppServices.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/AppServices.kt
@@ -20,6 +20,7 @@ import com.moneymanager.domain.repository.CsvImportReadRepository
 import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.DeviceReadRepository
+import com.moneymanager.domain.repository.ExchangeOrderReadRepository
 import com.moneymanager.domain.repository.ImportDirectoryReadRepository
 import com.moneymanager.domain.repository.ImportTimelineReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
@@ -81,6 +82,7 @@ data class TransactionsDomain(
     val attributeTypeRepository: AttributeTypeReadRepository,
     val transferRelationshipRepository: TransferRelationshipReadRepository,
     val tradeRepository: TradeReadRepository,
+    val exchangeOrderRepository: ExchangeOrderReadRepository,
     val importEngine: ImportEngine,
 )
 
@@ -137,6 +139,7 @@ fun Application.toAppServices(importEngine: ImportEngine) =
                 attributeTypeRepository = transactions.attributeTypeRepository,
                 transferRelationshipRepository = transactions.transferRelationshipRepository,
                 tradeRepository = transactions.tradeRepository,
+                exchangeOrderRepository = transactions.exchangeOrderRepository,
                 importEngine = importEngine,
             ),
         people =

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -95,6 +95,9 @@ import com.moneymanager.ui.screens.apistrategy.editor.ApiStrategyEditorScreen
 import com.moneymanager.ui.screens.csvstrategy.CsvImportStrategyAuditScreen
 import com.moneymanager.ui.screens.csvstrategy.CsvStrategiesScreen
 import com.moneymanager.ui.screens.csvstrategy.editor.CsvStrategyEditorScreen
+import com.moneymanager.ui.screens.orders.ExchangeOrderAuditScreen
+import com.moneymanager.ui.screens.orders.OrderDetailScreen
+import com.moneymanager.ui.screens.orders.OrdersScreen
 import com.moneymanager.ui.screens.qif.QifStrategyEditorScreen
 import com.moneymanager.ui.screens.transactions.AccountTransactionsScreen
 import com.moneymanager.ui.screens.transactions.TradeEntryDialog
@@ -224,7 +227,12 @@ fun MoneyManagerApp(
                             NavigationBarItem(
                                 icon = { Text("\uD83D\uDCB0") },
                                 label = { Text("Accounts") },
-                                selected = currentScreen is Screen.Accounts || currentScreen is Screen.AccountTransactions,
+                                selected =
+                                    currentScreen is Screen.Accounts ||
+                                        currentScreen is Screen.AccountTransactions ||
+                                        currentScreen is Screen.ExchangeOrders ||
+                                        currentScreen is Screen.ExchangeOrderDetail ||
+                                        currentScreen is Screen.ExchangeOrderAuditHistory,
                                 onClick = { navigationHistory.navigateTo(Screen.Accounts()) },
                             )
                             NavigationBarItem(
@@ -463,6 +471,7 @@ fun MoneyManagerApp(
                                                 attributeTypeRepository = services.transactions.attributeTypeRepository,
                                                 personRepository = services.people.personRepository,
                                                 personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
+                                                exchangeOrderRepository = services.transactions.exchangeOrderRepository,
                                                 maintenance = services.imports.maintenance,
                                                 onAccountIdChange = { accountId ->
                                                     currentlyViewedAccountId = accountId
@@ -488,9 +497,68 @@ fun MoneyManagerApp(
                                                 onFeeLinkClick = { transferId ->
                                                     navigateToTransferAccount(transferId, isPositiveAmount = false)
                                                 },
+                                                onOrdersClick = { accountId, accountName ->
+                                                    navigationHistory.navigateTo(Screen.ExchangeOrders(accountId, accountName))
+                                                },
+                                                onOrderLinkClick = { orderId ->
+                                                    navigationHistory.navigateTo(Screen.ExchangeOrderDetail(orderId))
+                                                },
                                                 scrollToTransferId = screen.scrollToTransferId,
                                                 initialCurrencyId = screen.selectedCurrencyId,
                                                 externalRefreshTrigger = transactionRefreshTrigger,
+                                            )
+                                        }
+                                        entry<Screen.ExchangeOrders> { screen ->
+                                            OrdersScreen(
+                                                accountId = screen.accountId,
+                                                exchangeOrderRepository = services.transactions.exchangeOrderRepository,
+                                                onOrderClick = { orderId ->
+                                                    navigationHistory.navigateTo(Screen.ExchangeOrderDetail(orderId))
+                                                },
+                                                onBack = { navigationHistory.navigateBack() },
+                                            )
+                                        }
+                                        entry<Screen.ExchangeOrderDetail> { screen ->
+                                            OrderDetailScreen(
+                                                orderId = screen.orderId,
+                                                exchangeOrderRepository = services.transactions.exchangeOrderRepository,
+                                                onFillTradeClick = { fill ->
+                                                    // A trade shares the transaction_id space, so the transactions
+                                                    // screen's scroll-to accepts its id as a TransferId.
+                                                    val account = accounts.find { it.id == fill.fromAccountId }
+                                                    navigationHistory.navigateTo(
+                                                        Screen.AccountTransactions(
+                                                            accountId = fill.fromAccountId,
+                                                            accountName = account?.name ?: fill.fromAccountId.toString(),
+                                                            scrollToTransferId = TransferId(fill.id.id),
+                                                        ),
+                                                    )
+                                                },
+                                                onFillTradeAuditClick = { fill ->
+                                                    // The trade audit screen resolves a trade by its shared
+                                                    // transaction id, so its TransferId reaches its trade_audit trail.
+                                                    navigationHistory.navigateTo(Screen.AuditHistory(TransferId(fill.id.id)))
+                                                },
+                                                onAuditClick = { orderId ->
+                                                    navigationHistory.navigateTo(Screen.ExchangeOrderAuditHistory(orderId))
+                                                },
+                                                onBack = { navigationHistory.navigateBack() },
+                                            )
+                                        }
+                                        entry<Screen.ExchangeOrderAuditHistory> { screen ->
+                                            ExchangeOrderAuditScreen(
+                                                orderId = screen.orderId,
+                                                auditRepository = services.audit.auditRepository,
+                                                onApiSourceClick = { sessionId, requestId, jsonPath ->
+                                                    navigationHistory.navigateTo(
+                                                        Screen.ApiSessionTraffic(
+                                                            sessionId = sessionId,
+                                                            highlightRequestId = requestId,
+                                                            highlightJsonPath = jsonPath,
+                                                        ),
+                                                    )
+                                                },
+                                                onBack = { navigationHistory.navigateBack() },
                                             )
                                         }
                                         entry<Screen.Imports>(clazzContentKey = { "Imports" }) { screen ->

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvAccountSourceAuditE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvAccountSourceAuditE2ETest.kt
@@ -145,6 +145,7 @@ class CsvAccountSourceAuditE2ETest {
                             currencyRepository = dc.currencyRepository,
                             cryptoRepository = dc.cryptoRepository,
                             tradeRepository = dc.tradeRepository,
+                            exchangeOrderRepository = dc.exchangeOrderRepository,
                             attributeTypeRepository = dc.attributeTypeRepository,
                             relationshipTypeRepository = dc.relationshipTypeRepository,
                             csvImportStrategyRepository = dc.csvImportStrategyRepository,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvReimportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/screens/CsvReimportE2ETest.kt
@@ -417,6 +417,7 @@ class CsvReimportE2ETest {
             currencyRepository = dc.currencyRepository,
             cryptoRepository = dc.cryptoRepository,
             tradeRepository = dc.tradeRepository,
+            exchangeOrderRepository = dc.exchangeOrderRepository,
             attributeTypeRepository = dc.attributeTypeRepository,
             relationshipTypeRepository = dc.relationshipTypeRepository,
             csvImportStrategyRepository = dc.csvImportStrategyRepository,

--- a/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
+++ b/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/navigation/Screen.kt
@@ -8,6 +8,7 @@ import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.ApiRequestId
 import com.moneymanager.domain.model.ApiSessionId
 import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.ExchangeOrderId
 import com.moneymanager.domain.model.PersonId
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategyId
@@ -205,6 +206,28 @@ sealed class Screen : NavKey {
     @Serializable
     data object ConnectApi : Screen() {
         override val title: String get() = "Connect API Account"
+    }
+
+    @Serializable
+    data class ExchangeOrders(
+        val accountId: AccountId,
+        val accountName: String,
+    ) : Screen() {
+        override val title: String get() = "$accountName Orders"
+    }
+
+    @Serializable
+    data class ExchangeOrderDetail(
+        val orderId: ExchangeOrderId,
+    ) : Screen() {
+        override val title: String get() = "Order"
+    }
+
+    @Serializable
+    data class ExchangeOrderAuditHistory(
+        val orderId: ExchangeOrderId,
+    ) : Screen() {
+        override val title: String get() = "Order Audit"
     }
 
     @Serializable

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategiesScreen.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiStrategiesScreen.kt
@@ -43,8 +43,10 @@ import com.moneymanager.domain.model.apistrategy.export.ApiStrategyExportMapper
 import com.moneymanager.domain.repository.ApiImportStrategyReadRepository
 import com.moneymanager.importengineapi.createApiStrategy
 import com.moneymanager.importengineapi.deleteApiStrategy
+import com.moneymanager.importengineapi.updateApiStrategy
 import com.moneymanager.ui.LocalImportEngine
 import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
@@ -64,6 +66,9 @@ fun ApiStrategiesScreen(
     }
 
     var strategyPendingDelete by remember { mutableStateOf<ApiImportStrategy?>(null) }
+    // A parsed import waiting on overwrite confirmation: already reconciled onto the existing row's id
+    // (so confirming just calls update), null when no same-named strategy exists.
+    var strategyPendingOverwrite by remember { mutableStateOf<ApiImportStrategy?>(null) }
     var importError by remember { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
 
@@ -80,7 +85,15 @@ fun ApiStrategiesScreen(
                             val export = ApiStrategyExportCodec.decode(result.content)
                             val strategy =
                                 ApiStrategyExportMapper.fromExport(export, ApiImportStrategyId(Uuid.random()), Clock.System.now())
-                            importEngine.createApiStrategy(strategy)
+                            // Create outright when the name is new; otherwise confirm before clobbering
+                            // the existing same-named strategy (overwriting is a destructive replace of
+                            // its configuration, and the name is UNIQUE so a blind create would fail).
+                            val existing = apiImportStrategyRepository.getStrategyByName(strategy.name).first()
+                            if (existing == null) {
+                                importEngine.createApiStrategy(strategy)
+                            } else {
+                                strategyPendingOverwrite = strategy.copy(id = existing.id, createdAt = existing.createdAt)
+                            }
                             importError = null
                         } catch (expected: Exception) {
                             importError = "Failed to import strategy: ${expected.message}"
@@ -159,6 +172,41 @@ fun ApiStrategiesScreen(
                 }
             }
         }
+    }
+
+    // Overwrite confirmation dialog: the imported file matches an existing strategy by name.
+    strategyPendingOverwrite?.let { updated ->
+        AlertDialog(
+            onDismissRequest = { strategyPendingOverwrite = null },
+            title = { Text("Overwrite Strategy") },
+            text = {
+                Text(
+                    "A strategy named \"${updated.name}\" already exists. Importing this file will replace its " +
+                        "configuration with the imported version. This cannot be undone. Continue?",
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        scope.launch {
+                            @Suppress("TooGenericExceptionCaught")
+                            try {
+                                importEngine.updateApiStrategy(updated)
+                                importError = null
+                            } catch (expected: Exception) {
+                                importError = "Failed to import strategy: ${expected.message}"
+                            }
+                        }
+                        strategyPendingOverwrite = null
+                    },
+                ) {
+                    Text("Overwrite", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { strategyPendingOverwrite = null }) { Text("Cancel") }
+            },
+        )
     }
 
     // Delete confirmation dialog

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/orders/ExchangeOrderAuditScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/orders/ExchangeOrderAuditScreen.kt
@@ -1,0 +1,78 @@
+package com.moneymanager.ui.screens.orders
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.moneymanager.domain.model.ApiRequestId
+import com.moneymanager.domain.model.ApiSessionId
+import com.moneymanager.domain.model.AuditType
+import com.moneymanager.domain.model.ExchangeOrderAuditEntry
+import com.moneymanager.domain.model.ExchangeOrderId
+import com.moneymanager.domain.repository.AuditReadRepository
+import com.moneymanager.ui.audit.AuditDiffCard
+import com.moneymanager.ui.audit.AuditScreen
+import com.moneymanager.ui.audit.AuditScreenData
+import com.moneymanager.ui.audit.FieldValueRow
+import com.moneymanager.ui.audit.SourceInfoSection
+
+/**
+ * Revision history of one exchange order. Each entry shows the audited snapshot and its provenance;
+ * an API-sourced revision links back to the exact request/JSON node of the session that imported it.
+ */
+@Composable
+fun ExchangeOrderAuditScreen(
+    orderId: ExchangeOrderId,
+    auditRepository: AuditReadRepository,
+    onApiSourceClick: (ApiSessionId, ApiRequestId, String) -> Unit = { _, _, _ -> },
+    onBack: () -> Unit,
+) {
+    AuditScreen(
+        defaultTitle = "Order Audit: $orderId",
+        entityTypeName = "order",
+        loadKey = orderId,
+        loadData = {
+            val entries = auditRepository.getAuditHistoryForExchangeOrder(orderId)
+            AuditScreenData(
+                title = "Order Audit: ${entries.firstOrNull()?.orderRef ?: orderId}",
+                diffs = entries,
+            )
+        },
+        diffKey = { it.id },
+        onBack = onBack,
+        diffCard = { entry -> ExchangeOrderAuditDiffCard(entry, onApiSourceClick) },
+    )
+}
+
+@Composable
+private fun ExchangeOrderAuditDiffCard(
+    entry: ExchangeOrderAuditEntry,
+    onApiSourceClick: (ApiSessionId, ApiRequestId, String) -> Unit,
+) {
+    AuditDiffCard(
+        auditType = entry.auditType,
+        auditTimestamp = entry.auditTimestamp,
+        revisionId = entry.revisionId,
+    ) {
+        // The audit triggers snapshot the row as it was (UPDATE records the pre-change values with
+        // the new revision id), so each card is that revision's full field set.
+        Text(
+            text =
+                when (entry.auditType) {
+                    AuditType.INSERT -> "Created with:"
+                    AuditType.UPDATE -> "Previous values:"
+                    AuditType.DELETE -> "Deleted (final values):"
+                },
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        FieldValueRow("Order id", entry.orderRef)
+        FieldValueRow("Side", entry.side)
+        entry.orderType?.let { FieldValueRow("Type", it) }
+        entry.timeInForce?.let { FieldValueRow("Time in force", it) }
+        entry.status?.let { FieldValueRow("Status", it) }
+        entry.quantity?.let { FieldValueRow("Quantity", it) }
+        entry.limitPrice?.let { FieldValueRow("Limit price", it) }
+        entry.avgPrice?.let { FieldValueRow("Average price", it) }
+        SourceInfoSection(entry.source, onApiSourceClick = onApiSourceClick)
+    }
+}

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/orders/OrderDetailScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/orders/OrderDetailScreen.kt
@@ -1,0 +1,185 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.ui.screens.orders
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.moneymanager.domain.model.ExchangeOrderId
+import com.moneymanager.domain.model.Trade
+import com.moneymanager.domain.repository.ExchangeOrderReadRepository
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
+import com.moneymanager.ui.util.formatAmount
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+private val FIELD_LABEL_WIDTH = 130.dp
+
+/**
+ * One exchange order: its exchange-reported fields plus the fill trades linked via
+ * `exchange_order_trade`. Clicking a fill jumps to it in the account transactions list.
+ */
+@Composable
+fun OrderDetailScreen(
+    orderId: ExchangeOrderId,
+    exchangeOrderRepository: ExchangeOrderReadRepository,
+    onFillTradeClick: (Trade) -> Unit = {},
+    onFillTradeAuditClick: (Trade) -> Unit = {},
+    onAuditClick: (ExchangeOrderId) -> Unit = {},
+    onBack: () -> Unit = {},
+) {
+    val order by rememberFlowAsStateWithSchemaErrorHandling(orderId, initial = null) {
+        exchangeOrderRepository.getOrderById(orderId)
+    }
+    val fills by rememberFlowAsStateWithSchemaErrorHandling(orderId, initial = emptyList()) {
+        exchangeOrderRepository.getFillTradesForOrder(orderId)
+    }
+
+    val currentOrder = order ?: return
+    val timeZone = TimeZone.currentSystemDefault()
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(16.dp).testTag("orderDetail"),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onBack) { Text("← Back") }
+                TextButton(onClick = { onAuditClick(orderId) }) { Text("Audit history") }
+            }
+        }
+        item {
+            Card(elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    OrderField("Order id", currentOrder.orderRef)
+                    OrderField("Side", currentOrder.side)
+                    OrderField("Type", currentOrder.orderType)
+                    OrderField("Time in force", currentOrder.timeInForce)
+                    OrderField("Status", currentOrder.status)
+                    OrderField("Quantity", currentOrder.quantity)
+                    OrderField("Limit price", currentOrder.limitPrice)
+                    OrderField("Average price", currentOrder.avgPrice)
+                    OrderField("Created", currentOrder.createdAt.toLocalDateTime(timeZone).toString())
+                    OrderField("Updated", currentOrder.updatedAt?.toLocalDateTime(timeZone)?.toString())
+                }
+            }
+        }
+        item {
+            Text(
+                text = if (fills.size == 1) "1 fill trade" else "${fills.size} fill trades",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+        items(items = fills, key = { it.id.id }) { fill ->
+            FillTradeCard(
+                fill = fill,
+                onClick = { onFillTradeClick(fill) },
+                onAuditClick = { onFillTradeAuditClick(fill) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun OrderField(
+    label: String,
+    value: String?,
+) {
+    if (value.isNullOrBlank()) return
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(FIELD_LABEL_WIDTH),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Composable
+private fun FillTradeCard(
+    fill: Trade,
+    onClick: () -> Unit,
+    onAuditClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).testTag("fillTrade-${fill.id.id}"),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(start = 12.dp, top = 4.dp, bottom = 4.dp, end = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            val dateTime = fill.timestamp.toLocalDateTime(TimeZone.currentSystemDefault())
+            Text(
+                text = "${dateTime.date} ${dateTime.time}",
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                modifier = Modifier.weight(0.28f),
+            )
+            Text(
+                text = fill.description,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                modifier = Modifier.weight(0.26f).padding(horizontal = 8.dp),
+            )
+            Text(
+                text = "-${formatAmount(fill.from)}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.End,
+                maxLines = 1,
+                modifier = Modifier.weight(0.18f),
+            )
+            Text(
+                text = "+${formatAmount(fill.to)}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.End,
+                maxLines = 1,
+                modifier = Modifier.weight(0.18f),
+            )
+            // Fill trades have their own audit trail (they are real trades); link to it directly rather
+            // than only via the parent order.
+            IconButton(
+                onClick = onAuditClick,
+                modifier = Modifier.testTag("fillTradeAudit-${fill.id.id}"),
+            ) {
+                Text(text = "📜", style = MaterialTheme.typography.bodyLarge)
+            }
+        }
+    }
+}

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/orders/OrderDetailScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/orders/OrderDetailScreen.kt
@@ -55,13 +55,14 @@ fun OrderDetailScreen(
         exchangeOrderRepository.getFillTradesForOrder(orderId)
     }
 
-    val currentOrder = order ?: return
     val timeZone = TimeZone.currentSystemDefault()
 
     LazyColumn(
         modifier = Modifier.fillMaxSize().padding(16.dp).testTag("orderDetail"),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        // Rendered before the order resolves, so back navigation stays reachable while the flow is
+        // still loading — or forever, if the id names an order that no longer exists.
         item {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -69,9 +70,25 @@ fun OrderDetailScreen(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 TextButton(onClick = onBack) { Text("← Back") }
-                TextButton(onClick = { onAuditClick(orderId) }) { Text("Audit history") }
+                TextButton(
+                    onClick = { onAuditClick(orderId) },
+                    enabled = order != null,
+                ) { Text("Audit history") }
             }
         }
+
+        val currentOrder = order
+        if (currentOrder == null) {
+            item {
+                Text(
+                    text = "Order not found",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            return@LazyColumn
+        }
+
         item {
             Card(elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)) {
                 Column(

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/orders/OrdersScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/orders/OrdersScreen.kt
@@ -1,0 +1,153 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.ui.screens.orders
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.ExchangeOrder
+import com.moneymanager.domain.model.ExchangeOrderId
+import com.moneymanager.domain.repository.ExchangeOrderReadRepository
+import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Per-account list of exchange orders (all statuses — open limit orders included). Clicking a row
+ * opens the order detail with its fill trades.
+ */
+@Composable
+fun OrdersScreen(
+    accountId: AccountId,
+    exchangeOrderRepository: ExchangeOrderReadRepository,
+    onOrderClick: (ExchangeOrderId) -> Unit = {},
+    onBack: () -> Unit = {},
+) {
+    val orders by rememberFlowAsStateWithSchemaErrorHandling(accountId, initial = emptyList()) {
+        exchangeOrderRepository.getOrdersByAccount(accountId)
+    }
+    val fillCounts by rememberFlowAsStateWithSchemaErrorHandling(accountId, initial = emptyMap()) {
+        exchangeOrderRepository.getFillCountsByAccount(accountId)
+    }
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TextButton(onClick = onBack) { Text("← Back") }
+        }
+        if (orders.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("No orders", style = MaterialTheme.typography.bodyLarge)
+            }
+            return@Column
+        }
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().testTag("ordersList"),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(items = orders, key = { it.id.id }) { order ->
+                OrderCard(
+                    order = order,
+                    fillCount = fillCounts[order.id] ?: 0L,
+                    onClick = { onOrderClick(order.id) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OrderCard(
+    order: ExchangeOrder,
+    fillCount: Long,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            val date = order.createdAt.toLocalDateTime(TimeZone.currentSystemDefault()).date
+            Text(
+                text = "$date",
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                modifier = Modifier.weight(0.15f),
+            )
+            Text(
+                text = order.side,
+                style = MaterialTheme.typography.bodyMedium,
+                color =
+                    if (order.side.equals("BUY", ignoreCase = true)) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    },
+                maxLines = 1,
+                modifier = Modifier.weight(0.1f),
+            )
+            Text(
+                text = listOfNotNull(order.orderType, order.timeInForce).joinToString(" · "),
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                modifier = Modifier.weight(0.2f),
+            )
+            Text(
+                text = order.quantity.orEmpty(),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.End,
+                maxLines = 1,
+                modifier = Modifier.weight(0.15f),
+            )
+            Text(
+                text = order.avgPrice ?: order.limitPrice ?: "",
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.End,
+                maxLines = 1,
+                modifier = Modifier.weight(0.15f),
+            )
+            Column(
+                horizontalAlignment = Alignment.End,
+                modifier = Modifier.weight(0.15f),
+            ) {
+                Text(
+                    text = order.status.orEmpty(),
+                    style = MaterialTheme.typography.labelLarge,
+                    maxLines = 1,
+                )
+                Text(
+                    text = if (fillCount == 1L) "1 fill" else "$fillCount fills",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionCard.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionCard.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -41,6 +40,7 @@ import androidx.compose.ui.unit.sp
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AccountRow
+import com.moneymanager.domain.model.ExchangeOrderId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.TransactionKind
 import com.moneymanager.domain.model.Transfer
@@ -58,14 +58,12 @@ internal fun TransactionKind.icon(): ImageVector =
     when (this) {
         TransactionKind.TRANSFER -> Icons.AutoMirrored.Filled.ArrowForward
         TransactionKind.TRADE -> Icons.Filled.Refresh
-        TransactionKind.ORDER -> Icons.Filled.ShoppingCart
     }
 
 internal fun TransactionKind.displayLabel(): String =
     when (this) {
         TransactionKind.TRANSFER -> "Transfer"
         TransactionKind.TRADE -> "Trade"
-        TransactionKind.ORDER -> "Order"
     }
 
 @Composable
@@ -78,6 +76,7 @@ fun AccountTransactionCard(
     onEditClick: (Transfer) -> Unit = {},
     onAuditClick: (TransferId) -> Unit = {},
     onFeeLinkClick: (TransferId) -> Unit = {},
+    onOrderLinkClick: (ExchangeOrderId) -> Unit = {},
 ) {
     // Determine which account to display based on the current view
     // The account column should show the OTHER account in the transaction
@@ -251,6 +250,15 @@ fun AccountTransactionCard(
                         containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = mutedAlpha),
                         contentColor = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = mutedAlpha),
                         onClick = { onFeeLinkClick(linkedFundingId) },
+                    )
+                }
+                // A trade that fills an exchange order links to that order's detail screen.
+                runningBalance.exchangeOrderId?.let { orderId ->
+                    FeeBadge(
+                        text = "Order",
+                        containerColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = mutedAlpha),
+                        contentColor = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = mutedAlpha),
+                        onClick = { onOrderLinkClick(orderId) },
                     )
                 }
                 if (runningBalance.description.isNotBlank()) {

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TooltipAnchorPosition
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
@@ -61,6 +62,7 @@ import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.Asset
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.ExchangeOrderId
 import com.moneymanager.domain.model.TransactionId
 import com.moneymanager.domain.model.TransactionKind
 import com.moneymanager.domain.model.Transfer
@@ -70,6 +72,7 @@ import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.AttributeTypeReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
+import com.moneymanager.domain.repository.ExchangeOrderReadRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.domain.repository.TransactionReadRepository
@@ -187,12 +190,15 @@ fun AccountTransactionsScreen(
     attributeTypeRepository: AttributeTypeReadRepository,
     personRepository: PersonReadRepository,
     personAccountOwnershipRepository: PersonAccountOwnershipReadRepository,
+    exchangeOrderRepository: ExchangeOrderReadRepository,
     maintenance: Maintenance,
     onAccountIdChange: (AccountId) -> Unit = {},
     onCurrencyIdChange: (CurrencyId?) -> Unit = {},
     onAccountClick: (AccountId, String, CurrencyId?, TransferId?) -> Unit = { _, _, _, _ -> },
     onAuditClick: (TransferId) -> Unit = {},
     onFeeLinkClick: (TransferId) -> Unit = {},
+    onOrdersClick: (AccountId, String) -> Unit = { _, _ -> },
+    onOrderLinkClick: (ExchangeOrderId) -> Unit = {},
     scrollToTransferId: TransferId? = null,
     initialCurrencyId: CurrencyId? = null,
     externalRefreshTrigger: Int = 0,
@@ -1080,6 +1086,27 @@ fun AccountTransactionsScreen(
                     }
                 }
 
+                // Exchange accounts with imported orders get a shortcut to the per-account Orders list.
+                val orderCount by rememberFlowAsStateWithSchemaErrorHandling(selectedAccountId, initial = 0L) {
+                    exchangeOrderRepository.countOrdersByAccount(selectedAccountId)
+                }
+                if (orderCount > 0) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                    ) {
+                        TextButton(
+                            onClick = {
+                                val name = allAccounts.firstOrNull { it.id == selectedAccountId }?.name ?: ""
+                                onOrdersClick(selectedAccountId, name)
+                            },
+                            modifier = Modifier.testTag("ordersButton"),
+                        ) {
+                            Text("Orders ($orderCount)")
+                        }
+                    }
+                }
+
                 Box(modifier = Modifier.fillMaxSize()) {
                     LazyColumn(
                         state = listState,
@@ -1107,6 +1134,7 @@ fun AccountTransactionsScreen(
                                     }
                                 },
                                 onAuditClick = onAuditClick,
+                                onOrderLinkClick = onOrderLinkClick,
                                 onFeeLinkClick = { linkedTransferId ->
                                     val targetIndex =
                                         displayedRunningBalances.indexOfFirst { it.transactionId.id == linkedTransferId.id }

--- a/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
+++ b/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/AccountTransactionsScreenTest.kt
@@ -34,6 +34,7 @@ import com.moneymanager.domain.model.Category
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.DbLocation
+import com.moneymanager.domain.model.ExchangeOrderId
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.PageWithTargetIndex
 import com.moneymanager.domain.model.PagingInfo
@@ -49,6 +50,7 @@ import com.moneymanager.domain.repository.AccountWriteRepository
 import com.moneymanager.domain.repository.AttributeTypeWriteRepository
 import com.moneymanager.domain.repository.CategoryWriteRepository
 import com.moneymanager.domain.repository.CurrencyWriteRepository
+import com.moneymanager.domain.repository.ExchangeOrderReadRepository
 import com.moneymanager.domain.repository.PersonAccountOwnershipWriteRepository
 import com.moneymanager.domain.repository.PersonWriteRepository
 import com.moneymanager.domain.repository.TransactionWriteRepository
@@ -114,6 +116,7 @@ class AccountTransactionsScreenTest {
                         attributeTypeRepository = createAttributeTypeRepository(),
                         personRepository = createPersonRepository(),
                         personAccountOwnershipRepository = createPersonAccountOwnershipRepository(),
+                        exchangeOrderRepository = createExchangeOrderRepository(),
                         maintenance = createMaintenance(),
                         onAccountIdChange = {},
                         onCurrencyIdChange = {},
@@ -184,6 +187,7 @@ class AccountTransactionsScreenTest {
                         attributeTypeRepository = attributeTypeRepository,
                         personRepository = personRepository,
                         personAccountOwnershipRepository = personAccountOwnershipRepository,
+                        exchangeOrderRepository = createExchangeOrderRepository(),
                         maintenance = maintenance,
                         onAccountIdChange = { currentAccountId = it },
                         onCurrencyIdChange = {},
@@ -276,6 +280,7 @@ class AccountTransactionsScreenTest {
                         attributeTypeRepository = attributeTypeRepository,
                         personRepository = personRepository,
                         personAccountOwnershipRepository = personAccountOwnershipRepository,
+                        exchangeOrderRepository = createExchangeOrderRepository(),
                         maintenance = maintenance,
                         onAccountIdChange = { currentAccountId = it },
                         onCurrencyIdChange = {},
@@ -342,6 +347,7 @@ class AccountTransactionsScreenTest {
                         attributeTypeRepository = createAttributeTypeRepository(),
                         personRepository = createPersonRepository(),
                         personAccountOwnershipRepository = createPersonAccountOwnershipRepository(),
+                        exchangeOrderRepository = createExchangeOrderRepository(),
                         maintenance = createMaintenance(),
                         onAccountClick = { accountId, _, _, transferId ->
                             clickedAccountId = accountId
@@ -447,6 +453,7 @@ class AccountTransactionsScreenTest {
                         attributeTypeRepository = createAttributeTypeRepository(),
                         personRepository = createPersonRepository(),
                         personAccountOwnershipRepository = createPersonAccountOwnershipRepository(),
+                        exchangeOrderRepository = createExchangeOrderRepository(),
                         maintenance = createMaintenance(),
                         scrollToTransferId = anchor.id,
                     )
@@ -551,6 +558,62 @@ class AccountTransactionsScreenTest {
         }
 
     @Test
+    fun orderBadge_showsOnLinkedTradeRow_andReportsItsOrderId() =
+        runMoneyManagerComposeUiTest {
+            // A trade row filling an exchange order carries the order id from the AccountRow join and
+            // renders a clickable "Order" badge; a trade with no order shows none.
+            val now = Clock.System.now()
+            val usd = Currency(id = CurrencyId(1L), code = "USD", name = "US Dollar")
+            val exchange = Account(id = AccountId(10L), name = "Exchange", openingDate = now)
+            val orderId = ExchangeOrderId(77L)
+            val linkedRow =
+                AccountRow(
+                    transactionId = TransferId(20L),
+                    timestamp = now,
+                    description = "Buy BTC/USD",
+                    accountId = exchange.id,
+                    transactionAmount = Money(500, usd),
+                    runningBalance = Money(500, usd),
+                    sourceAccountId = exchange.id,
+                    targetAccountId = exchange.id,
+                    exchangeOrderId = orderId,
+                    kind = TransactionKind.TRADE,
+                )
+            val unlinkedRow =
+                linkedRow.copy(
+                    transactionId = TransferId(21L),
+                    description = "Sell BTC/USD",
+                    exchangeOrderId = null,
+                )
+
+            var clicked: ExchangeOrderId? = null
+            setContent {
+                ProvideSchemaAwareScope {
+                    Column {
+                        AccountTransactionCard(
+                            runningBalance = linkedRow,
+                            accounts = listOf(exchange),
+                            screenSizeClass = ScreenSizeClass.Expanded,
+                            onOrderLinkClick = { clicked = it },
+                        )
+                        AccountTransactionCard(
+                            runningBalance = unlinkedRow,
+                            accounts = listOf(exchange),
+                            screenSizeClass = ScreenSizeClass.Expanded,
+                            onOrderLinkClick = { clicked = it },
+                        )
+                    }
+                }
+            }
+            waitForIdle()
+
+            onAllNodesWithText("Order").assertCountEquals(1)
+            onNodeWithText("Order").performClick()
+            waitForIdle()
+            assertEquals(orderId, clicked)
+        }
+
+    @Test
     fun sameAccountTrade_rendersBothAssetLegs_withoutDuplicateListKeys() =
         runMoneyManagerComposeUiTest {
             // A trade inside one account (e.g. BTC→USD on an exchange) produces two running-balance
@@ -611,6 +674,7 @@ class AccountTransactionsScreenTest {
                         attributeTypeRepository = createAttributeTypeRepository(),
                         personRepository = createPersonRepository(),
                         personAccountOwnershipRepository = createPersonAccountOwnershipRepository(),
+                        exchangeOrderRepository = createExchangeOrderRepository(),
                         maintenance = createMaintenance(),
                         onAccountIdChange = {},
                         onCurrencyIdChange = {},
@@ -744,6 +808,7 @@ class AccountTransactionsScreenTest {
                         attributeTypeRepository = createAttributeTypeRepository(),
                         personRepository = createPersonRepository(),
                         personAccountOwnershipRepository = createPersonAccountOwnershipRepository(),
+                        exchangeOrderRepository = createExchangeOrderRepository(),
                         maintenance = createMaintenance(),
                         onFeeLinkClick = { navigated = true },
                     )
@@ -854,6 +919,7 @@ class AccountTransactionsScreenTest {
                                     attributeTypeRepository = repositories.attributeTypeRepository,
                                     personRepository = repositories.personRepository,
                                     personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                                    exchangeOrderRepository = repositories.exchangeOrderRepository,
                                     maintenance = createDbMaintenance(repositories),
                                     onAccountIdChange = { currentAccountId = it },
                                     onCurrencyIdChange = {},
@@ -1064,6 +1130,7 @@ class AccountTransactionsScreenTest {
                                     attributeTypeRepository = repositories.attributeTypeRepository,
                                     personRepository = repositories.personRepository,
                                     personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                                    exchangeOrderRepository = repositories.exchangeOrderRepository,
                                     maintenance = createDbMaintenance(repositories),
                                     onAccountIdChange = { currentAccountId = it },
                                     onCurrencyIdChange = {},
@@ -1244,6 +1311,7 @@ class AccountTransactionsScreenTest {
                                     attributeTypeRepository = repositories.attributeTypeRepository,
                                     personRepository = repositories.personRepository,
                                     personAccountOwnershipRepository = repositories.personAccountOwnershipRepository,
+                                    exchangeOrderRepository = repositories.exchangeOrderRepository,
                                     maintenance = createDbMaintenance(repositories),
                                     onAccountIdChange = { currentAccountId = it },
                                     onCurrencyIdChange = {},
@@ -1505,6 +1573,15 @@ class AccountTransactionsScreenTest {
             everySuspend { analyze() } returns Duration.ZERO
             everySuspend { refreshMaterializedViews() } returns Duration.ZERO
             everySuspend { fullRefreshMaterializedViews() } returns Duration.ZERO
+        }
+
+    private fun createExchangeOrderRepository(): ExchangeOrderReadRepository =
+        mock(MockMode.autoUnit) {
+            every { countOrdersByAccount(any()) } returns flowOf(0L)
+            every { getOrdersByAccount(any()) } returns flowOf(emptyList())
+            every { getFillCountsByAccount(any()) } returns flowOf(emptyMap())
+            every { getOrderById(any()) } returns flowOf(null)
+            every { getFillTradesForOrder(any()) } returns flowOf(emptyList())
         }
 
     private fun createDbMaintenance(repositories: DatabaseComponent): Maintenance = DbMaintenance(repositories.maintenanceService)

--- a/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/OrdersScreenTest.kt
+++ b/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/OrdersScreenTest.kt
@@ -1,0 +1,283 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.ui.screens
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.waitUntilExactlyOneExists
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.ApiRequestId
+import com.moneymanager.domain.model.ApiSessionId
+import com.moneymanager.domain.model.AuditType
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.EntityType
+import com.moneymanager.domain.model.ExchangeOrder
+import com.moneymanager.domain.model.ExchangeOrderAuditEntry
+import com.moneymanager.domain.model.ExchangeOrderId
+import com.moneymanager.domain.model.JsonPath
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.SourceRecord
+import com.moneymanager.domain.model.Trade
+import com.moneymanager.domain.model.TradeId
+import com.moneymanager.domain.repository.AuditReadRepository
+import com.moneymanager.domain.repository.ExchangeOrderReadRepository
+import com.moneymanager.ui.error.ProvideSchemaAwareScope
+import com.moneymanager.ui.screens.orders.ExchangeOrderAuditScreen
+import com.moneymanager.ui.screens.orders.OrderDetailScreen
+import com.moneymanager.ui.screens.orders.OrdersScreen
+import com.moneymanager.ui.test.runMoneyManagerComposeUiTest
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlinx.coroutines.flow.flowOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTestApi::class)
+class OrdersScreenTest {
+    private val accountId = AccountId(10L)
+    private val orderId = ExchangeOrderId(1L)
+    private val createdAt = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+
+    private val order =
+        ExchangeOrder(
+            id = orderId,
+            accountId = accountId,
+            orderRef = "6142909958761646675",
+            clientOid = "co-1",
+            side = "SELL",
+            orderType = "LIMIT",
+            timeInForce = "GOOD_TILL_CANCEL",
+            status = "FILLED",
+            limitPrice = "0.0000010999",
+            quantity = "1630",
+            avgPrice = "0.0000010999",
+            createdAt = createdAt,
+        )
+
+    private val usd = Currency(id = CurrencyId(1L), code = "USD", name = "US Dollar")
+    private val btc = Currency(id = CurrencyId(2L), code = "BTC", name = "Bitcoin")
+
+    private val fillTrade =
+        Trade(
+            id = TradeId(42L),
+            timestamp = createdAt,
+            description = "Buy BTC/USD",
+            fromAccountId = accountId,
+            from = Money(50_000_00L, usd),
+            toAccountId = accountId,
+            to = Money(1_00L, btc),
+        )
+
+    private fun repository(
+        orders: List<ExchangeOrder> = listOf(order),
+        fills: List<Trade> = listOf(fillTrade),
+    ): ExchangeOrderReadRepository =
+        mock(MockMode.autoUnit) {
+            every { getOrdersByAccount(any()) } returns flowOf(orders)
+            every { getFillCountsByAccount(any()) } returns flowOf(orders.associate { it.id to fills.size.toLong() })
+            every { getOrderById(any()) } returns flowOf(orders.firstOrNull())
+            every { getFillTradesForOrder(any()) } returns flowOf(fills)
+            every { countOrdersByAccount(any()) } returns flowOf(orders.size.toLong())
+        }
+
+    @Test
+    fun ordersList_rendersOrderRows_andClickReportsOrderId() =
+        runMoneyManagerComposeUiTest {
+            var clicked: ExchangeOrderId? = null
+            setContent {
+                ProvideSchemaAwareScope {
+                    OrdersScreen(
+                        accountId = accountId,
+                        exchangeOrderRepository = repository(),
+                        onOrderClick = { clicked = it },
+                    )
+                }
+            }
+            waitUntilExactlyOneExists(hasText("SELL"))
+            waitForIdle()
+            onNodeWithText("LIMIT · GOOD_TILL_CANCEL").assertIsDisplayed()
+            onNodeWithText("FILLED").assertIsDisplayed()
+            onNodeWithText("1 fill").assertIsDisplayed()
+
+            onNodeWithText("SELL").performClick()
+            waitForIdle()
+            assertEquals(orderId, clicked)
+        }
+
+    @Test
+    fun ordersList_showsEmptyState_whenAccountHasNoOrders() =
+        runMoneyManagerComposeUiTest {
+            setContent {
+                ProvideSchemaAwareScope {
+                    OrdersScreen(
+                        accountId = accountId,
+                        exchangeOrderRepository = repository(orders = emptyList(), fills = emptyList()),
+                    )
+                }
+            }
+            waitUntilExactlyOneExists(hasText("No orders"))
+            waitForIdle()
+        }
+
+    @Test
+    fun orderDetail_rendersFieldsAndFills_andClickReportsFillTrade() =
+        runMoneyManagerComposeUiTest {
+            var clickedFill: Trade? = null
+            setContent {
+                ProvideSchemaAwareScope {
+                    OrderDetailScreen(
+                        orderId = orderId,
+                        exchangeOrderRepository = repository(),
+                        onFillTradeClick = { clickedFill = it },
+                    )
+                }
+            }
+            waitUntilExactlyOneExists(hasText("6142909958761646675"))
+            waitForIdle()
+            onNodeWithText("SELL").assertIsDisplayed()
+            onNodeWithText("FILLED").assertIsDisplayed()
+            onNodeWithText("1 fill trade").assertIsDisplayed()
+            onNodeWithText("Buy BTC/USD").assertIsDisplayed()
+
+            onNodeWithText("Buy BTC/USD").performClick()
+            waitForIdle()
+            assertEquals(fillTrade, clickedFill)
+        }
+
+    @Test
+    fun orderDetail_fillTrade_hasOwnAuditButton_reportingTheFill() =
+        runMoneyManagerComposeUiTest {
+            var auditedFill: Trade? = null
+            setContent {
+                ProvideSchemaAwareScope {
+                    OrderDetailScreen(
+                        orderId = orderId,
+                        exchangeOrderRepository = repository(),
+                        onFillTradeAuditClick = { auditedFill = it },
+                    )
+                }
+            }
+            waitUntilExactlyOneExists(hasTestTag("fillTradeAudit-${fillTrade.id.id}"))
+            waitForIdle()
+
+            onNodeWithTag("fillTradeAudit-${fillTrade.id.id}").performClick()
+            waitForIdle()
+            assertEquals(fillTrade, auditedFill)
+        }
+
+    @Test
+    fun ordersList_backButton_reportsBack() =
+        runMoneyManagerComposeUiTest {
+            var backClicks = 0
+            setContent {
+                ProvideSchemaAwareScope {
+                    OrdersScreen(
+                        accountId = accountId,
+                        exchangeOrderRepository = repository(),
+                        onBack = { backClicks++ },
+                    )
+                }
+            }
+            waitUntilExactlyOneExists(hasText("← Back"))
+            waitForIdle()
+
+            onNodeWithText("← Back").performClick()
+            waitForIdle()
+            assertEquals(1, backClicks)
+        }
+
+    @Test
+    fun orderDetail_auditButton_reportsOrderId() =
+        runMoneyManagerComposeUiTest {
+            var auditOrder: ExchangeOrderId? = null
+            setContent {
+                ProvideSchemaAwareScope {
+                    OrderDetailScreen(
+                        orderId = orderId,
+                        exchangeOrderRepository = repository(),
+                        onAuditClick = { auditOrder = it },
+                    )
+                }
+            }
+            waitUntilExactlyOneExists(hasText("Audit history"))
+            waitForIdle()
+
+            onNodeWithText("Audit history").performClick()
+            waitForIdle()
+            assertEquals(orderId, auditOrder)
+        }
+
+    @Test
+    fun orderAudit_rendersEntry_andApiSourceLinksToImportingRequest() =
+        runMoneyManagerComposeUiTest {
+            val sessionId = ApiSessionId(5L)
+            val requestId = ApiRequestId(9L)
+            val jsonPath = "\$.result.data[0]"
+            val entry =
+                ExchangeOrderAuditEntry(
+                    id = 1L,
+                    auditTimestamp = createdAt,
+                    auditType = AuditType.INSERT,
+                    orderId = orderId,
+                    revisionId = 1L,
+                    accountId = accountId,
+                    orderRef = order.orderRef,
+                    clientOid = order.clientOid,
+                    side = order.side,
+                    orderType = order.orderType,
+                    timeInForce = order.timeInForce,
+                    status = order.status,
+                    limitPrice = order.limitPrice,
+                    quantity = order.quantity,
+                    avgPrice = order.avgPrice,
+                    createdAt = createdAt,
+                    updatedAt = null,
+                    source =
+                        SourceRecord(
+                            id = 1L,
+                            entityType = EntityType.EXCHANGE_ORDER,
+                            entityId = orderId.id,
+                            revisionId = 1L,
+                            source = Source.Api(sessionId, requestId, JsonPath(jsonPath)),
+                            deviceId = 1L,
+                            deviceInfo = null,
+                            fileName = null,
+                            createdAt = createdAt,
+                        ),
+                )
+            val auditRepository =
+                mock<AuditReadRepository>(MockMode.autoUnit) {
+                    everySuspend { getAuditHistoryForExchangeOrder(any()) } returns listOf(entry)
+                }
+
+            var linked: Triple<ApiSessionId, ApiRequestId, String>? = null
+            setContent {
+                ProvideSchemaAwareScope {
+                    ExchangeOrderAuditScreen(
+                        orderId = orderId,
+                        auditRepository = auditRepository,
+                        onApiSourceClick = { s, r, p -> linked = Triple(s, r, p) },
+                        onBack = {},
+                    )
+                }
+            }
+            waitUntilExactlyOneExists(hasText("FILLED"))
+            waitForIdle()
+
+            onNodeWithText("API Import").performClick()
+            waitForIdle()
+            assertEquals(Triple(sessionId, requestId, jsonPath), linked)
+        }
+}

--- a/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/OrdersScreenTest.kt
+++ b/app/ui/transactions/src/commonTest/kotlin/com/moneymanager/ui/screens/OrdersScreenTest.kt
@@ -157,6 +157,28 @@ class OrdersScreenTest {
         }
 
     @Test
+    fun orderDetail_backButtonStaysReachable_whenTheOrderDoesNotResolve() =
+        runMoneyManagerComposeUiTest {
+            // A stale/deleted order id never emits an order; the user must still be able to navigate away.
+            var backClicks = 0
+            setContent {
+                ProvideSchemaAwareScope {
+                    OrderDetailScreen(
+                        orderId = orderId,
+                        exchangeOrderRepository = repository(orders = emptyList(), fills = emptyList()),
+                        onBack = { backClicks++ },
+                    )
+                }
+            }
+            waitUntilExactlyOneExists(hasText("Order not found"))
+            waitForIdle()
+
+            onNodeWithText("← Back").performClick()
+            waitForIdle()
+            assertEquals(1, backClicks)
+        }
+
+    @Test
     fun orderDetail_fillTrade_hasOwnAuditButton_reportingTheFill() =
         runMoneyManagerComposeUiTest {
             var auditedFill: Trade? = null


### PR DESCRIPTION
## What

Models exchange orders (from the Crypto.com Exchange API `private/get-order-history` endpoint) as a persistent entity with bidirectional links to their fill trades, plus a dedicated UI.

### Schema & engine
- New `exchange_order` table — audited (`exchange_order_audit` + triggers), upserted by `(account_id, order_ref)`; a status/price change updates in place and bumps the revision. Orders are **metadata, not transactions**: their economics live in the fill trades, so they never participate in balances.
- New `exchange_order_trade(order_id, trade_id UNIQUE)` link table (un-audited join table, like `transfer_relationship`).
- New `EXCHANGE_ORDER(12)` entity type; provenance recorded per revision via the unified `entity_source` store.
- `ImportOrderIntent` (with `tradeKeys`) through the sole-writer ImportEngine; a trade key that doesn't resolve in the batch fails loudly instead of silently dropping the link. All orders import — open and cancelled included.

### Strategy config
- New `ApiTradeMappings` fields: `limitPriceField`, `avgPriceField`, `updateTimestampField`, `clientOidField`, `timeInForceField` (all nullable-with-default → codec-compatible).
- The built-in Crypto.com Exchange strategy now maps `order_type` — the previous `type` mapping never matched the live payload, which means the `"(LIMIT)"` trade-description suffix never fired in production. The suffix logic is removed outright, keeping trade descriptions byte-stable for content-based dedupe. Installed strategies will show "update available" in the catalog (expected — the canonical hash changed).

### UI
- Per-account **Orders** screen (side/type/status/qty/price + fill counts) reachable from the account transactions screen when the account has orders.
- **Order detail**: exchange-reported fields, fill trades (click → jump to the trade in the transactions list; each fill also has its own audit button), order **audit history** whose API-sourced revisions link back to the exact request/JSON node in the API traffic screen.
- "Order" badge on trade rows (one extra indexed LEFT JOIN in the AccountRow queries) → order detail. Bidirectional order↔trade navigation.
- `TransactionKind.ORDER` removed — orders are not transaction rows, so the type column/tooltip no longer offers it.

### Fixes along the way
- API strategy file import ("Import file") now create-or-updates by name behind an **overwrite confirmation dialog**, instead of failing with a `name UNIQUE` constraint violation.
- Google Drive: an `invalid_grant` on token refresh (expired/revoked refresh token) clears the stored token and re-runs the loopback consent flow transparently instead of surfacing an error.

## Notes
- BETA no-migrations rule: the schema change means local databases are recreated (expected).
- E2E coverage: order import + fill linking, idempotent re-import, status-change re-import (revision bump), unfilled-order standalone import, audit-source coverage for the new entity, repository upsert/link/cascade tests, and UI tests for the badge, list, detail, audit links, and back/audit buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exchange imports now include orders, including open orders and links to related trade fills.
  * Added account order lists, order details, fill-trade views, and order audit history.
  * Transactions linked to orders now display an Order badge for quick navigation.
  * Order imports are deduplicated and updated in place when details change.
  * Added overwrite confirmation when importing an API strategy with an existing name.

* **Bug Fixes**
  * Google Drive authentication now recovers from expired or invalid refresh tokens by restarting sign-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->