### PR TITLE
Generalize funding-card last-4 into regex-against-attribute account routing

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/AttributeAccountMatcher.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/AttributeAccountMatcher.kt
@@ -1,0 +1,46 @@
+package com.moneymanager.csvimporter
+
+import com.moneymanager.domain.model.AccountAttribute
+import com.moneymanager.domain.model.AccountId
+
+/**
+ * Resolves a CSV value to the account whose account-attribute pattern matches it. Built from the
+ * account attributes of one type (e.g. `card-last4`): each attribute value is split into
+ * whitespace/comma-separated tokens, and every token is compiled to a case-insensitive [Regex].
+ * A value matches an account when any of that account's tokens is [Regex.containsMatchIn] it. The
+ * match wins only when it is unambiguous — a value claimed by more than one account resolves to null
+ * so the row imports normally instead of reconciling to the wrong account. Mirrors the persisted
+ * `AccountMapping` router's regex semantics, but the patterns live on the accounts.
+ *
+ * A last-4 like "7721" is just a trivial regex, so existing `card-last4` attributes keep working; use
+ * `\s` for a literal space in a pattern, since spaces separate tokens.
+ */
+class AttributeAccountMatcher private constructor(
+    private val patterns: List<Pair<Regex, AccountId>>,
+) {
+    /** The single account whose pattern matches [value], or null when none or more than one does. */
+    fun match(value: String): AccountId? {
+        val accounts = patterns.mapNotNull { (regex, accountId) -> accountId.takeIf { regex.containsMatchIn(value) } }.toSet()
+        return accounts.singleOrNull()
+    }
+
+    companion object {
+        /** Splits an attribute value into its individual pattern tokens (whitespace/comma-separated). */
+        private val TOKEN_DELIMITER = Regex("[\\s,]+")
+
+        fun from(attributes: List<AccountAttribute>): AttributeAccountMatcher =
+            AttributeAccountMatcher(
+                attributes.flatMap { attribute ->
+                    attribute.value
+                        .split(TOKEN_DELIMITER)
+                        .map { it.trim() }
+                        .filter { it.isNotEmpty() }
+                        .map { Regex(it, RegexOption.IGNORE_CASE) to attribute.accountId }
+                },
+            )
+
+        /** Builds a registry keyed by attribute-type name from a mixed list of account attributes. */
+        fun registry(attributes: List<AccountAttribute>): Map<String, AttributeAccountMatcher> =
+            attributes.groupBy { it.attributeType.name }.mapValues { (_, attrs) -> from(attrs) }
+    }
+}

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -4,7 +4,6 @@ package com.moneymanager.csvimporter
 
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.Account
-import com.moneymanager.domain.model.AccountAttribute
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.CryptoAsset
@@ -218,28 +217,6 @@ data class CsvBulkResult(
     override val filesFailed: Int,
 ) : BulkImportResult
 
-/** Splits a `card-last4` attribute value into its individual last-4 tokens (whitespace/comma-separated). */
-private val CARD_LAST4_DELIMITER = Regex("[\\s,]+")
-
-/**
- * Builds the funding-card index used by strategies with a
- * [CsvImportStrategy.fundingCardColumn]: last-4 → the account that funds it. [cardLast4Attributes] are
- * the `card-last4` account attributes (see [com.moneymanager.domain.model.WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID]);
- * each may list several last-4s separated by whitespace or commas. A last-4 claimed by more than one
- * account is ambiguous and dropped, so those rows import normally instead of reconciling to the wrong
- * account.
- */
-fun fundingCardAccountIndex(cardLast4Attributes: List<AccountAttribute>): Map<String, AccountId> {
-    val byLast4 = mutableMapOf<String, MutableSet<AccountId>>()
-    for (attribute in cardLast4Attributes) {
-        for (last4 in attribute.value.split(CARD_LAST4_DELIMITER)) {
-            val token = last4.trim()
-            if (token.isNotEmpty()) byLast4.getOrPut(token) { mutableSetOf() } += attribute.accountId
-        }
-    }
-    return byLast4.mapNotNull { (last4, accounts) -> accounts.singleOrNull()?.let { last4 to it } }.toMap()
-}
-
 /**
  * Applies the matching strategy to every [imports] file. Each file's strategy is auto-matched from its
  * column headers, so files from different banks each get the right strategy; files with no match are
@@ -262,7 +239,7 @@ suspend fun bulkApplyCsv(
     onProgress: suspend (BulkImportProgress) -> Unit,
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
     cryptoRepository: CryptoReadRepository? = null,
-    fundingCardAccounts: Map<String, AccountId> = emptyMap(),
+    attributeAccountMatchers: Map<String, AttributeAccountMatcher> = emptyMap(),
 ): CsvBulkResult {
     var filesImported = 0
     var transfers = 0
@@ -305,7 +282,7 @@ suspend fun bulkApplyCsv(
                     onProgress = { tracker.phase(index, csvImport.originalFileName, it) },
                     engineBatchSize = BULK_ENGINE_BATCH_SIZE,
                     cryptoRepository = cryptoRepository,
-                    fundingCardAccounts = fundingCardAccounts,
+                    attributeAccountMatchers = attributeAccountMatchers,
                 ) ?: return@forEachIndexed
             filesImported++
             transfers += result.successCount
@@ -351,7 +328,7 @@ suspend fun applyStagedCsv(
     onProgress: (suspend (ImportProgress) -> Unit)? = null,
     engineBatchSize: Int = Int.MAX_VALUE,
     cryptoRepository: CryptoReadRepository? = null,
-    fundingCardAccounts: Map<String, AccountId> = emptyMap(),
+    attributeAccountMatchers: Map<String, AttributeAccountMatcher> = emptyMap(),
 ): CsvImportResult? {
     val allRows = csvImportRepository.getImportRows(csvImport.id, limit = csvImport.rowCount.coerceAtLeast(1), offset = 0)
     val rows = allRows.filter { it.importStatus == null || it.importStatus == ImportStatus.ERROR }
@@ -392,6 +369,7 @@ suspend fun applyStagedCsv(
             passThroughAccounts,
             historicalAccountNames,
             cryptoAssets,
+            attributeAccountMatchers,
         ).prepareImport(rows)
 
     return runCsvImport(
@@ -413,7 +391,7 @@ suspend fun applyStagedCsv(
         passThroughAccounts = passThroughAccounts,
         onProgress = onProgress,
         engineBatchSize = engineBatchSize,
-        fundingCardAccounts = fundingCardAccounts,
+        attributeAccountMatchers = attributeAccountMatchers,
     )
 }
 
@@ -472,6 +450,7 @@ fun buildCsvMapper(
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
     historicalAccountNames: Map<String, AccountId> = emptyMap(),
     cryptoAssets: List<CryptoAsset> = emptyList(),
+    attributeAccountMatchers: Map<String, AttributeAccountMatcher> = emptyMap(),
 ): CsvTransferMapper =
     CsvTransferMapper(
         strategy = strategy,
@@ -484,6 +463,7 @@ fun buildCsvMapper(
         historicalAccountNames = historicalAccountNames,
         sourceAccountOverride = sourceAccountOverride,
         passThroughDetector = passThroughAccounts.takeIf { it.isNotEmpty() }?.let { PassThroughDetector(it) },
+        attributeAccountMatchers = attributeAccountMatchers,
     )
 
 /**
@@ -647,7 +627,7 @@ suspend fun runCsvImport(
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
     onProgress: (suspend (ImportProgress) -> Unit)? = null,
     engineBatchSize: Int = Int.MAX_VALUE,
-    fundingCardAccounts: Map<String, AccountId> = emptyMap(),
+    attributeAccountMatchers: Map<String, AttributeAccountMatcher> = emptyMap(),
 ): CsvImportResult {
     logger.info { "Starting CSV import with ${basePrep.validTransfers.size} valid transfers" }
 
@@ -705,6 +685,7 @@ suspend fun runCsvImport(
             historicalAccountNames = historicalAccountNames,
             sourceAccountOverride = selectedSourceAccountId,
             passThroughDetector = passThroughAccounts.takeIf { it.isNotEmpty() }?.let { PassThroughDetector(it) },
+            attributeAccountMatchers = attributeAccountMatchers,
         )
 
     // Handle case when all rows are already processed (rows is already filtered by the caller)
@@ -882,12 +863,14 @@ suspend fun runCsvImport(
                         }
                     }
                 }
-            // Funding-card reconcile hint: resolve the row's funding-card last-4 to the account that
-            // must hold the matching funding leg (e.g. Curve's "7721" -> the Crypto.com Card account).
-            // Never point at the row's own source conduit (a self-reconcile makes no sense).
+            // Funding reconcile hint: match the row's funding value against the strategy's funding
+            // attribute type to find the account that must hold the matching funding leg (e.g. Curve's
+            // "7721" -> the Crypto.com Card account, via the `card-last4` attribute regexes). Never point
+            // at the row's own source conduit (a self-reconcile makes no sense).
+            val fundingMatcher = strategy.fundingAttributeMatch?.let { attributeAccountMatchers[it.attributeTypeName] }
             val fundingAccountId =
-                row.fundingCardLast4
-                    ?.let { fundingCardAccounts[it] }
+                row.fundingMatchValue
+                    ?.let { fundingMatcher?.match(it) }
                     ?.takeIf { it != row.transfer.sourceAccountId }
             ImportTransfer(
                 rowKey = ImportRowKey.CsvRow(row.rowIndex),

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvReimport.kt
@@ -375,7 +375,7 @@ suspend fun planCsvReimport(
     transferSourceRepository: TransferSourceReadRepository,
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
     cryptoAssets: List<CryptoAsset> = emptyList(),
-    fundingCardAccounts: Map<String, AccountId> = emptyMap(),
+    attributeAccountMatchers: Map<String, AttributeAccountMatcher> = emptyMap(),
     onProgress: (suspend (ImportProgress) -> Unit)? = null,
 ): ReimportPlan {
     onProgress?.invoke(ImportProgress("Loading rows"))
@@ -399,6 +399,7 @@ suspend fun planCsvReimport(
             passThroughAccounts,
             historicalAccountNames,
             cryptoAssets,
+            attributeAccountMatchers,
         ).prepareImport(allRows)
 
     onProgress?.invoke(ImportProgress("Analyzing rows (pass 1 of 2)"))
@@ -418,6 +419,7 @@ suspend fun planCsvReimport(
             effectiveSource,
             passThroughAccounts,
             cryptoAssets = cryptoAssets,
+            attributeAccountMatchers = attributeAccountMatchers,
         ).prepareImport(allRows)
     val reversals =
         computeReimportReversals(
@@ -451,7 +453,7 @@ suspend fun planCsvReimport(
             allRows = allRows,
             mappedPrep = mappedPrep,
             strategy = strategy,
-            fundingCardAccounts = fundingCardAccounts,
+            attributeAccountMatchers = attributeAccountMatchers,
             excludedRowIndexes = rewrites.map { it.rowIndex }.toSet() + reversalRowIndexes + tradeConversions.map { it.rowIndex },
             existingTransfers = existingTransfers,
             loadTransfersTouchingAccount = { accountId, startDate, endDate ->
@@ -602,14 +604,15 @@ suspend fun computeFundingReconcileReruns(
     allRows: List<CsvRow>,
     mappedPrep: ImportPreparation,
     strategy: CsvImportStrategy,
-    fundingCardAccounts: Map<String, AccountId>,
+    attributeAccountMatchers: Map<String, AttributeAccountMatcher>,
     excludedRowIndexes: Set<Long>,
     existingTransfers: Map<TransferId, Transfer>,
     loadTransfersTouchingAccount: suspend (AccountId, Instant, Instant) -> List<Transfer>,
     onProgress: (suspend (ImportProgress) -> Unit)? = null,
 ): List<ReimportFundingReconcile> {
     val window = strategy.crossSourceReconcileWindowSeconds?.seconds ?: return emptyList()
-    if (strategy.fundingCardColumn == null || fundingCardAccounts.isEmpty()) return emptyList()
+    val fundingMatcher =
+        strategy.fundingAttributeMatch?.let { attributeAccountMatchers[it.attributeTypeName] } ?: return emptyList()
     val rowsByIndex = allRows.associateBy { it.rowIndex }
 
     // Candidate rows: already IMPORTED conduit spends that resolve a funding account and are not yet
@@ -629,7 +632,7 @@ suspend fun computeFundingReconcileReruns(
             val row = rowsByIndex[mapped.rowIndex] ?: return@mapNotNull null
             if (row.importStatus != ImportStatus.IMPORTED) return@mapNotNull null
             val transferId = row.transferId ?: return@mapNotNull null
-            val fundingAccount = mapped.fundingCardLast4?.let { fundingCardAccounts[it] } ?: return@mapNotNull null
+            val fundingAccount = mapped.fundingMatchValue?.let { fundingMatcher.match(it) } ?: return@mapNotNull null
             val conduit = mapped.transfer.sourceAccountId
             if (fundingAccount == conduit) return@mapNotNull null
             val existing = existingTransfers[transferId] ?: return@mapNotNull null
@@ -891,7 +894,7 @@ suspend fun executeCsvReimport(
     refreshViews: Boolean = true,
     cryptoRepository: CryptoReadRepository? = null,
     tradeRepository: TradeReadRepository? = null,
-    fundingCardAccounts: Map<String, AccountId> = emptyMap(),
+    attributeAccountMatchers: Map<String, AttributeAccountMatcher> = emptyMap(),
 ): CsvReimportResult {
     val merged = mutableListOf<ReimportMerge>()
     val skipped = plan.skipped.toMutableList()
@@ -1068,7 +1071,7 @@ suspend fun executeCsvReimport(
             passThroughAccounts = passThroughAccounts,
             cryptoRepository = cryptoRepository,
             onProgress = onProgress,
-            fundingCardAccounts = fundingCardAccounts,
+            attributeAccountMatchers = attributeAccountMatchers,
             engineBatchSize = REIMPORT_ENGINE_BATCH_SIZE,
         )
 
@@ -1314,7 +1317,7 @@ suspend fun bulkReimportCsv(
     passThroughAccounts: List<PassThroughAccount> = emptyList(),
     cryptoRepository: CryptoReadRepository? = null,
     tradeRepository: TradeReadRepository? = null,
-    fundingCardAccounts: Map<String, AccountId> = emptyMap(),
+    attributeAccountMatchers: Map<String, AttributeAccountMatcher> = emptyMap(),
 ): CsvBulkReimportResult {
     var filesImported = 0
     var transfers = 0
@@ -1365,7 +1368,7 @@ suspend fun bulkReimportCsv(
                     passThroughAccounts = passThroughAccounts,
                     onProgress = { tracker.phase(index, csvImport.originalFileName, it) },
                     cryptoAssets = cryptoAssets,
-                    fundingCardAccounts = fundingCardAccounts,
+                    attributeAccountMatchers = attributeAccountMatchers,
                 )
             val result =
                 executeCsvReimport(
@@ -1384,7 +1387,7 @@ suspend fun bulkReimportCsv(
                     refreshViews = false,
                     cryptoRepository = cryptoRepository,
                     tradeRepository = tradeRepository,
-                    fundingCardAccounts = fundingCardAccounts,
+                    attributeAccountMatchers = attributeAccountMatchers,
                 )
             filesImported++
             transfers += result.importResult?.successCount ?: 0

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvTransferMapper.kt
@@ -24,6 +24,7 @@ import com.moneymanager.domain.model.csv.ImportStatus
 import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
 import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
+import com.moneymanager.domain.model.csvstrategy.AttributeMatchAccountMapping
 import com.moneymanager.domain.model.csvstrategy.ColumnExtraction
 import com.moneymanager.domain.model.csvstrategy.ColumnPairSwap
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
@@ -97,8 +98,8 @@ sealed interface MappingResult {
         val passThrough: CsvPassThrough? = null,
         /** Set when the row is one leg of an asset conversion (see [ConversionConfig]); null otherwise. */
         val conversionLeg: ConversionLegInfo? = null,
