### PR TITLE
Curve CSV import with funding-card reconciliation

### DIFF
--- a/.idea/runConfigurations/generateCatalogSite.xml
+++ b/.idea/runConfigurations/generateCatalogSite.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="generateCatalogSite" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="generateCatalogSite" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -4,6 +4,7 @@ package com.moneymanager.csvimporter
 
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountAttribute
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.CryptoAsset
@@ -218,6 +219,25 @@ data class CsvBulkResult(
 ) : BulkImportResult
 
 /**
+ * Builds the funding-card index used by strategies with a
+ * [CsvImportStrategy.fundingCardColumn]: last-4 → the account that funds it. [cardLast4Attributes] are
+ * the `card-last4` account attributes (see [com.moneymanager.domain.model.WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID]);
+ * each may list several last-4s separated by whitespace or commas. A last-4 claimed by more than one
+ * account is ambiguous and dropped, so those rows import normally instead of reconciling to the wrong
+ * account.
+ */
+fun fundingCardAccountIndex(cardLast4Attributes: List<AccountAttribute>): Map<String, AccountId> {
+    val byLast4 = mutableMapOf<String, MutableSet<AccountId>>()
+    for (attribute in cardLast4Attributes) {
+        for (last4 in attribute.value.split(Regex("[\\s,]+"))) {
+            val token = last4.trim()
+            if (token.isNotEmpty()) byLast4.getOrPut(token) { mutableSetOf() } += attribute.accountId
+        }
+    }
+    return byLast4.mapNotNull { (last4, accounts) -> accounts.singleOrNull()?.let { last4 to it } }.toMap()
+}
+
+/**
  * Applies the matching strategy to every [imports] file. Each file's strategy is auto-matched from its
  * column headers, so files from different banks each get the right strategy; files with no match are
  * skipped and counted. Payee/counterparty accounts auto-create with their detected names (no per-file
@@ -239,6 +259,7 @@ suspend fun bulkApplyCsv(
     onProgress: suspend (BulkImportProgress) -> Unit,
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
     cryptoRepository: CryptoReadRepository? = null,
+    fundingCardAccounts: Map<String, AccountId> = emptyMap(),
 ): CsvBulkResult {
     var filesImported = 0
     var transfers = 0
@@ -281,6 +302,7 @@ suspend fun bulkApplyCsv(
                     onProgress = { tracker.phase(index, csvImport.originalFileName, it) },
                     engineBatchSize = BULK_ENGINE_BATCH_SIZE,
                     cryptoRepository = cryptoRepository,
+                    fundingCardAccounts = fundingCardAccounts,
                 ) ?: return@forEachIndexed
             filesImported++
             transfers += result.successCount
@@ -326,6 +348,7 @@ suspend fun applyStagedCsv(
     onProgress: (suspend (ImportProgress) -> Unit)? = null,
     engineBatchSize: Int = Int.MAX_VALUE,
     cryptoRepository: CryptoReadRepository? = null,
+    fundingCardAccounts: Map<String, AccountId> = emptyMap(),
 ): CsvImportResult? {
     val allRows = csvImportRepository.getImportRows(csvImport.id, limit = csvImport.rowCount.coerceAtLeast(1), offset = 0)
     val rows = allRows.filter { it.importStatus == null || it.importStatus == ImportStatus.ERROR }
@@ -387,6 +410,7 @@ suspend fun applyStagedCsv(
         passThroughAccounts = passThroughAccounts,
         onProgress = onProgress,
         engineBatchSize = engineBatchSize,
+        fundingCardAccounts = fundingCardAccounts,
     )
 }
 
@@ -547,15 +571,25 @@ fun buildFirstRowByAccountName(
     newAccountNames: Map<String, String>,
 ): Map<String, Long> {
     val firstRow = mutableMapOf<String, Long>()
+
+    fun record(
+        name: String,
+        rowIndex: Long,
+    ) {
+        val finalName = name.trim()
+        if (finalName.isNotBlank() && finalName !in firstRow) firstRow[finalName] = rowIndex
+    }
     preparation.validTransfers
         .sortedBy { it.rowIndex }
         .forEach { transfer ->
             transfer.discoveredMappings.forEach { mapping ->
-                val finalName =
-                    (newAccountNames[mapping.targetAccountName] ?: mapping.targetAccountName).trim()
-                if (finalName.isNotBlank() && finalName !in firstRow) {
-                    firstRow[finalName] = transfer.rowIndex
-                }
+                record(newAccountNames[mapping.targetAccountName] ?: mapping.targetAccountName, transfer.rowIndex)
+            }
+            // Pass-through (conduit) rows create the conduit + merchant accounts outside the discovered-
+            // mapping path, so record their originating row too — otherwise their provenance has no row
+            // and the audit "Row" link points at the non-existent row 0.
+            transfer.passThrough?.let { pt ->
+                (pt.conduitNames + pt.merchantName).forEach { record(it, transfer.rowIndex) }
             }
         }
     return firstRow
@@ -610,6 +644,7 @@ suspend fun runCsvImport(
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
     onProgress: (suspend (ImportProgress) -> Unit)? = null,
     engineBatchSize: Int = Int.MAX_VALUE,
+    fundingCardAccounts: Map<String, AccountId> = emptyMap(),
 ): CsvImportResult {
     logger.info { "Starting CSV import with ${basePrep.validTransfers.size} valid transfers" }
 
@@ -844,6 +879,13 @@ suspend fun runCsvImport(
                         }
                     }
                 }
+            // Funding-card reconcile hint: resolve the row's funding-card last-4 to the account that
+            // must hold the matching funding leg (e.g. Curve's "7721" -> the Crypto.com Card account).
+            // Never point at the row's own source conduit (a self-reconcile makes no sense).
+            val fundingAccountId =
+                row.fundingCardLast4
+                    ?.let { fundingCardAccounts[it] }
+                    ?.takeIf { it != row.transfer.sourceAccountId }
             ImportTransfer(
                 rowKey = ImportRowKey.CsvRow(row.rowIndex),
                 fromAccount = AccountRef.Existing(row.transfer.sourceAccountId),
@@ -857,6 +899,7 @@ suspend fun runCsvImport(
                 fee = fee,
                 passThrough = passThrough,
                 batchRelationships = listOfNotNull(conversionLinkByRow[row.rowIndex]),
+                reconcileFundingAccountId = fundingAccountId,
             )
         }
 

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -218,6 +218,9 @@ data class CsvBulkResult(
     override val filesFailed: Int,
 ) : BulkImportResult
 
+/** Splits a `card-last4` attribute value into its individual last-4 tokens (whitespace/comma-separated). */
+private val CARD_LAST4_DELIMITER = Regex("[\\s,]+")
+
 /**
  * Builds the funding-card index used by strategies with a
  * [CsvImportStrategy.fundingCardColumn]: last-4 → the account that funds it. [cardLast4Attributes] are
@@ -229,7 +232,7 @@ data class CsvBulkResult(
 fun fundingCardAccountIndex(cardLast4Attributes: List<AccountAttribute>): Map<String, AccountId> {
     val byLast4 = mutableMapOf<String, MutableSet<AccountId>>()
     for (attribute in cardLast4Attributes) {
-        for (last4 in attribute.value.split(Regex("[\\s,]+"))) {
+        for (last4 in attribute.value.split(CARD_LAST4_DELIMITER)) {
             val token = last4.trim()
             if (token.isNotEmpty()) byLast4.getOrPut(token) { mutableSetOf() } += attribute.accountId
         }

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -38,6 +38,7 @@ import com.moneymanager.importengineapi.ImportOperation
 import com.moneymanager.importengineapi.ImportProgress
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
+import com.moneymanager.importengineapi.selectNearestUnconsumedFundingLeg
 import kotlinx.coroutines.flow.first
 import org.lighthousegames.logging.logging
 import kotlin.time.Duration.Companion.seconds
@@ -77,6 +78,9 @@ enum class ReimportSkipReason {
 
     /** Deleting a row's old transfer for a transfer→trade conversion failed; the row was left as-is. */
     TRADE_CONVERSION_FAILED,
+
+    /** Deleting a row's old transfer for a funding-card reconcile failed; the row was left as-is. */
+    FUNDING_RECONCILE_FAILED,
 }
 
 /** One duplicate-account merge the re-import will perform (or performed). */
@@ -450,7 +454,9 @@ suspend fun planCsvReimport(
             fundingCardAccounts = fundingCardAccounts,
             excludedRowIndexes = rewrites.map { it.rowIndex }.toSet() + reversalRowIndexes + tradeConversions.map { it.rowIndex },
             existingTransfers = existingTransfers,
-            loadTransfersTouchingAccount = { accountId -> transactionRepository.getTransactionsByAccount(accountId).first() },
+            loadTransfersTouchingAccount = { accountId, startDate, endDate ->
+                transactionRepository.getTransactionsByAccountAndDateRange(accountId, startDate, endDate).first()
+            },
             onProgress = onProgress,
         )
     // Rows whose transfers a reversal moves back are excluded from value updates: the reversal owns that
