### PR TITLE
Fix sample data generation, cover every entity type, and cache SQLite statements

### DIFF
--- a/app/db/core/build.gradle.kts
+++ b/app/db/core/build.gradle.kts
@@ -42,12 +42,17 @@ kotlin {
                 // sqldelight.runtime + read/write are used directly by jvmMain (JvmDatabaseManager uses
                 // the read Schema); declared here per dependency-analysis (the SQLDelight plugin that
                 // used to supply the runtime now lives in :app:db:read/:write).
+                // CachingJdbcSqliteDriver extends SQLDelight's JdbcDriver.
+                api(libs.sqldelight.jdbc.driver)
                 api(libs.sqldelight.runtime)
                 api(projects.app.db.write)
                 api(projects.utils.currency)
 
-                implementation(libs.sqldelight.sqlite.driver)
                 implementation(projects.app.db.seed)
+
+                // No longer used directly (CachingJdbcSqliteDriver replaces JdbcSqliteDriver), but it
+                // supplies the xerial JDBC driver that DriverManager resolves the `jdbc:sqlite:` URL with.
+                runtimeOnly(libs.sqldelight.sqlite.driver)
             }
         }
 

--- a/app/db/core/src/jvmMain/kotlin/com/moneymanager/database/CachingJdbcSqliteDriver.kt
+++ b/app/db/core/src/jvmMain/kotlin/com/moneymanager/database/CachingJdbcSqliteDriver.kt
@@ -1,0 +1,187 @@
+package com.moneymanager.database
+
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlPreparedStatement
+import app.cash.sqldelight.driver.jdbc.ConnectionManager.Transaction
+import app.cash.sqldelight.driver.jdbc.JdbcCursor
+import app.cash.sqldelight.driver.jdbc.JdbcDriver
+import app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.PreparedStatement
+import java.util.Properties
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.concurrent.getOrSet
+
+/**
+ * A file-backed SQLite driver that keeps compiled statements around instead of re-preparing them.
+ *
+ * SQLDelight's stock [JdbcDriver] calls `Connection.prepareStatement` on every execute and closes the
+ * statement afterwards, ignoring the `identifier` it is handed for exactly this purpose (its Android
+ * counterpart does cache). Since SQLite compiles the SQL on prepare, a bulk import spent more time
+ * compiling its handful of insert statements than running them — profiling a sample-data import showed
+ * `NativeDB.prepare` outweighing statement execution by ~1.6x.
+ *
+ * Statements are cached per [Connection] and keyed by SQLDelight's `identifier` (statements without one
+ * — pragmas, schema DDL — are prepared and closed as before, since they run once). Closing a connection
+ * closes its cached statements, so the cache cannot outlive the connection it belongs to.
+ *
+ * Connection handling mirrors SQLDelight's own `JdbcSqliteDriver` for file databases: one connection per
+ * thread, opened on demand and closed when no transaction is in flight. That class is final, so this is a
+ * sibling rather than a subclass.
+ */
+class CachingJdbcSqliteDriver(
+    private val url: String,
+    private val properties: Properties = Properties(),
+) : JdbcDriver() {
+    private val transactions = ThreadLocal<Transaction>()
+    private val connections = ThreadLocal<Connection>()
+    private val statementCaches = ConcurrentHashMap<Connection, MutableMap<Int, CachedStatement>>()
+    private val listeners = linkedMapOf<String, MutableSet<Query.Listener>>()
+
+    override var transaction: Transaction?
+        get() = transactions.get()
+        set(value) {
+            val currentTransaction = transactions.get()
+            transactions.set(value)
+            if (value == null && currentTransaction != null) {
+                closeConnection(currentTransaction.connection)
+            }
+        }
+
+    override fun getConnection(): Connection = connections.getOrSet { DriverManager.getConnection(url, properties) }
+
+    override fun closeConnection(connection: Connection) {
+        check(connections.get() == connection) { "Connections must be closed on the thread that opened them" }
+        if (transaction == null) {
+            statementCaches.remove(connection)?.values?.forEach { it.statement.close() }
+            connection.close()
+            connections.remove()
+        }
+    }
+
+    override fun close() = Unit
+
+    // SQLite transactions are explicit statements rather than autoCommit toggling, matching JdbcSqliteDriver.
+    override fun Connection.beginTransaction() {
+        prepareStatement("BEGIN TRANSACTION").use(PreparedStatement::execute)
+    }
+
+    override fun Connection.endTransaction() {
+        prepareStatement("END TRANSACTION").use(PreparedStatement::execute)
+    }
+
+    override fun Connection.rollbackTransaction() {
+        prepareStatement("ROLLBACK TRANSACTION").use(PreparedStatement::execute)
+    }
+
+    override fun execute(
+        identifier: Int?,
+        sql: String,
+        parameters: Int,
+        binders: (SqlPreparedStatement.() -> Unit)?,
+    ): QueryResult<Long> {
+        val (connection, onClose) = connectionAndClose()
+        try {
+            return QueryResult.Value(
+                withStatement(connection, identifier, sql, binders) { statement ->
+                    if (statement.execute()) 0L else statement.updateCount.toLong()
+                },
+            )
+        } finally {
+            onClose()
+        }
+    }
+
+    override fun <R> executeQuery(
+        identifier: Int?,
+        sql: String,
+        mapper: (SqlCursor) -> QueryResult<R>,
+        parameters: Int,
+        binders: (SqlPreparedStatement.() -> Unit)?,
+    ): QueryResult<R> {
+        val (connection, onClose) = connectionAndClose()
+        try {
+            return withStatement(connection, identifier, sql, binders) { statement ->
+                statement.executeQuery().use { resultSet -> mapper(JdbcCursor(resultSet)) }
+            }
+        } finally {
+            onClose()
+        }
+    }
+
+    /**
+     * Runs [body] against a statement for [sql]: the cached one when SQLDelight gave an [identifier],
+     * otherwise a throw-away statement closed on the way out.
+     */
+    private fun <R> withStatement(
+        connection: Connection,
+        identifier: Int?,
+        sql: String,
+        binders: (SqlPreparedStatement.() -> Unit)?,
+        body: (PreparedStatement) -> R,
+    ): R {
+        if (identifier == null) {
+            return connection.prepareStatement(sql).use { statement ->
+                bind(statement, binders)
+                body(statement)
+            }
+        }
+        val cache = statementCaches.getOrPut(connection) { mutableMapOf() }
+        val cached = cache[identifier]
+        // SQLDelight derives the identifier from the SQL, so a hit should always be the same statement;
+        // compare anyway, because a hash collision would otherwise run the wrong SQL.
+        val entry =
+            if (cached != null && cached.sql == sql) {
+                cached
+            } else {
+                cached?.statement?.close()
+                CachedStatement(sql, connection.prepareStatement(sql)).also { cache[identifier] = it }
+            }
+        bind(entry.statement, binders)
+        return body(entry.statement)
+    }
+
+    private class CachedStatement(
+        val sql: String,
+        val statement: PreparedStatement,
+    )
+
+    private fun bind(
+        statement: PreparedStatement,
+        binders: (SqlPreparedStatement.() -> Unit)?,
+    ) {
+        // A reused statement still holds the previous row's parameters; clear them so a binder that skips
+        // a parameter can never silently inherit a stale value.
+        statement.clearParameters()
+        if (binders != null) JdbcPreparedStatement(statement).binders()
+    }
+
+    override fun addListener(
+        vararg queryKeys: String,
+        listener: Query.Listener,
+    ) {
+        synchronized(listeners) {
+            queryKeys.forEach { listeners.getOrPut(it) { linkedSetOf() }.add(listener) }
+        }
+    }
+
+    override fun removeListener(
+        vararg queryKeys: String,
+        listener: Query.Listener,
+    ) {
+        synchronized(listeners) {
+            queryKeys.forEach { listeners[it]?.remove(listener) }
+        }
+    }
+
+    override fun notifyListeners(vararg queryKeys: String) {
+        val listenersToNotify = linkedSetOf<Query.Listener>()
+        synchronized(listeners) {
+            queryKeys.forEach { listeners[it]?.let(listenersToNotify::addAll) }
+        }
+        listenersToNotify.forEach(Query.Listener::queryResultsChanged)
+    }
+}

