### PR TITLE
Fix CSV import FK crash and prevent duplicate account creation

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -562,6 +562,29 @@ fun buildFirstRowByAccountName(
 }
 
 /**
+ * Turns any row still carrying [UNRESOLVED_ACCOUNT_ID] after the post-creation re-map into an error
+ * row. By then every account a row needs exists, so a surviving placeholder means the row's account
+ * could not be resolved; importing it would violate the transfer's account foreign key and abort the
+ * whole file, losing the rows that are fine.
+ */
+private fun ImportPreparation.withUnresolvedAccountsAsErrors(): ImportPreparation {
+    val (unresolved, resolved) =
+        validTransfers.partition {
+            it.transfer.sourceAccountId == UNRESOLVED_ACCOUNT_ID || it.transfer.targetAccountId == UNRESOLVED_ACCOUNT_ID
+        }
+    if (unresolved.isEmpty()) return this
+    logger.warn { "Skipping ${unresolved.size} row(s) whose account could not be resolved after account creation" }
+    return copy(
+        validTransfers = resolved,
+        errorRows =
+            errorRows +
+                unresolved.map {
+                    MappingResult.Error(it.rowIndex, "Account could not be resolved; the row references an account that does not exist")
+                },
+    )
+}
+
+/**
  * Applies [strategy] to [rows] of a single [csvImport] and writes back per-row statuses. Creates new
  * accounts the user accepted, persists/auto-captures account mappings, runs the central import engine,
  * and records the strategy application. Shared by the single-file dialog and the bulk path; the bulk
@@ -652,7 +675,7 @@ suspend fun runCsvImport(
         return CsvImportResult(successCount = 0, failedRows = emptyList())
     }
 
-    val finalPrep = mapper.prepareImport(rows)
+    val finalPrep = mapper.prepareImport(rows).withUnresolvedAccountsAsErrors()
     val validCount = finalPrep.validTransfers.size
     val errorCount = finalPrep.errorRows.size
     logger.info { "Prepared $validCount valid transfers, $errorCount error rows" }

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -112,6 +112,13 @@ sealed interface MappingResult {
 }
 
 /**
+ * Stand-in id for an account that does not exist yet: the mapper's first pass emits it for accounts it
+ * has asked the caller to create. It must never survive the re-map that follows account creation — a
+ * transfer carrying it would violate the transfer's account foreign key and abort the whole file.
+ */
+val UNRESOLVED_ACCOUNT_ID = AccountId(-1)
+
+/**
  * A new account that needs to be created during import.
  */
 data class NewAccount(
@@ -478,7 +485,7 @@ class CsvTransferMapper(
             // source of a debit, the target of a credit). The applier pairs and links the legs afterwards.
             val conversionDetection = detectConversionLeg(values)
             if (conversionDetection != null) {
-                targetAccountId = resolveExistingAccountId(conversionDetection.accountName) ?: AccountId(-1)
+                targetAccountId = resolveExistingAccountId(conversionDetection.accountName) ?: UNRESOLVED_ACCOUNT_ID
             }
 
             // Both account fields can read the same column (e.g. Crypto.com's card strategy resolves both
@@ -493,7 +500,7 @@ class CsvTransferMapper(
             if (tradeTo == null &&
                 sourceAccountOverride == null &&
                 sourceAccountId == targetAccountId &&
-                sourceAccountId != AccountId(-1)
+                sourceAccountId != UNRESOLVED_ACCOUNT_ID
             ) {
                 strategy.fieldMappings[TransferField.SOURCE_ACCOUNT]?.let {
                     sourceAccountId = parseAccount(it, values, applyPersistedMappings = false)
@@ -525,11 +532,16 @@ class CsvTransferMapper(
             // other way, so the conduit replaces the row's counterparty on whichever side it sits.
             // Detection + the conduit/merchant names come entirely from user-editable config (the
             // engine stays agnostic).
+            // A conduit is resolved exactly the way [accountExists] decides whether to create it (current
+            // name, then historical name): resolving it any more narrowly would leave the conduit side
+            // dangling at AccountId(-1) for a conduit that was never created because it already exists.
             val passThroughMatch = passThroughDetector?.detect(description)
             val chainConduitIds =
-                passThroughMatch?.accounts?.mapNotNull { existingAccounts[it.conduitAccountName]?.id }.orEmpty()
+                passThroughMatch?.accounts?.mapNotNull { resolveExistingAccountId(it.conduitAccountName) }.orEmpty()
             val conduitAccountId =
-                passThroughMatch?.let { existingAccounts[it.accounts.first().conduitAccountName]?.id ?: AccountId(-1) }
+                passThroughMatch?.let {
+                    resolveExistingAccountId(it.accounts.first().conduitAccountName) ?: UNRESOLVED_ACCOUNT_ID
+                }
             // Persisted account mappings apply to the merchant AFTER the full chain of prefixes was
             // peeled (e.g. "Crv*Paypal *Amazoncouk 1234" → "Amazoncouk 1234" → mapping ".*Amazoncouk.*"
             // → Amazon). A mapping that targets any conduit of the chain (or a deleted account) is
@@ -560,12 +572,12 @@ class CsvTransferMapper(
             // A transfer must move between two distinct accounts (enforced by a DB CHECK). If both legs
             // resolved to the same real account (e.g. an account mapping that matches this row on both
             // sides), surface it as a per-row error instead of letting one bad row abort the whole file.
-            // AccountId(-1) is the "new account" placeholder; two not-yet-created accounts stay distinct.
+            // The placeholder id is the "new account" marker; two not-yet-created accounts stay distinct.
             // A trade row is exempt: the trade CHECK only requires the ASSETS to differ, so a same-account
             // cross-asset exchange (e.g. BTC→ETH inside one wallet) is valid.
             if (tradeTo == null &&
                 effectiveSourceAccountId == effectiveTargetAccountId &&
-                effectiveSourceAccountId != AccountId(-1)
+                effectiveSourceAccountId != UNRESOLVED_ACCOUNT_ID
             ) {
                 val accountName =
                     existingAccounts.entries.firstOrNull { it.value.id == effectiveSourceAccountId }?.key
@@ -627,7 +639,7 @@ class CsvTransferMapper(
                         // Discover the source under the same persisted-mapping rule its id was resolved with:
                         // if the source leg was re-resolved without persisted mappings (collision above), a
                         // genuinely new source account must still be discovered/created rather than suppressed
-                        // by a persisted mapping — otherwise it would dangle as AccountId(-1).
+                        // by a persisted mapping — otherwise it would dangle unresolved.
                         strategy.fieldMappings[TransferField.SOURCE_ACCOUNT]?.let {
                             add(discoverNewAccount(it, values, applyPersistedMappings = sourceUsedPersistedMappings))
                         }
@@ -910,7 +922,7 @@ class CsvTransferMapper(
 
                 val name = templatedAccountName(mapping, csvValue)
                 resolveExistingAccountId(name)
-                    ?: AccountId(-1) // Placeholder for new accounts
+                    ?: UNRESOLVED_ACCOUNT_ID // Placeholder for new accounts
             }
             is ConditionalAccountMapping -> parseAccount(resolveConditional(mapping, values), values, applyPersistedMappings)
             is AccountLookupMapping -> {
@@ -924,7 +936,7 @@ class CsvTransferMapper(
                 // Fall back to lookup by name (current, then historical for renamed accounts)
                 val name = getAccountName(mapping, values)
                 resolveExistingAccountId(name)
-                    ?: AccountId(-1) // Placeholder for new accounts
+                    ?: UNRESOLVED_ACCOUNT_ID // Placeholder for new accounts
             }
             is RegexAccountMapping -> {
                 // For RegexAccountMapping, we need to determine which column/value
@@ -938,7 +950,7 @@ class CsvTransferMapper(
 
                 // Fall back to lookup by name (current, then historical for renamed accounts)
                 resolveExistingAccountId(result.accountName)
-                    ?: AccountId(-1) // Placeholder for new accounts
+                    ?: UNRESOLVED_ACCOUNT_ID // Placeholder for new accounts
             }
             else -> throw IllegalArgumentException("Invalid account mapping type: ${mapping::class}")
         }

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvTransferMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvTransferMapperTest.kt
@@ -205,6 +205,47 @@ class CsvTransferMapperTest {
     }
 
     @Test
+    fun `mapRow resolves a conduit whose account is only reachable under its historical name`() {
+        val strategy = createStrategy()
+        val payPal =
+            PassThroughAccount(
+                id = PassThroughAccountId(2),
+                name = "PayPal",
+                conduitAccountName = "PayPal",
+                rules =
+                    listOf(
+                        PassThroughRule(
+                            detectionPattern = "(?i)^PAYPAL\\s*\\*",
+                            merchantPattern = "(?i)^PAYPAL\\s*\\*\\s*(.+?)(?:\\s{2,}.*)?$",
+                        ),
+                    ),
+            )
+        // The live account is "PAYPAL", so the conduit name "PayPal" only resolves through the
+        // historical-name index — the same index accountExists() consults when deciding whether the
+        // conduit needs creating. Resolving it any more narrowly left the conduit side unresolved and
+        // the transfer failed the account foreign key on insert.
+        val payPalAccount = Account(id = AccountId(48), name = "PAYPAL", openingDate = Clock.System.now())
+        val mapper =
+            CsvTransferMapper(
+                strategy = strategy,
+                columns = columns,
+                existingAccounts = mapOf(payPalAccount.name to payPalAccount),
+                existingCurrencies = mapOf(testCurrencyId to testCurrency),
+                existingCurrenciesByCode = mapOf(testCurrency.code.uppercase() to testCurrency),
+                historicalAccountNames = mapOf("paypal" to payPalAccount.id),
+                passThroughDetector = PassThroughDetector(listOf(payPal)),
+            )
+
+        val row = CsvRow(rowIndex = 1, values = listOf("15/12/2024", "Paypal *Thepihut", "-50.00", "Paypal *Thepihut"))
+        val result = mapper.mapRow(row)
+
+        assertIs<MappingResult.Success>(result)
+        assertEquals(payPalAccount.id, result.transfer.targetAccountId)
+        // The conduit already exists, so only the merchant is created.
+        assertEquals(listOf("Thepihut"), result.newAccounts.map { it.name })
+    }
+
+    @Test
     fun `mapRow routes a chained Curve-PayPal row through both conduits`() {
         val strategy = createStrategy()
         val curve =

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -4,6 +4,7 @@ package com.moneymanager.database.importer
 import com.moneymanager.bigdecimal.BigInteger
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.Category
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.Money
@@ -34,6 +35,7 @@ import com.moneymanager.importengineapi.LocalOrderKey
 import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.importengineapi.LocalTradeKey
 import com.moneymanager.importengineapi.PersonMatchKey
+import com.moneymanager.importengineapi.createAccounts
 import com.moneymanager.importengineapi.createCrypto
 import com.moneymanager.importengineapi.createTrade
 import com.moneymanager.importengineapi.getOrCreateAttributeType
@@ -129,6 +131,112 @@ class ImportEngineDbTest : DbTest() {
                 ),
         )
     }
+
+    /**
+     * An API counterparty intent: matched by the provider's external id, carrying it as an attribute.
+     * [sortCode] + [accountNumber] give it a bank identity, marking it a real bank account rather than
+     * a merchant.
+     */
+    private fun counterpartyByExternalId(
+        key: LocalAccountKey,
+        name: String,
+        externalId: String,
+        sortCode: String? = null,
+        accountNumber: String? = null,
+    ): ImportAccountIntent {
+        val externalIdType = AttributeTypeId(WellKnownIds.ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID)
+        val attributes = mutableListOf(NewAttribute(externalIdType, externalId))
+        if (sortCode != null && accountNumber != null) {
+            attributes += NewAttribute(AttributeTypeId(WellKnownIds.ACCOUNT_SORT_CODE_ATTR_TYPE_ID), sortCode)
+            attributes += NewAttribute(AttributeTypeId(WellKnownIds.ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID), accountNumber)
+        }
+        return ImportAccountIntent(
+            key = key,
+            match = AccountMatchKey.ByExternalId(externalIdType, externalId),
+            name = name,
+            openingDate = baseTime,
+            source = Source.SampleGenerator,
+            attributes = attributes,
+        )
+    }
+
+    private suspend fun accountsNamed(name: String): Int =
+        repositories.accountRepository
+            .getAllAccounts()
+            .first()
+            .count { it.name == name }
+
+    @Test
+    fun counterpartiesWithDifferentExternalIdsButOneName_collapseToOneAccount() =
+        runTest {
+            // A provider can mint several external ids for one merchant within a single import (Monzo
+            // issued two ids for "Curve"). Both intents must land on one account, not fork a duplicate.
+            val result =
+                engine().import(
+                    ImportBatch(
+                        accountsToCreate =
+                            listOf(
+                                counterpartyByExternalId(LocalAccountKey("a"), "Curve", "id-1"),
+                                counterpartyByExternalId(LocalAccountKey("b"), "Curve", "id-2"),
+                            ),
+                    ),
+                )
+
+            assertEquals(1, result.accountsCreated)
+            assertEquals(1, accountsNamed("Curve"))
+        }
+
+    @Test
+    fun personalCounterpartiesSharingAName_stayDistinctAccounts() =
+        runTest {
+            // Two people can share a name while owning different bank accounts, so a name collision must
+            // not merge them — the name fallback applies only to accounts with no bank identity.
+            val result =
+                engine().import(
+                    ImportBatch(
+                        accountsToCreate =
+                            listOf(
+                                counterpartyByExternalId(
+                                    LocalAccountKey("a"),
+                                    "Nikolay Metchev",
+                                    "bank:090128:76266558",
+                                    sortCode = "090128",
+                                    accountNumber = "76266558",
+                                ),
+                                counterpartyByExternalId(
+                                    LocalAccountKey("b"),
+                                    "Nikolay Metchev",
+                                    "bank:040004:74006361",
+                                    sortCode = "040004",
+                                    accountNumber = "74006361",
+                                ),
+                            ),
+                    ),
+                )
+
+            assertEquals(2, result.accountsCreated)
+            assertEquals(2, accountsNamed("Nikolay Metchev"))
+        }
+
+    @Test
+    fun createAccounts_reusesAnExistingAccountWithTheSameName() =
+        runTest {
+            val existing = createSourceAccount()
+
+            val ids =
+                engine().createAccounts(
+                    listOf(
+                        Account(id = AccountId(0), name = "Checking", openingDate = baseTime),
+                        // The same name twice in one list must also collapse onto one account.
+                        Account(id = AccountId(0), name = "Curve", openingDate = baseTime),
+                        Account(id = AccountId(0), name = "Curve", openingDate = baseTime),
+                    ),
+                ) { Source.SampleGenerator }
+
+            assertEquals(existing, ids[0])
+            assertEquals(ids[1], ids[2])
+            assertEquals(1, accountsNamed("Curve"))
+        }
 
     @Test
     fun createsAccountAndTransfer_thenDedupesOnReimport() =

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineActions.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineActions.kt
@@ -136,8 +136,11 @@ suspend fun ImportEngine.getOrCreateAttributeTypes(names: List<String>): Map<Str
     if (names.isEmpty()) emptyMap() else import(ImportBatch(attributeTypeNames = names)).attributeTypeIds
 
 /**
- * Creates [accounts] (always new, no matching), returning their ids in input order. [sourceFor] gives
- * each account's provenance. Mirrors `AccountWriteRepository.createAccountsBatch` but via the engine.
+ * Gets or creates [accounts] by name, returning their ids in input order. [sourceFor] gives each
+ * account's provenance. Matching by name (rather than creating unconditionally) makes the call
+ * idempotent: an importer that believes an account is new because its own name lookup missed — a
+ * case difference, a stale snapshot, the same name twice in one list — reuses the existing account
+ * instead of adding a second one with the same name.
  */
 suspend fun ImportEngine.createAccounts(
     accounts: List<Account>,
@@ -149,7 +152,7 @@ suspend fun ImportEngine.createAccounts(
             ImportAccountIntent(
                 key = LocalAccountKey("create-$index"),
                 source = sourceFor(account),
-                match = AccountMatchKey.AlwaysCreate,
+                match = AccountMatchKey.ByName(account.name),
                 name = account.name,
                 openingDate = account.openingDate,
                 categoryId = account.categoryId,
@@ -159,7 +162,7 @@ suspend fun ImportEngine.createAccounts(
     return intents.map { requireNotNull(result.createdAccountIds[it.key]) { "Account ${it.name} was not created" } }
 }
 
-/** Creates a single new account (always new, no matching) and returns its id. */
+/** Gets or creates a single account by name (see [createAccounts]) and returns its id. */
 suspend fun ImportEngine.createAccount(
     account: Account,
     source: Source,

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -639,11 +639,16 @@ class ImportEngineImpl(
                 .toMutableMap()
         val byAttr = buildExistingAccountAttrIndex(batch.accountsToCreate)
         val byPersonalKey = buildExistingPersonalKeyIndex(batch.accountsToCreate)
+        // Names of accounts created earlier in THIS batch, so a later same-named intent with no other
+        // way to match reuses that account instead of forking a duplicate. Kept separate from [byName]
+        // (which also holds pre-existing accounts) because the name fallback must not reach across to a
+        // pre-existing account that merely shares a name — see [matchAccount].
+        val batchCreatedByName = mutableMapOf<String, AccountId>()
 
         val keyToId = mutableMapOf<LocalAccountKey, AccountId>()
         var created = 0
         for (intent in batch.accountsToCreate) {
-            val match = matchAccount(intent, byName, byAttr, byPersonalKey)
+            val match = matchAccount(intent, byName, byAttr, byPersonalKey, batchCreatedByName)
             if (match != null) {
                 // A bank-identity (adopted) match re-points the existing account onto this intent only for
                 // own/source accounts; counterparties merge in silently keeping the existing account as-is.
@@ -655,6 +660,7 @@ class ImportEngineImpl(
             created++
             keyToId[intent.key] = newId
             indexNewAccount(intent, newId, byName, byAttr, byPersonalKey)
+            intent.name?.let { batchCreatedByName.putIfAbsent(it, newId) }
         }
         return AccountResolution(keyToId, created)
     }
@@ -670,6 +676,7 @@ class ImportEngineImpl(
         byName: Map<String, AccountId>,
         byAttr: Map<Pair<AttributeTypeId, String>, AccountId>,
         byPersonalKey: Map<String, AccountId>,
+        batchCreatedByName: Map<String, AccountId>,
     ): AccountMatch? {
         val primary =
             when (val match = intent.match) {
@@ -680,12 +687,24 @@ class ImportEngineImpl(
                 is AccountMatchKey.AlwaysCreate -> null
             }
         if (primary != null) return AccountMatch(primary, adopted = false)
+        val bankKey = intentBankKey(intent)
         // Fallback: an intent that carries bank details (sort code + account number attributes) but didn't
         // match by its primary key adopts a pre-existing account for the same real bank account — e.g. a
         // source account adopting a counterparty another provider created, keeping imports order-independent.
         // The matched account is re-pointed (renamed + the intent's own attributes added) so this provider
         // resolves it by id next time, while its bank attributes keep the other provider matching it.
-        return intentBankKey(intent)?.let { byPersonalKey[it] }?.let { AccountMatch(it, adopted = true) }
+        bankKey?.let { byPersonalKey[it] }?.let { return AccountMatch(it, adopted = true) }
+        // Last resort for an intent with no bank identity — a merchant/conduit counterparty rather than a
+        // real bank account: reuse an account of the same name created earlier IN THIS BATCH. A provider
+        // routinely mints several external ids for one merchant (Monzo issued two for "Curve"), so without
+        // this the second id forks another same-named account. Scoped to batch-created names — never a
+        // pre-existing account — so an own/source account can't merge into an unrelated account that
+        // merely shares its name. Accounts that carry bank details are excluded too: two people can share
+        // a name while owning different accounts.
+        if (bankKey == null && intent.match !is AccountMatchKey.AlwaysCreate) {
+            intent.name?.let { batchCreatedByName[it] }?.let { return AccountMatch(it, adopted = false) }
+        }
+        return null
     }
 
     /**


### PR DESCRIPTION
## What

Fixes two related account-resolution defects found importing Crypto.com CSVs against the real database.

### 1. Foreign-key crash on card CSV files
Every `card_transactions_record_*.csv` aborted with `SQLITE_CONSTRAINT_FOREIGNKEY` on `transfer.source/target_account_id`.

`CsvTransferMapper` resolved a pass-through conduit account's id with an exact-case, live-names-only lookup, while `accountExists()` — which decides whether the conduit needs creating — also consults the case-insensitive **historical-name** index. A live account named `PAYPAL` with a config conduit `PayPal` was therefore judged to exist (so not created) yet resolved to no id, leaving the transfer's account side at the `AccountId(-1)` placeholder and failing the whole file's insert on the transfer FK.

- Conduit ids now resolve via the same current-then-historical path `accountExists()` uses, so the create decision and the id lookup can't disagree.
- Introduced a named `UNRESOLVED_ACCOUNT_ID` for the placeholder.
- Added an applier safety net: any row still carrying the placeholder after account creation becomes a per-row error with a readable message, instead of a raw SQLite FK error that aborts the file.

### 2. Duplicate `Curve` / `Coinbase` accounts
The engine matched API counterparties **only** by external id. Monzo minted two different merchant ids for one merchant within a single import, so each unknown id forked another account named `Curve`.

- `ImportEngineImpl.matchAccount` now falls back to reusing a same-named account **created earlier in the same batch** when an intent has no other way to match. Scoped to intents with **no bank identity** (no sort code + account number) and to same-batch names only — so an own/source account never merges into an unrelated pre-existing account that merely shares a name, and two people sharing a name keep distinct accounts.
- The CSV/QIF `ImportEngine.createAccounts`/`createAccount` helper is now **get-or-create by name** rather than always-create, making it idempotent against a stale account snapshot or a case/name miss (the same failure mode behind defect 1).

## Tests
- New `ImportEngineDbTest` cases: same-name counterparties with different external ids collapse to one account; personal counterparties sharing a name but with different bank details stay distinct; `createAccounts` reuses an existing account and collapses same-name duplicates in one list.
- New `CsvTransferMapperTest` case: a conduit reachable only under its historical name resolves instead of dangling.
- Existing Starling API E2E and the full `build buildHealth` pass.

## Not included
No retroactive cleanup — existing duplicates aren't merged. The two `Curve` accounts (5 vs ~3,700 transfers) should be merged from the Accounts screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV imports now flag transfers with unresolved accounts as errors instead of failing the entire import.
  * Improved recognition of pass-through accounts using historical names.
  * Prevented duplicate accounts when importing entries with matching names, while preserving distinct accounts with different banking details.
* **Improvements**
  * Account creation now reuses existing accounts by name where appropriate, including within the same import batch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->