@@ -599,7 +605,7 @@ suspend fun computeFundingReconcileReruns(
     fundingCardAccounts: Map<String, AccountId>,
     excludedRowIndexes: Set<Long>,
     existingTransfers: Map<TransferId, Transfer>,
-    loadTransfersTouchingAccount: suspend (AccountId) -> List<Transfer>,
+    loadTransfersTouchingAccount: suspend (AccountId, Instant, Instant) -> List<Transfer>,
     onProgress: (suspend (ImportProgress) -> Unit)? = null,
 ): List<ReimportFundingReconcile> {
     val window = strategy.crossSourceReconcileWindowSeconds?.seconds ?: return emptyList()
@@ -633,11 +639,16 @@ suspend fun computeFundingReconcileReruns(
     if (candidates.isEmpty()) return emptyList()
 
     // Funding legs (fundingAccount -> conduit) bucketed by (source, amount); the conduit is shared by
-    // all conduit spends of one strategy, so one load per distinct conduit covers every candidate.
+    // all conduit spends of one strategy, so one load per distinct conduit covers every candidate. Bound
+    // the load to the candidates' timestamp span ± the reconcile window (a matching leg must fall inside
+    // it), so a long-lived conduit isn't fully scanned on this UI-triggered path — mirrors the bounded
+    // candidate load in ImportEngineImpl.loadExisting.
     onProgress?.invoke(ImportProgress("Checking funding-card reconciliation"))
+    val minTs = candidates.minOf { it.timestamp } - window
+    val maxTs = candidates.maxOf { it.timestamp } + window
     val legsByConduitAmount = mutableMapOf<Triple<AccountId, AccountId, Money>, MutableList<Transfer>>()
     for (conduit in candidates.map { it.conduit }.toSet()) {
-        for (leg in loadTransfersTouchingAccount(conduit)) {
+        for (leg in loadTransfersTouchingAccount(conduit, minTs, maxTs)) {
             if (leg.targetAccountId != conduit) continue
             legsByConduitAmount.getOrPut(Triple(leg.sourceAccountId, conduit, leg.amount)) { mutableListOf() } += leg
         }
@@ -645,11 +656,11 @@ suspend fun computeFundingReconcileReruns(
     val consumed = mutableSetOf<TransferId>()
     return candidates.mapNotNull { candidate ->
         val bucket = legsByConduitAmount[Triple(candidate.fundingAccount, candidate.conduit, candidate.amount)] ?: return@mapNotNull null
-        val leg =
-            bucket
-                .filter { it.id !in consumed && (candidate.timestamp - it.timestamp).absoluteValue <= window }
-                .minByOrNull { (candidate.timestamp - it.timestamp).absoluteValue } ?: return@mapNotNull null
-        consumed += leg.id
+        // Same one-to-one, nearest-timestamp choice the engine's funding reconcile makes, so plan and re-run agree.
+        val legId =
+            selectNearestUnconsumedFundingLeg(bucket.map { it.id to it }, candidate.timestamp, window, consumed)
+                ?: return@mapNotNull null
+        consumed += legId
         ReimportFundingReconcile(candidate.rowIndex, candidate.transferId, candidate.description)
     }
 }
@@ -1036,7 +1047,7 @@ suspend fun executeCsvReimport(
                 ReimportSkippedAccount(
                     accountId = null,
                     accountName = reconcile.description,
-                    reason = ReimportSkipReason.REWRITE_FAILED,
+                    reason = ReimportSkipReason.FUNDING_RECONCILE_FAILED,
                     detail = expected.message ?: "Funding reconcile failed",
                 )
         }

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -40,6 +40,7 @@ import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.LocalAccountKey
 import kotlinx.coroutines.flow.first
 import org.lighthousegames.logging.logging
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -118,6 +119,20 @@ data class ReimportRewrite(
 )
 
 /**
+ * One already-imported conduit-spend row (e.g. a Curve spend) that now resolves a funding card to an
+ * account holding a matching funding leg, so re-running it makes the engine reconcile it (excluded +
+ * linked) instead of double-counting. The plain transfer is deleted and the row reset so the re-run
+ * imports it reconciled. Only rows that will actually reconcile (a matching unconsumed funding leg
+ * exists) are listed, so rows whose funder isn't imported don't churn on every re-import.
+ */
+data class ReimportFundingReconcile(
+    val rowIndex: Long,
+    val transferId: TransferId,
+    /** The row's statement description, for the preview. */
+    val description: String,
+)
+
+/**
  * One already-imported row that the current strategy maps to a cross-asset TRADE but whose persisted
  * transaction is a single-asset transfer (imported before the strategy gained TO_CURRENCY/TO_AMOUNT
  * mappings, so the credited leg was lost and the counterparty is typically a junk description-named
@@ -181,6 +196,8 @@ data class ReimportPlan(
     val reversals: List<ReimportReversal> = emptyList(),
     /** Already-imported single-asset transfers the current strategy now maps to cross-asset trades. */
     val tradeConversions: List<ReimportTradeConversion> = emptyList(),
+    /** Already-imported conduit spends that will reconcile against a funding leg once re-run. */
+    val fundingReconciles: List<ReimportFundingReconcile> = emptyList(),
 ) {
     val isEmpty: Boolean
         get() =
@@ -189,7 +206,8 @@ data class ReimportPlan(
                 rewrites.isEmpty() &&
                 valueUpdates.isEmpty() &&
                 reversals.isEmpty() &&
-                tradeConversions.isEmpty()
+                tradeConversions.isEmpty() &&
+                fundingReconciles.isEmpty()
 }
 
 /** The outcome of an executed re-import. */
@@ -208,6 +226,8 @@ data class CsvReimportResult(
     val reversedMerges: List<ReimportReversal> = emptyList(),
     /** Rows whose single-asset transfer was deleted and re-imported as a cross-asset trade. */
     val convertedRows: List<ReimportTradeConversion> = emptyList(),
+    /** Conduit-spend rows deleted and re-imported so they reconcile against a funding leg. */
+    val reconciledRows: List<ReimportFundingReconcile> = emptyList(),
 )
 
 /** Raw merge detection output: duplicate → single target, plus duplicates with competing targets. */
@@ -351,6 +371,7 @@ suspend fun planCsvReimport(
     transferSourceRepository: TransferSourceReadRepository,
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
     cryptoAssets: List<CryptoAsset> = emptyList(),
+    fundingCardAccounts: Map<String, AccountId> = emptyMap(),
     onProgress: (suspend (ImportProgress) -> Unit)? = null,
 ): ReimportPlan {
     onProgress?.invoke(ImportProgress("Loading rows"))
@@ -420,10 +441,21 @@ suspend fun planCsvReimport(
             relationshipRepository = relationshipRepository,
             onProgress = onProgress,
         ) { transferId -> existingTransfers[transferId] }
+    val reversalRowIndexes = reversals.flatMapTo(mutableSetOf()) { it.rowIndexes }
+    val fundingReconciles =
+        computeFundingReconcileReruns(
+            allRows = allRows,
+            mappedPrep = mappedPrep,
+            strategy = strategy,
+            fundingCardAccounts = fundingCardAccounts,
+            excludedRowIndexes = rewrites.map { it.rowIndex }.toSet() + reversalRowIndexes + tradeConversions.map { it.rowIndex },
+            existingTransfers = existingTransfers,
+            loadTransfersTouchingAccount = { accountId -> transactionRepository.getTransactionsByAccount(accountId).first() },
+            onProgress = onProgress,
+        )
     // Rows whose transfers a reversal moves back are excluded from value updates: the reversal owns that
     // transfer's account move, and a value update would re-send the pre-reversal (survivor) accounts.
-    // Trade-conversion rows are excluded too — their transfer is deleted, not updated.
-    val reversalRowIndexes = reversals.flatMapTo(mutableSetOf()) { it.rowIndexes }
+    // Trade-conversion + funding-reconcile rows are excluded too — their transfer is deleted, not updated.
     val valueUpdates =
         computeReimportValueUpdates(
             allRows = allRows,
@@ -431,7 +463,8 @@ suspend fun planCsvReimport(
             rewrittenRowIndexes =
                 rewrites.map { it.rowIndex }.toSet() +
                     reversalRowIndexes +
-                    tradeConversions.map { it.rowIndex },
+                    tradeConversions.map { it.rowIndex } +
+                    fundingReconciles.map { it.rowIndex },
             existingTransferLookup = { transferId -> existingTransfers[transferId] },
             onProgress = onProgress,
         )
@@ -479,6 +512,7 @@ suspend fun planCsvReimport(
         valueUpdates = valueUpdates,
         reversals = reversals,
         tradeConversions = tradeConversions,
+        fundingReconciles = fundingReconciles,
     )
 }
 
@@ -543,6 +577,81 @@ private suspend fun valueUpdateFor(
         sourceAccountId = existing.sourceAccountId,
         targetAccountId = existing.targetAccountId,
     )
+}
+
+/**
+ * Finds already-imported conduit-spend rows that were imported plain (unreconciled) but now — because
+ * their funding card resolves to an account holding a matching funding leg — would reconcile if re-run.
+ * Only rows for which an unconsumed funding leg actually exists (same funding account → conduit, same
+ * amount+currency within [CsvImportStrategy.crossSourceReconcileWindowSeconds]) are returned, so rows
+ * whose funder was never imported don't get reset on every re-import. Consumes each funding leg once
+ * (nearest timestamp), matching the engine's [com.moneymanager.importer] funding-reconcile so the
+ * plan and the re-run agree on which rows will link.
+ *
+ * NB: does not exclude funding legs already consumed by a PRE-EXISTING reconcile (needs a bulk
+ * relationship load); mirrors the engine's documented "candidates aren't consumed across the persisted
+ * set" imperfection. Already-reconciled rows are skipped (their transfer carries the exclusion attr).
+ */
+suspend fun computeFundingReconcileReruns(
+    allRows: List<CsvRow>,
+    mappedPrep: ImportPreparation,
+    strategy: CsvImportStrategy,
+    fundingCardAccounts: Map<String, AccountId>,
+    excludedRowIndexes: Set<Long>,
+    existingTransfers: Map<TransferId, Transfer>,
+    loadTransfersTouchingAccount: suspend (AccountId) -> List<Transfer>,
+    onProgress: (suspend (ImportProgress) -> Unit)? = null,
+): List<ReimportFundingReconcile> {
+    val window = strategy.crossSourceReconcileWindowSeconds?.seconds ?: return emptyList()
+    if (strategy.fundingCardColumn == null || fundingCardAccounts.isEmpty()) return emptyList()
+    val rowsByIndex = allRows.associateBy { it.rowIndex }
+
+    // Candidate rows: already IMPORTED conduit spends that resolve a funding account and are not yet
+    // reconciled (their persisted transfer carries no "excluded" attribute).
+    data class Candidate(
+        val rowIndex: Long,
+        val transferId: TransferId,
+        val conduit: AccountId,
+        val fundingAccount: AccountId,
+        val amount: Money,
+        val timestamp: Instant,
+        val description: String,
+    )
+    val candidates =
+        mappedPrep.validTransfers.mapNotNull { mapped ->
+            if (mapped.rowIndex in excludedRowIndexes) return@mapNotNull null
+            val row = rowsByIndex[mapped.rowIndex] ?: return@mapNotNull null
+            if (row.importStatus != ImportStatus.IMPORTED) return@mapNotNull null
+            val transferId = row.transferId ?: return@mapNotNull null
+            val fundingAccount = mapped.fundingCardLast4?.let { fundingCardAccounts[it] } ?: return@mapNotNull null
+            val conduit = mapped.transfer.sourceAccountId
+            if (fundingAccount == conduit) return@mapNotNull null
+            val existing = existingTransfers[transferId] ?: return@mapNotNull null
+            if (existing.attributes.any { it.attributeType.name == "excluded" }) return@mapNotNull null
+            Candidate(mapped.rowIndex, transferId, conduit, fundingAccount, existing.amount, existing.timestamp, existing.description)
+        }
+    if (candidates.isEmpty()) return emptyList()
+
+    // Funding legs (fundingAccount -> conduit) bucketed by (source, amount); the conduit is shared by
+    // all conduit spends of one strategy, so one load per distinct conduit covers every candidate.
+    onProgress?.invoke(ImportProgress("Checking funding-card reconciliation"))
+    val legsByConduitAmount = mutableMapOf<Triple<AccountId, AccountId, Money>, MutableList<Transfer>>()
+    for (conduit in candidates.map { it.conduit }.toSet()) {
+        for (leg in loadTransfersTouchingAccount(conduit)) {
+            if (leg.targetAccountId != conduit) continue
+            legsByConduitAmount.getOrPut(Triple(leg.sourceAccountId, conduit, leg.amount)) { mutableListOf() } += leg
+        }
+    }
+    val consumed = mutableSetOf<TransferId>()
+    return candidates.mapNotNull { candidate ->
+        val bucket = legsByConduitAmount[Triple(candidate.fundingAccount, candidate.conduit, candidate.amount)] ?: return@mapNotNull null
+        val leg =
+            bucket
+                .filter { it.id !in consumed && (candidate.timestamp - it.timestamp).absoluteValue <= window }
+                .minByOrNull { (candidate.timestamp - it.timestamp).absoluteValue } ?: return@mapNotNull null
+        consumed += leg.id
+        ReimportFundingReconcile(candidate.rowIndex, candidate.transferId, candidate.description)
+    }
 }
 
 private fun Money.display(): String = "${toDisplayValue()} ${asset.code}"
@@ -771,6 +880,7 @@ suspend fun executeCsvReimport(
     refreshViews: Boolean = true,
     cryptoRepository: CryptoReadRepository? = null,
     tradeRepository: TradeReadRepository? = null,
+    fundingCardAccounts: Map<String, AccountId> = emptyMap(),
 ): CsvReimportResult {
     val merged = mutableListOf<ReimportMerge>()
     val skipped = plan.skipped.toMutableList()
@@ -891,6 +1001,47 @@ suspend fun executeCsvReimport(
         }
     }
 
+    // One batch per reconcile: the plain conduit-spend transfer is deleted and its row status reset in
+    // the same batch, so the re-run below re-imports it through the engine's funding-card reconcile
+    // (which links it to the funding leg + excludes it instead of double-counting).
+    val reconciled = mutableListOf<ReimportFundingReconcile>()
+    for ((index, reconcile) in plan.fundingReconciles.withIndex()) {
+        onProgress?.invoke(
+            ImportProgress(
+                "Reconciling conduit spends",
+                fraction = index.toFloat() / plan.fundingReconciles.size,
+                processed = index,
+                total = plan.fundingReconciles.size,
+            ),
+        )
+        try {
+            importEngine.import(
+                ImportBatch(
+                    transfers =
+                        listOf(
+                            ImportTransfer(
+                                source = Source.Csv(csvImport.id),
+                                operation = ImportOperation.DELETE,
+                                existingId = reconcile.transferId,
+                            ),
+                        ),
+                    dedupePolicy = DedupePolicy.None,
+                    csvImportMutations = listOf(CsvImportMutation.ResetRowStatuses(csvImport.id, listOf(reconcile.rowIndex))),
+                ),
+            )
+            reconciled += reconcile
+        } catch (expected: Exception) {
+            logger.warn(expected) { "Re-import funding reconcile of row ${reconcile.rowIndex} ('${reconcile.description}') failed" }
+            skipped +=
+                ReimportSkippedAccount(
+                    accountId = null,
+                    accountName = reconcile.description,
+                    reason = ReimportSkipReason.REWRITE_FAILED,
+                    detail = expected.message ?: "Funding reconcile failed",
+                )
+        }
+    }
+
     val importResult =
         applyStagedCsv(
             csvImport = csvImport,
@@ -906,6 +1057,7 @@ suspend fun executeCsvReimport(
             passThroughAccounts = passThroughAccounts,
             cryptoRepository = cryptoRepository,
             onProgress = onProgress,
+            fundingCardAccounts = fundingCardAccounts,
             engineBatchSize = REIMPORT_ENGINE_BATCH_SIZE,
         )
 
@@ -927,6 +1079,7 @@ suspend fun executeCsvReimport(
         updatedRows = updatedRows,
         reversedMerges = reversedMerges,
         convertedRows = converted,
+        reconciledRows = reconciled,
     )
 }
 
@@ -1150,6 +1303,7 @@ suspend fun bulkReimportCsv(
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
     cryptoRepository: CryptoReadRepository? = null,
     tradeRepository: TradeReadRepository? = null,
+    fundingCardAccounts: Map<String, AccountId> = emptyMap(),
 ): CsvBulkReimportResult {
     var filesImported = 0
     var transfers = 0
@@ -1200,6 +1354,7 @@ suspend fun bulkReimportCsv(
                     passThroughAccounts = passThroughAccounts,
                     onProgress = { tracker.phase(index, csvImport.originalFileName, it) },
                     cryptoAssets = cryptoAssets,
+                    fundingCardAccounts = fundingCardAccounts,
                 )
             val result =
                 executeCsvReimport(
@@ -1218,6 +1373,7 @@ suspend fun bulkReimportCsv(
                     refreshViews = false,
                     cryptoRepository = cryptoRepository,
                     tradeRepository = tradeRepository,
+                    fundingCardAccounts = fundingCardAccounts,
                 )
             filesImported++
             transfers += result.importResult?.successCount ?: 0

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -97,6 +97,8 @@ sealed interface MappingResult {
         val passThrough: CsvPassThrough? = null,
         /** Set when the row is one leg of an asset conversion (see [ConversionConfig]); null otherwise. */
         val conversionLeg: ConversionLegInfo? = null,
+        /** Raw funding-card value from [CsvImportStrategy.fundingCardColumn]; null when unset/blank. */
+        val fundingCardLast4: String? = null,
     ) : MappingResult {
         /** Convenience for flows where only the target side can discover a new account. */
         val newAccountName: String? get() = newAccounts.firstOrNull()?.name
@@ -197,6 +199,12 @@ data class CsvTransferWithAttributes(
     val passThrough: CsvPassThrough? = null,
     /** Set when the row is one leg of an asset conversion (see [ConversionConfig]); null otherwise. */
     val conversionLeg: ConversionLegInfo? = null,
+    /**
+     * Raw value of the strategy's [CsvImportStrategy.fundingCardColumn] for this row (e.g. a card's
+     * last-4 like "7721"); null when the strategy declares no funding-card column or the cell is blank.
+     * The applier resolves it to a funding account for the funding-card reconcile.
+     */
+    val fundingCardLast4: String? = null,
 )
 
 /**
@@ -370,6 +378,7 @@ class CsvTransferMapper(
                             personalCounterpartyName = result.personalCounterpartyName,
                             passThrough = result.passThrough,
                             conversionLeg = result.conversionLeg,
+                            fundingCardLast4 = result.fundingCardLast4,
                         ),
                     )
                     // Count by status
@@ -684,6 +693,8 @@ class CsvTransferMapper(
                 passThrough = passThrough,
                 conversionLeg =
                     conversionDetection?.let { ConversionLegInfo(side = it.side, pairingKey = it.pairingKey) },
+                fundingCardLast4 =
+                    strategy.fundingCardColumn?.let { getColumnValueOrNull(it, originalValues)?.trim()?.takeIf { v -> v.isNotBlank() } },
             )
         } catch (expected: Exception) {
             MappingResult.Error(row.rowIndex, expected.message ?: "Unknown error")

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/BuildFirstRowByAccountNameTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/BuildFirstRowByAccountNameTest.kt
@@ -1,0 +1,66 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.csvimporter
+
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+
+class BuildFirstRowByAccountNameTest {
+    private val gbp = Currency(id = CurrencyId(1), code = "GBP", name = "British Pound")
+    private val time = Instant.fromEpochMilliseconds(1_700_000_000_000)
+
+    private fun row(
+        rowIndex: Long,
+        passThrough: CsvPassThrough? = null,
+        discoveredMappings: List<DiscoveredAccountMapping> = emptyList(),
+    ) = CsvTransferWithAttributes(
+        transfer =
+            Transfer(
+                id = TransferId(0),
+                timestamp = time,
+                description = "row $rowIndex",
+                sourceAccountId = AccountId(1),
+                targetAccountId = AccountId(2),
+                amount = Money(100, gbp),
+            ),
+        attributes = emptyList(),
+        rowIndex = rowIndex,
+        passThrough = passThrough,
+        discoveredMappings = discoveredMappings,
+    )
+
+    private fun prep(rows: List<CsvTransferWithAttributes>) =
+        ImportPreparation(validTransfers = rows, errorRows = emptyList(), newAccounts = emptySet(), existingAccountMatches = emptyMap())
+
+    @Test
+    fun passThroughConduitAndMerchant_recordTheirOriginatingRow() {
+        // A Curve pass-through row creates the conduit ("Curve") and merchant ("Rila Borovets Ad S")
+        // accounts outside the discovered-mapping path; both must still get their originating row so the
+        // account audit's "Row" link is valid (not the non-existent row 0).
+        val passThrough =
+            CsvPassThrough(
+                conduitNames = listOf("Curve"),
+                merchantName = "Rila Borovets Ad S",
+                merchantAccountId = null,
+                spendDescriptions = listOf("Rila Borovets Ad S"),
+                relationshipTypeId = 3,
+            )
+        val result = buildFirstRowByAccountName(prep(listOf(row(1), row(5, passThrough = passThrough))), emptyMap())
+        assertEquals(5L, result["Curve"])
+        assertEquals(5L, result["Rila Borovets Ad S"])
+    }
+
+    @Test
+    fun earliestRowWins_forARepeatedMerchant() {
+        val pt = { CsvPassThrough(listOf("Curve"), "Tesco", null, listOf("Tesco"), 3) }
+        val result = buildFirstRowByAccountName(prep(listOf(row(7, passThrough = pt()), row(3, passThrough = pt()))), emptyMap())
+        assertEquals(3L, result["Tesco"])
+    }
+}

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/StrategySelectorTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/StrategySelectorTest.kt
@@ -2,6 +2,7 @@
 
 package com.moneymanager.csvimporter
 
+import com.moneymanager.builtin.BuiltInCsvStrategies
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.CsvImportStrategyId
 import com.moneymanager.domain.model.CurrencyId
@@ -200,5 +201,89 @@ class StrategySelectorTest {
         val a = strategy("A")
         val selected = listOf(b, a).selectForCsv("x.csv", columns, rows(""))
         assertEquals("A", selected?.name)
+    }
+
+    @Test
+    fun `a Curve export selects the Curve CSV strategy`() {
+        val builtIns = BuiltInCsvStrategies.builtInCsvStrategies(Clock.System.now())
+        val curveColumns =
+            listOf(
+                CsvColumn(CsvColumnId(Uuid.random()), 0, ""),
+                CsvColumn(CsvColumnId(Uuid.random()), 1, "Created Date"),
+                CsvColumn(CsvColumnId(Uuid.random()), 2, "Merchant Name"),
+                CsvColumn(CsvColumnId(Uuid.random()), 3, "Funding Card Last 4 Digits"),
+                CsvColumn(CsvColumnId(Uuid.random()), 4, "Merchant MCC Code"),
+                CsvColumn(CsvColumnId(Uuid.random()), 5, "Txn Currency"),
+                CsvColumn(CsvColumnId(Uuid.random()), 6, "Txn Amount"),
+            )
+        val curveRows =
+            listOf(
+                CsvRow(rowIndex = 1L, values = listOf("1", "2026-06-16", "TFL", "7721", "4111", "GBP", "1.75")),
+                CsvRow(rowIndex = 2L, values = listOf("2", "2026-06-15", "AMAZON", "1142", "5999", "GBP", "62.24")),
+            )
+        val selected = builtIns.selectForCsv("Transaction History 2026-06-16.csv", curveColumns, curveRows)
+        assertEquals("Curve CSV", selected?.name)
+    }
+
+    @Test
+    fun `a Wise export still selects the Wise CSV strategy alongside Curve`() {
+        // Both Curve and Wise name their export "transaction-history"-ish, so this guards against the
+        // Curve fileNamePattern hijacking a Wise file — the disjoint column sets must keep them apart.
+        val builtIns = BuiltInCsvStrategies.builtInCsvStrategies(Clock.System.now())
+        val wiseHeaders =
+            listOf(
+                "ID",
+                "Status",
+                "Direction",
+                "Created on",
+                "Finished on",
+                "Source fee amount",
+                "Source fee currency",
+                "Target fee amount",
+                "Target fee currency",
+                "Source name",
+                "Source amount (after fees)",
+                "Source currency",
+                "Target name",
+                "Target amount (after fees)",
+                "Target currency",
+                "Exchange rate",
+                "Reference",
+                "Batch",
+                "Created by",
+                "Category",
+                "Note",
+            )
+        val wiseColumns = wiseHeaders.mapIndexed { i, name -> CsvColumn(CsvColumnId(Uuid.random()), i, name) }
+        val wiseRow =
+            CsvRow(
+                rowIndex = 1L,
+                values =
+                    listOf(
+                        "TRANSFER-1",
+                        "COMPLETED",
+                        "OUT",
+                        "2026-05-30 08:01:36",
+                        "2026-05-30 08:01:50",
+                        "0.00",
+                        "EUR",
+                        "",
+                        "",
+                        "Nikolay",
+                        "150.0",
+                        "EUR",
+                        "Teodora",
+                        "150.0",
+                        "EUR",
+                        "1.0",
+                        "gift",
+                        "",
+                        "Nikolay",
+                        "General",
+                        "",
+                    ),
+            )
+        val selected = builtIns.selectForCsv("transaction-history.csv", wiseColumns, listOf(wiseRow))
+        assertEquals("Wise CSV", selected?.name)
     }
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
@@ -415,6 +415,7 @@ class CsvStrategyExportService(
                 fileNamePattern = export.fileNamePattern,
                 crossSourceReconcileWindowSeconds = export.crossSourceReconcileWindowSeconds,
                 conversionConfig = export.conversionConfig,
+                fundingCardColumn = export.fundingCardColumn,
                 createdAt = now,
                 updatedAt = now,
             )

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CurveCsvE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CurveCsvE2ETest.kt
@@ -1,0 +1,451 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.database.csv
+
+import com.moneymanager.csvimporter.BulkImportProgress
+import com.moneymanager.csvimporter.CsvBulkResult
+import com.moneymanager.csvimporter.bulkApplyCsv
+import com.moneymanager.csvimporter.executeCsvReimport
+import com.moneymanager.csvimporter.fundingCardAccountIndex
+import com.moneymanager.csvimporter.planCsvReimport
+import com.moneymanager.database.assertBulkProgress
+import com.moneymanager.domain.Maintenance
+import com.moneymanager.domain.model.AttributeTypeId
+import com.moneymanager.domain.model.CsvImportId
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.WellKnownIds
+import com.moneymanager.domain.model.csv.CsvImport
+import com.moneymanager.importengineapi.createAccountMapping
+import com.moneymanager.test.database.DbTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Instant
+
+/**
+ * End-to-end test for the Curve CSV import and its interaction with the pass-through pipeline.
+ *
+ * Curve is a card aggregator, so a Curve payment shows up twice: once on the underlying card's
+ * statement as "Crv*<merchant>" (which the pass-through detector expands into a Curve -> merchant
+ * spend leg), and once in Curve's own export as a direct Curve -> merchant row. Because the merchant
+ * account is derived from the merchant text on BOTH sides, the two representations line up in one of
+ * three ways, all exercised here:
+ *  - same merchant text  -> the Curve row is a plain (fuzzy) duplicate and is dropped;
+ *  - different text mapped to the same account -> cross-source reconciliation keeps it, excluded+linked;
+ *  - a foreign-currency row -> no GBP card counterpart, so it imports standalone in its own currency.
+ */
+class CurveCsvE2ETest : DbTest() {
+    override val installBuiltInStrategies: Boolean = true
+
+    // The foreign-currency Curve row needs its currency (EUR) to exist.
+    override val seedAllCurrencies: Boolean = true
+
+    private val now = Clock.System.now()
+
+    private val maintenance =
+        object : Maintenance {
+            override suspend fun reindex(): Duration = Duration.ZERO
+
+            override suspend fun vacuum(): Duration = Duration.ZERO
+
+            override suspend fun analyze(): Duration = Duration.ZERO
+
+            override suspend fun refreshMaterializedViews(): Duration = Duration.ZERO
+
+            override suspend fun fullRefreshMaterializedViews(): Duration = Duration.ZERO
+        }
+
+    // crypto.com card export headers, reused to produce the underlying "Crv*<merchant>" statement row.
+    private val cardHeaders =
+        listOf(
+            "Timestamp (UTC)",
+            "Transaction Description",
+            "Currency",
+            "Amount",
+            "To Currency",
+            "To Amount",
+            "Native Currency",
+            "Native Amount",
+            "Native Amount (in USD)",
+            "Transaction Kind",
+            "Transaction Hash",
+        )
+
+    private fun cardRow(
+        timestamp: String,
+        description: String,
+        nativeAmount: String,
+    ): List<String> = listOf(timestamp, description, "GBP", nativeAmount, "", "", "GBP", nativeAmount, "0.0", "", "")
+
+    private val curveHeaders =
+        listOf(
+            "",
+            "Created Date",
+            "Merchant Name",
+            "Funding Card Last 4 Digits",
+            "Merchant MCC Code",
+            "Txn Currency",
+            "Txn Amount",
+        )
+
+    private fun curveRow(
+        index: String,
+        date: String,
+        merchant: String,
+        currency: String,
+        amount: String,
+        fundingCard: String = "7721",
+    ): List<String> = listOf(index, date, merchant, fundingCard, "5999", currency, amount)
+
+    private suspend fun stage(
+        fileName: String,
+        headers: List<String>,
+        rows: List<List<String>>,
+    ): CsvImport {
+        val id =
+            repositories.csvImportRepository.createImport(
+                fileName = fileName,
+                headers = headers,
+                rows = rows,
+                fileChecksum = "checksum-$fileName",
+                fileLastModified = now,
+            )
+        return repositories.csvImportRepository.getImport(id).first()!!
+    }
+
+    private suspend fun applyAll(imports: List<CsvImport>): CsvBulkResult {
+        val progress = mutableListOf<BulkImportProgress>()
+        val cardLast4 =
+            repositories.accountAttributeRepository
+                .getByType(AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID))
+                .first()
+        val result =
+            bulkApplyCsv(
+                imports = imports,
+                sourceAccountOverride = null,
+                strategies = repositories.csvImportStrategyRepository.getAllStrategies().first(),
+                currencies = repositories.currencyRepository.getAllCurrencies().first(),
+                accountMappingRepository = repositories.accountMappingRepository,
+                accountRepository = repositories.accountRepository,
+                csvImportRepository = repositories.csvImportRepository,
+                maintenance = maintenance,
+                importEngine = repositories.importEngine,
+                onProgress = { progress += it },
+                passThroughAccounts = repositories.passThroughAccountRepository.getAll().first(),
+                cryptoRepository = repositories.cryptoRepository,
+                fundingCardAccounts = fundingCardAccountIndex(cardLast4),
+            )
+        assertBulkProgress(progress, imports.size)
+        return result
+    }
+
+    /** Registers a card last-4 (or space-separated list) on an account so Curve rows reconcile to it. */
+    private suspend fun registerCard(
+        accountName: String,
+        last4: String,
+    ) {
+        val accounts = repositories.accountRepository.getAllAccounts().first()
+        val accountId = accounts.first { it.name == accountName }.id
+        repositories.accountAttributeRepository.insert(
+            accountId,
+            AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID),
+            last4,
+        )
+    }
+
+    /** Re-imports an already-imported file (plan + execute), threading the funding-card index. */
+    private suspend fun reimport(importId: CsvImportId) {
+        val current = repositories.csvImportRepository.getImport(importId).first()!!
+        val strategy =
+            repositories.csvImportStrategyRepository
+                .getAllStrategies()
+                .first()
+                .first { it.name == "Curve CSV" }
+        val currencies = repositories.currencyRepository.getAllCurrencies().first()
+        val passThroughAccounts = repositories.passThroughAccountRepository.getAll().first()
+        val fca =
+            fundingCardAccountIndex(
+                repositories.accountAttributeRepository
+                    .getByType(AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID))
+                    .first(),
+            )
+        val plan =
+            planCsvReimport(
+                csvImport = current,
+                strategy = strategy,
+                sourceAccountOverride = null,
+                currencies = currencies,
+                accountMappingRepository = repositories.accountMappingRepository,
+                accountRepository = repositories.accountRepository,
+                csvImportRepository = repositories.csvImportRepository,
+                transactionRepository = repositories.transactionRepository,
+                relationshipRepository = repositories.transferRelationshipRepository,
+                transferSourceRepository = repositories.transferSourceRepository,
+                passThroughAccounts = passThroughAccounts,
+                fundingCardAccounts = fca,
+            )
+        executeCsvReimport(
+            plan = plan,
+            csvImport = current,
+            strategy = strategy,
+            sourceAccountOverride = null,
+            currencies = currencies,
+            accountMappingRepository = repositories.accountMappingRepository,
+            accountRepository = repositories.accountRepository,
+            csvImportRepository = repositories.csvImportRepository,
+            maintenance = maintenance,
+            importEngine = repositories.importEngine,
+            passThroughAccounts = passThroughAccounts,
+            fundingCardAccounts = fca,
+        )
+    }
+
+    private suspend fun transfersBetween(
+        sourceName: String,
+        targetName: String,
+    ): List<Transfer> {
+        val accounts = repositories.accountRepository.getAllAccounts().first()
+        val sourceId = accounts.firstOrNull { it.name == sourceName }?.id ?: return emptyList()
+        val targetId = accounts.firstOrNull { it.name == targetName }?.id ?: return emptyList()
+        return repositories.transactionRepository
+            .getTransactionsByAccount(sourceId)
+            .first()
+            .filter { it.sourceAccountId == sourceId && it.targetAccountId == targetId }
+    }
+
+    @Test
+    fun curveCsvSpend_reconcilesWithMappedCardMerchant_andForeignRowStandsAlone() =
+        runTest {
+            // Underlying card statement: a Curve payment forwarded to the crypto.com card. The
+            // pass-through detector expands it into Crypto.com Card -> Curve (funding) and
+            // Curve -> Amazon (spend, described "Amazon").
+            val card =
+                stage(
+                    "card_transactions_record_20231120_210200.csv",
+                    cardHeaders,
+                    listOf(cardRow("2023-11-19 21:15:00", "Crv*Amazon", "-12.99")),
+                )
+            assertEquals(1, applyAll(listOf(card)).filesImported)
+            assertEquals(1, transfersBetween("Curve", "Amazon").size, "card import creates the spend leg")
+
+            // Map Curve's differently-worded merchant onto the same account, so the two spend legs
+            // resolve to the same account but keep distinct descriptions — the realistic reconcile case
+            // (identical text would instead be a plain fuzzy duplicate).
+            val amazonId =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Amazon" }
+                    .id
+            repositories.importEngine.createAccountMapping(Regex("(?i)^Prime Video$"), amazonId)
+
+            // Curve's own export: the same GBP spend under a different name (reconciles) plus a
+            // foreign-currency spend (no GBP card counterpart, so it stands alone).
+            val curve =
+                stage(
+                    "Transaction History 2023-11-19.csv",
+                    curveHeaders,
+                    listOf(
+                        curveRow("1", "2023-11-19", "Prime Video", "GBP", "12.99"),
+                        curveRow("2", "2023-11-18", "Mavroni", "EUR", "50.00"),
+                    ),
+                )
+            val result = applyAll(listOf(curve))
+            assertEquals(1, result.filesImported)
+            assertEquals(0, result.filesSkippedNoStrategy, "the Curve file matches the Curve CSV strategy")
+            assertEquals(0, result.filesFailed)
+
+            // Both Curve -> Amazon legs are kept, but exactly one is excluded + reconciled-linked.
+            repositories.maintenanceService.refreshMaterializedViews()
+            val amazonLegs = transfersBetween("Curve", "Amazon")
+            assertEquals(2, amazonLegs.size, "both the card-derived and Curve-derived spend legs are kept")
+            val excluded =
+                amazonLegs.filter { t -> t.attributes.any { it.attributeType.name == "excluded" && it.value == "reconciled" } }
+            assertEquals(1, excluded.size, "exactly one Amazon leg is excluded as reconciled")
+            val original = amazonLegs.single { it.id != excluded.single().id }
+            val reconciledLink =
+                repositories.transferRelationshipRepository
+                    .getByTransfer(excluded.single().id)
+                    .first()
+                    .single { it.relationshipType.name == "reconciled" }
+            assertEquals(excluded.single().id, reconciledLink.id1)
+            assertEquals(original.id, reconciledLink.id2)
+
+            // The foreign-currency row imports as a standalone Curve -> Mavroni EUR spend (no card
+            // counterpart to reconcile against), keeping Curve's real FX amount.
+            val mavroni = transfersBetween("Curve", "Mavroni").single()
+            assertEquals("EUR", mavroni.amount.asset.code)
+            assertEquals("50", mavroni.amount.toDisplayValue().toString())
+            assertTrue(
+                mavroni.attributes.none { it.attributeType.name == "excluded" },
+                "the foreign-currency spend is not reconciled/excluded",
+            )
+        }
+
+    @Test
+    fun curveCsvSpend_reconcilesAgainstFundingLegByCardNumber_evenWhenMerchantDiffers() =
+        runTest {
+            // The card statement records the Curve charge as "Crv*Sainsburys London"; the pass-through
+            // makes a funding leg (Crypto.com Card -> Curve) and a spend leg (Curve -> "Sainsburys London").
+            val card =
+                stage(
+                    "card_transactions_record_20231120_210200.csv",
+                    cardHeaders,
+                    listOf(cardRow("2023-11-19 21:15:00", "Crv*Sainsburys London", "-22.93")),
+                )
+            assertEquals(1, applyAll(listOf(card)).filesImported)
+            // Register the funding card's last-4 on the Crypto.com Card account (as a user would).
+            registerCard("Crypto.com Card", "7721")
+
+            // Curve's export names the merchant differently ("SAINSBURYS") — merchant reconcile can't
+            // match — but the funding card 7721 identifies the funding leg to reconcile against. A second
+            // row is funded by an unregistered card (1142) and must import as a normal new spend.
+            val curve =
+                stage(
+                    "Transaction History 2023-11-19.csv",
+                    curveHeaders,
+                    listOf(
+                        curveRow("1", "2023-11-19", "SAINSBURYS", "GBP", "22.93", fundingCard = "7721"),
+                        curveRow("2", "2023-11-19", "ALDI", "GBP", "31.25", fundingCard = "1142"),
+                    ),
+                )
+            assertEquals(1, applyAll(listOf(curve)).filesImported)
+            repositories.maintenanceService.refreshMaterializedViews()
+
+            // The 7721 spend reconciled against the funding leg (excluded + linked), despite the merchant
+            // name differing from the card's "Sainsburys London".
+            val sainsburys = transfersBetween("Curve", "SAINSBURYS").single()
+            assertTrue(
+                sainsburys.attributes.any { it.attributeType.name == "excluded" && it.value == "reconciled" },
+                "the 7721 Curve spend is reconciled",
+            )
+            val fundingLeg = transfersBetween("Crypto.com Card", "Curve").single()
+            val link =
+                repositories.transferRelationshipRepository
+                    .getByTransfer(sainsburys.id)
+                    .first()
+                    .single { it.relationshipType.name == "reconciled" }
+            assertEquals(sainsburys.id, link.id1)
+            assertEquals(fundingLeg.id, link.id2, "linked to the funding leg identified by the card number")
+
+            // The 1142 spend has no registered card, so it imports as an ordinary (non-excluded) spend.
+            val aldi = transfersBetween("Curve", "ALDI").single()
+            assertTrue(aldi.attributes.none { it.attributeType.name == "excluded" }, "unregistered-card row is not reconciled")
+        }
+
+    @Test
+    fun reimport_retroactivelyReconciles_afterCardRegistered() =
+        runTest {
+            // The realistic sequence: the card statement is imported (creating the funding leg), the Curve
+            // file is imported BEFORE any card is registered (so it lands as a plain, unreconciled spend),
+            // then the user registers the card and re-imports — which must retroactively reconcile it.
+            val card =
+                stage(
+                    "card_transactions_record_20231120_210200.csv",
+                    cardHeaders,
+                    listOf(cardRow("2023-11-19 21:15:00", "Crv*Sainsburys London", "-22.93")),
+                )
+            applyAll(listOf(card))
+            val curve =
+                stage(
+                    "Transaction History 2023-11-19.csv",
+                    curveHeaders,
+                    listOf(curveRow("1", "2023-11-19", "SAINSBURYS", "GBP", "22.93", fundingCard = "7721")),
+                )
+            applyAll(listOf(curve))
+            assertTrue(
+                transfersBetween("Curve", "SAINSBURYS").single().attributes.none { it.attributeType.name == "excluded" },
+                "not reconciled before the card is registered",
+            )
+
+            registerCard("Crypto.com Card", "7721")
+            reimport(curve.id)
+            repositories.maintenanceService.refreshMaterializedViews()
+
+            val sainsburys = transfersBetween("Curve", "SAINSBURYS").single()
+            assertTrue(
+                sainsburys.attributes.any { it.attributeType.name == "excluded" && it.value == "reconciled" },
+                "re-import reconciles the spend once the card is registered",
+            )
+            val fundingLeg = transfersBetween("Crypto.com Card", "Curve").single()
+            val link =
+                repositories.transferRelationshipRepository
+                    .getByTransfer(sainsburys.id)
+                    .first()
+                    .single { it.relationshipType.name == "reconciled" }
+            assertEquals(fundingLeg.id, link.id2, "linked to the funding leg")
+
+            // Re-running again is a no-op: already reconciled, so the plan doesn't reset it.
+            reimport(curve.id)
+            assertEquals(1, transfersBetween("Curve", "SAINSBURYS").size)
+            assertTrue(transfersBetween("Curve", "SAINSBURYS").single().attributes.any { it.attributeType.name == "excluded" })
+        }
+
+    @Test
+    fun curveCsvSpend_withIdenticalMerchant_isDroppedAsDuplicate_notDoubleCounted() =
+        runTest {
+            // Same merchant text on both sides: the card's pass-through spend leg and the Curve row are
+            // byte-identical (Curve -> Amazon, "Amazon", £12.99), differing only in the date-only vs
+            // datetime stamp. The Curve row must be dropped as a fuzzy duplicate so the spend counts once.
+            val card =
+                stage(
+                    "card_transactions_record_20231120_210200.csv",
+                    cardHeaders,
+                    listOf(cardRow("2023-11-19 21:15:00", "Crv*Amazon", "-12.99")),
+                )
+            applyAll(listOf(card))
+
+            val curve =
+                stage(
+                    "Transaction History 2023-11-19.csv",
+                    curveHeaders,
+                    listOf(curveRow("1", "2023-11-19", "Amazon", "GBP", "12.99")),
+                )
+            val result = applyAll(listOf(curve))
+            assertEquals(0, result.transfersCreated, "the identical Curve spend is a duplicate, not imported")
+            assertEquals(1, transfersBetween("Curve", "Amazon").size, "spend counted once")
+        }
+
+    @Test
+    fun reimportingTheCurveFile_producesOnlyDuplicates() =
+        runTest {
+            val curve =
+                stage(
+                    "Transaction History 2023-11-19.csv",
+                    curveHeaders,
+                    listOf(
+                        curveRow("1", "2023-11-19", "Amazon", "GBP", "12.99"),
+                        curveRow("2", "2023-11-18", "Mavroni", "EUR", "50.00"),
+                    ),
+                )
+            applyAll(listOf(curve))
+
+            suspend fun allTransfers(): List<Transfer> =
+                repositories.transactionRepository
+                    .getTransactionsByDateRange(
+                        startDate = Instant.parse("2023-01-01T00:00:00Z"),
+                        endDate = Instant.parse("2024-12-31T00:00:00Z"),
+                    ).first()
+            val afterFirst = allTransfers().size
+
+            // Curve has no stable per-row id (col 0 is a running index), so re-import relies on
+            // all-fields dedupe. Re-staging the same content under a new name must import nothing.
+            val curveAgain =
+                stage(
+                    "Transaction History 2024-01-01.csv",
+                    curveHeaders,
+                    listOf(
+                        curveRow("1", "2023-11-19", "Amazon", "GBP", "12.99"),
+                        curveRow("2", "2023-11-18", "Mavroni", "EUR", "50.00"),
+                    ),
+                )
+            val second = applyAll(listOf(curveAgain))
+            assertEquals(0, second.filesFailed, "re-import must not fail")
+            assertEquals(0, second.transfersCreated, "everything is a duplicate on re-import")
+            assertEquals(afterFirst, allTransfers().size)
+        }
+}

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/TransferRelationshipReconciliationTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/TransferRelationshipReconciliationTest.kt
@@ -199,6 +199,91 @@ class TransferRelationshipReconciliationTest : DbTest() {
         }
 
     @Test
+    fun passThroughChain_readsReconciled_whenTheFundingLegIsReconciled() =
+        runTest {
+            // A Curve funding-card reconcile links the conduit's export spend to the FUNDING leg
+            // (card -> conduit). The sibling SPEND leg (conduit -> merchant, the "Via conduit" row) must
+            // then also read as reconciled — the whole chain is reconciled, not just the funding leg.
+            val currency = gbp()
+            val cardId = createAccount("Crypto.com Card")
+            val conduitId = createAccount("Curve")
+            val merchantId = createAccount("Sainsburys London")
+            val curveMerchantId = createAccount("SAINSBURYS")
+            val passThroughTypeId = RelationshipTypeId(DatabaseConfig.PASS_THROUGH_RELATIONSHIP_TYPE_ID)
+
+            fun funding() =
+                Transfer(
+                    id = TransferId(-1),
+                    timestamp = baseTime,
+                    description = "Curve",
+                    sourceAccountId = cardId,
+                    targetAccountId = conduitId,
+                    amount = Money(2293, currency),
+                )
+
+            fun spend() =
+                Transfer(
+                    id = TransferId(-2),
+                    timestamp = baseTime,
+                    description = "Sainsburys London",
+                    sourceAccountId = conduitId,
+                    targetAccountId = merchantId,
+                    amount = Money(2293, currency),
+                )
+            val chainIds =
+                repositories.transactionRepository.importTransfers(
+                    transfers = listOf(funding(), spend()),
+                    newAttributes = emptyMap(),
+                    newRelationships =
+                        mapOf(
+                            TransferId(-1) to
+                                listOf(NewRelationship(relatedTransferId = TransferId(-2), typeId = passThroughTypeId)),
+                        ),
+                    sources = List(2) { Source.SampleGenerator },
+                    updates = emptyList(),
+                    updateSources = emptyList(),
+                )
+            val fundingId = chainIds[0]
+            val spendId = chainIds[1]
+
+            // The Curve export's own record of the spend, reconciled (excluded + linked) against the funding leg.
+            val excludedTypeId = AttributeTypeId(DatabaseConfig.EXCLUDED_ATTR_TYPE_ID)
+            val reconciledTypeId = RelationshipTypeId(DatabaseConfig.RECONCILED_RELATIONSHIP_TYPE_ID)
+            val curveSpendId =
+                repositories.transactionRepository
+                    .importTransfers(
+                        transfers =
+                            listOf(
+                                Transfer(
+                                    id = TransferId(-1),
+                                    timestamp = baseTime,
+                                    description = "SAINSBURYS",
+                                    sourceAccountId = conduitId,
+                                    targetAccountId = curveMerchantId,
+                                    amount = Money(2293, currency),
+                                ),
+                            ),
+                        newAttributes = mapOf(TransferId(-1) to listOf(NewAttribute(excludedTypeId, "reconciled"))),
+                        newRelationships =
+                            mapOf(TransferId(-1) to listOf(NewRelationship(relatedTransferId = fundingId, typeId = reconciledTypeId))),
+                        sources = listOf(Source.SampleGenerator),
+                        updates = emptyList(),
+                        updateSources = emptyList(),
+                    ).single()
+
+            repositories.maintenanceService.fullRefreshMaterializedViews()
+            val conduitRows =
+                repositories.transactionRepository
+                    .getRunningBalanceByAccountPaginated(conduitId, pageSize = 50, pagingInfo = null)
+                    .items
+                    .associateBy { it.transactionId }
+
+            assertEquals(true, conduitRows.getValue(fundingId).isReconciled, "funding leg is directly reconciled")
+            assertEquals(true, conduitRows.getValue(spendId).isReconciled, "spend leg reads reconciled via its funding leg")
+            assertEquals(true, conduitRows.getValue(curveSpendId).isReconciled, "the Curve export spend is reconciled")
+        }
+
+    @Test
     fun feeTransfer_inBatchRelationshipResolvesToSiblingsRealId() =
         runTest {
             val currency = gbp()

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/accountAttribute/AccountAttributeSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/accountAttribute/AccountAttributeSelect.sq
@@ -20,3 +20,15 @@ SELECT
 FROM account_attribute
 JOIN attribute_type ON account_attribute.attribute_type_id = attribute_type.id
 WHERE account_attribute.id = ?;
+
+selectByType:
+SELECT
+    account_attribute.id,
+    account_attribute.account_id,
+    account_attribute.attribute_type_id,
+    account_attribute.attribute_value,
+    attribute_type.name AS attribute_type_name
+FROM account_attribute
+JOIN attribute_type ON account_attribute.attribute_type_id = attribute_type.id
+WHERE account_attribute.attribute_type_id = ?
+ORDER BY account_attribute.account_id;

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transfer/TransferSelect.sq
@@ -122,10 +122,18 @@ SELECT
     COALESCE(transfer.source_account_id, trade.from_account_id) AS source_account_id,
     COALESCE(transfer.target_account_id, trade.to_account_id) AS target_account_id,
     running_balance_materialized_view.is_excluded,
+    -- A pass-through (conduit) leg reads as reconciled when its chain counterpart is: a funding-card
+    -- reconcile links the conduit spend to the FUNDING leg, so the sibling SPEND leg (the "Via conduit"
+    -- row) — and vice versa — must show reconciled too, since the whole chain is reconciled.
+    -- pass_through_as_funding.id2 is this row's spend leg (when this row is the funding leg);
+    -- pass_through_as_spend.id1 is this row's funding leg (when this row is the spend leg); both are NULL
+    -- for non-conduit rows, so the extra checks are no-ops there.
     CASE WHEN EXISTS (
         SELECT 1 FROM transfer_relationship tr
-        WHERE (tr.id1 = running_balance_materialized_view.id OR tr.id2 = running_balance_materialized_view.id)
-          AND tr.relationship_type_id = 1   -- RECONCILED_RELATIONSHIP_TYPE_ID; mirrors the hardcoded -1 used for is_excluded
+        WHERE tr.relationship_type_id = 1   -- RECONCILED_RELATIONSHIP_TYPE_ID; mirrors the hardcoded -1 used for is_excluded
+          AND (tr.id1 = running_balance_materialized_view.id OR tr.id2 = running_balance_materialized_view.id
+               OR tr.id1 = pass_through_as_funding.id2 OR tr.id2 = pass_through_as_funding.id2
+               OR tr.id1 = pass_through_as_spend.id1 OR tr.id2 = pass_through_as_spend.id1)
     ) THEN 1 ELSE 0 END AS is_reconciled,
     -- The linked fee transfer when this row is the main transaction (id1 of a `fee` relationship),
     -- and the linked main transaction when this row is the fee transfer (id2). FEE_RELATIONSHIP_TYPE_ID = 2.
@@ -184,10 +192,18 @@ SELECT
     COALESCE(transfer.source_account_id, trade.from_account_id) AS source_account_id,
     COALESCE(transfer.target_account_id, trade.to_account_id) AS target_account_id,
     running_balance_materialized_view.is_excluded,
+    -- A pass-through (conduit) leg reads as reconciled when its chain counterpart is: a funding-card
+    -- reconcile links the conduit spend to the FUNDING leg, so the sibling SPEND leg (the "Via conduit"
+    -- row) — and vice versa — must show reconciled too, since the whole chain is reconciled.
+    -- pass_through_as_funding.id2 is this row's spend leg (when this row is the funding leg);
+    -- pass_through_as_spend.id1 is this row's funding leg (when this row is the spend leg); both are NULL
+    -- for non-conduit rows, so the extra checks are no-ops there.
     CASE WHEN EXISTS (
         SELECT 1 FROM transfer_relationship tr
-        WHERE (tr.id1 = running_balance_materialized_view.id OR tr.id2 = running_balance_materialized_view.id)
-          AND tr.relationship_type_id = 1   -- RECONCILED_RELATIONSHIP_TYPE_ID; mirrors the hardcoded -1 used for is_excluded
+        WHERE tr.relationship_type_id = 1   -- RECONCILED_RELATIONSHIP_TYPE_ID; mirrors the hardcoded -1 used for is_excluded
+          AND (tr.id1 = running_balance_materialized_view.id OR tr.id2 = running_balance_materialized_view.id
+               OR tr.id1 = pass_through_as_funding.id2 OR tr.id2 = pass_through_as_funding.id2
+               OR tr.id1 = pass_through_as_spend.id1 OR tr.id2 = pass_through_as_spend.id1)
     ) THEN 1 ELSE 0 END AS is_reconciled,
     -- The linked fee transfer when this row is the main transaction (id1 of a `fee` relationship),
     -- and the linked main transaction when this row is the fee transfer (id2). FEE_RELATIONSHIP_TYPE_ID = 2.
@@ -254,10 +270,18 @@ SELECT
     COALESCE(transfer.source_account_id, trade.from_account_id) AS source_account_id,
     COALESCE(transfer.target_account_id, trade.to_account_id) AS target_account_id,
     running_balance_materialized_view.is_excluded,
+    -- A pass-through (conduit) leg reads as reconciled when its chain counterpart is: a funding-card
+    -- reconcile links the conduit spend to the FUNDING leg, so the sibling SPEND leg (the "Via conduit"
+    -- row) — and vice versa — must show reconciled too, since the whole chain is reconciled.
+    -- pass_through_as_funding.id2 is this row's spend leg (when this row is the funding leg);
+    -- pass_through_as_spend.id1 is this row's funding leg (when this row is the spend leg); both are NULL
+    -- for non-conduit rows, so the extra checks are no-ops there.
     CASE WHEN EXISTS (
         SELECT 1 FROM transfer_relationship tr
-        WHERE (tr.id1 = running_balance_materialized_view.id OR tr.id2 = running_balance_materialized_view.id)
-          AND tr.relationship_type_id = 1   -- RECONCILED_RELATIONSHIP_TYPE_ID; mirrors the hardcoded -1 used for is_excluded
+        WHERE tr.relationship_type_id = 1   -- RECONCILED_RELATIONSHIP_TYPE_ID; mirrors the hardcoded -1 used for is_excluded
+          AND (tr.id1 = running_balance_materialized_view.id OR tr.id2 = running_balance_materialized_view.id
+               OR tr.id1 = pass_through_as_funding.id2 OR tr.id2 = pass_through_as_funding.id2
+               OR tr.id1 = pass_through_as_spend.id1 OR tr.id2 = pass_through_as_spend.id1)
     ) THEN 1 ELSE 0 END AS is_reconciled,
     -- The linked fee transfer when this row is the main transaction (id1 of a `fee` relationship),
     -- and the linked main transaction when this row is the fee transfer (id2). FEE_RELATIONSHIP_TYPE_ID = 2.

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/AccountAttributeReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/AccountAttributeReadRepositoryImpl.kt
@@ -36,4 +36,24 @@ class AccountAttributeReadRepositoryImpl(
                     )
                 }
             }
+
+    override fun getByType(typeId: AttributeTypeId): Flow<List<AccountAttribute>> =
+        selectQueries
+            .selectByType(typeId.id)
+            .asFlow()
+            .mapToList(Dispatchers.Default)
+            .map { list ->
+                list.map { row ->
+                    AccountAttribute(
+                        id = row.id,
+                        accountId = AccountId(row.account_id),
+                        attributeType =
+                            AttributeType(
+                                id = AttributeTypeId(row.attribute_type_id),
+                                name = row.attribute_type_name,
+                            ),
+                        value = row.attribute_value,
+                    )
+                }
+            }
 }

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyReadRepositoryImpl.kt
@@ -57,6 +57,7 @@ class CsvImportStrategyReadRepositoryImpl(
             fileNamePattern = entity.file_name_pattern,
             crossSourceReconcileWindowSeconds = entity.cross_source_reconcile_window_seconds,
             conversionConfig = FieldMappingJsonCodec.decodeConversionConfig(entity.conversion_config_json),
+            fundingCardColumn = entity.funding_card_column,
             createdAt = Instant.fromEpochMilliseconds(entity.created_at),
             updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
         )

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategy.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategy.sq
@@ -12,6 +12,7 @@ CREATE TABLE csv_import_strategy (
     file_name_pattern TEXT,
     cross_source_reconcile_window_seconds INTEGER,
     conversion_config_json TEXT,
+    funding_card_column TEXT,
     created_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000),
     updated_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000)
 );