--- a/app/db/core/src/jvmMain/kotlin/com/moneymanager/database/CachingJdbcSqliteDriver.kt
+++ b/app/db/core/src/jvmMain/kotlin/com/moneymanager/database/CachingJdbcSqliteDriver.kt
@@ -137,7 +137,9 @@ class CachingJdbcSqliteDriver(
             if (cached != null && cached.sql == sql) {
                 cached
             } else {
-                cached?.statement?.close()
+                // Drop the stale entry first: if the re-prepare below throws, the cache must not keep
+                // pointing at a statement this just closed.
+                cache.remove(identifier)?.statement?.close()
                 CachedStatement(sql, connection.prepareStatement(sql)).also { cache[identifier] = it }
             }
         bind(entry.statement, binders)

--- a/app/db/core/src/jvmMain/kotlin/com/moneymanager/database/JvmDatabaseManager.kt
+++ b/app/db/core/src/jvmMain/kotlin/com/moneymanager/database/JvmDatabaseManager.kt
@@ -1,6 +1,5 @@
 package com.moneymanager.database
 
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.moneymanager.currency.Currency
 import com.moneymanager.database.sql.seed.MoneyManagerDatabase
 import com.moneymanager.domain.model.DEFAULT_DATABASE_PATH
@@ -52,7 +51,7 @@ class JvmDatabaseManager(
                 Properties().apply {
                     put("foreign_keys", "true")
                 }
-            val driver = JdbcSqliteDriver(location.jdbcUrl, properties)
+            val driver = CachingJdbcSqliteDriver(location.jdbcUrl, properties)
 
             onProgress(DatabaseInitializationProgress("Applying database settings...", 4, 7))
             // Apply cross-platform pragmas (foreign_keys already set via Properties above).

--- a/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/util/SampleDataGenerator.kt
+++ b/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/util/SampleDataGenerator.kt
@@ -2,27 +2,43 @@
 
 package com.moneymanager.ui.util
 
-import com.moneymanager.bigdecimal.BigDecimal
+import com.moneymanager.bigdecimal.BigInteger
 import com.moneymanager.domain.Maintenance
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Asset
+import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.Category
+import com.moneymanager.domain.model.CryptoAsset
+import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.Money
 import com.moneymanager.domain.model.NewAttribute
+import com.moneymanager.domain.model.RelationshipTypeId
 import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.importengineapi.AccountMatchKey
 import com.moneymanager.importengineapi.AccountRef
+import com.moneymanager.importengineapi.BatchRelationship
 import com.moneymanager.importengineapi.DedupePolicy
 import com.moneymanager.importengineapi.ImportAccountIntent
 import com.moneymanager.importengineapi.ImportBatch
 import com.moneymanager.importengineapi.ImportCategoryIntent
+import com.moneymanager.importengineapi.ImportCryptoIntent
 import com.moneymanager.importengineapi.ImportEngine
+import com.moneymanager.importengineapi.ImportFee
+import com.moneymanager.importengineapi.ImportOrderIntent
 import com.moneymanager.importengineapi.ImportOwnershipIntent
+import com.moneymanager.importengineapi.ImportPassThrough
 import com.moneymanager.importengineapi.ImportPersonIntent
 import com.moneymanager.importengineapi.ImportRowKey
+import com.moneymanager.importengineapi.ImportTradeIntent
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.importengineapi.LocalCategoryKey
+import com.moneymanager.importengineapi.LocalCryptoKey
+import com.moneymanager.importengineapi.LocalOrderKey
 import com.moneymanager.importengineapi.LocalPersonKey
+import com.moneymanager.importengineapi.LocalTradeKey
 import com.moneymanager.importengineapi.PersonMatchKey
 import com.moneymanager.importengineapi.getOrCreateAttributeTypes
 import com.moneymanager.importengineapi.normalizeNameKey
@@ -31,6 +47,7 @@ import kotlinx.coroutines.flow.first
 import kotlin.random.Random
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -38,30 +55,267 @@ import kotlin.time.Instant
 // instead of freezing on one giant transaction for the hundreds of thousands of rows this generates.
 private const val SAMPLE_IMPORT_BATCH_SIZE = 5000
 
-private const val ACCOUNT_COUNT = 100
+private const val CONVERSION_RELATIONSHIP_TYPE_NAME = "conversion"
+
+// An order and its fills must be imported together (the engine resolves the fills' keys), so this is a
+// count of orders rather than of rows.
+private const val ORDER_IMPORT_CHUNK_SIZE = 10
+
+// Rough shares of observed wall-clock for the three write phases; see GenerationProgress.fraction.
+private const val TRANSFER_PHASE_WEIGHT = 0.6f
+private const val TRADE_ORDER_PHASE_WEIGHT = 0.25f
+private const val REFRESH_PHASE_WEIGHT = 0.15f
 
 /**
- * Generates sample data through the central [ImportEngine] — the sole DB writer for entities and
- * transfers — so accounts, people, ownerships and transactions are created exactly the way a real
- * import creates them (with `Source.SampleGenerator` provenance). Attribute types are resolved
- * (get-or-create) through the engine up front and then referenced by id from the batch.
+ * How much data [generateSampleData] produces. SMALL still covers every feature (crypto, trades,
+ * orders, fees, pass-throughs, conversions); LARGE additionally stresses the app with a database the
+ * size of a heavy real-world user's.
+ */
+enum class SampleDataSize(
+    val label: String,
+    val accountCount: Int,
+    private val heavyRange: IntRange,
+    private val mediumRange: IntRange,
+    private val lightRange: IntRange,
+    val cryptoTransferCount: Int,
+    val passThroughCount: Int,
+    val conversionPairCount: Int,
+    val tradeCount: Int,
+    val standaloneOrderCount: Int,
+) {
+    // Trades and orders are written one row per transaction by the engine, so they cost roughly a
+    // second each — far more than a transfer. Their counts stay small even in LARGE.
+    SMALL("Small", 15, 1000..2000, 300..800, 50..150, 200, 60, 40, 60, 6),
+    LARGE("Large", 100, 5000..10000, 1000..3000, 100..500, 2000, 400, 200, 400, 20),
+    ;
+
+    /** Transaction count for one account: 20% of accounts are heavy, 50% medium, the rest light. */
+    fun transactionCount(
+        accountIndex: Int,
+        random: Random,
+    ): Int {
+        val range =
+            when {
+                accountIndex < accountCount / 5 -> heavyRange
+                accountIndex < accountCount * 7 / 10 -> mediumRange
+                else -> lightRange
+            }
+        return random.nextInt(range.first, range.last + 1)
+    }
+}
+
+// Named accounts that exist so the batch can exercise the features that need dedicated counterparties.
+private val EXCHANGE_ACCOUNT_NAMES = listOf("Crypto.com Exchange", "Kraken Spot", "Binance Spot")
+private val WALLET_ACCOUNT_NAMES = listOf("Ledger Cold Wallet", "MetaMask Wallet")
+private val CONDUIT_ACCOUNT_NAMES = listOf("Curve", "PayPal")
+private val MERCHANT_ACCOUNT_NAMES = listOf("Tesco", "Amazon", "Uber", "Steam", "Apple")
+private const val CONVERSION_ACCOUNT_NAME = "Crypto.com Conversion"
+private const val FEE_ACCOUNT_NAME = "Bank Fees"
+
+private val CRYPTO_ASSETS =
+    listOf(
+        "BTC" to "Bitcoin",
+        "ETH" to "Ethereum",
+        "SOL" to "Solana",
+        "USDC" to "USD Coin",
+        "USDT" to "Tether",
+        "DOGE" to "Dogecoin",
+        "ADA" to "Cardano",
+        "CRO" to "Cronos",
+        "SHIB" to "Shiba Inu",
+    )
+
+/**
+ * Generates sample data through the central [ImportEngine] — the sole DB writer — so every entity is
+ * created exactly the way a real import creates it (with `Source.SampleGenerator` provenance).
+ *
+ * The batches deliberately populate the whole [ImportBatch] surface that a real import can produce:
+ * categories, people, accounts, ownerships, crypto assets, transfers (plain, fee-bearing,
+ * pass-through chains, conversion pairs, excluded, unique-keyed, fiat and crypto denominated),
+ * trades, and exchange orders (fully filled, partially filled and unfilled).
  */
 suspend fun generateSampleData(
     currencyRepository: CurrencyReadRepository,
     importEngine: ImportEngine,
     maintenance: Maintenance,
     progressFlow: MutableStateFlow<GenerationProgress>,
+    size: SampleDataSize = SampleDataSize.LARGE,
 ) {
     val random = Random.Default
     val sampleSource = Source.SampleGenerator
 
-    // Step 1: Fetch currencies
-    progressFlow.emit(GenerationProgress(currentOperation = "Fetching currencies..."))
+    progressFlow.emit(GenerationProgress(size = size, currentOperation = "Fetching currencies..."))
 
+    val currencies = selectCurrencies(currencyRepository)
+
+    // Step 1: categories. Children need their parent's real id, so parents go in first.
+    val categoryHierarchy = generateCategoryHierarchy()
+    val totalCategories = categoryHierarchy.sumOf { 1 + it.children.size }
+    progressFlow.emit(
+        GenerationProgress(size = size, totalCategories = totalCategories, currentOperation = "Creating categories..."),
+    )
+    val categoryIds = createCategories(importEngine, categoryHierarchy, sampleSource)
+
+    // Step 2: crypto assets, so their ids are available to denominate crypto transfers and trades.
+    progressFlow.emit(
+        GenerationProgress(
+            size = size,
+            categoriesCreated = totalCategories,
+            totalCategories = totalCategories,
+            currentOperation = "Creating crypto assets...",
+        ),
+    )
+    val cryptoAssets = createCryptoAssets(importEngine, sampleSource)
+
+    val accounts = AccountPlan(size)
+    val baseProgress =
+        GenerationProgress(
+            size = size,
+            categoriesCreated = totalCategories,
+            totalCategories = totalCategories,
+            cryptoAssetsCreated = cryptoAssets.size,
+            totalAccounts = accounts.totalAccounts,
+        )
+
+    // Step 3: people, accounts, ownerships.
+    progressFlow.emit(baseProgress.copy(currentOperation = "Preparing accounts..."))
+
+    val peopleIntents = buildPeopleIntents(sampleSource)
+    val accountIntents = accounts.intents(random, categoryIds, sampleSource)
+    val ownershipIntents = buildOwnershipIntents(accounts.allKeys, peopleIntents, random, sampleSource)
+
+    // Step 4: attribute types (no engine creation path; resolved up front like real importers do).
+    progressFlow.emit(baseProgress.copy(currentOperation = "Creating attribute types..."))
+    val attributeTypeIdsByName = importEngine.getOrCreateAttributeTypes(ATTRIBUTE_TYPE_NAMES)
+    val attributeTypeIds = ATTRIBUTE_TYPE_NAMES.map { attributeTypeIdsByName.getValue(it) }
+
+    // Step 5: transfers.
+    val transactionCounts = List(size.accountCount) { size.transactionCount(it, random) }
+    val totalExpectedTransactions =
+        transactionCounts.sum() + size.cryptoTransferCount + size.passThroughCount + size.conversionPairCount * 3
+    progressFlow.emit(
+        baseProgress.copy(
+            totalTransactions = totalExpectedTransactions,
+            currentOperation = "Generating transactions...",
+        ),
+    )
+
+    val transfers =
+        TransferBuilder(
+            random = random,
+            size = size,
+            accounts = accounts,
+            currencies = currencies,
+            cryptoAssets = cryptoAssets,
+            attributeTypeIds = attributeTypeIds,
+            source = sampleSource,
+        ).build(transactionCounts)
+
+    // Step 6: hand the whole batch to the import engine — the single writer for accounts, people,
+    // ownerships and transfers. No deduplication: every generated transfer is imported.
+    val result =
+        importEngine.import(
+            batch =
+                ImportBatch(
+                    transfers = transfers,
+                    dedupePolicy = DedupePolicy.None,
+                    accountsToCreate = accountIntents,
+                    peopleToCreate = peopleIntents,
+                    ownerships = ownershipIntents,
+                    relationshipTypeNames = listOf(CONVERSION_RELATIONSHIP_TYPE_NAME),
+                ),
+            onProgress = { progress ->
+                val processed = progress.processed
+                progressFlow.emit(
+                    baseProgress.copy(
+                        // Accounts are created before the transfer-write phase, so by the time the engine
+                        // reports processed counts every account exists.
+                        accountsCreated = if (processed != null) accounts.totalAccounts else 0,
+                        transactionsCreated = processed ?: 0,
+                        totalTransactions = progress.total ?: totalExpectedTransactions,
+                        currentOperation =
+                            if (processed != null) {
+                                "Created $processed/${progress.total} transactions..."
+                            } else {
+                                progress.detail
+                            },
+                    ),
+                )
+            },
+            batchSize = SAMPLE_IMPORT_BATCH_SIZE,
+        )
+
+    val transfersProgress =
+        baseProgress.copy(
+            accountsCreated = accounts.totalAccounts,
+            transactionsCreated = result.transfersImported,
+            totalTransactions = totalExpectedTransactions,
+        )
+
+    // Step 7: trades and orders. Both reference real account ids, so they can only be built once the
+    // accounts of the previous batch exist.
+    val exchangeAccountIds = accounts.exchangeKeys.map { result.createdAccountIds.getValue(it) }
+    val (trades, orders) = buildTradesAndOrders(random, size, exchangeAccountIds, currencies, cryptoAssets, sampleSource)
+
+    val tradesProgress = transfersProgress.copy(totalTrades = trades.size, totalOrders = orders.size)
+    progressFlow.emit(tradesProgress.copy(currentOperation = "Creating trades and orders..."))
+
+    // Imported a chunk of orders at a time (each with its own fills, which an order must be batched
+    // with) so this phase reports progress instead of leaving the dialog pinned while it runs.
+    val tradesByKey = trades.associateBy { it.key }
+    var tradesCreated = 0
+    var ordersCreated = 0
+    for (orderChunk in orders.chunked(ORDER_IMPORT_CHUNK_SIZE)) {
+        val chunkTrades = orderChunk.flatMap { order -> order.tradeKeys.map { tradesByKey.getValue(it) } }
+        importEngine.import(ImportBatch(trades = chunkTrades, orders = orderChunk))
+        tradesCreated += chunkTrades.size
+        ordersCreated += orderChunk.size
+        progressFlow.emit(
+            tradesProgress.copy(
+                tradesCreated = tradesCreated,
+                ordersCreated = ordersCreated,
+                currentOperation = "Created $ordersCreated/${orders.size} orders with $tradesCreated/${trades.size} fills...",
+            ),
+        )
+    }
+
+    val refreshProgress =
+        tradesProgress.copy(
+            tradesCreated = trades.size,
+            ordersCreated = orders.size,
+        )
+    progressFlow.emit(refreshProgress.copy(currentOperation = "Refreshing balances (this takes a moment)..."))
+    maintenance.refreshMaterializedViews()
+
+    progressFlow.emit(refreshProgress.copy(refreshed = true, currentOperation = "Sample data generation complete!"))
+}
+
+/**
+ * A random amount between [minMajor] and [maxMajor] major units, built directly in the asset's own
+ * minor units so it is exact for every scale factor — 1 (JPY), 100 (USD), 1000 (BHD) and 10^18
+ * (crypto). Constructing a fixed 2-decimal [com.moneymanager.bigdecimal.BigDecimal] and converting it
+ * would throw "Rounding necessary" on a zero-decimal currency.
+ */
+internal fun randomMoney(
+    random: Random,
+    asset: Asset,
+    minMajor: Long,
+    maxMajor: Long,
+): Money {
+    val major = random.nextLong(minMajor, maxMajor + 1)
+    // Zero-decimal assets have no minor part; everything else gets a random fraction, which for crypto
+    // means a full 18 significant decimals.
+    val fraction = if (asset.scaleFactor > 1) random.nextLong(1, asset.scaleFactor) else 0L
+    val minorUnits = BigInteger(major) * BigInteger(asset.scaleFactor) + BigInteger(fraction)
+    return Money(minorUnits, asset)
+}
+
+private suspend fun selectCurrencies(currencyRepository: CurrencyReadRepository): List<Currency> {
     val allCurrencies = currencyRepository.getAllCurrencies().first()
     check(allCurrencies.isNotEmpty()) { "No currencies found in database. Please create currencies first." }
 
-    // Pick 10-20 popular currencies (or all if less than 20)
+    // Deliberately spans 0-decimal (JPY, KRW), 2-decimal and 3-decimal (BHD, KWD) currencies so the
+    // generated data exercises every scale factor.
     val popularCurrencyCodes =
         listOf(
             "USD",
@@ -82,105 +336,429 @@ suspend fun generateSampleData(
             "NOK",
             "DKK",
             "PLN",
-            "THB",
-            "ZAR",
+            "BHD",
+            "KWD",
         )
-
-    val selectedCurrencies =
+    val selected =
         allCurrencies
-            .filter { currency ->
-                popularCurrencyCodes.contains(currency.code)
-            }.take(20)
+            .filter { it.code in popularCurrencyCodes }
             .ifEmpty { allCurrencies.take(20) }
 
-    check(selectedCurrencies.isNotEmpty()) { "No currencies available for sample data generation." }
+    check(selected.isNotEmpty()) { "No currencies available for sample data generation." }
+    return selected
+}
 
-    // Step 2: Generate and create categories with hierarchical structure. Categories have no import-engine
-    // creation path, so they are created directly and then referenced by id from the account intents.
-    progressFlow.emit(GenerationProgress(currentOperation = "Generating categories..."))
-
-    val categoryHierarchy = generateCategoryHierarchy()
-    val totalCategories = categoryHierarchy.sumOf { 1 + it.children.size }
-
-    progressFlow.emit(
-        GenerationProgress(
-            totalCategories = totalCategories,
-            currentOperation = "Creating $totalCategories categories...",
-        ),
-    )
-
-    val categoryIds = mutableListOf<Long>()
-    var categoriesCreated = 0
-
-    for (parent in categoryHierarchy) {
-        val parentKey = LocalCategoryKey("parent")
-        val parentId =
-            importEngine
-                .import(
-                    ImportBatch.manualEdits(
-                        categories =
-                            listOf(
-                                ImportCategoryIntent(
-                                    key = parentKey,
-                                    source = sampleSource,
-                                    name = parent.category.name,
-                                    parentId = parent.category.parentId,
-                                ),
-                            ),
-                    ),
-                ).createdCategoryIds
-                .getValue(parentKey)
-        categoryIds.add(parentId)
-        categoriesCreated++
-
-        progressFlow.emit(
-            GenerationProgress(
-                categoriesCreated = categoriesCreated,
-                totalCategories = totalCategories,
-                currentOperation = "Creating categories...",
+private suspend fun createCategories(
+    importEngine: ImportEngine,
+    hierarchy: List<CategoryWithChildren>,
+    source: Source,
+): List<Long> {
+    val parentKeys = hierarchy.indices.map { LocalCategoryKey("category-parent-$it") }
+    val parentResult =
+        importEngine.import(
+            ImportBatch.manualEdits(
+                categories =
+                    hierarchy.mapIndexed { index, parent ->
+                        ImportCategoryIntent(key = parentKeys[index], source = source, name = parent.category.name)
+                    },
             ),
         )
+    val parentIds = parentKeys.map { parentResult.createdCategoryIds.getValue(it) }
 
-        for (child in parent.children) {
-            val childKey = LocalCategoryKey("child")
-            val childId =
-                importEngine
-                    .import(
-                        ImportBatch.manualEdits(
-                            categories =
-                                listOf(
-                                    ImportCategoryIntent(
-                                        key = childKey,
-                                        source = sampleSource,
-                                        name = child.name,
-                                        parentId = parentId,
-                                    ),
-                                ),
-                        ),
-                    ).createdCategoryIds
-                    .getValue(childKey)
-            categoryIds.add(childId)
-            categoriesCreated++
+    val childIntents =
+        hierarchy.flatMapIndexed { parentIndex, parent ->
+            parent.children.mapIndexed { childIndex, child ->
+                ImportCategoryIntent(
+                    key = LocalCategoryKey("category-child-$parentIndex-$childIndex"),
+                    source = source,
+                    name = child.name,
+                    parentId = parentIds[parentIndex],
+                )
+            }
+        }
+    val childResult = importEngine.import(ImportBatch.manualEdits(categories = childIntents))
 
-            progressFlow.emit(
-                GenerationProgress(
-                    categoriesCreated = categoriesCreated,
-                    totalCategories = totalCategories,
-                    currentOperation = "Creating categories...",
-                ),
+    return parentIds + childIntents.map { childResult.createdCategoryIds.getValue(it.key) }
+}
+
+private suspend fun createCryptoAssets(
+    importEngine: ImportEngine,
+    source: Source,
+): List<CryptoAsset> {
+    val intents =
+        CRYPTO_ASSETS.map { (code, name) ->
+            ImportCryptoIntent(key = LocalCryptoKey("crypto-$code"), source = source, code = code, name = name)
+        }
+    val result = importEngine.import(ImportBatch(cryptoAssets = intents))
+    return intents.mapIndexed { index, intent ->
+        val (code, name) = CRYPTO_ASSETS[index]
+        CryptoAsset(id = result.createdCryptoIds.getValue(intent.key), code = code, name = name)
+    }
+}
+
+/** The accounts of the batch: the generic ones plus the named ones each feature needs. */
+private class AccountPlan(
+    size: SampleDataSize,
+) {
+    val genericNames = generateAccountNames(size.accountCount)
+    val genericKeys = genericNames.indices.map { LocalAccountKey("acct-$it") }
+    val exchangeKeys = EXCHANGE_ACCOUNT_NAMES.indices.map { LocalAccountKey("exchange-$it") }
+    val walletKeys = WALLET_ACCOUNT_NAMES.indices.map { LocalAccountKey("wallet-$it") }
+    val conduitKeys = CONDUIT_ACCOUNT_NAMES.indices.map { LocalAccountKey("conduit-$it") }
+    val merchantKeys = MERCHANT_ACCOUNT_NAMES.indices.map { LocalAccountKey("merchant-$it") }
+    val conversionKey = LocalAccountKey("conversion")
+    val feeKey = LocalAccountKey("fees")
+
+    private val namesByKey: Map<LocalAccountKey, String> =
+        buildMap {
+            genericKeys.forEachIndexed { index, key -> put(key, genericNames[index]) }
+            exchangeKeys.forEachIndexed { index, key -> put(key, EXCHANGE_ACCOUNT_NAMES[index]) }
+            walletKeys.forEachIndexed { index, key -> put(key, WALLET_ACCOUNT_NAMES[index]) }
+            conduitKeys.forEachIndexed { index, key -> put(key, CONDUIT_ACCOUNT_NAMES[index]) }
+            merchantKeys.forEachIndexed { index, key -> put(key, MERCHANT_ACCOUNT_NAMES[index]) }
+            put(conversionKey, CONVERSION_ACCOUNT_NAME)
+            put(feeKey, FEE_ACCOUNT_NAME)
+        }
+
+    val allKeys: List<LocalAccountKey> = namesByKey.keys.toList()
+    val totalAccounts: Int get() = allKeys.size
+
+    fun intents(
+        random: Random,
+        categoryIds: List<Long>,
+        source: Source,
+    ): List<ImportAccountIntent> {
+        val now = Clock.System.now()
+        return allKeys.map { key ->
+            ImportAccountIntent(
+                key = key,
+                // The generator always creates fresh accounts; it never reuses existing ones.
+                match = AccountMatchKey.AlwaysCreate,
+                name = namesByKey.getValue(key),
+                openingDate = now.minus(random.nextInt(1, 3650).days),
+                source = source,
+                categoryId = categoryIds.random(random),
             )
         }
     }
+}
 
-    val baseProgress =
-        GenerationProgress(
-            categoriesCreated = categoriesCreated,
-            totalCategories = totalCategories,
+private class TransferBuilder(
+    private val random: Random,
+    private val size: SampleDataSize,
+    private val accounts: AccountPlan,
+    private val currencies: List<Currency>,
+    private val cryptoAssets: List<CryptoAsset>,
+    private val attributeTypeIds: List<AttributeTypeId>,
+    private val source: Source,
+) {
+    private val startDate = Instant.parse("2015-01-01T00:00:00Z")
+    private val endDate = Instant.parse("2025-12-31T23:59:59Z")
+    private val dateRangeMillis = endDate.toEpochMilliseconds() - startDate.toEpochMilliseconds()
+    private var rowIndex = 0L
+
+    fun build(transactionCounts: List<Int>): List<ImportTransfer> =
+        buildList {
+            addAll(plainTransfers(transactionCounts))
+            addAll(cryptoTransfers())
+            addAll(passThroughTransfers())
+            addAll(conversionTransfers())
+        }
+
+    /** Row keys deliberately alternate across the three producer kinds so provenance covers each. */
+    private fun nextRowKey(): ImportRowKey {
+        val index = rowIndex++
+        return when (index % 3) {
+            0L -> ImportRowKey.CsvRow(index)
+            1L -> ImportRowKey.QifRecord(index)
+            else -> ImportRowKey.Manual(index)
+        }
+    }
+
+    private fun randomTimestamp(): Instant =
+        Instant.fromEpochMilliseconds(startDate.toEpochMilliseconds() + random.nextLong(dateRangeMillis))
+
+    private fun randomAttributes(): List<NewAttribute> =
+        if (random.nextBoolean()) {
+            attributeTypeIds.shuffled(random).take(random.nextInt(1, 4)).map { typeId ->
+                NewAttribute(typeId, generateAttributeValue(random))
+            }
+        } else {
+            emptyList()
+        }
+
+    private fun plainTransfers(transactionCounts: List<Int>): List<ImportTransfer> {
+        val keys = accounts.genericKeys
+        val transfers = ArrayList<ImportTransfer>(transactionCounts.sum())
+        for (accountIndex in keys.indices) {
+            repeat(transactionCounts[accountIndex]) { transferIndex ->
+                var targetIndex = random.nextInt(keys.size - 1)
+                if (targetIndex >= accountIndex) targetIndex++
+
+                val currency = currencies.random(random)
+                val amount = randomMoney(random, currency, 1, 10_000)
+                val rowKey = nextRowKey()
+
+                transfers.add(
+                    ImportTransfer(
+                        rowKey = rowKey,
+                        fromAccount = AccountRef.Local(keys[accountIndex]),
+                        toAccount = AccountRef.Local(keys[targetIndex]),
+                        source = source,
+                        timestamp = randomTimestamp(),
+                        description = generateTransactionDescription(random),
+                        amount = amount,
+                        attributes = randomAttributes(),
+                        // A slice of rows carries a bank fee, an importer-style unique key, or is kept
+                        // out of balances — the corner cases the transactions UI has to render.
+                        fee =
+                            if (transferIndex % 17 == 0) {
+                                ImportFee(
+                                    source = AccountRef.Local(keys[accountIndex]),
+                                    target = AccountRef.Local(accounts.feeKey),
+                                    amount = randomMoney(random, currency, 1, 5),
+                                    description = "Transaction fee",
+                                    relationshipTypeId = RelationshipTypeId(WellKnownIds.FEE_RELATIONSHIP_TYPE_ID),
+                                    rowKey = rowKey,
+                                )
+                            } else {
+                                null
+                            },
+                        uniqueKey =
+                            if (transferIndex % 11 == 0) {
+                                mapOf("Transaction Code" to "TXN-$accountIndex-$transferIndex")
+                            } else {
+                                null
+                            },
+                        excludedFromBalances = transferIndex % 23 == 0,
+                    ),
+                )
+            }
+        }
+        return transfers
+    }
+
+    /** Crypto moves between an exchange account and a wallet, denominated in a crypto asset. */
+    private fun cryptoTransfers(): List<ImportTransfer> =
+        List(size.cryptoTransferCount) {
+            val exchange = accounts.exchangeKeys.random(random)
+            val wallet = accounts.walletKeys.random(random)
+            val asset = cryptoAssets.random(random)
+            val withdrawal = random.nextBoolean()
+            ImportTransfer(
+                rowKey = nextRowKey(),
+                fromAccount = AccountRef.Local(if (withdrawal) exchange else wallet),
+                toAccount = AccountRef.Local(if (withdrawal) wallet else exchange),
+                source = source,
+                timestamp = randomTimestamp(),
+                description = if (withdrawal) "Withdraw ${asset.code}" else "Deposit ${asset.code}",
+                amount = randomMoney(random, asset, 0, 2),
+                attributes = randomAttributes(),
+            )
+        }
+
+    /**
+     * Charges routed through conduit accounts: a single-hop chain (card → Curve → merchant), a
+     * multi-hop one (card → Curve → PayPal → merchant) and refunds coming back the other way.
+     */
+    private fun passThroughTransfers(): List<ImportTransfer> =
+        List(size.passThroughCount) { index ->
+            val card = accounts.genericKeys.random(random)
+            val merchant = accounts.merchantKeys.random(random)
+            val multiHop = index % 3 == 0
+            val incoming = index % 5 == 0
+            val conduits = if (multiHop) accounts.conduitKeys else listOf(accounts.conduitKeys.first())
+            val currency = currencies.random(random)
+            val amount = randomMoney(random, currency, 1, 500)
+            val rowKey = nextRowKey()
+            val merchantName = MERCHANT_ACCOUNT_NAMES[accounts.merchantKeys.indexOf(merchant)]
+
+            ImportTransfer(
+                rowKey = rowKey,
+                // The funding leg: card → first conduit, or first conduit → card for a refund.
+                fromAccount = AccountRef.Local(if (incoming) conduits.first() else card),
+                toAccount = AccountRef.Local(if (incoming) card else conduits.first()),
+                source = source,
+                timestamp = randomTimestamp(),
+                description = if (incoming) "Refund from $merchantName" else "Card payment to $merchantName",
+                amount = amount,
+                passThrough =
+                    ImportPassThrough(
+                        conduits = conduits.map { AccountRef.Local(it) },
+                        merchantTarget = AccountRef.Local(merchant),
+                        amount = amount,
+                        spendDescriptions = conduits.indices.map { merchantName },
+                        relationshipTypeId = RelationshipTypeId(WellKnownIds.PASS_THROUGH_RELATIONSHIP_TYPE_ID),
+                        rowKey = rowKey,
+                        incoming = incoming,
+                    ),
+            )
+        }
+
+    /**
+     * A conversion (e.g. a crypto.com wallet swap): several debits into a shared conversion account
+     * and one credit out of it, linked by an in-batch `conversion` relationship.
+     */
+    private fun conversionTransfers(): List<ImportTransfer> =
+        List(size.conversionPairCount) {
+            val wallet = accounts.exchangeKeys.random(random)
+            val timestamp = randomTimestamp()
+            val debitAssets = cryptoAssets.shuffled(random).take(2)
+            val creditAsset = cryptoAssets.random(random)
+
+            val debits =
+                debitAssets.map { asset ->
+                    ImportTransfer(
+                        rowKey = nextRowKey(),
+                        fromAccount = AccountRef.Local(wallet),
+                        toAccount = AccountRef.Local(accounts.conversionKey),
+                        source = source,
+                        timestamp = timestamp,
+                        description = "Convert ${asset.code}",
+                        amount = randomMoney(random, asset, 0, 1),
+                    )
+                }
+            val credit =
+                ImportTransfer(
+                    rowKey = nextRowKey(),
+                    fromAccount = AccountRef.Local(accounts.conversionKey),
+                    toAccount = AccountRef.Local(wallet),
+                    source = source,
+                    timestamp = timestamp,
+                    description = "Converted to ${creditAsset.code}",
+                    amount = randomMoney(random, creditAsset, 0, 1),
+                    batchRelationships =
+                        debits.map { debit ->
+                            BatchRelationship(
+                                relatedRowKey = requireNotNull(debit.rowKey),
+                                typeName = CONVERSION_RELATIONSHIP_TYPE_NAME,
+                            )
+                        },
+                )
+            debits + credit
+        }.flatten()
+}
+
+/**
+ * Trades (the fills) and the exchange orders they belong to. Orders cover every shape the Orders UI
+ * has to render: fully filled from several fills, partially filled, and unfilled (ACTIVE/CANCELED).
+ */
+private fun buildTradesAndOrders(
+    random: Random,
+    size: SampleDataSize,
+    exchangeAccountIds: List<AccountId>,
+    currencies: List<Currency>,
+    cryptoAssets: List<CryptoAsset>,
+    source: Source,
+): Pair<List<ImportTradeIntent>, List<ImportOrderIntent>> {
+    val quoteCurrency = currencies.firstOrNull { it.code == "USD" } ?: currencies.first()
+    val startDate = Instant.parse("2020-01-01T00:00:00Z")
+    val rangeMillis = Instant.parse("2025-12-31T00:00:00Z").toEpochMilliseconds() - startDate.toEpochMilliseconds()
+
+    val trades = ArrayList<ImportTradeIntent>(size.tradeCount)
+    val orders = ArrayList<ImportOrderIntent>()
+
+    var tradeIndex = 0
+    var orderIndex = 0
+    while (tradeIndex < size.tradeCount) {
+        val accountId = exchangeAccountIds.random(random)
+        val asset = cryptoAssets.random(random)
+        val createdAt = Instant.fromEpochMilliseconds(startDate.toEpochMilliseconds() + random.nextLong(rangeMillis))
+        val buy = random.nextBoolean()
+        val fillCount = minOf(random.nextInt(1, 4), size.tradeCount - tradeIndex)
+
+        val fillKeys =
+            List(fillCount) { fill ->
+                val key = LocalTradeKey("trade-${tradeIndex++}")
+                val cryptoLeg = randomMoney(random, asset, 0, 2)
+                val fiatLeg = randomMoney(random, quoteCurrency, 10, 5_000)
+                trades.add(
+                    ImportTradeIntent(
+                        key = key,
+                        source = source,
+                        timestamp = createdAt.plus((fill + 1).minutes),
+                        description =
+                            if (buy) {
+                                "Buy ${asset.code} fill ${fill + 1}"
+                            } else {
+                                "Sell ${asset.code} fill ${fill + 1}"
+                            },
+                        fromAccountId = accountId,
+                        toAccountId = accountId,
+                        fromAmount = if (buy) fiatLeg else cryptoLeg,
+                        toAmount = if (buy) cryptoLeg else fiatLeg,
+                    ),
+                )
+                key
+            }
+
+        val limit = orderIndex % 2 == 0
+        val partial = orderIndex % 5 == 0
+        orders.add(
+            ImportOrderIntent(
+                key = LocalOrderKey("order-$orderIndex"),
+                source = source,
+                accountId = accountId,
+                orderRef = "SAMPLE-ORDER-$orderIndex",
+                // Some venues report no client id; keep both shapes in the data.
+                clientOid = if (orderIndex % 3 == 0) null else "client-oid-$orderIndex",
+                side = if (buy) "BUY" else "SELL",
+                orderType = if (limit) "LIMIT" else "MARKET",
+                timeInForce = if (limit) "GOOD_TILL_CANCEL" else null,
+                status = if (partial) "PARTIALLY_FILLED" else "FILLED",
+                limitPrice = if (limit) randomPrice(random) else null,
+                quantity = randomPrice(random),
+                avgPrice = randomPrice(random),
+                createdAt = createdAt,
+                updatedAt = createdAt.plus((fillCount + 1).minutes),
+                tradeKeys = fillKeys,
+            ),
         )
+        orderIndex++
+    }
 
-    // Step 3: People intents
-    progressFlow.emit(baseProgress.copy(currentOperation = "Preparing people..."))
+    // Orders that never filled: no linked trades, no average price.
+    repeat(size.standaloneOrderCount) { index ->
+        val createdAt = Instant.fromEpochMilliseconds(startDate.toEpochMilliseconds() + random.nextLong(rangeMillis))
+        orders.add(
+            ImportOrderIntent(
+                key = LocalOrderKey("order-$orderIndex"),
+                source = source,
+                accountId = exchangeAccountIds.random(random),
+                orderRef = "SAMPLE-ORDER-$orderIndex",
+                clientOid = null,
+                side = if (index % 2 == 0) "BUY" else "SELL",
+                orderType = "LIMIT",
+                timeInForce = "FILL_OR_KILL",
+                status = if (index % 2 == 0) "ACTIVE" else "CANCELED",
+                limitPrice = randomPrice(random),
+                quantity = randomPrice(random),
+                avgPrice = null,
+                createdAt = createdAt,
+                updatedAt = null,
+            ),
+        )
+        orderIndex++
+    }
 
+    return trades to orders
+}
+
+private fun randomPrice(random: Random): String = "${random.nextInt(1, 60_000)}.${random.nextInt(10, 99)}"
+
+private val ATTRIBUTE_TYPE_NAMES =
+    listOf(
+        "Reference Number",
+        "Merchant ID",
+        "Order ID",
+        "Invoice Number",
+        "Receipt Number",
+        "Confirmation Code",
+        "Transaction Code",
+        "Check Number",
+    )
+
+private fun buildPeopleIntents(source: Source): List<ImportPersonIntent> {
     val peopleNames =
         listOf(
             Triple("John", "Michael", "Doe"),
@@ -195,196 +773,38 @@ suspend fun generateSampleData(
             Triple("Henry", "David", "Ford"),
         )
 
-    val peopleIntents =
-        peopleNames.mapIndexed { index, (firstName, middleName, lastName) ->
-            val fullName = listOfNotNull(firstName, middleName, lastName).joinToString(" ")
-            ImportPersonIntent(
-                key = LocalPersonKey("person-$index"),
-                match = PersonMatchKey.ByNameKey(normalizeNameKey(fullName)),
-                firstName = firstName,
-                middleName = middleName,
-                lastName = lastName,
-                source = sampleSource,
-            )
-        }
-
-    // Step 4: Account intents with category assignments
-    progressFlow.emit(baseProgress.copy(currentOperation = "Preparing accounts..."))
-
-    val now = Clock.System.now()
-    val accountNames = generateAccountNames()
-    val accountKeys = List(accountNames.size) { LocalAccountKey("acct-$it") }
-    val accountIntents =
-        accountNames.mapIndexed { index, name ->
-            ImportAccountIntent(
-                key = accountKeys[index],
-                // The generator always creates fresh accounts; it never reuses existing ones.
-                match = AccountMatchKey.AlwaysCreate,
-                name = name,
-                openingDate = now.minus(random.nextInt(1, 3650).days),
-                source = sampleSource,
-                categoryId = categoryIds.random(random),
-            )
-        }
-
-    // Step 5: Ownership intents — most accounts have one owner, some are joint (two owners).
-    val ownershipIntents =
-        accountKeys.flatMap { accountKey ->
-            val ownerCount = if (random.nextDouble() < 0.15) 2 else 1
-            peopleIntents.shuffled(random).take(ownerCount).map { person ->
-                ImportOwnershipIntent(
-                    personKey = person.key,
-                    account = AccountRef.Local(accountKey),
-                    source = sampleSource,
-                )
-            }
-        }
-
-    // Step 6: Attribute types (no engine creation path; resolved up front like real importers do).
-    progressFlow.emit(baseProgress.copy(currentOperation = "Creating attribute types..."))
-
-    val attributeTypeNames =
-        listOf(
-            "Reference Number",
-            "Merchant ID",
-            "Order ID",
-            "Invoice Number",
-            "Receipt Number",
-            "Confirmation Code",
-            "Transaction Code",
-            "Check Number",
+    return peopleNames.mapIndexed { index, (firstName, middleName, lastName) ->
+        val fullName = listOfNotNull(firstName, middleName, lastName).joinToString(" ")
+        ImportPersonIntent(
+            key = LocalPersonKey("person-$index"),
+            match = PersonMatchKey.ByNameKey(normalizeNameKey(fullName)),
+            firstName = firstName,
+            middleName = middleName,
+            lastName = lastName,
+            source = source,
         )
+    }
+}
 
-    val attributeTypeIdsByName = importEngine.getOrCreateAttributeTypes(attributeTypeNames)
-    val attributeTypeIds = attributeTypeNames.map { attributeTypeIdsByName.getValue(it) }
-
-    // Step 7: Determine transaction counts per account (variable distribution)
-    val transactionCounts =
-        List(ACCOUNT_COUNT) { i ->
-            when {
-                i < 20 -> random.nextInt(5000, 10001) // 20% get 5000-10000 transactions
-                i < 70 -> random.nextInt(1000, 3001) // 50% get 1000-3000 transactions
-                else -> random.nextInt(100, 501) // 30% get 100-500 transactions
-            }
-        }
-    val totalExpectedTransactions = transactionCounts.sum()
-
-    progressFlow.emit(
-        baseProgress.copy(
-            totalTransactions = totalExpectedTransactions,
-            currentOperation = "Generating transactions with attributes...",
-        ),
-    )
-
-    // Step 8: Generate transfers referencing batch-local accounts.
-    val startDate = Instant.parse("2015-01-01T00:00:00Z")
-    val endDate = Instant.parse("2025-12-31T23:59:59Z")
-    val dateRangeMillis = endDate.toEpochMilliseconds() - startDate.toEpochMilliseconds()
-
-    val transfers = ArrayList<ImportTransfer>(totalExpectedTransactions)
-    var rowIndex = 0L
-    for (accountIndex in accountKeys.indices) {
-        val transactionCount = transactionCounts[accountIndex]
-        repeat(transactionCount) {
-            // Random timestamp between 2015-2025
-            val randomMillis = random.nextLong(dateRangeMillis)
-            val timestamp = Instant.fromEpochMilliseconds(startDate.toEpochMilliseconds() + randomMillis)
-
-            // Random target account (different from source)
-            var targetIndex = random.nextInt(accountKeys.size - 1)
-            if (targetIndex >= accountIndex) targetIndex++
-
-            // Random currency
-            val currency = selectedCurrencies.random(random)
-
-            // Random amount (1-10000 with 2 decimal places)
-            val amountCents = random.nextInt(100, 1000001)
-            val amount = BigDecimal("${amountCents / 100}.${(amountCents % 100).toString().padStart(2, '0')}")
-
-            // 50% of transactions get 1-3 attributes
-            val attributes: List<NewAttribute> =
-                if (random.nextBoolean()) {
-                    val numAttributes = random.nextInt(1, 4) // 1-3 attributes
-                    attributeTypeIds.shuffled(random).take(numAttributes).map { typeId ->
-                        NewAttribute(typeId, generateAttributeValue(random))
-                    }
-                } else {
-                    emptyList()
-                }
-
-            transfers.add(
-                ImportTransfer(
-                    rowKey = ImportRowKey.CsvRow(rowIndex++),
-                    fromAccount = AccountRef.Local(accountKeys[accountIndex]),
-                    toAccount = AccountRef.Local(accountKeys[targetIndex]),
-                    source = sampleSource,
-                    timestamp = timestamp,
-                    description = generateTransactionDescription(random),
-                    amount = Money.fromDisplayValue(amount, currency),
-                    attributes = attributes,
-                ),
+/** Most accounts have one owner; some are joint (two owners). */
+private fun buildOwnershipIntents(
+    accountKeys: List<LocalAccountKey>,
+    people: List<ImportPersonIntent>,
+    random: Random,
+    source: Source,
+): List<ImportOwnershipIntent> =
+    accountKeys.flatMap { accountKey ->
+        val ownerCount = if (random.nextDouble() < 0.15) 2 else 1
+        people.shuffled(random).take(ownerCount).map { person ->
+            ImportOwnershipIntent(
+                personKey = person.key,
+                account = AccountRef.Local(accountKey),
+                source = source,
             )
         }
     }
 
-    // Step 9: Hand the whole batch to the import engine — the single writer for accounts, people,
-    // ownerships and transfers. No deduplication: every generated transfer is imported.
-    val batch =
-        ImportBatch(
-            transfers = transfers,
-            dedupePolicy = DedupePolicy.None,
-            accountsToCreate = accountIntents,
-            peopleToCreate = peopleIntents,
-            ownerships = ownershipIntents,
-        )
-
-    importEngine.import(
-        batch = batch,
-        onProgress = { progress ->
-            val processed = progress.processed
-            progressFlow.emit(
-                baseProgress.copy(
-                    // Accounts are created before the transfer-write phase, so by the time the engine
-                    // reports processed counts every account exists.
-                    accountsCreated = if (processed != null) ACCOUNT_COUNT else baseProgress.accountsCreated,
-                    transactionsCreated = processed ?: 0,
-                    totalTransactions = progress.total ?: totalExpectedTransactions,
-                    currentOperation =
-                        if (processed != null) {
-                            "Created $processed/${progress.total} transactions..."
-                        } else {
-                            progress.detail
-                        },
-                ),
-            )
-        },
-        batchSize = SAMPLE_IMPORT_BATCH_SIZE,
-    )
-
-    // Refresh materialized views
-    progressFlow.emit(
-        baseProgress.copy(
-            accountsCreated = ACCOUNT_COUNT,
-            transactionsCreated = totalExpectedTransactions,
-            totalTransactions = totalExpectedTransactions,
-            currentOperation = "Refreshing materialized views...",
-        ),
-    )
-    maintenance.refreshMaterializedViews()
-
-    // Final progress update
-    progressFlow.emit(
-        baseProgress.copy(
-            accountsCreated = ACCOUNT_COUNT,
-            transactionsCreated = totalExpectedTransactions,
-            totalTransactions = totalExpectedTransactions,
-            currentOperation = "Sample data generation complete!",
-        ),
-    )
-}
-
-private fun generateAccountNames(): List<String> {
-    val count = ACCOUNT_COUNT
+private fun generateAccountNames(count: Int): List<String> {
     val prefixes =
         listOf(
             "Personal",
@@ -430,24 +850,18 @@ private fun generateAccountNames(): List<String> {
         )
 
     val names = mutableListOf<String>()
-
-    // Generate unique names
     var index = 0
     while (names.size < count) {
+        val prefix = prefixes.random()
+        val suffix = suffixes.random()
         if (index < count / 2) {
-            // First half: Prefix + Suffix
-            val prefix = prefixes.random()
-            val suffix = suffixes.random()
             val name = "$prefix $suffix"
             if (!names.contains(name)) {
                 names.add(name)
             }
         } else {
-            // Second half: Add numbers to ensure uniqueness
-            val prefix = prefixes.random()
-            val suffix = suffixes.random()
-            val number = (names.size / 10) + 1
-            names.add("$prefix $suffix $number")
+            // Second half: add numbers to ensure uniqueness
+            names.add("$prefix $suffix ${(names.size / 10) + 1}")
         }
         index++
     }
@@ -707,11 +1121,38 @@ private fun generateCategoryHierarchy(): List<CategoryWithChildren> =
     )
 
 data class GenerationProgress(
+    val size: SampleDataSize = SampleDataSize.LARGE,
     val accountsCreated: Int = 0,
-    val totalAccounts: Int = ACCOUNT_COUNT,
+    val totalAccounts: Int = 0,
     val categoriesCreated: Int = 0,
     val totalCategories: Int = 0,
+    val cryptoAssetsCreated: Int = 0,
     val transactionsCreated: Int = 0,
     val totalTransactions: Int = 0,
+    val tradesCreated: Int = 0,
+    val totalTrades: Int = 0,
+    val ordersCreated: Int = 0,
+    val totalOrders: Int = 0,
+    val refreshed: Boolean = false,
     val currentOperation: String = "Initializing...",
-)
+) {
+    /**
+     * Overall progress across all three write phases. Transfers dominate but do not finish the job —
+     * counting only them left the bar pinned at 100% while trades, orders and the balance refresh
+     * still ran. The weights are rough shares of observed wall-clock.
+     */
+    val fraction: Float
+        get() {
+            val transfers = if (totalTransactions > 0) transactionsCreated.toFloat() / totalTransactions else 0f
+            val tradesAndOrders =
+                if (totalTrades + totalOrders > 0) {
+                    (tradesCreated + ordersCreated).toFloat() / (totalTrades + totalOrders)
+                } else {
+                    0f
+                }
+            val refresh = if (refreshed) 1f else 0f
+            return transfers * TRANSFER_PHASE_WEIGHT +
+                tradesAndOrders * TRADE_ORDER_PHASE_WEIGHT +
+                refresh * REFRESH_PHASE_WEIGHT
+        }
+}

--- a/app/ui/foundation/src/commonTest/kotlin/com/moneymanager/ui/util/SampleDataGeneratorTest.kt
+++ b/app/ui/foundation/src/commonTest/kotlin/com/moneymanager/ui/util/SampleDataGeneratorTest.kt
@@ -1,0 +1,61 @@
+package com.moneymanager.ui.util
+
+import com.moneymanager.bigdecimal.BigInteger
+import com.moneymanager.domain.model.Asset
+import com.moneymanager.domain.model.CryptoAsset
+import com.moneymanager.domain.model.CryptoId
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.Money
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SampleDataGeneratorTest {
+    private val assets: List<Asset> =
+        listOf(
+            // 0-decimal fiat: the scale factor that used to make the generator throw "Rounding necessary".
+            Currency(id = CurrencyId(1), code = "JPY", name = "Japanese Yen", scaleFactor = 1),
+            Currency(id = CurrencyId(2), code = "USD", name = "US Dollar", scaleFactor = 100),
+            Currency(id = CurrencyId(3), code = "BHD", name = "Bahraini Dinar", scaleFactor = 1000),
+            CryptoAsset(id = CryptoId(1), code = "ETH", name = "Ethereum"),
+        )
+
+    @Test
+    fun randomMoneyRoundTripsExactlyForEveryScaleFactor() {
+        val random = Random(42)
+        for (asset in assets) {
+            repeat(500) {
+                val money = randomMoney(random, asset, 0, 10_000)
+                assertEquals(asset, money.asset)
+                // fromDisplayValue is what threw "Rounding necessary" on a 0-decimal currency; an exact
+                // round-trip proves the generated amount fits the asset's precision.
+                assertEquals(money, Money.fromDisplayValue(money.toDisplayValue(), asset))
+            }
+        }
+    }
+
+    @Test
+    fun randomMoneyOnZeroDecimalCurrencyHasNoFraction() {
+        val yen = assets.first { it.code == "JPY" }
+        val random = Random(7)
+        repeat(200) {
+            val displayValue = randomMoney(random, yen, 1, 5_000).toDisplayValue().toString()
+            assertTrue('.' !in displayValue, "JPY amount $displayValue must be whole")
+        }
+    }
+
+    @Test
+    fun randomMoneyIsAlwaysPositive() {
+        val random = Random(1)
+        val zero = BigInteger(0)
+        for (asset in assets) {
+            repeat(200) {
+                val minMajor = if (asset.scaleFactor > 1) 0L else 1L
+                val money = randomMoney(random, asset, minMajor, 3)
+                assertTrue(money.amount > zero, "${asset.code} amount ${money.amount} must be > 0")
+            }
+        }
+    }
+}

--- a/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/SettingsScreen.kt
+++ b/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/SettingsScreen.kt
@@ -639,11 +639,14 @@ fun SettingsScreen(
                                     size = sampleDataSize,
                                 )
 
+                                // The final counts come from the flow itself: the collector above feeds the
+                                // progress dialog and may not have delivered the last emission yet.
+                                val finalProgress = progressFlow.value
                                 successMessage = "Sample data generated successfully! " +
-                                    "Created ${generationProgress.accountsCreated} accounts, " +
-                                    "${generationProgress.transactionsCreated} transactions, " +
-                                    "${generationProgress.tradesCreated} trades and " +
-                                    "${generationProgress.ordersCreated} orders."
+                                    "Created ${finalProgress.accountsCreated} accounts, " +
+                                    "${finalProgress.transactionsCreated} transactions, " +
+                                    "${finalProgress.tradesCreated} trades and " +
+                                    "${finalProgress.ordersCreated} orders."
                                 showProgressDialog = false
                             } catch (expected: Exception) {
                                 errorMessage = "Failed to generate sample data: ${expected.message}"

--- a/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/SettingsScreen.kt
+++ b/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -19,6 +20,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -55,6 +57,7 @@ import com.moneymanager.ui.error.collectAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.rememberDatabaseLocationPicker
 import com.moneymanager.ui.util.GenerationProgress
+import com.moneymanager.ui.util.SampleDataSize
 import com.moneymanager.ui.util.generateSampleData
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
@@ -179,6 +182,7 @@ fun SettingsScreen(
     var showWarningDialog by remember { mutableStateOf(false) }
     var isGenerating by remember { mutableStateOf(false) }
     var showProgressDialog by remember { mutableStateOf(false) }
+    var sampleDataSize by remember { mutableStateOf(SampleDataSize.SMALL) }
     var generationProgress by remember { mutableStateOf(GenerationProgress()) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var successMessage by remember { mutableStateOf<String?>(null) }
@@ -583,10 +587,29 @@ fun SettingsScreen(
             onDismissRequest = { showWarningDialog = false },
             title = { Text("Generate Sample Data?") },
             text = {
-                Text(
-                    "This will create 100 accounts with thousands of transactions spanning 2015-2025. " +
-                        "This operation cannot be easily undone. Continue?",
-                )
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        "This creates accounts, people, categories, crypto assets, transactions " +
+                            "(including fees, pass-throughs and conversions), trades and exchange orders " +
+                            "spanning 2015-2025. This operation cannot be easily undone.",
+                    )
+                    SampleDataSize.entries.forEach { option ->
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier =
+                                Modifier.selectable(
+                                    selected = sampleDataSize == option,
+                                    onClick = { sampleDataSize = option },
+                                ),
+                        ) {
+                            RadioButton(
+                                selected = sampleDataSize == option,
+                                onClick = { sampleDataSize = option },
+                            )
+                            Text("${option.label} — ${option.accountCount} accounts")
+                        }
+                    }
+                }
             },
             confirmButton = {
                 TextButton(
@@ -613,11 +636,14 @@ fun SettingsScreen(
                                     importEngine = importEngine,
                                     maintenance = maintenance,
                                     progressFlow = progressFlow,
+                                    size = sampleDataSize,
                                 )
 
                                 successMessage = "Sample data generated successfully! " +
-                                    "Created ${generationProgress.accountsCreated} accounts and " +
-                                    "${generationProgress.transactionsCreated} transactions."
+                                    "Created ${generationProgress.accountsCreated} accounts, " +
+                                    "${generationProgress.transactionsCreated} transactions, " +
+                                    "${generationProgress.tradesCreated} trades and " +
+                                    "${generationProgress.ordersCreated} orders."
                                 showProgressDialog = false
                             } catch (expected: Exception) {
                                 errorMessage = "Failed to generate sample data: ${expected.message}"
@@ -655,35 +681,21 @@ fun SettingsScreen(
                     )
 
                     LinearProgressIndicator(
-                        progress = {
-                            val totalProgress = generationProgress.accountsCreated + generationProgress.transactionsCreated
-                            val totalExpected = generationProgress.totalAccounts + generationProgress.totalTransactions
-                            if (totalExpected > 0) {
-                                totalProgress.toFloat() / totalExpected.toFloat()
-                            } else {
-                                0f
-                            }
-                        },
+                        progress = { generationProgress.fraction },
                         modifier = Modifier.fillMaxWidth(),
                     )
 
                     Text(
                         text =
                             "Created ${generationProgress.accountsCreated}/${generationProgress.totalAccounts} accounts, " +
-                                "${generationProgress.transactionsCreated}/${generationProgress.totalTransactions} transactions",
+                                "${generationProgress.transactionsCreated}/${generationProgress.totalTransactions} transactions, " +
+                                "${generationProgress.tradesCreated}/${generationProgress.totalTrades} trades, " +
+                                "${generationProgress.ordersCreated}/${generationProgress.totalOrders} orders",
                         style = MaterialTheme.typography.bodySmall,
                     )
 
-                    val totalProgress = generationProgress.accountsCreated + generationProgress.transactionsCreated
-                    val totalExpected = generationProgress.totalAccounts + generationProgress.totalTransactions
-                    val percentage =
-                        if (totalExpected > 0) {
-                            (totalProgress.toFloat() / totalExpected.toFloat() * 100).toInt()
-                        } else {
-                            0
-                        }
                     Text(
-                        text = "$percentage% complete",
+                        text = "${(generationProgress.fraction * 100).toInt()}% complete",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.primary,
                     )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -187,6 +187,7 @@ sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", ver
 sqldelight-coroutines-extensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 sqldelight-dialect-sqlite = { module = "app.cash.sqldelight:sqlite-3-25-dialect", version.ref = "sqldelight" }
 sqldelight-gradle-plugin = { module = "app.cash.sqldelight:gradle-plugin", version.ref = "sqldelight" }
+sqldelight-jdbc-driver = { module = "app.cash.sqldelight:jdbc-driver", version.ref = "sqldelight" }
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }
 sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }


### PR DESCRIPTION
## Why

**Generate Sample Data was broken.** It failed with a red `Failed to generate sample data: Rounding necessary` and wrote nothing at all. Amounts were always built with 2 decimal places (`BigDecimal("123.45")`) while the currency was drawn at random from a list containing **JPY and KRW**, whose scale factor is `1`. `Money.fromDisplayValue` multiplies by the scale factor and calls `toBigIntegerExact()`, which throws on `123.45 × 1` — and since the whole transfer list is built before `importEngine.import` runs, the first zero-decimal draw killed the run before any write.

**The generator had also fallen behind the domain**, producing only categories, people, accounts, ownerships and plain transfers. Everything added since — crypto, trades, exchange orders, fees, pass-throughs, conversions — was never exercised.

**Imports were slower than they needed to be.** Profiling (JFR) showed SQLite spending ~1.6× as long *compiling* statements as executing them.

## What

**Rounding fix.** Amounts are now generated directly in the asset's own minor units (`randomMoney`), exact for every scale factor — 1 (JPY), 100 (USD), 1000 (BHD), 10^18 (crypto). Zero-decimal currencies deliberately stay in the sample set: they are now regression coverage rather than a landmine. `SampleDataGeneratorTest` pins this with a round-trip assertion across all four scale factors.

**Full-surface sample data.** The generator now drives (nearly) the whole `ImportBatch` surface:
- 9 crypto assets, with exchange/wallet accounts and crypto-denominated transfers at full 18-decimal precision
- trades (fiat↔crypto fills) and exchange orders — fully filled from several fills, partially filled, and unfilled (ACTIVE/CANCELED with no trades), across MARKET/LIMIT, BUY/SELL, with and without `clientOid`/`limitPrice`/`avgPrice`
- fee-bearing transfers, pass-through chains (single-hop, multi-hop card→Curve→PayPal→merchant, and `incoming` refunds), conversion pairs linked by in-batch `conversion` relationships, excluded-from-balances rows, unique-keyed rows, and row keys spanning CSV/QIF/Manual provenance

**Volume is a choice** (Small / Large) in the Generate dialog, and progress now reports all three write phases — transfers, trades/orders, and the balance refresh — instead of pinning the bar at 100% while the last two still ran.

**`CachingJdbcSqliteDriver` (JVM).** SQLDelight's `JdbcDriver` calls `connection.prepareStatement(sql)` on every execute and closes it, ignoring the `identifier` it is handed for exactly this purpose (its Android driver *does* cache). The new driver keeps compiled statements per connection, keyed by that identifier, comparing the SQL on a hit so a hash collision can't run the wrong statement. Statements without an identifier (pragmas, schema DDL) still prepare-and-close. `JdbcSqliteDriver` is final, so this is a sibling class; connection handling and query-listener plumbing mirror it.

Measured: a 20k-transfer insert goes **3.74s → 2.30s**, and `NativeDB.prepare` falls from **2098 → 320** profile samples. This speeds up all desktop DB work, not just sample generation.

## Verification

- `./gradlew build buildHealth` green; existing db/importer/csvimporter suites all run through the new driver (via `JvmDatabaseManager`).
- Driven end-to-end in the real app against a throwaway database: generation succeeds with no error, and Accounts / Transactions / Trades / Orders render — crypto balances with 18 decimals, orders with linked fills plus unfilled ones, fee- and pass-through-linked transfers, excluded rows. The progress dialog reports each phase ("Created 50/214 orders with 100/400 fills… 66%", then "Refreshing balances… 85%").

## Not in scope

CSV/QIF strategies and staged imports, import directories, API sessions, and account merges are still not generated. Follow-ups worth doing: batching `recompute`'s per-row running-balance inserts, and revisiting commit granularity for trades/orders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added size options when generating sample data, including smaller and larger datasets.
  - Sample data generation now includes richer scenarios such as transfers, trades, orders, and cryptocurrency activity.
  - Generation progress now reports more detailed stages and displays trades and orders in the progress and completion messages.

- **Improvements**
  - Improved database performance and reliability during local data operations.
  - Enhanced generated sample amounts across different currencies, including zero-decimal currencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->