### PR TITLE
Fix strategy catalog and cloud sync layouts on mobile

### DIFF
--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/setup/SetupWizardScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/setup/SetupWizardScreen.kt
@@ -1,8 +1,11 @@
 package com.moneymanager.ui.screens.setup
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -183,15 +186,19 @@ private fun ColumnScope.StepBody(
             }
         SetupWizardStep.STRATEGY_SYNC ->
             if (strategySyncController != null) {
-                StrategyCloudCard(
-                    controller = strategySyncController,
-                    library = services.imports.strategyLibrary,
-                    appVersion = appVersion,
-                    accountRepository = services.accounts.accountRepository,
-                    categoryRepository = services.accounts.categoryRepository,
-                    currencyRepository = services.accounts.currencyRepository,
-                    personRepository = services.people.personRepository,
-                )
+                // The card grows with the strategy list and the wizard body doesn't scroll on its own,
+                // so it would be clipped on a phone once the list is longer than the step.
+                Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState())) {
+                    StrategyCloudCard(
+                        controller = strategySyncController,
+                        library = services.imports.strategyLibrary,
+                        appVersion = appVersion,
+                        accountRepository = services.accounts.accountRepository,
+                        categoryRepository = services.accounts.categoryRepository,
+                        currencyRepository = services.accounts.currencyRepository,
+                        personRepository = services.people.personRepository,
+                    )
+                }
             }
         SetupWizardStep.IMPORT_DIRECTORIES ->
             ImportDirectoriesScreen(

--- a/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/StrategyCatalogScreen.kt
+++ b/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/StrategyCatalogScreen.kt
@@ -1,5 +1,6 @@
 package com.moneymanager.ui.screens
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -134,7 +136,10 @@ fun StrategyCatalogScreen(
             }
         }
 
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            modifier = Modifier.horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             FilterChip(selected = kindFilter == null, onClick = { kindFilter = null }, label = { Text("All") })
             for ((kind, label) in kindFilterChips) {
                 FilterChip(selected = kindFilter == kind, onClick = { kindFilter = kind }, label = { Text(label) })
@@ -179,7 +184,12 @@ fun StrategyCatalogScreen(
             Text("The catalog is empty.", fontStyle = FontStyle.Italic)
         }
 
-        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        // weight(1f): without it the list is measured last with whatever height the header and chips
+        // leave over, which on a phone is nothing.
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth().weight(1f),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
             items(filteredItems, key = { "${it.entry.kind}:${it.entry.name}" }) { item ->
                 CatalogRow(
                     item = item,


### PR DESCRIPTION
## What

Two mobile layout fixes on the strategy screens.

**Strategy catalog** (`StrategyCatalogScreen`): the `LazyColumn` of catalog entries had no `weight(1f)`, so inside its parent `Column` it was measured last with only the leftover height. On a desktop window that leftover is large; on a phone the title, the wrapped two-line description and the filter-chip row consume the full screen, so the list got zero height — the filter chips rendered and nothing appeared below them. The list now takes `weight(1f)`. The chip row (All / CSV / QIF / API / Pass-through) also can't fit a phone's width, so it is now horizontally scrollable.

**Strategies (Cloud)** (`StrategyCloudCard` in the setup wizard): the wizard renders each step body in a `weight(1f)` column that doesn't scroll, so once the strategy list grew past the step's height the rest of the card — including "Sync now" and "Disconnect" — was clipped and unreachable. That step's card is now wrapped in a scrolling column. Settings was already fine: it wraps its content in a page-level `verticalScroll`. Only the sync step is wrapped, because the catalog step's `LazyColumn` needs a bounded height and would break inside a `verticalScroll`.

## Why

Both screens were unusable on a phone.

## Testing

`./gradlew build` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mes6xVoB9Nqqz5fg3Tyto1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup and strategy catalog layouts on smaller screens.
  * Added scrolling support to prevent content from being clipped.
  * Enabled horizontal scrolling for filter options when they exceed the available width.
  * Improved strategy list sizing beneath the catalog header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->