-        /** Raw funding-card value from [CsvImportStrategy.fundingCardColumn]; null when unset/blank. */
-        val fundingCardLast4: String? = null,
+        /** Raw funding value from [CsvImportStrategy.fundingAttributeMatch]'s column; null when unset/blank. */
+        val fundingMatchValue: String? = null,
     ) : MappingResult {
         /** Convenience for flows where only the target side can discover a new account. */
         val newAccountName: String? get() = newAccounts.firstOrNull()?.name
@@ -200,11 +201,11 @@ data class CsvTransferWithAttributes(
     /** Set when the row is one leg of an asset conversion (see [ConversionConfig]); null otherwise. */
     val conversionLeg: ConversionLegInfo? = null,
     /**
-     * Raw value of the strategy's [CsvImportStrategy.fundingCardColumn] for this row (e.g. a card's
-     * last-4 like "7721"); null when the strategy declares no funding-card column or the cell is blank.
-     * The applier resolves it to a funding account for the funding-card reconcile.
+     * Raw value of the strategy's [CsvImportStrategy.fundingAttributeMatch] column for this row (e.g. a
+     * card's last-4 like "7721"); null when the strategy declares no funding match or the cell is blank.
+     * The applier matches it against the funding attribute type to resolve the funding account.
      */
-    val fundingCardLast4: String? = null,
+    val fundingMatchValue: String? = null,
 )
 
 /**
@@ -279,6 +280,12 @@ class CsvTransferMapper(
     private val sourceAccountOverride: AccountId? = null,
     /** Detects pass-through (conduit) charges (e.g. Curve) from the row description; null disables it. */
     private val passThroughDetector: PassThroughDetector? = null,
+    /**
+     * Attribute-account matchers keyed by attribute-type name (see [AttributeAccountMatcher]). Consulted
+     * by [AttributeMatchAccountMapping] account fields to resolve an account from a column value's regex
+     * match against account attributes. The applier uses the same registry for funding reconciliation.
+     */
+    private val attributeAccountMatchers: Map<String, AttributeAccountMatcher> = emptyMap(),
 ) {
     private val columnIndexByName: Map<String, Int> =
         columns.associate { it.originalName to it.columnIndex }
@@ -378,7 +385,7 @@ class CsvTransferMapper(
                             personalCounterpartyName = result.personalCounterpartyName,
                             passThrough = result.passThrough,
                             conversionLeg = result.conversionLeg,
-                            fundingCardLast4 = result.fundingCardLast4,
+                            fundingMatchValue = result.fundingMatchValue,
                         ),
                     )
                     // Count by status