--- a/app/db/seed/src/commonMain/sqldelight/com/moneymanager/database/sql/seed/StaticSeed.sq
+++ b/app/db/seed/src/commonMain/sqldelight/com/moneymanager/database/sql/seed/StaticSeed.sq
@@ -38,6 +38,7 @@ INSERT INTO attribute_type (id, name) VALUES (-3, 'built-in type');
 INSERT INTO attribute_type (id, name) VALUES (-5, 'account-sort-code');
 INSERT INTO attribute_type (id, name) VALUES (-6, 'account-account-number');
 INSERT INTO attribute_type (id, name) VALUES (-7, 'counterparty-name-key');
+INSERT INTO attribute_type (id, name) VALUES (-8, 'card-last4');
 
 INSERT INTO relationship_type (id, name) VALUES (1, 'reconciled');
 INSERT INTO relationship_type (id, name) VALUES (2, 'fee');

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportStrategyWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportStrategyWriteRepositoryImpl.kt
@@ -64,6 +64,7 @@ class CsvImportStrategyWriteRepositoryImpl(
                     file_name_pattern = strategy.fileNamePattern,
                     cross_source_reconcile_window_seconds = strategy.crossSourceReconcileWindowSeconds,
                     conversion_config_json = FieldMappingJsonCodec.encodeConversionConfig(strategy.conversionConfig),
+                    funding_card_column = strategy.fundingCardColumn,
                     updated_at = now.toEpochMilliseconds(),
                     id = strategy.id.id.toString(),
                 )

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/CsvImportStrategyInsert.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/CsvImportStrategyInsert.kt
@@ -24,5 +24,6 @@ fun CsvImportStrategyWriteQueries.insertStrategy(strategy: CsvImportStrategy) {
         file_name_pattern = strategy.fileNamePattern,
         cross_source_reconcile_window_seconds = strategy.crossSourceReconcileWindowSeconds,
         conversion_config_json = FieldMappingJsonCodec.encodeConversionConfig(strategy.conversionConfig),
+        funding_card_column = strategy.fundingCardColumn,
     )
 }

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategyWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategyWrite.sq
@@ -1,12 +1,12 @@
 -- Insert a new strategy. created_at/updated_at are filled by their column DEFAULTs (current time).
 insert:
-INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json, file_name_pattern, cross_source_reconcile_window_seconds, conversion_config_json)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json, file_name_pattern, cross_source_reconcile_window_seconds, conversion_config_json, funding_card_column)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- Update an existing strategy
 update:
 UPDATE csv_import_strategy
-SET revision_id = revision_id + 1, name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, content_match_rules_json = ?, file_name_pattern = ?, cross_source_reconcile_window_seconds = ?, conversion_config_json = ?, updated_at = ?
+SET revision_id = revision_id + 1, name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, content_match_rules_json = ?, file_name_pattern = ?, cross_source_reconcile_window_seconds = ?, conversion_config_json = ?, funding_card_column = ?, updated_at = ?
 WHERE id = ?;
 
 -- Delete a strategy by ID

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/FundingLegMatcher.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/FundingLegMatcher.kt
@@ -1,0 +1,30 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.importengineapi
+
+import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.TransferId
+import kotlin.time.Duration
+import kotlin.time.Instant
+
+/**
+ * Picks the funding leg a conduit-spend row should reconcile against: the unconsumed [candidates]
+ * transfer whose timestamp is nearest [targetTimestamp] and within [window], or null when none qualifies.
+ *
+ * Callers bucket their own candidates by (fundingAccount, conduit, amount) first, so this resolves only
+ * the one-to-one, nearest-timestamp choice — the single rule the engine's `ImportDeduper` funding
+ * reconcile and the re-import planner (`CsvReimport.computeFundingReconcileReruns`) must agree on. Sharing
+ * it here keeps those two paths from drifting. [consumed] holds the ids already claimed in this batch; the
+ * caller adds the returned id to its own set (scope is one import — see `ImportDeduper.consumedFundingIds`).
+ */
+fun selectNearestUnconsumedFundingLeg(
+    candidates: List<Pair<TransferId, Transfer>>,
+    targetTimestamp: Instant,
+    window: Duration,
+    consumed: Set<TransferId>,
+): TransferId? =
+    candidates
+        .asSequence()
+        .filter { (id, existing) -> id !in consumed && (targetTimestamp - existing.timestamp).absoluteValue <= window }
+        .minByOrNull { (_, existing) -> (targetTimestamp - existing.timestamp).absoluteValue }
+        ?.first

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportBatch.kt
@@ -452,6 +452,13 @@ data class ImportTransfer(
     val fee: ImportFee? = null,
     /** An optional conduit pass-through (e.g. Curve), expanded by the engine into a linked spend leg. */
     val passThrough: ImportPassThrough? = null,
+    /**
+     * When set (a conduit-spend import like Curve that named its funding card), the account that must
+     * hold the matching funding leg (funding → this transfer's source conduit). Enables the
+     * funding-card reconcile pass (see [DedupePolicy.FuzzyAllFields]): the row reconciles against an
+     * unconsumed funding leg of the same amount+currency within the window, ignoring the merchant.
+     */
+    val reconcileFundingAccountId: AccountId? = null,
     /** [ImportOperation.CREATE] (default), or UPDATE/DELETE of [existingId]. */
     override val operation: ImportOperation = ImportOperation.CREATE,
     /** The transfer to UPDATE/DELETE (required for those operations). */

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
@@ -16,6 +16,7 @@ import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.DedupePolicy
 import com.moneymanager.importengineapi.ImportTransfer
 import com.moneymanager.importengineapi.StringSimilarity
+import com.moneymanager.importengineapi.selectNearestUnconsumedFundingLeg
 import kotlin.time.Duration
 import kotlin.time.Instant
 
@@ -189,6 +190,11 @@ class ImportDeduper(
     // Funding legs already claimed by an earlier funding-card reconcile in this batch. Unlike the other
     // reconcile paths (which deliberately don't consume), a conduit like Curve emits many rows of the
     // same amount (e.g. daily £1.75 TFL), so each funding leg must reconcile at most one incoming row.
+    // Scope is a single import() call: this does NOT know which funding legs a previous, separate batch
+    // already consumed, so a later batch's row could re-link to an already-reconciled funding leg if the
+    // amount+window coincide. In practice a conduit export is imported in one batch, so the collision
+    // needs two overlapping conduit imports; CsvReimport.computeFundingReconcileReruns mirrors this same
+    // single-batch limitation.
     private val consumedFundingIds = mutableSetOf<TransferId>()
 
     fun classify(transfers: List<ImportTransfer>): List<Classified> =
@@ -308,11 +314,7 @@ class ImportDeduper(
         val key = DirectedAmountKey(fundingAccountId, transfer.fromAccount.requireId(), transfer.amount)
         val matchId =
             reconcileCandidatesByDirectedAmount[key]
-                ?.asSequence()
-                ?.filter { (id, existing) ->
-                    id !in consumedFundingIds && (timestamp - existing.timestamp).absoluteValue <= window
-                }?.minByOrNull { (_, existing) -> (timestamp - existing.timestamp).absoluteValue }
-                ?.first
+                ?.let { selectNearestUnconsumedFundingLeg(it, timestamp, window, consumedFundingIds) }
                 ?: return null
         consumedFundingIds += matchId
         val attributes =

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
@@ -186,6 +186,11 @@ class ImportDeduper(
     private val batchUniqueKey = mutableMapOf<Map<String, String>, Int>()
     private val batchMatchCandidates = mutableListOf<Pair<Int, Transfer>>()
 
+    // Funding legs already claimed by an earlier funding-card reconcile in this batch. Unlike the other
+    // reconcile paths (which deliberately don't consume), a conduit like Curve emits many rows of the
+    // same amount (e.g. daily £1.75 TFL), so each funding leg must reconcile at most one incoming row.
+    private val consumedFundingIds = mutableSetOf<TransferId>()
+
     fun classify(transfers: List<ImportTransfer>): List<Classified> =
         transfers.mapIndexed { index, transfer -> classifyOne(index, transfer) }
 
@@ -274,6 +279,50 @@ class ImportDeduper(
         return Classified(
             // Drop any fee: a cross-source duplicate's fee is itself a duplicate, so it must not be
             // re-created (it would double-count) — the original source's fee already covers it.
+            transfer.copy(attributes = attributes, relationships = relationships, fee = null),
+            ImportStatus.IMPORTED,
+            existing = null,
+        )
+    }
+
+    /**
+     * Reconciles a conduit spend (e.g. a Curve export row, `conduit -> merchant`) against the funding
+     * leg that put the money into the conduit (`fundingAccount -> conduit`), when the row named its
+     * funding card and it resolved to [ImportTransfer.reconcileFundingAccountId]. Matches on
+     * amount+currency (via [Money] equality) and timestamp within the window, IGNORING the merchant —
+     * so it links across the merchant-naming differences that defeat [classifyAsReconciled]. Each
+     * funding leg is consumed at most once (repeated same-amount rows), preferring the nearest
+     * timestamp. The row is kept IMPORTED but excluded and linked to the funding leg, so the spend is
+     * counted once (the funding leg's own pass-through spend leg remains the merchant record).
+     */
+    private fun classifyAsFundingReconciled(
+        transfer: ImportTransfer,
+        window: Duration?,
+        exclusionTypeId: AttributeTypeId?,
+        relationshipTypeId: RelationshipTypeId?,
+    ): Classified? {
+        if (window == null || exclusionTypeId == null || relationshipTypeId == null) return null
+        val fundingAccountId = transfer.reconcileFundingAccountId ?: return null
+        val timestamp = transfer.timestamp ?: return null
+        // Funding leg is fundingAccount -> conduit; the incoming row's source IS the conduit.
+        val key = DirectedAmountKey(fundingAccountId, transfer.fromAccount.requireId(), transfer.amount)
+        val matchId =
+            reconcileCandidatesByDirectedAmount[key]
+                ?.asSequence()
+                ?.filter { (id, existing) ->
+                    id !in consumedFundingIds && (timestamp - existing.timestamp).absoluteValue <= window
+                }?.minByOrNull { (_, existing) -> (timestamp - existing.timestamp).absoluteValue }
+                ?.first
+                ?: return null
+        consumedFundingIds += matchId
+        val attributes =
+            if (transfer.attributes.any { it.typeId == exclusionTypeId }) {
+                transfer.attributes
+            } else {
+                transfer.attributes + NewAttribute(exclusionTypeId, "reconciled")
+            }
+        val relationships = transfer.relationships + NewRelationship(relatedTransferId = matchId, typeId = relationshipTypeId)
+        return Classified(
             transfer.copy(attributes = attributes, relationships = relationships, fee = null),
             ImportStatus.IMPORTED,
             existing = null,
@@ -416,6 +465,15 @@ class ImportDeduper(
                 if (attributesAreIdentical(transfer, existing)) ImportStatus.DUPLICATE else ImportStatus.UPDATED
             return Classified(transfer, status, existing.transferId)
         }
+        // Funding-card reconcile (before fuzzy): a conduit spend whose funding card resolved to an
+        // account reconciles against that account's funding leg by amount+currency+window, ignoring the
+        // merchant — so it links (excluded) instead of dropping as a fuzzy duplicate or double-counting.
+        classifyAsFundingReconciled(
+            transfer,
+            policy.reconcileWindow,
+            policy.reconciledExclusionAttributeTypeId,
+            policy.reconciledRelationshipTypeId,
+        )?.let { return it }
         // Second pass: tolerate bank re-export drift (close date, similar description) — the amount
         // must still match exactly, so only that bucket needs scanning.
         transfer.amount?.let { amount ->

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -91,6 +91,7 @@ import com.moneymanager.importengineapi.forRow
 import com.moneymanager.importengineapi.normalizeNameKey
 import com.moneymanager.importengineapi.personalCounterpartyKey
 import kotlinx.coroutines.flow.first
+import kotlin.time.Duration
 import kotlin.time.Instant
 
 /**
@@ -990,14 +991,24 @@ class ImportEngineImpl(
 
         val accountIds =
             transfers
-                .flatMap { listOf(requireId(it.fromAccount), requireId(it.toAccount)) }
-                .toSet()
+                .flatMap {
+                    // Include any funding-card reconcile account: the funding leg lives on it (and on the
+                    // conduit), so load its history even when the batch never moves money to/from it.
+                    listOfNotNull(requireId(it.fromAccount), requireId(it.toAccount), it.reconcileFundingAccountId)
+                }.toSet()
 
         val rawTransfers =
             when (batch.dedupePolicy) {
                 is DedupePolicy.FuzzyAllFields -> {
-                    val minTs = transfers.minOf { requireNotNull(it.timestamp) }
-                    val maxTs = transfers.maxOf { requireNotNull(it.timestamp) }
+                    val policy = batch.dedupePolicy as DedupePolicy.FuzzyAllFields
+                    // Widen the load window by the dedupe slack so an existing transfer whose timestamp
+                    // sits just outside the incoming batch's own span — but still within the fuzzy date
+                    // tolerance or the cross-source reconcile window — is available as a candidate. This
+                    // matters for date-only exports (e.g. Curve stamps a date that parses to noon) where
+                    // the counterpart card leg lands hours later the same day, or a day or two later.
+                    val slack = maxOf(policy.dateTolerance, policy.reconcileWindow ?: Duration.ZERO)
+                    val minTs = transfers.minOf { requireNotNull(it.timestamp) } - slack
+                    val maxTs = transfers.maxOf { requireNotNull(it.timestamp) } + slack
                     accountIds
                         .flatMap {
                             transactionRepository.getTransactionsByAccountAndDateRange(it, minTs, maxTs).first()

--- a/app/importer/src/commonTest/kotlin/com/moneymanager/importer/ImportDeduperTest.kt
+++ b/app/importer/src/commonTest/kotlin/com/moneymanager/importer/ImportDeduperTest.kt
@@ -355,6 +355,121 @@ class ImportDeduperTest {
         assertTrue(result.transfer.relationships.isEmpty())
     }
 
+    // Funding-card reconcile: a conduit (e.g. Curve) spend, `conduit -> merchant`, reconciles against
+    // the funding leg `fundingAccount -> conduit` by amount+window, ignoring the merchant.
+    private val conduit = AccountId(10)
+    private val fundingAcct = AccountId(20)
+    private val merchant = AccountId(2)
+    private val otherMerchant = AccountId(3)
+
+    private fun curveRow(
+        rowIndex: Long,
+        timestamp: Instant = baseTime,
+        amount: Long = 5,
+        merchantId: AccountId = merchant,
+        fundingHint: AccountId? = fundingAcct,
+        description: String = "Merchant",
+    ) = importTransfer(
+        rowIndex = rowIndex,
+        description = description,
+        amount = amount,
+        timestamp = timestamp,
+        src = conduit,
+        tgt = merchantId,
+    ).copy(reconcileFundingAccountId = fundingHint)
+
+    private fun fundingLeg(
+        id: Long,
+        timestamp: Instant = baseTime,
+        amount: Long = 5,
+    ) = existing(id, description = "Crv*Whatever", amount = amount, timestamp = timestamp, src = fundingAcct, tgt = conduit)
+
+    @Test
+    fun fundingReconcile_matchesFundingLegIgnoringMerchant() {
+        // The funding leg has a different account pair and description than the incoming spend, so only
+        // the funding-card reconcile (amount + window, merchant-agnostic) can link them.
+        val deduper = ImportDeduper(reconcilingFuzzyPolicy, existing = listOf(fundingLeg(9)))
+        val result = deduper.classify(listOf(curveRow(0, timestamp = baseTime + 30.minutes))).single()
+        assertEquals(ImportStatus.IMPORTED, result.status)
+        assertEquals(
+            NewAttribute(AttributeTypeId(-1), "reconciled"),
+            result.transfer.attributes.single { it.typeId == AttributeTypeId(-1) },
+        )
+        assertEquals(
+            NewRelationship(relatedTransferId = TransferId(9), typeId = RelationshipTypeId(1)),
+            result.transfer.relationships.single(),
+        )
+    }
+
+    @Test
+    fun fundingReconcile_runsBeforeFuzzyDuplicate() {
+        // The incoming spend is byte-identical to an existing conduit->merchant spend leg (same source
+        // conduit, same amount, same description) — which fuzzy would drop as a DUPLICATE. With a
+        // funding hint it instead reconciles against the funding leg (kept, excluded, linked).
+        val spendLeg = existing(5, description = "Merchant", src = conduit, tgt = merchant)
+        val deduper = ImportDeduper(reconcilingFuzzyPolicy, existing = listOf(spendLeg, fundingLeg(9)))
+        val result = deduper.classify(listOf(curveRow(0, timestamp = baseTime + 5.minutes))).single()
+        assertEquals(ImportStatus.IMPORTED, result.status)
+        // Linked to the FUNDING leg (9), not the spend leg (5).
+        assertEquals(
+            TransferId(9),
+            result.transfer.relationships
+                .single()
+                .relatedTransferId,
+        )
+    }
+
+    @Test
+    fun fundingReconcile_consumesFundingLegOneToOne() {
+        // Two identical Curve rows (repeated daily £5) but only one funding leg: the first reconciles,
+        // the second finds no unconsumed funding leg and imports as a new spend.
+        val deduper = ImportDeduper(reconcilingFuzzyPolicy, existing = listOf(fundingLeg(9)))
+        val result = deduper.classify(listOf(curveRow(0), curveRow(1)))
+        assertEquals(ImportStatus.IMPORTED, result[0].status)
+        assertTrue(result[0].transfer.attributes.any { it.typeId == AttributeTypeId(-1) }, "first is reconciled")
+        assertEquals(ImportStatus.IMPORTED, result[1].status)
+        assertTrue(result[1].transfer.attributes.none { it.typeId == AttributeTypeId(-1) }, "second is a plain import")
+    }
+
+    @Test
+    fun fundingReconcile_prefersNearestTimestamp() {
+        val far = fundingLeg(8, timestamp = baseTime)
+        val near = fundingLeg(9, timestamp = baseTime + 40.minutes)
+        val deduper = ImportDeduper(reconcilingFuzzyPolicy, existing = listOf(far, near))
+        val result = deduper.classify(listOf(curveRow(0, timestamp = baseTime + 45.minutes))).single()
+        assertEquals(
+            TransferId(9),
+            result.transfer.relationships
+                .single()
+                .relatedTransferId,
+        )
+    }
+
+    @Test
+    fun fundingReconcile_noHintLeavesRowUnchanged() {
+        // Without a resolved funding account the row is a plain new spend (the funding pass is skipped).
+        val deduper = ImportDeduper(reconcilingFuzzyPolicy, existing = listOf(fundingLeg(9)))
+        val result = deduper.classify(listOf(curveRow(0, fundingHint = null, merchantId = otherMerchant))).single()
+        assertEquals(ImportStatus.IMPORTED, result.status)
+        assertTrue(result.transfer.attributes.none { it.typeId == AttributeTypeId(-1) })
+    }
+
+    @Test
+    fun fundingReconcile_amountMismatchDoesNotMatch() {
+        val deduper = ImportDeduper(reconcilingFuzzyPolicy, existing = listOf(fundingLeg(9, amount = 5)))
+        val result = deduper.classify(listOf(curveRow(0, amount = 6))).single()
+        assertEquals(ImportStatus.IMPORTED, result.status)
+        assertTrue(result.transfer.attributes.none { it.typeId == AttributeTypeId(-1) })
+    }
+
+    @Test
+    fun fundingReconcile_outsideWindowDoesNotMatch() {
+        val deduper = ImportDeduper(reconcilingFuzzyPolicy, existing = listOf(fundingLeg(9)))
+        val result = deduper.classify(listOf(curveRow(0, timestamp = baseTime + 90.minutes))).single()
+        assertEquals(ImportStatus.IMPORTED, result.status)
+        assertTrue(result.transfer.attributes.none { it.typeId == AttributeTypeId(-1) })
+    }
+
     @Test
     fun fuzzy_sameCoreDifferentAttributesIsUpdated() {
         val typeId = AttributeTypeId(42)

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/WellKnownIds.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/WellKnownIds.kt
@@ -31,6 +31,17 @@ object WellKnownIds {
      */
     const val ACCOUNT_COUNTERPARTY_NAME_KEY_ATTR_TYPE_ID: Long = -7
 
+    /**
+     * "card-last4" account attribute: the last-4 digits (whitespace/comma-separated for multiple) of
+     * the cards funded from this account. A CSV strategy with a
+     * [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.fundingCardColumn] uses it to
+     * reconcile a conduit (e.g. Curve) spend against the funding leg into this account.
+     */
+    const val ACCOUNT_CARD_LAST4_ATTR_TYPE_ID: Long = -8
+
+    /** Name of the [ACCOUNT_CARD_LAST4_ATTR_TYPE_ID] attribute type. */
+    const val ACCOUNT_CARD_LAST4_ATTR_TYPE_NAME: String = "card-last4"
+
     /** "reconciled" relationship type: id1 mirrors id2 seen from another source. */
     const val RECONCILED_RELATIONSHIP_TYPE_ID: Long = 1
 

--- a/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategy.kt
+++ b/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategy.kt
@@ -47,6 +47,13 @@ data class ContentMatchRule(
  *                            separate debited/credited rows; the importer routes the legs through a
  *                            shared counterparty account and links each debit to its credit (see
  *                            [ConversionConfig]). Null when the source has no such conversions.
+ * @property fundingCardColumn When set, names the CSV column carrying the last-4 digits of the card
+ *                             that funded each row (e.g. Curve's "Funding Card Last 4 Digits"). A row
+ *                             whose last-4 resolves — via the `card-last4` account attribute — to a
+ *                             single account is reconciled against an unconsumed funding leg into the
+ *                             row's source account (same amount+currency within
+ *                             [crossSourceReconcileWindowSeconds]), ignoring the merchant. Null
+ *                             disables funding-card reconciliation.
  * @property createdAt Timestamp when this strategy was created
  * @property updatedAt Timestamp when this strategy was last modified
  */
@@ -62,6 +69,7 @@ data class CsvImportStrategy(
     val fileNamePattern: String? = null,
     val crossSourceReconcileWindowSeconds: Long? = null,
     val conversionConfig: ConversionConfig? = null,
+    val fundingCardColumn: String? = null,
     val createdAt: Instant,
     val updatedAt: Instant,
 ) {

--- a/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExport.kt
+++ b/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExport.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
 package com.moneymanager.domain.model.csvstrategy.export
 
 import com.moneymanager.domain.model.accountmapping.export.AccountMappingExport
@@ -13,6 +15,7 @@ import com.moneymanager.domain.model.csvstrategy.RowCondition
 import com.moneymanager.domain.model.csvstrategy.RowPreprocessingRule
 import com.moneymanager.domain.model.csvstrategy.TransferField
 import com.moneymanager.domain.model.serialization.SortedStringSetSerializer
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.Serializable
 
 /**
@@ -34,6 +37,8 @@ import kotlinx.serialization.Serializable
  * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.crossSourceReconcileWindowSeconds])
  * @property conversionConfig Asset-conversion configuration (already portable, no IDs)
  * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.conversionConfig])
+ * @property fundingCardColumn Name of the column carrying the funding-card last-4 (already portable)
+ * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.fundingCardColumn])
  */
 @Serializable
 data class CsvStrategyExport(
@@ -56,6 +61,12 @@ data class CsvStrategyExport(
     val fileNamePattern: String? = null,
     val crossSourceReconcileWindowSeconds: Long? = null,
     val conversionConfig: ConversionConfig? = null,
+    // Omitted from JSON when null (unlike the fields above, which encode their null under the codec's
+    // encodeDefaults=true) so ADDING this field does not change the canonical hash of every existing
+    // strategy — only a strategy that actually sets it (Curve) rehashes. Prevents a spurious "all
+    // strategies changed" on catalog/Drive sync. See StrategyArtifactCodec.canonicalHash.
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
+    val fundingCardColumn: String? = null,
 )
 
 /**

--- a/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExportMapper.kt
+++ b/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExportMapper.kt
@@ -49,6 +49,7 @@ object CsvStrategyExportMapper {
             fileNamePattern = strategy.fileNamePattern,
             crossSourceReconcileWindowSeconds = strategy.crossSourceReconcileWindowSeconds,
             conversionConfig = strategy.conversionConfig,
+            fundingCardColumn = strategy.fundingCardColumn,
         )
 
     private fun FieldMapping.toExport(

--- a/app/model/repository/read/src/commonMain/kotlin/com/moneymanager/domain/repository/AccountAttributeReadRepository.kt
+++ b/app/model/repository/read/src/commonMain/kotlin/com/moneymanager/domain/repository/AccountAttributeReadRepository.kt
@@ -2,6 +2,7 @@ package com.moneymanager.domain.repository
 
 import com.moneymanager.domain.model.AccountAttribute
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AttributeTypeId
 import kotlinx.coroutines.flow.Flow
 
 interface AccountAttributeReadRepository {
@@ -10,4 +11,10 @@ interface AccountAttributeReadRepository {
      * Results are ordered by attribute type name.
      */
     fun getByAccount(accountId: AccountId): Flow<List<AccountAttribute>>
+
+    /**
+     * Gets every account's attribute of the given type (e.g. `card-last4`), ordered by account id.
+     * Used to build a value → account index without loading every account's full attribute set.
+     */
+    fun getByType(typeId: AttributeTypeId): Flow<List<AccountAttribute>>
 }

--- a/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
+++ b/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
@@ -42,6 +42,7 @@ object BuiltInCsvStrategies {
     val cryptoComCardStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-000000000007")
     val cryptoComFiatStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-000000000008")
     val cryptoComCryptoStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-000000000009")
+    val curveCsvStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-00000000000a")
 
     /** Fixed account names shared by the crypto.com Card and Fiat strategies, so both files resolve the same accounts. */
     private const val CRYPTO_COM_CARD_ACCOUNT = "Crypto.com Card"
@@ -83,6 +84,21 @@ object BuiltInCsvStrategies {
     /** Account name prefix shared with the Wise API import strategy ("Wise: " + currency code). */
     private const val WISE_ACCOUNT_PREFIX = "Wise: "
 
+    /**
+     * The Curve conduit account. Matches [com.moneymanager.builtin.BuiltInPassThroughs.curve]'s
+     * conduitAccountName, so a Curve CSV row's spend leg (Curve -> merchant) is the same shape as the
+     * spend leg the pass-through detector synthesises from an underlying card's "CRV*<merchant>" row,
+     * letting cross-source reconciliation link the two.
+     */
+    private const val CURVE_CONDUIT_ACCOUNT = "Curve"
+
+    /**
+     * Cross-source reconciliation window for the Curve CSV strategy. Curve's export stamps only a
+     * Created Date (no time), and a card authorisation can settle a day or two later, so allow 48h —
+     * still gated on an exact same-merchant-account + same amount + same currency match.
+     */
+    private const val CURVE_RECONCILE_WINDOW_SECONDS = 172_800L
+
     private fun builtInCsvMappingId(
         strategyGroup: Int,
         index: Int,
@@ -107,6 +123,8 @@ object BuiltInCsvStrategies {
 
     private fun cryptoComCryptoMappingId(index: Int): FieldMappingId = builtInCsvMappingId(strategyGroup = 7, index = index)
 
+    private fun curveCsvMappingId(index: Int): FieldMappingId = builtInCsvMappingId(strategyGroup = 8, index = index)
+
     /**
      * All built-in CSV import strategies seeded into a fresh database. [qifCurrencyId] is the fixed
      * currency the QIF strategies carry (the default the QIF import dialog pre-selects); it is resolved
@@ -124,6 +142,7 @@ object BuiltInCsvStrategies {
             buildCryptoComCardStrategy(now),
             buildCryptoComFiatStrategy(now),
             buildCryptoComCryptoStrategy(now),
+            buildCurveCsvStrategy(now),
         )
 
     /**
@@ -570,6 +589,116 @@ object BuiltInCsvStrategies {
                     pairingWindowSeconds = CRYPTO_COM_CONVERSION_PAIRING_WINDOW_SECONDS,
                     relationshipTypeName = "conversion",
                 ),
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    /**
+     * Built-in strategy for Curve's "Transaction History <date>.csv" export. Curve is a card
+     * aggregator: a Curve payment is forwarded to an underlying card, so each Curve row is the
+     * merchant-facing side of a movement whose funding side lives on the underlying card's statement.
+     *
+     * Every row is mapped to a spend leg [CURVE_CONDUIT_ACCOUNT] -> merchant, matching the spend leg the
+     * pass-through detector already synthesises from the underlying card's "CRV*<merchant>" row (see
+     * [com.moneymanager.builtin.BuiltInPassThroughs.curve]). Cross-source reconciliation
+     * ([com.moneymanager.importer.ImportDeduper.reconcileMatches]) then links the two whenever they
+     * resolve to the same merchant account, same amount and same currency within
+     * [CURVE_RECONCILE_WINDOW_SECONDS] — so the merchant spend is counted once. The funding leg
+     * (card -> Curve) is contributed by the underlying-card import, not this file.
+     *
+     * Reconciliation is exact on the merchant account, so it links only where both sources resolve the
+     * same account — the merchant text differs across sources (card "Crv*Amzn Mktplace" vs Curve
+     * "AMAZON"), so alignment relies on persisted account mappings, the same normalisation used for the
+     * card variants. Foreign-currency rows (Curve records the merchant-side amount/currency, not the GBP
+     * the card was billed) can never match the GBP funding side, so they import as standalone Curve
+     * spends in their own currency by design.
+     *
+     * The export's first column has a BLANK header (a running row index); it is part of the
+     * identification column set but is otherwise unused. Amounts are always positive spends out of
+     * Curve, so there is deliberately no flip-on-positive.
+     */
+    fun buildCurveCsvStrategy(now: Instant): CsvImportStrategy {
+        val fieldMappings =
+            mapOf(
+                // Fixed conduit source so every Curve row lands in the shared Curve account and lines up
+                // with the pass-through spend leg. The catch-all pattern always matches.
+                TransferField.SOURCE_ACCOUNT to
+                    RegexAccountMapping(
+                        id = curveCsvMappingId(1),
+                        fieldType = TransferField.SOURCE_ACCOUNT,
+                        columnName = "Merchant Name",
+                        rules = listOf(RegexRule(pattern = "^", accountName = CURVE_CONDUIT_ACCOUNT)),
+                    ),
+                // Merchant account, looked up/created from the clean Merchant Name; persisted account
+                // mappings apply, so a user can normalise Curve's name onto the same account the card's
+                // pass-through spend leg resolves to (which is what makes reconciliation link them).
+                TransferField.TARGET_ACCOUNT to
+                    AccountLookupMapping(
+                        id = curveCsvMappingId(2),
+                        fieldType = TransferField.TARGET_ACCOUNT,
+                        columnName = "Merchant Name",
+                    ),
+                TransferField.TIMESTAMP to
+                    DateTimeParsingMapping(
+                        id = curveCsvMappingId(3),
+                        fieldType = TransferField.TIMESTAMP,
+                        dateColumnName = "Created Date",
+                        dateFormat = "yyyy-MM-dd",
+                    ),
+                TransferField.DESCRIPTION to
+                    DirectColumnMapping(
+                        id = curveCsvMappingId(4),
+                        fieldType = TransferField.DESCRIPTION,
+                        columnName = "Merchant Name",
+                    ),
+                TransferField.AMOUNT to
+                    AmountParsingMapping(
+                        id = curveCsvMappingId(5),
+                        fieldType = TransferField.AMOUNT,
+                        mode = AmountMode.SINGLE_COLUMN,
+                        amountColumnName = "Txn Amount",
+                    ),
+                TransferField.CURRENCY to
+                    CurrencyLookupMapping(
+                        id = curveCsvMappingId(6),
+                        fieldType = TransferField.CURRENCY,
+                        columnName = "Txn Currency",
+                    ),
+                TransferField.TIMEZONE to
+                    HardCodedTimezoneMapping(
+                        id = curveCsvMappingId(7),
+                        fieldType = TransferField.TIMEZONE,
+                        timezoneId = "UTC",
+                    ),
+            )
+        val attributeMappings =
+            listOf(
+                AttributeColumnMapping("Funding Card Last 4 Digits", "curve-funding-card"),
+                AttributeColumnMapping("Merchant MCC Code", "curve-mcc"),
+            )
+        return CsvImportStrategy(
+            id = CsvImportStrategyId(curveCsvStrategyId),
+            name = "Curve CSV",
+            identificationColumns =
+                setOf(
+                    "",
+                    "Created Date",
+                    "Merchant Name",
+                    "Funding Card Last 4 Digits",
+                    "Merchant MCC Code",
+                    "Txn Currency",
+                    "Txn Amount",
+                ),
+            fieldMappings = fieldMappings,
+            attributeMappings = attributeMappings,
+            // Only a tiebreaker among column-matched candidates; Curve's column set is disjoint from
+            // Wise's transaction-history.csv, so the two never compete.
+            fileNamePattern = "^Transaction History",
+            crossSourceReconcileWindowSeconds = CURVE_RECONCILE_WINDOW_SECONDS,
+            // Reconcile each spend against the funding leg on the account whose card-last4 matches this
+            // column, so a Curve charge isn't double-counted against the underlying card's own import.
+            fundingCardColumn = "Funding Card Last 4 Digits",
             createdAt = now,
             updatedAt = now,
         )

--- a/app/ui/audit/src/commonMain/kotlin/com/moneymanager/ui/audit/AuditComponents.kt
+++ b/app/ui/audit/src/commonMain/kotlin/com/moneymanager/ui/audit/AuditComponents.kt
@@ -167,26 +167,32 @@ fun SourceInfoSection(
                     }
                 }
                 is Source.Csv -> {
-                    val rowIndex = origin.rowIndex ?: 0
+                    val rowIndex = origin.rowIndex
                     val fileName = source.fileName
                     FieldValueRow("Origin", "CSV Import", labelWidth = labelWidth)
                     if (onCsvSourceClick != null) {
+                        // The File link always opens the import; entities derived from the import as a
+                        // whole (e.g. a pass-through conduit/merchant account, which has no single
+                        // originating row) only show a Row link when the row is actually known — otherwise
+                        // it would link to the non-existent "row 0".
                         CsvSourceLinkRow(
                             label = "File",
                             value = fileName ?: "Unknown file",
                             importId = origin.importId,
-                            rowIndex = rowIndex,
+                            rowIndex = rowIndex ?: 0,
                             onCsvSourceClick = onCsvSourceClick,
                             labelWidth = labelWidth,
                         )
-                        CsvSourceLinkRow(
-                            label = "Row",
-                            value = rowIndex.toString(),
-                            importId = origin.importId,
-                            rowIndex = rowIndex,
-                            onCsvSourceClick = onCsvSourceClick,
-                            labelWidth = labelWidth,
-                        )
+                        if (rowIndex != null) {
+                            CsvSourceLinkRow(
+                                label = "Row",
+                                value = rowIndex.toString(),
+                                importId = origin.importId,
+                                rowIndex = rowIndex,
+                                onCsvSourceClick = onCsvSourceClick,
+                                labelWidth = labelWidth,
+                            )
+                        }
                     } else if (fileName != null) {
                         FieldValueRow("File", fileName, labelWidth = labelWidth)
                     }

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -729,6 +729,7 @@ fun MoneyManagerApp(
                                                 csvImportStrategyRepository = services.imports.csvImportStrategyRepository,
                                                 accountMappingRepository = services.imports.accountMappingRepository,
                                                 accountRepository = services.accounts.accountRepository,
+                                                accountAttributeRepository = services.accounts.accountAttributeRepository,
                                                 categoryRepository = services.accounts.categoryRepository,
                                                 currencyRepository = services.accounts.currencyRepository,
                                                 personRepository = services.people.personRepository,

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
@@ -148,6 +148,7 @@ fun ImportsScreen(
                     csvImportStrategyRepository = csvImportStrategyRepository,
                     accountMappingRepository = accountMappingRepository,
                     accountRepository = accountRepository,
+                    accountAttributeRepository = accountAttributeRepository,
                     categoryRepository = categoryRepository,
                     currencyRepository = currencyRepository,
                     cryptoRepository = cryptoRepository,

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -50,14 +50,17 @@ import com.moneymanager.csvimporter.NewAccount
 import com.moneymanager.csvimporter.buildCreatedAccountNameOverrides
 import com.moneymanager.csvimporter.buildPendingAccountMappings
 import com.moneymanager.csvimporter.ensureCryptoAssets
+import com.moneymanager.csvimporter.fundingCardAccountIndex
 import com.moneymanager.csvimporter.hasBlankNewAccountNames
 import com.moneymanager.csvimporter.runCsvImport
 import com.moneymanager.csvimporter.selectForCsv
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.CryptoAsset
 import com.moneymanager.domain.model.Transfer
+import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.model.accountmapping.AccountMapping
 import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvImport
@@ -66,6 +69,7 @@ import com.moneymanager.domain.model.csv.ImportStatus
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.HardCodedAccountMapping
 import com.moneymanager.domain.model.csvstrategy.TransferField
+import com.moneymanager.domain.repository.AccountAttributeReadRepository
 import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
@@ -96,6 +100,7 @@ fun ApplyStrategyDialog(
     csvImportStrategyRepository: CsvImportStrategyReadRepository,
     accountMappingRepository: AccountMappingReadRepository,
     accountRepository: AccountReadRepository,
+    accountAttributeRepository: AccountAttributeReadRepository,
     categoryRepository: CategoryReadRepository,
     currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
@@ -120,6 +125,9 @@ fun ApplyStrategyDialog(
         .getAll()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     val passThroughDetector = passThroughAccounts.takeIf { it.isNotEmpty() }?.let { PassThroughDetector(it) }
+    val cardLast4Attributes by accountAttributeRepository
+        .getByType(AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID))
+        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     var selectedStrategy by remember { mutableStateOf<CsvImportStrategy?>(null) }
     var selectedSourceAccountId by remember { mutableStateOf<AccountId?>(null) }
@@ -416,6 +424,7 @@ fun ApplyStrategyDialog(
                                     importEngine = importEngine,
                                     cryptoAssets = resolvedCrypto,
                                     passThroughAccounts = passThroughAccounts,
+                                    fundingCardAccounts = fundingCardAccountIndex(cardLast4Attributes),
                                 )
                             onImportComplete(result)
                         } catch (expected: Exception) {

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
@@ -19,12 +19,16 @@ import androidx.compose.ui.unit.dp
 import com.moneymanager.csvimporter.BulkImportProgress
 import com.moneymanager.csvimporter.STRATEGY_CONTENT_SAMPLE_SIZE
 import com.moneymanager.csvimporter.bulkApplyCsv
+import com.moneymanager.csvimporter.fundingCardAccountIndex
 import com.moneymanager.csvimporter.needsSourceAccountOverride
 import com.moneymanager.csvimporter.selectForCsv
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AttributeTypeId
+import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.repository.AccountAttributeReadRepository
 import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
@@ -56,6 +60,7 @@ fun CsvImportAllDialog(
     csvImportStrategyRepository: CsvImportStrategyReadRepository,
     accountMappingRepository: AccountMappingReadRepository,
     accountRepository: AccountReadRepository,
+    accountAttributeRepository: AccountAttributeReadRepository,
     categoryRepository: CategoryReadRepository,
     currencyRepository: CurrencyReadRepository,
     cryptoRepository: CryptoReadRepository,
@@ -71,6 +76,9 @@ fun CsvImportAllDialog(
     val strategies by csvImportStrategyRepository.getAllStrategies().collectAsStateWithSchemaErrorHandling(emptyList())
     val currencies by currencyRepository.getAllCurrencies().collectAsStateWithSchemaErrorHandling(emptyList())
     val passThroughAccounts by passThroughAccountRepository.getAll().collectAsStateWithSchemaErrorHandling(emptyList())
+    val cardLast4Attributes by accountAttributeRepository
+        .getByType(AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID))
+        .collectAsStateWithSchemaErrorHandling(emptyList())
 
     var sourceAccountId by remember { mutableStateOf<AccountId?>(null) }
     var isImporting by remember { mutableStateOf(false) }
@@ -159,6 +167,7 @@ fun CsvImportAllDialog(
                                         onProgress = { progress = it },
                                         passThroughAccounts = passThroughAccounts,
                                         cryptoRepository = cryptoRepository,
+                                        fundingCardAccounts = fundingCardAccountIndex(cardLast4Attributes),
                                     )
                                 summary = result.toSummary()
                             } finally {

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportDetailScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportDetailScreen.kt
@@ -35,6 +35,7 @@ import com.moneymanager.domain.model.CsvImportId
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.TransferId
 import com.moneymanager.domain.model.csv.CsvRow
+import com.moneymanager.domain.repository.AccountAttributeReadRepository
 import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
@@ -66,6 +67,7 @@ fun CsvImportDetailScreen(
     csvImportStrategyRepository: CsvImportStrategyReadRepository,
     accountMappingRepository: AccountMappingReadRepository,
     accountRepository: AccountReadRepository,
+    accountAttributeRepository: AccountAttributeReadRepository,
     categoryRepository: CategoryReadRepository,
     currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
@@ -426,6 +428,7 @@ fun CsvImportDetailScreen(
             csvImportStrategyRepository = csvImportStrategyRepository,
             accountMappingRepository = accountMappingRepository,
             accountRepository = accountRepository,
+            accountAttributeRepository = accountAttributeRepository,
             categoryRepository = categoryRepository,
             currencyRepository = currencyRepository,
             personRepository = personRepository,
@@ -457,6 +460,7 @@ fun CsvImportDetailScreen(
             csvImportStrategyRepository = csvImportStrategyRepository,
             accountMappingRepository = accountMappingRepository,
             accountRepository = accountRepository,
+            accountAttributeRepository = accountAttributeRepository,
             categoryRepository = categoryRepository,
             currencyRepository = currencyRepository,
             personRepository = personRepository,

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportsScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportsScreen.kt
@@ -39,6 +39,7 @@ import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.CsvImportId
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.timeline.ImportFileDateRange
+import com.moneymanager.domain.repository.AccountAttributeReadRepository
 import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
@@ -76,6 +77,7 @@ fun CsvImportsScreen(
     csvImportStrategyRepository: CsvImportStrategyReadRepository,
     accountMappingRepository: AccountMappingReadRepository,
     accountRepository: AccountReadRepository,
+    accountAttributeRepository: AccountAttributeReadRepository,
     categoryRepository: CategoryReadRepository,
     currencyRepository: CurrencyReadRepository,
     cryptoRepository: CryptoReadRepository,
@@ -270,6 +272,7 @@ fun CsvImportsScreen(
                     csvImportStrategyRepository = csvImportStrategyRepository,
                     accountMappingRepository = accountMappingRepository,
                     accountRepository = accountRepository,
+                    accountAttributeRepository = accountAttributeRepository,
                     categoryRepository = categoryRepository,
                     currencyRepository = currencyRepository,
                     cryptoRepository = cryptoRepository,
@@ -289,6 +292,7 @@ fun CsvImportsScreen(
                     csvImportStrategyRepository = csvImportStrategyRepository,
                     accountMappingRepository = accountMappingRepository,
                     accountRepository = accountRepository,
+                    accountAttributeRepository = accountAttributeRepository,
                     categoryRepository = categoryRepository,
                     currencyRepository = currencyRepository,
                     cryptoRepository = cryptoRepository,

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvReimportAllDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvReimportAllDialog.kt
@@ -24,12 +24,16 @@ import com.moneymanager.csvimporter.BulkImportProgress
 import com.moneymanager.csvimporter.CsvBulkReimportResult
 import com.moneymanager.csvimporter.STRATEGY_CONTENT_SAMPLE_SIZE
 import com.moneymanager.csvimporter.bulkReimportCsv
+import com.moneymanager.csvimporter.fundingCardAccountIndex
 import com.moneymanager.csvimporter.needsSourceAccountOverride
 import com.moneymanager.csvimporter.selectForCsv
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AttributeTypeId
+import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.repository.AccountAttributeReadRepository
 import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
@@ -67,6 +71,7 @@ fun CsvReimportAllDialog(
     csvImportStrategyRepository: CsvImportStrategyReadRepository,
     accountMappingRepository: AccountMappingReadRepository,
     accountRepository: AccountReadRepository,
+    accountAttributeRepository: AccountAttributeReadRepository,
     categoryRepository: CategoryReadRepository,
     currencyRepository: CurrencyReadRepository,
     cryptoRepository: CryptoReadRepository,
@@ -86,6 +91,9 @@ fun CsvReimportAllDialog(
     val strategies by csvImportStrategyRepository.getAllStrategies().collectAsStateWithSchemaErrorHandling(emptyList())
     val currencies by currencyRepository.getAllCurrencies().collectAsStateWithSchemaErrorHandling(emptyList())
     val passThroughAccounts by passThroughAccountRepository.getAll().collectAsStateWithSchemaErrorHandling(emptyList())
+    val cardLast4Attributes by accountAttributeRepository
+        .getByType(AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID))
+        .collectAsStateWithSchemaErrorHandling(emptyList())
 
     var sourceAccountId by remember { mutableStateOf<AccountId?>(null) }
     var isRunning by remember { mutableStateOf(false) }
@@ -193,6 +201,7 @@ fun CsvReimportAllDialog(
                                         passThroughAccounts = passThroughAccounts,
                                         cryptoRepository = cryptoRepository,
                                         tradeRepository = tradeRepository,
+                                        fundingCardAccounts = fundingCardAccountIndex(cardLast4Attributes),
                                     )
                             } finally {
                                 isRunning = false

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
@@ -26,15 +26,19 @@ import androidx.compose.ui.unit.dp
 import com.moneymanager.csvimporter.CsvReimportResult
 import com.moneymanager.csvimporter.ReimportPlan
 import com.moneymanager.csvimporter.executeCsvReimport
+import com.moneymanager.csvimporter.fundingCardAccountIndex
 import com.moneymanager.csvimporter.needsSourceAccountOverride
 import com.moneymanager.csvimporter.planCsvReimport
 import com.moneymanager.csvimporter.selectForCsv
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AttributeTypeId
+import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.model.csv.ImportStatus
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
+import com.moneymanager.domain.repository.AccountAttributeReadRepository
 import com.moneymanager.domain.repository.AccountMappingReadRepository
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.CategoryReadRepository
@@ -79,6 +83,7 @@ fun ReimportDialog(
     csvImportStrategyRepository: CsvImportStrategyReadRepository,
     accountMappingRepository: AccountMappingReadRepository,
     accountRepository: AccountReadRepository,
+    accountAttributeRepository: AccountAttributeReadRepository,
     categoryRepository: CategoryReadRepository,
     currencyRepository: CurrencyReadRepository,
     personRepository: PersonReadRepository,
@@ -99,6 +104,9 @@ fun ReimportDialog(
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     val passThroughAccounts by passThroughAccountRepository
         .getAll()
+        .collectAsStateWithSchemaErrorHandling(initial = emptyList())
+    val cardLast4Attributes by accountAttributeRepository
+        .getByType(AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID))
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     var strategy by remember { mutableStateOf<CsvImportStrategy?>(null) }
@@ -130,7 +138,7 @@ fun ReimportDialog(
     val sourceReady = !needsSourcePicker || selectedSourceAccountId != null
 
     // Build the read-only merge preview once the inputs are ready.
-    LaunchedEffect(strategy, selectedSourceAccountId, currencies, passThroughAccounts) {
+    LaunchedEffect(strategy, selectedSourceAccountId, currencies, passThroughAccounts, cardLast4Attributes) {
         val currentStrategy = strategy ?: return@LaunchedEffect
         if (currencies.isEmpty()) return@LaunchedEffect
         try {
@@ -150,6 +158,7 @@ fun ReimportDialog(
                     // Crypto tickers on already-imported rows must resolve for the value-update and
                     // transfer→trade conversion scans, so pass the full asset set.
                     cryptoAssets = cryptoRepository.getAllCryptoAssets().first(),
+                    fundingCardAccounts = fundingCardAccountIndex(cardLast4Attributes),
                     onProgress = { planProgress = it },
                 )
             errorMessage = null
@@ -253,6 +262,7 @@ fun ReimportDialog(
                                     onProgress = { executeProgress = it },
                                     cryptoRepository = cryptoRepository,
                                     tradeRepository = tradeRepository,
+                                    fundingCardAccounts = fundingCardAccountIndex(cardLast4Attributes),
                                 )
                             onComplete(result)
                         } catch (expected: CancellationException) {
@@ -447,6 +457,34 @@ private fun ReimportPlanPreview(
                     "These rows exchange one asset for another: each row's old single-asset transaction(s) " +
                         "are deleted — including any manual edits made to them — and the row is re-imported " +
                         "as a trade.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (plan.fundingReconciles.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Conduit spends to reconcile against their funding card (${plan.fundingReconciles.size}):",
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            plan.fundingReconciles.take(VALUE_UPDATE_PREVIEW_LIMIT).forEach { reconcile ->
+                Text(text = "• ${reconcile.description}", style = MaterialTheme.typography.bodySmall)
+            }
+            if (plan.fundingReconciles.size > VALUE_UPDATE_PREVIEW_LIMIT) {
+                Text(
+                    text = "…and ${plan.fundingReconciles.size - VALUE_UPDATE_PREVIEW_LIMIT} more",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text =
+                    "These spends match a funding leg on the account holding their card number, so each is " +
+                        "re-imported linked to that leg and excluded from balances (counted once) instead of " +
+                        "double-counting the underlying card charge.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorState.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorState.kt
@@ -92,6 +92,7 @@ internal class CsvStrategyEditorState(
     // Not yet editable in the UI; carried through so saving never drops them.
     var contentMatchRules by mutableStateOf(initial?.contentMatchRules.orEmpty())
     var crossSourceReconcileWindowSeconds by mutableStateOf(initial?.crossSourceReconcileWindowSeconds)
+    var fundingCardColumn by mutableStateOf(initial?.fundingCardColumn)
 
     // Initial primary columns, used to avoid clobbering saved fallbacks on edit-mode load.
     val initialTargetAccountColumnName: String? = initial?.targetAccountColumnName
@@ -236,6 +237,7 @@ internal class CsvStrategyEditorState(
             contentMatchRules = contentMatchRules,
             fileNamePattern = fileNamePattern.takeIf { it.isNotBlank() },
             crossSourceReconcileWindowSeconds = crossSourceReconcileWindowSeconds,
+            fundingCardColumn = fundingCardColumn,
         )
 }
 

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyFormState.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyFormState.kt
@@ -195,6 +195,7 @@ internal data class StrategyFormState(
     val contentMatchRules: List<ContentMatchRule>,
     val fileNamePattern: String?,
     val crossSourceReconcileWindowSeconds: Long?,
+    val fundingCardColumn: String?,
 )
 
 /**
@@ -470,6 +471,7 @@ internal fun extractFormStateFromStrategy(
         contentMatchRules = strategy.contentMatchRules,
         fileNamePattern = strategy.fileNamePattern,
         crossSourceReconcileWindowSeconds = strategy.crossSourceReconcileWindowSeconds,
+        fundingCardColumn = strategy.fundingCardColumn,
     )
 }
 
@@ -629,6 +631,7 @@ internal fun buildStrategyFromFormState(
         contentMatchRules = state.contentMatchRules,
         fileNamePattern = state.fileNamePattern?.takeIf { it.isNotBlank() },
         crossSourceReconcileWindowSeconds = state.crossSourceReconcileWindowSeconds,
+        fundingCardColumn = state.fundingCardColumn?.takeIf { it.isNotBlank() },
         createdAt = createdAt,
         updatedAt = updatedAt,
     )


### PR DESCRIPTION
## What

Adds support for importing Curve's own `Transaction History <date>.csv` export, reconciled against the underlying card statements so a Curve charge isn't double-counted.

Curve is a card aggregator: a payment is forwarded to an underlying card, so it appears twice — once on the card statement (`CRV*<merchant>`, already expanded into a `card → Curve → merchant` pass-through chain) and once in Curve's own export (`Curve → merchant`). Merchant names differ across the two sources, so plain merchant-based reconciliation barely matched (in real data ~117/4258, leaving ~1400 double-counted spends). Instead we reconcile on the **funding card**.

## How

- **Built-in `Curve CSV` strategy** (`BuiltInCsvStrategies`): source hard-coded to the `Curve` conduit, date-only timestamp, foreign-currency, `Funding Card Last 4 Digits` column.
- **Funding-card reconcile:** a new well-known `card-last4` account attribute maps a card's last-4 digits to the account that funds it (set via Edit Account). `ImportDeduper.classifyAsFundingReconciled` links a conduit spend to an unconsumed matching funding leg (`fundingAccount → conduit`, same amount+currency within the window, consume-once, nearest timestamp), **ignoring the merchant**.
- **Config plumbing:** `CsvImportStrategy.fundingCardColumn` through the DB schema / write / read / export / editor chain. The export field uses `@EncodeDefault(NEVER)` so adding it doesn't churn every existing strategy's canonical hash (which would flag all strategies as "changed" on catalog/Drive sync).
- **Retroactive reconcile on re-import** (`computeFundingReconcileReruns`): resets already-imported conduit spends that now match a funding leg, so registering a card takes effect without recreating the DB. Only rows with an actual matching leg are reset (no churn).
- **`loadExisting`** widens the `FuzzyAllFields` candidate window by the dedupe slack, so date-only rows still see a same-day/next-day counterpart.
- **UI:** a pass-through spend leg (the "Via conduit" row) now reads as reconciled when its chain counterpart is (`TransferSelect.sq`); pass-through conduit/merchant accounts record their originating row, and the account audit no longer renders a broken "Row 0" link for row-less provenance.

## Tests

- `CurveCsvE2ETest` — reconcile-via-mapping, funding-card reconcile by last-4 (differing merchant), unregistered-card row imports as new, foreign standalone, identical→dropped, re-import idempotency, retroactive re-import reconcile.
- `ImportDeduperTest` — funding-reconcile match / consume-once / nearest-timestamp / no-hint / amount+window misses.
- `TransferRelationshipReconciliationTest` — spend leg reads reconciled when its funding leg is.
- `BuildFirstRowByAccountNameTest`, `StrategySelectorTest`, export round-trip + catalog lockstep.

**BETA note:** adds a schema column (`funding_card_column`) and a seed row (`card-last4` attribute type), so local databases are recreated on next launch (per the no-migrations BETA policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in support for importing Curve transaction history CSV files.
  * CSV strategies can now identify card last-four values to reconcile spending with matching funding transactions.
  * Re-imports can retroactively reconcile previously unmatched transactions.
  * Strategy editing and export now support configuring the funding-card column.
* **Bug Fixes**
  * Improved duplicate handling and reconciliation for pass-through transactions.
  * Fixed audit links from displaying an invalid row when the source row is unavailable.
* **Tests**
  * Added coverage for Curve imports, reconciliation, re-imports, and strategy detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->