@@ -693,8 +700,10 @@ class CsvTransferMapper(
                 passThrough = passThrough,
                 conversionLeg =
                     conversionDetection?.let { ConversionLegInfo(side = it.side, pairingKey = it.pairingKey) },
-                fundingCardLast4 =
-                    strategy.fundingCardColumn?.let { getColumnValueOrNull(it, originalValues)?.trim()?.takeIf { v -> v.isNotBlank() } },
+                fundingMatchValue =
+                    strategy.fundingAttributeMatch?.let {
+                        getColumnValueOrNull(it.column, originalValues)?.trim()?.takeIf { v -> v.isNotBlank() }
+                    },
             )
         } catch (expected: Exception) {
             MappingResult.Error(row.rowIndex, expected.message ?: "Unknown error")
@@ -936,6 +945,19 @@ class CsvTransferMapper(
                     ?: UNRESOLVED_ACCOUNT_ID // Placeholder for new accounts
             }
             is ConditionalAccountMapping -> parseAccount(resolveConditional(mapping, values), values, applyPersistedMappings)
+            is AttributeMatchAccountMapping -> {
+                val csvValue = getColumnValue(mapping.columnName, values).trim()
+
+                // Persisted mappings win first (renamed accounts), then the account-attribute regex match.
+                if (applyPersistedMappings) {
+                    findPersistedMapping(csvValue)?.let { return it }
+                }
+                attributeAccountMatchers[mapping.attributeTypeName]?.match(csvValue)?.let { return it }
+
+                // No attribute matched: fall back to ordinary name lookup on the raw value.
+                resolveExistingAccountId(csvValue)
+                    ?: UNRESOLVED_ACCOUNT_ID // Placeholder for new accounts
+            }
             is AccountLookupMapping -> {
                 val csvValue = getColumnValue(mapping.columnName, values)
 
@@ -1039,6 +1061,21 @@ class CsvTransferMapper(
                 } else {
                     NewAccount(name, mapping.defaultCategoryId) to
                         DiscoveredAccountMapping(csvValue, name)
+                }
+            }
+            is AttributeMatchAccountMapping -> {
+                val csvValue = getColumnValue(mapping.columnName, values).trim()
+                // No new account when a persisted mapping or an attribute regex resolves the value, or
+                // when the raw value is blank / already an existing account.
+                if ((applyPersistedMappings && findPersistedMapping(csvValue) != null) ||
+                    attributeAccountMatchers[mapping.attributeTypeName]?.match(csvValue) != null ||
+                    csvValue.isBlank() ||
+                    accountExists(csvValue)
+                ) {
+                    null
+                } else {
+                    NewAccount(csvValue, mapping.defaultCategoryId) to
+                        DiscoveredAccountMapping(csvValue, csvValue)
                 }
             }
             is ConditionalAccountMapping -> discoverNewAccount(resolveConditional(mapping, values), values, applyPersistedMappings)

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/AttributeAccountMatcherTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/AttributeAccountMatcherTest.kt
@@ -1,0 +1,85 @@
+package com.moneymanager.csvimporter
+
+import com.moneymanager.domain.model.AccountAttribute
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AttributeType
+import com.moneymanager.domain.model.AttributeTypeId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AttributeAccountMatcherTest {
+    private var nextId = 1L
+
+    private fun attribute(
+        accountId: Long,
+        value: String,
+        typeName: String = "card-last4",
+    ): AccountAttribute =
+        AccountAttribute(
+            id = nextId++,
+            accountId = AccountId(accountId),
+            attributeType = AttributeType(id = AttributeTypeId(-8), name = typeName),
+            value = value,
+        )
+
+    @Test
+    fun `trivial digit token matches the funding column value`() {
+        val matcher = AttributeAccountMatcher.from(listOf(attribute(accountId = 10, value = "7721")))
+
+        assertEquals(AccountId(10), matcher.match("7721"))
+        assertNull(matcher.match("1234"))
+    }
+
+    @Test
+    fun `a real regex pattern matches by containsMatchIn`() {
+        val matcher = AttributeAccountMatcher.from(listOf(attribute(accountId = 20, value = "ACME.*LTD")))
+
+        assertEquals(AccountId(20), matcher.match("CARD PAYMENT TO ACME TRADING LTD"))
+        assertNull(matcher.match("ACME TRADING"))
+    }
+
+    @Test
+    fun `multiple whitespace or comma separated tokens each match`() {
+        val matcher = AttributeAccountMatcher.from(listOf(attribute(accountId = 30, value = "7721, 1234 9999")))
+
+        assertEquals(AccountId(30), matcher.match("7721"))
+        assertEquals(AccountId(30), matcher.match("1234"))
+        assertEquals(AccountId(30), matcher.match("9999"))
+    }
+
+    @Test
+    fun `a value claimed by more than one account is ambiguous and ignored`() {
+        val matcher =
+            AttributeAccountMatcher.from(
+                listOf(
+                    attribute(accountId = 40, value = "7721"),
+                    attribute(accountId = 41, value = "7721"),
+                ),
+            )
+
+        assertNull(matcher.match("7721"))
+    }
+
+    @Test
+    fun `matching is case insensitive`() {
+        val matcher = AttributeAccountMatcher.from(listOf(attribute(accountId = 50, value = "paypal")))
+
+        assertEquals(AccountId(50), matcher.match("PayPal Europe"))
+    }
+
+    @Test
+    fun `registry groups matchers by attribute type name`() {
+        val registry =
+            AttributeAccountMatcher.registry(
+                listOf(
+                    attribute(accountId = 60, value = "7721", typeName = "card-last4"),
+                    attribute(accountId = 61, value = "acme", typeName = "merchant-key"),
+                ),
+            )
+
+        assertEquals(AccountId(60), registry.getValue("card-last4").match("7721"))
+        assertEquals(AccountId(61), registry.getValue("merchant-key").match("ACME LTD"))
+        assertNull(registry["card-last4"]?.match("acme"))
+    }
+}

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvTransferMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CsvTransferMapperTest.kt
@@ -4,7 +4,10 @@ package com.moneymanager.csvimporter
 
 import com.moneymanager.bigdecimal.BigInteger
 import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountAttribute
 import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AttributeType
+import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.CsvImportStrategyId
 import com.moneymanager.domain.model.Currency
 import com.moneymanager.domain.model.CurrencyId
@@ -15,6 +18,7 @@ import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
 import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
+import com.moneymanager.domain.model.csvstrategy.AttributeMatchAccountMapping
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
 import com.moneymanager.domain.model.csvstrategy.DateTimeParsingMapping
@@ -1592,5 +1596,82 @@ class CsvTransferMapperTest {
         assertEquals(true, result.passThrough?.incoming)
         assertEquals("Amazon", result.passThrough?.merchantName)
         assertEquals(amazonAccount.id, result.passThrough?.merchantAccountId)
+    }
+
+    // ============= AttributeMatchAccountMapping (regex-against-attribute account resolution) =============
+
+    private fun attributeMatchStrategy(): CsvImportStrategy {
+        val base = createStrategy()
+        return base.copy(
+            fieldMappings =
+                base.fieldMappings +
+                    (
+                        TransferField.TARGET_ACCOUNT to
+                            AttributeMatchAccountMapping(
+                                id = FieldMappingId(Uuid.random()),
+                                fieldType = TransferField.TARGET_ACCOUNT,
+                                columnName = "Payee",
+                                attributeTypeName = "card-last4",
+                            )
+                    ),
+        )
+    }
+
+    private fun cardLast4Matchers(
+        accountId: AccountId,
+        value: String,
+    ): Map<String, AttributeAccountMatcher> =
+        mapOf(
+            "card-last4" to
+                AttributeAccountMatcher.from(
+                    listOf(
+                        AccountAttribute(
+                            id = 1,
+                            accountId = accountId,
+                            attributeType = AttributeType(id = AttributeTypeId(-8), name = "card-last4"),
+                            value = value,
+                        ),
+                    ),
+                ),
+        )
+
+    @Test
+    fun `AttributeMatchAccountMapping resolves the target account by attribute regex`() {
+        val mapper =
+            CsvTransferMapper(
+                strategy = attributeMatchStrategy(),
+                columns = columns,
+                existingAccounts = mapOf("PayPal" to testTargetAccount.copy(name = "PayPal")),
+                existingCurrencies = mapOf(testCurrencyId to testCurrency),
+                existingCurrenciesByCode = mapOf(testCurrency.code.uppercase() to testCurrency),
+                attributeAccountMatchers = cardLast4Matchers(testTargetAccountId, "9999"),
+            )
+
+        val row = CsvRow(rowIndex = 1, values = listOf("15/12/2024", "Some payment", "-50.00", "9999"))
+        val result = mapper.mapRow(row)
+
+        assertIs<MappingResult.Success>(result)
+        assertEquals(testTargetAccountId, result.transfer.targetAccountId)
+        assertTrue(result.newAccounts.isEmpty())
+    }
+
+    @Test
+    fun `AttributeMatchAccountMapping falls back to name lookup when no attribute matches`() {
+        val mapper =
+            CsvTransferMapper(
+                strategy = attributeMatchStrategy(),
+                columns = columns,
+                existingAccounts = emptyMap(),
+                existingCurrencies = mapOf(testCurrencyId to testCurrency),
+                existingCurrenciesByCode = mapOf(testCurrency.code.uppercase() to testCurrency),
+                attributeAccountMatchers = cardLast4Matchers(testTargetAccountId, "9999"),
+            )
+
+        val row = CsvRow(rowIndex = 1, values = listOf("15/12/2024", "Some payment", "-50.00", "Netflix"))
+        val result = mapper.mapRow(row)
+
+        assertIs<MappingResult.Success>(result)
+        // No attribute matched "Netflix", so it falls back to a name lookup that creates a new account.
+        assertEquals(listOf("Netflix"), result.newAccounts.map { it.name })
     }
 }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
@@ -13,6 +13,7 @@ import com.moneymanager.domain.model.accountmapping.AccountMapping
 import com.moneymanager.domain.model.accountmapping.export.AccountMappingExport
 import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
+import com.moneymanager.domain.model.csvstrategy.AttributeMatchAccountMapping
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
@@ -29,6 +30,7 @@ import com.moneymanager.domain.model.csvstrategy.TimezoneLookupMapping
 import com.moneymanager.domain.model.csvstrategy.TransferField
 import com.moneymanager.domain.model.csvstrategy.export.AccountLookupExport
 import com.moneymanager.domain.model.csvstrategy.export.AmountParsingExport
+import com.moneymanager.domain.model.csvstrategy.export.AttributeMatchAccountExport
 import com.moneymanager.domain.model.csvstrategy.export.ConditionalAccountExport
 import com.moneymanager.domain.model.csvstrategy.export.CsvStrategyExport
 import com.moneymanager.domain.model.csvstrategy.export.CsvStrategyExportMapper
@@ -239,6 +241,8 @@ class CsvStrategyExportService(
                 addCategoryReferenceIfMissing(mappingExport.defaultCategoryName, fieldType, referenceData, unresolvedReferences)
             is TemplateAccountExport ->
                 addCategoryReferenceIfMissing(mappingExport.defaultCategoryName, fieldType, referenceData, unresolvedReferences)
+            is AttributeMatchAccountExport ->
+                addCategoryReferenceIfMissing(mappingExport.defaultCategoryName, fieldType, referenceData, unresolvedReferences)
             is ConditionalAccountExport -> {
                 collectUnresolvedReferences(mappingExport.whenTrue, fieldType, referenceData, unresolvedReferences)
                 collectUnresolvedReferences(mappingExport.whenFalse, fieldType, referenceData, unresolvedReferences)
@@ -415,7 +419,7 @@ class CsvStrategyExportService(
                 fileNamePattern = export.fileNamePattern,
                 crossSourceReconcileWindowSeconds = export.crossSourceReconcileWindowSeconds,
                 conversionConfig = export.conversionConfig,
-                fundingCardColumn = export.fundingCardColumn,
+                fundingAttributeMatch = export.fundingAttributeMatch,
                 createdAt = now,
                 updatedAt = now,
             )
@@ -509,6 +513,16 @@ class CsvStrategyExportService(
                     columnName = columnName,
                     rules = rules,
                     fallbackColumns = fallbackColumns,
+                    defaultCategoryId =
+                        categoriesByName[defaultCategoryName]?.id
+                            ?: Category.UNCATEGORIZED_ID,
+                )
+            is AttributeMatchAccountExport ->
+                AttributeMatchAccountMapping(
+                    id = newId,
+                    fieldType = fieldType,
+                    columnName = columnName,
+                    attributeTypeName = attributeTypeName,
                     defaultCategoryId =
                         categoriesByName[defaultCategoryName]?.id
                             ?: Category.UNCATEGORIZED_ID,

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CurveCsvE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CurveCsvE2ETest.kt
@@ -2,11 +2,11 @@
 
 package com.moneymanager.database.csv
 
+import com.moneymanager.csvimporter.AttributeAccountMatcher
 import com.moneymanager.csvimporter.BulkImportProgress
 import com.moneymanager.csvimporter.CsvBulkResult
 import com.moneymanager.csvimporter.bulkApplyCsv
 import com.moneymanager.csvimporter.executeCsvReimport
-import com.moneymanager.csvimporter.fundingCardAccountIndex
 import com.moneymanager.csvimporter.planCsvReimport
 import com.moneymanager.database.assertBulkProgress
 import com.moneymanager.domain.Maintenance
@@ -119,10 +119,8 @@ class CurveCsvE2ETest : DbTest() {
 
     private suspend fun applyAll(imports: List<CsvImport>): CsvBulkResult {
         val progress = mutableListOf<BulkImportProgress>()
-        val cardLast4 =
-            repositories.accountAttributeRepository
-                .getByType(AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID))
-                .first()
+        val attributeMatchers =
+            AttributeAccountMatcher.registry(repositories.accountAttributeRepository.getAll().first())
         val result =
             bulkApplyCsv(
                 imports = imports,
@@ -137,7 +135,7 @@ class CurveCsvE2ETest : DbTest() {
                 onProgress = { progress += it },
                 passThroughAccounts = repositories.passThroughAccountRepository.getAll().first(),
                 cryptoRepository = repositories.cryptoRepository,
-                fundingCardAccounts = fundingCardAccountIndex(cardLast4),
+                attributeAccountMatchers = attributeMatchers,
             )
         assertBulkProgress(progress, imports.size)
         return result
@@ -168,11 +166,7 @@ class CurveCsvE2ETest : DbTest() {
         val currencies = repositories.currencyRepository.getAllCurrencies().first()
         val passThroughAccounts = repositories.passThroughAccountRepository.getAll().first()
         val fca =
-            fundingCardAccountIndex(
-                repositories.accountAttributeRepository
-                    .getByType(AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID))
-                    .first(),
-            )
+            AttributeAccountMatcher.registry(repositories.accountAttributeRepository.getAll().first())
         val plan =
             planCsvReimport(
                 csvImport = current,
@@ -186,7 +180,7 @@ class CurveCsvE2ETest : DbTest() {
                 relationshipRepository = repositories.transferRelationshipRepository,
                 transferSourceRepository = repositories.transferSourceRepository,
                 passThroughAccounts = passThroughAccounts,
-                fundingCardAccounts = fca,
+                attributeAccountMatchers = fca,
             )
         executeCsvReimport(
             plan = plan,
@@ -200,7 +194,7 @@ class CurveCsvE2ETest : DbTest() {
             maintenance = maintenance,
             importEngine = repositories.importEngine,
             passThroughAccounts = passThroughAccounts,
-            fundingCardAccounts = fca,
+            attributeAccountMatchers = fca,
         )
     }
 

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CurveCsvE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/CurveCsvE2ETest.kt
@@ -165,7 +165,7 @@ class CurveCsvE2ETest : DbTest() {
                 .first { it.name == "Curve CSV" }
         val currencies = repositories.currencyRepository.getAllCurrencies().first()
         val passThroughAccounts = repositories.passThroughAccountRepository.getAll().first()
-        val fca =
+        val attributeMatchers =
             AttributeAccountMatcher.registry(repositories.accountAttributeRepository.getAll().first())
         val plan =
             planCsvReimport(
@@ -180,7 +180,7 @@ class CurveCsvE2ETest : DbTest() {
                 relationshipRepository = repositories.transferRelationshipRepository,
                 transferSourceRepository = repositories.transferSourceRepository,
                 passThroughAccounts = passThroughAccounts,
-                attributeAccountMatchers = fca,
+                attributeAccountMatchers = attributeMatchers,
             )
         executeCsvReimport(
             plan = plan,
@@ -194,7 +194,7 @@ class CurveCsvE2ETest : DbTest() {
             maintenance = maintenance,
             importEngine = repositories.importEngine,
             passThroughAccounts = passThroughAccounts,
-            attributeAccountMatchers = fca,
+            attributeAccountMatchers = attributeMatchers,
         )
     }
 

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/json/FieldMappingJsonCodec.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/json/FieldMappingJsonCodec.kt
@@ -1,5 +1,6 @@
 package com.moneymanager.database.json
 
+import com.moneymanager.domain.model.csvstrategy.AttributeAccountMatch
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.ContentMatchRule
@@ -90,4 +91,14 @@ object FieldMappingJsonCodec {
      * Decodes an optional conversion config from a JSON string (null when the column is null).
      */
     fun decodeConversionConfig(jsonString: String?): ConversionConfig? = jsonString?.let { json.decodeFromString(it) }
+
+    /**
+     * Encodes an optional funding attribute-account match to a JSON string, or null when absent.
+     */
+    fun encodeAttributeAccountMatch(match: AttributeAccountMatch?): String? = match?.let { json.encodeToString(it) }
+
+    /**
+     * Decodes an optional funding attribute-account match from a JSON string (null when the column is null).
+     */
+    fun decodeAttributeAccountMatch(jsonString: String?): AttributeAccountMatch? = jsonString?.let { json.decodeFromString(it) }
 }

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/accountAttribute/AccountAttributeSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/accountAttribute/AccountAttributeSelect.sq
@@ -32,3 +32,14 @@ FROM account_attribute
 JOIN attribute_type ON account_attribute.attribute_type_id = attribute_type.id
 WHERE account_attribute.attribute_type_id = ?
 ORDER BY account_attribute.account_id;
+
+selectAll:
+SELECT
+    account_attribute.id,
+    account_attribute.account_id,
+    account_attribute.attribute_type_id,
+    account_attribute.attribute_value,
+    attribute_type.name AS attribute_type_name
+FROM account_attribute
+JOIN attribute_type ON account_attribute.attribute_type_id = attribute_type.id
+ORDER BY attribute_type.name, account_attribute.account_id;

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/AccountAttributeReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/AccountAttributeReadRepositoryImpl.kt
@@ -56,4 +56,24 @@ class AccountAttributeReadRepositoryImpl(
                     )
                 }
             }
+
+    override fun getAll(): Flow<List<AccountAttribute>> =
+        selectQueries
+            .selectAll()
+            .asFlow()
+            .mapToList(Dispatchers.Default)
+            .map { list ->
+                list.map { row ->
+                    AccountAttribute(
+                        id = row.id,
+                        accountId = AccountId(row.account_id),
+                        attributeType =
+                            AttributeType(
+                                id = AttributeTypeId(row.attribute_type_id),
+                                name = row.attribute_type_name,
+                            ),
+                        value = row.attribute_value,
+                    )
+                }
+            }
 }

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyReadRepositoryImpl.kt
@@ -57,7 +57,7 @@ class CsvImportStrategyReadRepositoryImpl(
             fileNamePattern = entity.file_name_pattern,
             crossSourceReconcileWindowSeconds = entity.cross_source_reconcile_window_seconds,
             conversionConfig = FieldMappingJsonCodec.decodeConversionConfig(entity.conversion_config_json),
-            fundingCardColumn = entity.funding_card_column,
+            fundingAttributeMatch = FieldMappingJsonCodec.decodeAttributeAccountMatch(entity.funding_attribute_match_json),
             createdAt = Instant.fromEpochMilliseconds(entity.created_at),
             updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
         )

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategy.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategy.sq
@@ -12,7 +12,7 @@ CREATE TABLE csv_import_strategy (
     file_name_pattern TEXT,
     cross_source_reconcile_window_seconds INTEGER,
     conversion_config_json TEXT,
-    funding_card_column TEXT,
+    funding_attribute_match_json TEXT,
     created_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000),
     updated_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000)
 );

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportStrategyWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportStrategyWriteRepositoryImpl.kt
@@ -64,7 +64,7 @@ class CsvImportStrategyWriteRepositoryImpl(
                     file_name_pattern = strategy.fileNamePattern,
                     cross_source_reconcile_window_seconds = strategy.crossSourceReconcileWindowSeconds,
                     conversion_config_json = FieldMappingJsonCodec.encodeConversionConfig(strategy.conversionConfig),
-                    funding_card_column = strategy.fundingCardColumn,
+                    funding_attribute_match_json = FieldMappingJsonCodec.encodeAttributeAccountMatch(strategy.fundingAttributeMatch),
                     updated_at = now.toEpochMilliseconds(),
                     id = strategy.id.id.toString(),
                 )

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/CsvImportStrategyInsert.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/CsvImportStrategyInsert.kt
@@ -24,6 +24,6 @@ fun CsvImportStrategyWriteQueries.insertStrategy(strategy: CsvImportStrategy) {
         file_name_pattern = strategy.fileNamePattern,
         cross_source_reconcile_window_seconds = strategy.crossSourceReconcileWindowSeconds,
         conversion_config_json = FieldMappingJsonCodec.encodeConversionConfig(strategy.conversionConfig),
-        funding_card_column = strategy.fundingCardColumn,
+        funding_attribute_match_json = FieldMappingJsonCodec.encodeAttributeAccountMatch(strategy.fundingAttributeMatch),
     )
 }

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategyWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategyWrite.sq
@@ -1,12 +1,12 @@
 -- Insert a new strategy. created_at/updated_at are filled by their column DEFAULTs (current time).
 insert:
-INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json, file_name_pattern, cross_source_reconcile_window_seconds, conversion_config_json, funding_card_column)
+INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json, file_name_pattern, cross_source_reconcile_window_seconds, conversion_config_json, funding_attribute_match_json)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- Update an existing strategy
 update:
 UPDATE csv_import_strategy
-SET revision_id = revision_id + 1, name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, content_match_rules_json = ?, file_name_pattern = ?, cross_source_reconcile_window_seconds = ?, conversion_config_json = ?, funding_card_column = ?, updated_at = ?
+SET revision_id = revision_id + 1, name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, content_match_rules_json = ?, file_name_pattern = ?, cross_source_reconcile_window_seconds = ?, conversion_config_json = ?, funding_attribute_match_json = ?, updated_at = ?
 WHERE id = ?;
 
 -- Delete a strategy by ID

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/WellKnownIds.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/WellKnownIds.kt
@@ -32,10 +32,13 @@ object WellKnownIds {
     const val ACCOUNT_COUNTERPARTY_NAME_KEY_ATTR_TYPE_ID: Long = -7
 
     /**
-     * "card-last4" account attribute: the last-4 digits (whitespace/comma-separated for multiple) of
-     * the cards funded from this account. A CSV strategy with a
-     * [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.fundingCardColumn] uses it to
-     * reconcile a conduit (e.g. Curve) spend against the funding leg into this account.
+     * "card-last4" account attribute: one or more whitespace/comma-separated regex tokens (typically the
+     * last-4 digits) identifying the cards funded from this account. It is the default attribute type for
+     * the generic attribute-account matcher: a CSV strategy with a
+     * [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.fundingAttributeMatch] (or an
+     * [com.moneymanager.domain.model.csvstrategy.AttributeMatchAccountMapping] field) matches a column
+     * value against these tokens to route a conduit (e.g. Curve) spend to the funding account. Nothing in
+     * code special-cases this id — it is just the built-in Curve strategy's chosen attribute type.
      */
     const val ACCOUNT_CARD_LAST4_ATTR_TYPE_ID: Long = -8
 

--- a/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategy.kt
+++ b/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategy.kt
@@ -20,6 +20,21 @@ data class ContentMatchRule(
 )
 
 /**
+ * Selects an account by matching a CSV [column]'s value against the regex patterns held by a given
+ * account-attribute type. Each account carries an attribute of [attributeTypeName] whose value is one
+ * or more whitespace/comma-separated regex tokens (e.g. the `card-last4` attribute lists a card's
+ * last-4 digits — a trivial regex — but any pattern is allowed; use `\s` for a literal space). A
+ * column value is matched (case-insensitively, [Regex.containsMatchIn]) against every token; when
+ * exactly one account matches it wins, and a value claimed by more than one account is ambiguous and
+ * ignored. Fully portable across databases: it names a column and an attribute type, never an account id.
+ */
+@Serializable
+data class AttributeAccountMatch(
+    val column: String,
+    val attributeTypeName: String,
+)
+
+/**
  * Represents a reusable CSV import strategy that defines how to map CSV columns
  * to Transfer fields.
  *
@@ -47,13 +62,13 @@ data class ContentMatchRule(
  *                            separate debited/credited rows; the importer routes the legs through a
  *                            shared counterparty account and links each debit to its credit (see
  *                            [ConversionConfig]). Null when the source has no such conversions.
- * @property fundingCardColumn When set, names the CSV column carrying the last-4 digits of the card
- *                             that funded each row (e.g. Curve's "Funding Card Last 4 Digits"). A row
- *                             whose last-4 resolves — via the `card-last4` account attribute — to a
- *                             single account is reconciled against an unconsumed funding leg into the
- *                             row's source account (same amount+currency within
- *                             [crossSourceReconcileWindowSeconds]), ignoring the merchant. Null
- *                             disables funding-card reconciliation.
+ * @property fundingAttributeMatch When set, resolves each row's hidden funding account by matching a
+ *                             CSV column against an account-attribute type (see [AttributeAccountMatch];
+ *                             e.g. Curve's "Funding Card Last 4 Digits" column against the `card-last4`
+ *                             attribute). A row whose value resolves to a single account is reconciled
+ *                             against an unconsumed funding leg into the row's source account (same
+ *                             amount+currency within [crossSourceReconcileWindowSeconds]), ignoring the
+ *                             merchant. Null disables funding reconciliation.
  * @property createdAt Timestamp when this strategy was created
  * @property updatedAt Timestamp when this strategy was last modified
  */
@@ -69,7 +84,7 @@ data class CsvImportStrategy(
     val fileNamePattern: String? = null,
     val crossSourceReconcileWindowSeconds: Long? = null,
     val conversionConfig: ConversionConfig? = null,
-    val fundingCardColumn: String? = null,
+    val fundingAttributeMatch: AttributeAccountMatch? = null,
     val createdAt: Instant,
     val updatedAt: Instant,
 ) {

--- a/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
+++ b/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/FieldMapping.kt
@@ -118,6 +118,28 @@ data class RegexAccountMapping(
 }
 
 /**
+ * Resolves an account by matching a CSV column value against the regex patterns stored in a given
+ * account-attribute type (see [AttributeAccountMatch] and the importer's attribute-account matcher).
+ * Each account carries an attribute of [attributeTypeName] whose value holds one or more
+ * whitespace/comma-separated regex tokens; the column value is tested (case-insensitively) against
+ * every account's tokens and the single matching account wins. A value matching more than one account
+ * is ambiguous; when nothing matches, the raw column value falls back to ordinary name lookup (as
+ * [RegexAccountMapping] does). Unlike [RegexAccountMapping] the patterns live on the accounts, so the
+ * same strategy routes to whatever accounts the user has tagged without editing the strategy.
+ *
+ * Persisted [CsvAccountMapping] overrides on the raw column value are applied first, so renamed
+ * accounts keep matching.
+ */
+@Serializable
+data class AttributeMatchAccountMapping(
+    override val id: FieldMappingId,
+    override val fieldType: TransferField,
+    val columnName: String,
+    val attributeTypeName: String,
+    val defaultCategoryId: Long = Category.UNCATEGORIZED_ID,
+) : FieldMapping
+
+/**
  * Looks up an account by templating a CSV column value into an account name.
  * The looked-up name is `prefix + columnValue + suffix` (e.g. "Wise: " + "EUR").
  * Useful when one logical account exists per currency and the CSV only carries

--- a/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExport.kt
+++ b/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExport.kt
@@ -5,6 +5,7 @@ package com.moneymanager.domain.model.csvstrategy.export
 import com.moneymanager.domain.model.accountmapping.export.AccountMappingExport
 import com.moneymanager.domain.model.accountmapping.export.SortedAccountMappingListSerializer
 import com.moneymanager.domain.model.csvstrategy.AmountMode
+import com.moneymanager.domain.model.csvstrategy.AttributeAccountMatch
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
 import com.moneymanager.domain.model.csvstrategy.ColumnExtraction
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
@@ -37,8 +38,8 @@ import kotlinx.serialization.Serializable
  * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.crossSourceReconcileWindowSeconds])
  * @property conversionConfig Asset-conversion configuration (already portable, no IDs)
  * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.conversionConfig])
- * @property fundingCardColumn Name of the column carrying the funding-card last-4 (already portable)
- * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.fundingCardColumn])
+ * @property fundingAttributeMatch Attribute-based funding-account match (already portable, no IDs)
+ * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.fundingAttributeMatch])
  */
 @Serializable
 data class CsvStrategyExport(
@@ -66,7 +67,7 @@ data class CsvStrategyExport(
     // strategy — only a strategy that actually sets it (Curve) rehashes. Prevents a spurious "all
     // strategies changed" on catalog/Drive sync. See StrategyArtifactCodec.canonicalHash.
     @EncodeDefault(EncodeDefault.Mode.NEVER)
-    val fundingCardColumn: String? = null,
+    val fundingAttributeMatch: AttributeAccountMatch? = null,
 )
 
 /**
@@ -112,6 +113,18 @@ data class RegexAccountExport(
     val columnName: String,
     val rules: List<RegexRule>,
     val fallbackColumns: List<String> = emptyList(),
+    val defaultCategoryName: String,
+) : FieldMappingExport
+
+/**
+ * Export format for [com.moneymanager.domain.model.csvstrategy.AttributeMatchAccountMapping].
+ * Uses category name instead of category ID; columnName + attributeTypeName are already portable.
+ */
+@Serializable
+data class AttributeMatchAccountExport(
+    override val fieldType: TransferField,
+    val columnName: String,
+    val attributeTypeName: String,
     val defaultCategoryName: String,
 ) : FieldMappingExport
 

--- a/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExportMapper.kt
+++ b/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExportMapper.kt
@@ -6,6 +6,7 @@ import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.accountmapping.export.AccountMappingExport
 import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
+import com.moneymanager.domain.model.csvstrategy.AttributeMatchAccountMapping
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
@@ -49,7 +50,7 @@ object CsvStrategyExportMapper {
             fileNamePattern = strategy.fileNamePattern,
             crossSourceReconcileWindowSeconds = strategy.crossSourceReconcileWindowSeconds,
             conversionConfig = strategy.conversionConfig,
-            fundingCardColumn = strategy.fundingCardColumn,
+            fundingAttributeMatch = strategy.fundingAttributeMatch,
         )
 
     private fun FieldMapping.toExport(
@@ -76,6 +77,13 @@ object CsvStrategyExportMapper {
                     columnName = columnName,
                     rules = rules,
                     fallbackColumns = fallbackColumns,
+                    defaultCategoryName = categoryNameById(defaultCategoryId) ?: Category.UNCATEGORIZED_NAME,
+                )
+            is AttributeMatchAccountMapping ->
+                AttributeMatchAccountExport(
+                    fieldType = fieldType,
+                    columnName = columnName,
+                    attributeTypeName = attributeTypeName,
                     defaultCategoryName = categoryNameById(defaultCategoryId) ?: Category.UNCATEGORIZED_NAME,
                 )
             is TemplateAccountMapping ->

--- a/app/model/repository/read/src/commonMain/kotlin/com/moneymanager/domain/repository/AccountAttributeReadRepository.kt
+++ b/app/model/repository/read/src/commonMain/kotlin/com/moneymanager/domain/repository/AccountAttributeReadRepository.kt
@@ -17,4 +17,11 @@ interface AccountAttributeReadRepository {
      * Used to build a value → account index without loading every account's full attribute set.
      */
     fun getByType(typeId: AttributeTypeId): Flow<List<AccountAttribute>>
+
+    /**
+     * Gets every account attribute across all types, ordered by attribute type name then account id.
+     * Used to build the attribute-account matcher registry (keyed by type name) for strategies whose
+     * funding match or `AttributeMatchAccountMapping` may reference any attribute type.
+     */
+    fun getAll(): Flow<List<AccountAttribute>>
 }

--- a/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
+++ b/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
@@ -4,9 +4,11 @@ package com.moneymanager.builtin
 
 import com.moneymanager.domain.model.CsvImportStrategyId
 import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
 import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
+import com.moneymanager.domain.model.csvstrategy.AttributeAccountMatch
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
 import com.moneymanager.domain.model.csvstrategy.ColumnExtraction
 import com.moneymanager.domain.model.csvstrategy.ColumnPairSwap
@@ -696,9 +698,14 @@ object BuiltInCsvStrategies {
             // Wise's transaction-history.csv, so the two never compete.
             fileNamePattern = "^Transaction History",
             crossSourceReconcileWindowSeconds = CURVE_RECONCILE_WINDOW_SECONDS,
-            // Reconcile each spend against the funding leg on the account whose card-last4 matches this
-            // column, so a Curve charge isn't double-counted against the underlying card's own import.
-            fundingCardColumn = "Funding Card Last 4 Digits",
+            // Reconcile each spend against the funding leg on the account whose card-last4 attribute
+            // matches this column, so a Curve charge isn't double-counted against the underlying card's
+            // own import.
+            fundingAttributeMatch =
+                AttributeAccountMatch(
+                    column = "Funding Card Last 4 Digits",
+                    attributeTypeName = WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_NAME,
+                ),
             createdAt = now,
             updatedAt = now,
         )

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ApplyStrategyDialog.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.moneymanager.csvimporter.AttributeAccountMatcher
 import com.moneymanager.csvimporter.CsvImportResult
 import com.moneymanager.csvimporter.CsvTransferMapper
 import com.moneymanager.csvimporter.DiscoveredAccountMapping
@@ -50,17 +51,14 @@ import com.moneymanager.csvimporter.NewAccount
 import com.moneymanager.csvimporter.buildCreatedAccountNameOverrides
 import com.moneymanager.csvimporter.buildPendingAccountMappings
 import com.moneymanager.csvimporter.ensureCryptoAssets
-import com.moneymanager.csvimporter.fundingCardAccountIndex
 import com.moneymanager.csvimporter.hasBlankNewAccountNames
 import com.moneymanager.csvimporter.runCsvImport
 import com.moneymanager.csvimporter.selectForCsv
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.Account
 import com.moneymanager.domain.model.AccountId
-import com.moneymanager.domain.model.AttributeTypeId
 import com.moneymanager.domain.model.CryptoAsset
 import com.moneymanager.domain.model.Transfer
-import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.model.accountmapping.AccountMapping
 import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvImport
@@ -125,8 +123,8 @@ fun ApplyStrategyDialog(
         .getAll()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
     val passThroughDetector = passThroughAccounts.takeIf { it.isNotEmpty() }?.let { PassThroughDetector(it) }
-    val cardLast4Attributes by accountAttributeRepository
-        .getByType(AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID))
+    val accountAttributes by accountAttributeRepository
+        .getAll()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     var selectedStrategy by remember { mutableStateOf<CsvImportStrategy?>(null) }
@@ -424,7 +422,7 @@ fun ApplyStrategyDialog(
                                     importEngine = importEngine,
                                     cryptoAssets = resolvedCrypto,
                                     passThroughAccounts = passThroughAccounts,
-                                    fundingCardAccounts = fundingCardAccountIndex(cardLast4Attributes),
+                                    attributeAccountMatchers = AttributeAccountMatcher.registry(accountAttributes),
                                 )
                             onImportComplete(result)
                         } catch (expected: Exception) {

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportAllDialog.kt
@@ -16,16 +16,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.csvimporter.AttributeAccountMatcher
 import com.moneymanager.csvimporter.BulkImportProgress
 import com.moneymanager.csvimporter.STRATEGY_CONTENT_SAMPLE_SIZE
 import com.moneymanager.csvimporter.bulkApplyCsv
-import com.moneymanager.csvimporter.fundingCardAccountIndex
 import com.moneymanager.csvimporter.needsSourceAccountOverride
 import com.moneymanager.csvimporter.selectForCsv
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.AccountId
-import com.moneymanager.domain.model.AttributeTypeId
-import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
@@ -76,8 +74,8 @@ fun CsvImportAllDialog(
     val strategies by csvImportStrategyRepository.getAllStrategies().collectAsStateWithSchemaErrorHandling(emptyList())
     val currencies by currencyRepository.getAllCurrencies().collectAsStateWithSchemaErrorHandling(emptyList())
     val passThroughAccounts by passThroughAccountRepository.getAll().collectAsStateWithSchemaErrorHandling(emptyList())
-    val cardLast4Attributes by accountAttributeRepository
-        .getByType(AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID))
+    val accountAttributes by accountAttributeRepository
+        .getAll()
         .collectAsStateWithSchemaErrorHandling(emptyList())
 
     var sourceAccountId by remember { mutableStateOf<AccountId?>(null) }
@@ -167,7 +165,7 @@ fun CsvImportAllDialog(
                                         onProgress = { progress = it },
                                         passThroughAccounts = passThroughAccounts,
                                         cryptoRepository = cryptoRepository,
-                                        fundingCardAccounts = fundingCardAccountIndex(cardLast4Attributes),
+                                        attributeAccountMatchers = AttributeAccountMatcher.registry(accountAttributes),
                                     )
                                 summary = result.toSummary()
                             } finally {

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvReimportAllDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvReimportAllDialog.kt
@@ -20,17 +20,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.csvimporter.AttributeAccountMatcher
 import com.moneymanager.csvimporter.BulkImportProgress
 import com.moneymanager.csvimporter.CsvBulkReimportResult
 import com.moneymanager.csvimporter.STRATEGY_CONTENT_SAMPLE_SIZE
 import com.moneymanager.csvimporter.bulkReimportCsv
-import com.moneymanager.csvimporter.fundingCardAccountIndex
 import com.moneymanager.csvimporter.needsSourceAccountOverride
 import com.moneymanager.csvimporter.selectForCsv
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.AccountId
-import com.moneymanager.domain.model.AttributeTypeId
-import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
@@ -91,8 +89,8 @@ fun CsvReimportAllDialog(
     val strategies by csvImportStrategyRepository.getAllStrategies().collectAsStateWithSchemaErrorHandling(emptyList())
     val currencies by currencyRepository.getAllCurrencies().collectAsStateWithSchemaErrorHandling(emptyList())
     val passThroughAccounts by passThroughAccountRepository.getAll().collectAsStateWithSchemaErrorHandling(emptyList())
-    val cardLast4Attributes by accountAttributeRepository
-        .getByType(AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID))
+    val accountAttributes by accountAttributeRepository
+        .getAll()
         .collectAsStateWithSchemaErrorHandling(emptyList())
 
     var sourceAccountId by remember { mutableStateOf<AccountId?>(null) }
@@ -201,7 +199,7 @@ fun CsvReimportAllDialog(
                                         passThroughAccounts = passThroughAccounts,
                                         cryptoRepository = cryptoRepository,
                                         tradeRepository = tradeRepository,
-                                        fundingCardAccounts = fundingCardAccountIndex(cardLast4Attributes),
+                                        attributeAccountMatchers = AttributeAccountMatcher.registry(accountAttributes),
                                     )
                             } finally {
                                 isRunning = false

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/ReimportDialog.kt
@@ -23,17 +23,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.csvimporter.AttributeAccountMatcher
 import com.moneymanager.csvimporter.CsvReimportResult
 import com.moneymanager.csvimporter.ReimportPlan
 import com.moneymanager.csvimporter.executeCsvReimport
-import com.moneymanager.csvimporter.fundingCardAccountIndex
 import com.moneymanager.csvimporter.needsSourceAccountOverride
 import com.moneymanager.csvimporter.planCsvReimport
 import com.moneymanager.csvimporter.selectForCsv
 import com.moneymanager.domain.Maintenance
 import com.moneymanager.domain.model.AccountId
-import com.moneymanager.domain.model.AttributeTypeId
-import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.model.csv.ImportStatus
@@ -105,8 +103,8 @@ fun ReimportDialog(
     val passThroughAccounts by passThroughAccountRepository
         .getAll()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
-    val cardLast4Attributes by accountAttributeRepository
-        .getByType(AttributeTypeId(WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_ID))
+    val accountAttributes by accountAttributeRepository
+        .getAll()
         .collectAsStateWithSchemaErrorHandling(initial = emptyList())
 
     var strategy by remember { mutableStateOf<CsvImportStrategy?>(null) }
@@ -138,7 +136,7 @@ fun ReimportDialog(
     val sourceReady = !needsSourcePicker || selectedSourceAccountId != null
 
     // Build the read-only merge preview once the inputs are ready.
-    LaunchedEffect(strategy, selectedSourceAccountId, currencies, passThroughAccounts, cardLast4Attributes) {
+    LaunchedEffect(strategy, selectedSourceAccountId, currencies, passThroughAccounts, accountAttributes) {
         val currentStrategy = strategy ?: return@LaunchedEffect
         if (currencies.isEmpty()) return@LaunchedEffect
         try {
@@ -158,7 +156,7 @@ fun ReimportDialog(
                     // Crypto tickers on already-imported rows must resolve for the value-update and
                     // transfer→trade conversion scans, so pass the full asset set.
                     cryptoAssets = cryptoRepository.getAllCryptoAssets().first(),
-                    fundingCardAccounts = fundingCardAccountIndex(cardLast4Attributes),
+                    attributeAccountMatchers = AttributeAccountMatcher.registry(accountAttributes),
                     onProgress = { planProgress = it },
                 )
             errorMessage = null
@@ -262,7 +260,7 @@ fun ReimportDialog(
                                     onProgress = { executeProgress = it },
                                     cryptoRepository = cryptoRepository,
                                     tradeRepository = tradeRepository,
-                                    fundingCardAccounts = fundingCardAccountIndex(cardLast4Attributes),
+                                    attributeAccountMatchers = AttributeAccountMatcher.registry(accountAttributes),
                                 )
                             onComplete(result)
                         } catch (expected: CancellationException) {

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AccountMappingEditors.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AccountMappingEditors.kt
@@ -48,6 +48,7 @@ internal fun TargetAccountModeSelector(
         listOf(
             TargetAccountMode.DIRECT_LOOKUP to "Lookup",
             TargetAccountMode.REGEX_MATCH to "Regex",
+            TargetAccountMode.ATTRIBUTE_MATCH to "Attribute",
             TargetAccountMode.TEMPLATE to "Template",
             TargetAccountMode.CONDITIONAL to "Conditional",
         )
@@ -118,6 +119,59 @@ internal fun TemplateAccountMappingEditor(
                 color = MaterialTheme.colorScheme.primary,
             )
         }
+    }
+}
+
+/**
+ * Editor for an attribute-match account mapping: a CSV [columnName] whose value is matched against the
+ * regex tokens held by every account's [attributeTypeName] attribute (case-insensitive), routing to the
+ * single matching account. Shared by the target-account "Attribute" mode and the funding-reconciliation
+ * section. [existingAttributeTypeNames] are only surfaced as a hint — a not-yet-created type may be typed.
+ */
+@Composable
+internal fun AttributeMatchAccountMappingEditor(
+    columnName: String?,
+    onColumnChanged: (String) -> Unit,
+    columnLabel: String,
+    attributeTypeName: String,
+    onAttributeTypeChanged: (String) -> Unit,
+    columns: List<CsvColumn>,
+    firstRow: CsvRow?,
+    existingAttributeTypeNames: List<String>,
+    enabled: Boolean,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        ColumnDropdown(
+            columns = columns,
+            selectedColumn = columnName,
+            onColumnSelected = onColumnChanged,
+            label = columnLabel,
+            sampleValue = getSampleValue(columns, firstRow, columnName),
+            enabled = enabled,
+            isError = columnName == null,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        val suggestions = existingAttributeTypeNames.filter { it != attributeTypeName }.take(5)
+        OutlinedTextField(
+            value = attributeTypeName,
+            onValueChange = onAttributeTypeChanged,
+            label = { Text("Account attribute type *") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = enabled,
+            isError = attributeTypeName.isBlank(),
+            supportingText = {
+                Text(
+                    if (attributeTypeName.isBlank()) {
+                        "Required (e.g. card-last4)"
+                    } else if (suggestions.isNotEmpty()) {
+                        "Existing types: ${suggestions.joinToString(", ")}"
+                    } else {
+                        "Each account's \"$attributeTypeName\" attribute holds the regex tokens to match"
+                    },
+                )
+            },
+        )
     }
 }
 

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AccountsTab.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AccountsTab.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.domain.model.AttributeType
+import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.domain.repository.AccountReadRepository
@@ -32,6 +34,7 @@ internal fun AccountsTab(
     rows: List<CsvRow>,
     firstRow: CsvRow?,
     enabled: Boolean,
+    existingAttributeTypes: List<AttributeType>,
     accountRepository: AccountReadRepository,
     categoryRepository: CategoryReadRepository,
     personRepository: PersonReadRepository,
@@ -91,7 +94,14 @@ internal fun AccountsTab(
         )
         TargetAccountModeSelector(
             selected = state.targetAccountMode,
-            onSelected = { state.targetAccountMode = it },
+            onSelected = { mode ->
+                state.targetAccountMode = mode
+                // Give the attribute-match mode a sensible default type on first entry so the field
+                // isn't blank; a non-attribute mode keeps its type null (so extract/save round-trips).
+                if (mode == TargetAccountMode.ATTRIBUTE_MATCH && state.targetAttributeTypeName.isNullOrBlank()) {
+                    state.targetAttributeTypeName = WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_NAME
+                }
+            },
             enabled = enabled,
         )
 
@@ -136,6 +146,20 @@ internal fun AccountsTab(
                         enabled = enabled,
                     )
                 }
+            }
+            TargetAccountMode.ATTRIBUTE_MATCH -> {
+                Spacer(modifier = Modifier.height(4.dp))
+                AttributeMatchAccountMappingEditor(
+                    columnName = state.targetAccountColumnName,
+                    onColumnChanged = { state.targetAccountColumnName = it },
+                    columnLabel = "Column matched against account attribute",
+                    attributeTypeName = state.targetAttributeTypeName.orEmpty(),
+                    onAttributeTypeChanged = { state.targetAttributeTypeName = it },
+                    columns = csvColumns,
+                    firstRow = firstRow,
+                    existingAttributeTypeNames = existingAttributeTypes.map { it.name },
+                    enabled = enabled,
+                )
             }
             TargetAccountMode.TEMPLATE -> {
                 Spacer(modifier = Modifier.height(4.dp))

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AdvancedTab.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AdvancedTab.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -15,6 +16,7 @@ import com.moneymanager.domain.model.accountmapping.AccountMapping
 import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvRow
 import com.moneymanager.ui.screens.accountmapping.AccountMappingsSection
+import com.moneymanager.ui.screens.csvstrategy.getSampleValue
 
 /**
  * Advanced tab: attributes, row preprocessing rules, companion transaction rules, and (in edit mode)
@@ -73,6 +75,48 @@ internal fun AdvancedTab(
                 existingAttributeTypes = existingAttributeTypes,
                 enabled = enabled,
                 firstRow = firstRow,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("Funding Reconciliation (Optional)", style = MaterialTheme.typography.titleSmall)
+        Text(
+            "Match a column against an account attribute to reconcile each row's hidden funding account " +
+                "(e.g. Curve's last-4 → the underlying card), so the spend isn't double-counted.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        OptionalColumnDropdown(
+            columns = csvColumns,
+            selectedColumn = state.fundingMatchColumn,
+            onColumnSelected = { state.fundingMatchColumn = it },
+            label = "Funding column (e.g. card last 4)",
+            sampleValue = getSampleValue(csvColumns, firstRow, state.fundingMatchColumn),
+            enabled = enabled,
+        )
+        if (!state.fundingMatchColumn.isNullOrBlank()) {
+            val existingTypeNames = existingAttributeTypes.map { it.name }.filter { it != state.fundingMatchAttributeTypeName }.take(5)
+            Spacer(modifier = Modifier.height(4.dp))
+            OutlinedTextField(
+                value = state.fundingMatchAttributeTypeName,
+                onValueChange = { state.fundingMatchAttributeTypeName = it },
+                label = { Text("Account attribute type *") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                enabled = enabled,
+                isError = state.fundingMatchAttributeTypeName.isBlank(),
+                supportingText = {
+                    Text(
+                        if (state.fundingMatchAttributeTypeName.isBlank()) {
+                            "Required (e.g. card-last4)"
+                        } else if (existingTypeNames.isNotEmpty()) {
+                            "Existing types: ${existingTypeNames.joinToString(", ")}"
+                        } else {
+                            "Each account's \"${state.fundingMatchAttributeTypeName}\" attribute holds the regex tokens to match"
+                        },
+                    )
+                },
             )
         }
 

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorScreen.kt
@@ -279,6 +279,7 @@ fun CsvStrategyEditorScreen(
                         rows = rows,
                         firstRow = firstRow,
                         enabled = !state.isSaving,
+                        existingAttributeTypes = existingAttributeTypes,
                         accountRepository = accountRepository,
                         categoryRepository = categoryRepository,
                         personRepository = personRepository,

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorState.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorState.kt
@@ -92,7 +92,7 @@ internal class CsvStrategyEditorState(
     // Not yet editable in the UI; carried through so saving never drops them.
     var contentMatchRules by mutableStateOf(initial?.contentMatchRules.orEmpty())
     var crossSourceReconcileWindowSeconds by mutableStateOf(initial?.crossSourceReconcileWindowSeconds)
-    var fundingCardColumn by mutableStateOf(initial?.fundingCardColumn)
+    var fundingAttributeMatch by mutableStateOf(initial?.fundingAttributeMatch)
 
     // Initial primary columns, used to avoid clobbering saved fallbacks on edit-mode load.
     val initialTargetAccountColumnName: String? = initial?.targetAccountColumnName
@@ -237,7 +237,7 @@ internal class CsvStrategyEditorState(
             contentMatchRules = contentMatchRules,
             fileNamePattern = fileNamePattern.takeIf { it.isNotBlank() },
             crossSourceReconcileWindowSeconds = crossSourceReconcileWindowSeconds,
-            fundingCardColumn = fundingCardColumn,
+            fundingAttributeMatch = fundingAttributeMatch,
         )
 }
 

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorState.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorState.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.moneymanager.domain.model.WellKnownIds
+import com.moneymanager.domain.model.csvstrategy.AttributeAccountMatch
 import com.moneymanager.domain.model.csvstrategy.FieldMapping
 import kotlinx.datetime.TimeZone
 
@@ -71,6 +73,10 @@ internal class CsvStrategyEditorState(
     var targetAccountColumnName by mutableStateOf(initial?.targetAccountColumnName)
     var targetAccountFallbackColumns by mutableStateOf(initial?.targetAccountFallbackColumns.orEmpty())
     var targetAccountMode by mutableStateOf(initial?.targetAccountMode ?: TargetAccountMode.DIRECT_LOOKUP)
+
+    // Nullable and seeded verbatim so a non-attribute target extracts/round-trips as null; the UI
+    // fills in the card-last4 default only when the user actually switches into attribute-match mode.
+    var targetAttributeTypeName by mutableStateOf(initial?.targetAttributeTypeName)
     var regexRules by mutableStateOf(initial?.regexRules.orEmpty())
     var targetTemplateColumnName by mutableStateOf(initial?.targetTemplateColumnName)
     var targetTemplatePrefix by mutableStateOf(initial?.targetTemplatePrefix.orEmpty())
@@ -89,10 +95,17 @@ internal class CsvStrategyEditorState(
     var companionTransactionRules by mutableStateOf(initial?.companionTransactionRules.orEmpty())
     var fileNamePattern by mutableStateOf(initial?.fileNamePattern.orEmpty())
 
+    // Funding reconciliation: match a CSV column value against an account attribute's regex tokens to
+    // resolve the hidden funding account (e.g. Curve's last-4 -> the underlying card). Edited as two
+    // fields and reassembled into an [AttributeAccountMatch] in [toFormState]; the attribute type
+    // defaults to `card-last4` but a match is only saved when a column is chosen.
+    var fundingMatchColumn by mutableStateOf(initial?.fundingAttributeMatch?.column)
+    var fundingMatchAttributeTypeName by
+        mutableStateOf(initial?.fundingAttributeMatch?.attributeTypeName ?: WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_NAME)
+
     // Not yet editable in the UI; carried through so saving never drops them.
     var contentMatchRules by mutableStateOf(initial?.contentMatchRules.orEmpty())
     var crossSourceReconcileWindowSeconds by mutableStateOf(initial?.crossSourceReconcileWindowSeconds)
-    var fundingAttributeMatch by mutableStateOf(initial?.fundingAttributeMatch)
 
     // Initial primary columns, used to avoid clobbering saved fallbacks on edit-mode load.
     val initialTargetAccountColumnName: String? = initial?.targetAccountColumnName
@@ -106,6 +119,8 @@ internal class CsvStrategyEditorState(
                     targetAccountColumnName != null &&
                         regexRules.isNotEmpty() &&
                         regexRules.all { it.accountName.isNotBlank() }
+                TargetAccountMode.ATTRIBUTE_MATCH ->
+                    targetAccountColumnName != null && !targetAttributeTypeName.isNullOrBlank()
                 TargetAccountMode.TEMPLATE -> targetTemplateColumnName != null
                 TargetAccountMode.CONDITIONAL ->
                     targetConditions.isNotEmpty() &&
@@ -116,6 +131,10 @@ internal class CsvStrategyEditorState(
 
     private val feeValid: Boolean
         get() = feeColumnName == null || feeConditions.all { it.isComplete() }
+
+    // A funding match is opt-in: valid when no column is chosen, otherwise its attribute type must be set.
+    private val fundingMatchValid: Boolean
+        get() = fundingMatchColumn.isNullOrBlank() || fundingMatchAttributeTypeName.isNotBlank()
 
     private val rowPreprocessingValid: Boolean
         get() =
@@ -167,7 +186,7 @@ internal class CsvStrategyEditorState(
 
     /** Whether the Advanced tab has an unsatisfied required field. */
     val advancedHasError: Boolean
-        get() = !rowPreprocessingValid || !companionRulesValid
+        get() = !rowPreprocessingValid || !companionRulesValid || !fundingMatchValid
 
     fun tabHasError(tab: EditorTab): Boolean =
         when (tab) {
@@ -190,6 +209,7 @@ internal class CsvStrategyEditorState(
                 feeValid &&
                 rowPreprocessingValid &&
                 companionRulesValid &&
+                fundingMatchValid &&
                 currencyValid &&
                 timezoneValid
 
@@ -218,6 +238,7 @@ internal class CsvStrategyEditorState(
             targetAccountColumnName = targetAccountColumnName,
             targetAccountFallbackColumns = targetAccountFallbackColumns,
             targetAccountMode = targetAccountMode,
+            targetAttributeTypeName = targetAttributeTypeName,
             regexRules = regexRules,
             targetTemplateColumnName = targetTemplateColumnName,
             targetTemplatePrefix = targetTemplatePrefix,
@@ -237,7 +258,14 @@ internal class CsvStrategyEditorState(
             contentMatchRules = contentMatchRules,
             fileNamePattern = fileNamePattern.takeIf { it.isNotBlank() },
             crossSourceReconcileWindowSeconds = crossSourceReconcileWindowSeconds,
-            fundingAttributeMatch = fundingAttributeMatch,
+            // Reassemble the funding match only when a column is chosen; the attribute type always has
+            // a value (defaulting to card-last4), so the column presence is what enables the feature.
+            fundingAttributeMatch =
+                fundingMatchColumn?.takeIf { it.isNotBlank() }?.let { column ->
+                    fundingMatchAttributeTypeName.takeIf { it.isNotBlank() }?.let { type ->
+                        AttributeAccountMatch(column = column, attributeTypeName = type)
+                    }
+                },
         )
 }
 

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyFormState.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyFormState.kt
@@ -14,6 +14,7 @@ import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
 import com.moneymanager.domain.model.csvstrategy.AttributeAccountMatch
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
+import com.moneymanager.domain.model.csvstrategy.AttributeMatchAccountMapping
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
 import com.moneymanager.domain.model.csvstrategy.ContentMatchRule
@@ -68,6 +69,7 @@ internal enum class SourceAccountMode {
 internal enum class TargetAccountMode {
     DIRECT_LOOKUP,
     REGEX_MATCH,
+    ATTRIBUTE_MATCH,
     TEMPLATE,
     CONDITIONAL,
 }
@@ -177,6 +179,7 @@ internal data class StrategyFormState(
     val targetAccountColumnName: String?,
     val targetAccountFallbackColumns: List<String>,
     val targetAccountMode: TargetAccountMode,
+    val targetAttributeTypeName: String?,
     val regexRules: List<RegexRule>,
     val targetTemplateColumnName: String?,
     val targetTemplatePrefix: String,
@@ -263,6 +266,7 @@ internal fun extractFormStateFromStrategy(
     val targetAccountFallbackColumns: List<String>
     val targetAccountMode: TargetAccountMode
     val regexRules: List<RegexRule>
+    var targetAttributeTypeName: String? = null
     var targetTemplateColumnName: String? = null
     var targetTemplatePrefix = ""
     var targetTemplateSuffix = ""
@@ -281,6 +285,13 @@ internal fun extractFormStateFromStrategy(
             targetAccountFallbackColumns = targetAccountMapping.fallbackColumns.mapNotNull { columnIfExists(it) }
             targetAccountMode = TargetAccountMode.REGEX_MATCH
             regexRules = targetAccountMapping.rules
+        }
+        is AttributeMatchAccountMapping -> {
+            targetAccountColumnName = columnIfExists(targetAccountMapping.columnName)
+            targetAccountFallbackColumns = emptyList()
+            targetAccountMode = TargetAccountMode.ATTRIBUTE_MATCH
+            regexRules = emptyList()
+            targetAttributeTypeName = targetAccountMapping.attributeTypeName
         }
         is TemplateAccountMapping -> {
             targetAccountColumnName = null
@@ -453,6 +464,7 @@ internal fun extractFormStateFromStrategy(
         targetAccountColumnName = targetAccountColumnName,
         targetAccountFallbackColumns = targetAccountFallbackColumns,
         targetAccountMode = targetAccountMode,
+        targetAttributeTypeName = targetAttributeTypeName,
         regexRules = regexRules,
         targetTemplateColumnName = targetTemplateColumnName,
         targetTemplatePrefix = targetTemplatePrefix,
@@ -534,6 +546,13 @@ internal fun buildStrategyFromFormState(
                             columnName = state.targetAccountColumnName!!,
                             rules = state.regexRules,
                             fallbackColumns = state.targetAccountFallbackColumns,
+                        )
+                    TargetAccountMode.ATTRIBUTE_MATCH ->
+                        AttributeMatchAccountMapping(
+                            id = FieldMappingId(Uuid.random()),
+                            fieldType = TransferField.TARGET_ACCOUNT,
+                            columnName = state.targetAccountColumnName!!,
+                            attributeTypeName = state.targetAttributeTypeName!!,
                         )
                     TargetAccountMode.TEMPLATE ->
                         TemplateAccountMapping(

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyFormState.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyFormState.kt
@@ -12,6 +12,7 @@ import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
 import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
+import com.moneymanager.domain.model.csvstrategy.AttributeAccountMatch
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
@@ -195,7 +196,7 @@ internal data class StrategyFormState(
     val contentMatchRules: List<ContentMatchRule>,
     val fileNamePattern: String?,
     val crossSourceReconcileWindowSeconds: Long?,
-    val fundingCardColumn: String?,
+    val fundingAttributeMatch: AttributeAccountMatch?,
 )
 
 /**
@@ -471,7 +472,7 @@ internal fun extractFormStateFromStrategy(
         contentMatchRules = strategy.contentMatchRules,
         fileNamePattern = strategy.fileNamePattern,
         crossSourceReconcileWindowSeconds = strategy.crossSourceReconcileWindowSeconds,
-        fundingCardColumn = strategy.fundingCardColumn,
+        fundingAttributeMatch = strategy.fundingAttributeMatch,
     )
 }
 
@@ -631,7 +632,7 @@ internal fun buildStrategyFromFormState(
         contentMatchRules = state.contentMatchRules,
         fileNamePattern = state.fileNamePattern?.takeIf { it.isNotBlank() },
         crossSourceReconcileWindowSeconds = state.crossSourceReconcileWindowSeconds,
-        fundingCardColumn = state.fundingCardColumn?.takeIf { it.isNotBlank() },
+        fundingAttributeMatch = state.fundingAttributeMatch,
         createdAt = createdAt,
         updatedAt = updatedAt,
     )

--- a/app/ui/imports/csv/src/commonTest/kotlin/com/moneymanager/ui/screens/csvstrategy/StrategyFormRoundTripTest.kt
+++ b/app/ui/imports/csv/src/commonTest/kotlin/com/moneymanager/ui/screens/csvstrategy/StrategyFormRoundTripTest.kt
@@ -8,7 +8,9 @@ import com.moneymanager.domain.model.csv.CsvColumnId
 import com.moneymanager.domain.model.csvstrategy.AccountLookupMapping
 import com.moneymanager.domain.model.csvstrategy.AmountMode
 import com.moneymanager.domain.model.csvstrategy.AmountParsingMapping
+import com.moneymanager.domain.model.csvstrategy.AttributeAccountMatch
 import com.moneymanager.domain.model.csvstrategy.AttributeColumnMapping
+import com.moneymanager.domain.model.csvstrategy.AttributeMatchAccountMapping
 import com.moneymanager.domain.model.csvstrategy.ColumnPairSwap
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
@@ -51,6 +53,7 @@ class StrategyFormRoundTripTest {
         when (mapping) {
             is AccountLookupMapping -> mapping.copy(id = fixedId)
             is RegexAccountMapping -> mapping.copy(id = fixedId)
+            is AttributeMatchAccountMapping -> mapping.copy(id = fixedId)
             is TemplateAccountMapping -> mapping.copy(id = fixedId)
             is ConditionalAccountMapping ->
                 mapping.copy(
@@ -190,6 +193,62 @@ class StrategyFormRoundTripTest {
         assertIs<ConditionalAccountMapping>(target)
         assertIs<TemplateAccountMapping>(target.whenTrue)
         assertIs<AccountLookupMapping>(target.whenFalse)
+    }
+
+    @Test
+    fun `attribute-match target mode and funding match round-trip`() {
+        val original =
+            CsvImportStrategy(
+                id = CsvImportStrategyId(Uuid.random()),
+                name = "Attr",
+                identificationColumns = setOf("Direction", "Created on"),
+                fieldMappings =
+                    mapOf(
+                        TransferField.SOURCE_ACCOUNT to
+                            TemplateAccountMapping(mappingId(1), TransferField.SOURCE_ACCOUNT, "Source currency", prefix = "Wise: "),
+                        TransferField.TARGET_ACCOUNT to
+                            AttributeMatchAccountMapping(
+                                id = mappingId(2),
+                                fieldType = TransferField.TARGET_ACCOUNT,
+                                columnName = "Target name",
+                                attributeTypeName = "card-last4",
+                            ),
+                        TransferField.TIMESTAMP to
+                            DateTimeParsingMapping(
+                                id = mappingId(5),
+                                fieldType = TransferField.TIMESTAMP,
+                                dateColumnName = "Created on",
+                                dateFormat = "yyyy-MM-dd",
+                            ),
+                        TransferField.DESCRIPTION to
+                            DirectColumnMapping(mappingId(6), TransferField.DESCRIPTION, "Reference"),
+                        TransferField.AMOUNT to
+                            AmountParsingMapping(
+                                id = mappingId(7),
+                                fieldType = TransferField.AMOUNT,
+                                mode = AmountMode.SINGLE_COLUMN,
+                                amountColumnName = "Source amount (after fees)",
+                            ),
+                        TransferField.CURRENCY to
+                            CurrencyLookupMapping(mappingId(8), TransferField.CURRENCY, "Source currency"),
+                        TransferField.TIMEZONE to
+                            HardCodedTimezoneMapping(mappingId(9), TransferField.TIMEZONE, "Europe/London"),
+                    ),
+                fundingAttributeMatch = AttributeAccountMatch(column = "Reference", attributeTypeName = "card-last4"),
+                createdAt = timestamp,
+                updatedAt = timestamp,
+            )
+        val availableColumns = columns.map { it.originalName }.toSet()
+
+        val state = extractFormStateFromStrategy(original, availableColumns)
+        val rebuilt = buildStrategyFromFormState(state, original.id, original.createdAt, original.updatedAt)
+
+        assertEquals(normalize(original.fieldMappings), normalize(rebuilt.fieldMappings))
+        assertEquals(original.fundingAttributeMatch, rebuilt.fundingAttributeMatch)
+        val target = rebuilt.fieldMappings[TransferField.TARGET_ACCOUNT]
+        assertIs<AttributeMatchAccountMapping>(target)
+        assertEquals("card-last4", target.attributeTypeName)
+        assertEquals("Target name", target.columnName)
     }
 
     @Test


### PR DESCRIPTION
## What

Generalizes the "funding-card last-4" reconciliation into a reusable **regex-against-an-attribute** account-routing mechanism.

Previously the feature was welded to one CSV column (`fundingCardColumn`), one attribute type (`card-last4`), one role (the hidden funding leg), and **exact-token** matching. This PR replaces that with a generic primitive: match a CSV column value against the case-insensitive regex tokens stored on account attributes, and route to the single matching account.

## Why

The last-4 logic was too specific to its one use case. Making it attribute + regex driven lets any strategy route to whatever accounts the user has tagged, without bespoke code — and reuses one matcher for both the funding leg and (new) main account resolution.

## Changes

- **`AttributeAccountMatcher`** (new, `app/csvimporter`) — compiles each account-attribute token to a case-insensitive `Regex`, matches via `containsMatchIn`, unambiguous-single-match-wins (ambiguous → ignored). Replaces the exact-token `fundingCardAccountIndex`.
- **Model**: `CsvImportStrategy.fundingCardColumn: String?` → portable `fundingAttributeMatch: AttributeAccountMatch?` (column + attributeTypeName). New `AttributeMatchAccountMapping` `FieldMapping` variant resolves the **main** SOURCE/TARGET account by attribute regex (falling back to name lookup), with export type + forward/reverse mappers.
- **Persistence**: schema column `funding_card_column` → `funding_attribute_match_json` (JSON, mirroring `conversionConfig`); codec + repos updated. New `AccountAttributeReadRepository.getAll()` lets the UI build a matcher registry across all attribute types.
- **Pipeline/UI**: matcher registry threaded through import/re-import; the 4 CSV dialogs build it from `getAll()`; strategy editor carries `fundingAttributeMatch` through.
- **Built-ins/docs**: Curve strategy now uses `fundingAttributeMatch(column, "card-last4")`; `card-last4` reframed as the default (non-special-cased) attribute type in `WellKnownIds`.
- **Tests**: new `AttributeAccountMatcherTest` + two `CsvTransferMapperTest` cases; `CurveCsvE2ETest` migrated to the new config (behavior unchanged).

## Notes

- DB is in BETA with no migrations (recreated on schema change), so `fundingCardColumn` is fully removed rather than kept as an alias, per the repo's DB policy.
- `./gradlew build buildHealth` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added attribute-based account matching for CSV imports, using configurable account attributes and regex tokens.
  * Added an “Attribute” target-account mapping option in the CSV strategy editor.
  * Added configurable funding reconciliation by selecting a CSV column and account attribute type.
  * Updated strategy export/import to preserve these matching settings.

* **Bug Fixes**
  * Improved ambiguous-match handling by leaving accounts unresolved when multiple accounts match.
  * CSV re-import and preview now use the same attribute-based matching behavior as regular imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->