### PR TITLE
Add editors for all missing CSV/API strategy config features

### DIFF
--- a/app/ui/imports/api/build.gradle.kts
+++ b/app/ui/imports/api/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
                 implementation(projects.app.importengineapi)
                 implementation(projects.app.ui.audit)
                 implementation(projects.app.ui.foundation)
+                implementation(projects.utils.bigdecimal)
                 implementation(projects.utils.compose.filePicker)
                 implementation(projects.utils.compose.scrollbar)
                 implementation(projects.utils.rest)

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/AdvancedTab.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/AdvancedTab.kt
@@ -3,6 +3,7 @@ package com.moneymanager.ui.screens.apistrategy.editor
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -39,5 +40,35 @@ internal fun AdvancedTab(
                 enabled = enabled,
             )
         }
+
+        HorizontalDivider()
+        SectionHeader("Proactive request signing (exchanges)")
+        Text(
+            text =
+                "A per-request HMAC signature computed for every call (Crypto.com/Binance/Kraken). Used " +
+                    "when the authentication type is SIGNED.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        RequestSigningEditor(
+            config = state.requestSigning,
+            onChange = { state.requestSigning = it },
+            enabled = enabled,
+        )
+
+        HorizontalDivider()
+        SectionHeader("Internal-transfer reconciliation")
+        Text(
+            text =
+                "Collapse this account's transfers that another owned account records at its own end " +
+                    "(e.g. App→Exchange) into one internal transfer.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        InternalTransferReconcileEditor(
+            config = state.internalTransferReconcile,
+            onChange = { state.internalTransferReconcile = it },
+            enabled = enabled,
+        )
     }
 }

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ApiEditorComponents.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ApiEditorComponents.kt
@@ -146,6 +146,46 @@ internal fun IntFieldRow(
     )
 }
 
+/**
+ * A field that edits a [Long] without narrowing. Keeps its own text buffer (keyed on [value] so an
+ * external change resyncs it) so intermediate empty/invalid input is shown without corrupting the model.
+ */
+@Composable
+internal fun LongFieldRow(
+    label: String,
+    value: Long,
+    onValueChange: (Long) -> Unit,
+    enabled: Boolean = true,
+    isError: Boolean = false,
+    supportingText: String? = null,
+) {
+    var text by remember(value) { mutableStateOf(value.toString()) }
+    val parseError = text.trim().toLongOrNull() == null
+    OutlinedTextField(
+        value = text,
+        onValueChange = {
+            text = it
+            it.trim().toLongOrNull()?.let(onValueChange)
+        },
+        label = { Text(label) },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+        enabled = enabled,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        isError = isError || parseError,
+        supportingText =
+            when {
+                parseError -> {
+                    { Text("Must be a whole number") }
+                }
+                supportingText != null -> {
+                    { Text(supportingText) }
+                }
+                else -> null
+            },
+    )
+}
+
 /** A Switch + label row. */
 @Composable
 internal fun ToggleRow(

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ApiStrategyEditorState.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ApiStrategyEditorState.kt
@@ -73,6 +73,14 @@ internal class ApiStrategyEditorState(
     var signing by mutableStateOf(initial?.signing)
     var peopleDownload by mutableStateOf(initial?.peopleDownload)
 
+    // Config-driven exchange fields (crypto.com/Binance/Kraken). Held as domain types directly and
+    // edited on the Endpoints tab (synthetic account, data endpoints) and Advanced tab (request
+    // signing, internal-transfer reconciliation).
+    var requestSigning by mutableStateOf(initial?.requestSigning)
+    var dataEndpoints by mutableStateOf(initial?.dataEndpoints.orEmpty())
+    var syntheticAccount by mutableStateOf(initial?.syntheticAccount)
+    var internalTransferReconcile by mutableStateOf(initial?.internalTransferReconcile)
+
     val generalHasError: Boolean
         get() = name.isBlank() || baseUrl.isBlank()
 
@@ -81,7 +89,14 @@ internal class ApiStrategyEditorState(
             accountsEndpoint.path.isBlank() ||
                 transactionsEndpoint.path.isBlank() ||
                 accountIdentifiersEndpoint?.path?.isBlank() == true ||
-                ancestorEndpoints.any { it.path.isBlank() }
+                ancestorEndpoints.any { it.path.isBlank() } ||
+                syntheticAccount?.let { !it.isValidForSave() } == true ||
+                !dataEndpoints.isValidForSave()
+
+    val advancedHasError: Boolean
+        get() =
+            requestSigning?.let { !it.isValidForSave() } == true ||
+                internalTransferReconcile?.let { !it.isValidForSave() } == true
 
     val accountMappingsHasError: Boolean
         get() = accountMappings.idField.isBlank() || accountMappings.descriptionField.isBlank()
@@ -113,8 +128,7 @@ internal class ApiStrategyEditorState(
             EditorTab.TRANSACTION_MAPPINGS -> transactionMappingsHasError
             EditorTab.PEOPLE -> peopleHasError
             EditorTab.RULES -> rulesHasError
-            // The Advanced tab (request signing) has no required fields, so it never blocks saving.
-            EditorTab.ADVANCED -> false
+            EditorTab.ADVANCED -> advancedHasError
         }
 
     val isValid: Boolean
@@ -124,7 +138,8 @@ internal class ApiStrategyEditorState(
                 !accountMappingsHasError &&
                 !transactionMappingsHasError &&
                 !peopleHasError &&
-                !rulesHasError
+                !rulesHasError &&
+                !advancedHasError
 
     fun toFormState(): ApiStrategyFormState =
         ApiStrategyFormState(
@@ -144,6 +159,10 @@ internal class ApiStrategyEditorState(
             builtInCounterpartyRules = builtInCounterpartyRules,
             signing = signing,
             peopleDownload = peopleDownload,
+            requestSigning = requestSigning,
+            dataEndpoints = dataEndpoints,
+            syntheticAccount = syntheticAccount,
+            internalTransferReconcile = internalTransferReconcile,
         )
 }
 

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ApiStrategyFormState.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ApiStrategyFormState.kt
@@ -3,11 +3,15 @@ package com.moneymanager.ui.screens.apistrategy.editor
 import com.moneymanager.domain.model.ApiImportStrategyId
 import com.moneymanager.domain.model.apistrategy.ApiAccountMappings
 import com.moneymanager.domain.model.apistrategy.ApiAuthType
+import com.moneymanager.domain.model.apistrategy.ApiDataEndpoint
 import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
+import com.moneymanager.domain.model.apistrategy.ApiInternalTransferReconcile
 import com.moneymanager.domain.model.apistrategy.ApiPeopleMappings
 import com.moneymanager.domain.model.apistrategy.ApiPersonImportConfig
+import com.moneymanager.domain.model.apistrategy.ApiRequestSigningConfig
 import com.moneymanager.domain.model.apistrategy.ApiSigningConfig
+import com.moneymanager.domain.model.apistrategy.ApiSyntheticAccount
 import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
 import com.moneymanager.domain.model.apistrategy.BuiltInCounterpartyRule
 import kotlin.time.Instant
@@ -35,6 +39,10 @@ data class ApiStrategyFormState(
     val builtInCounterpartyRules: List<BuiltInCounterpartyRule>,
     val signing: ApiSigningConfig?,
     val peopleDownload: ApiPersonImportConfig?,
+    val requestSigning: ApiRequestSigningConfig?,
+    val dataEndpoints: List<ApiDataEndpoint>,
+    val syntheticAccount: ApiSyntheticAccount?,
+    val internalTransferReconcile: ApiInternalTransferReconcile?,
 )
 
 /** Projects a mapping's `customFields` map + `uniqueIdentifierFields` set onto editable rows. */
@@ -70,6 +78,10 @@ fun extractFormStateFromStrategy(strategy: ApiImportStrategy): ApiStrategyFormSt
         builtInCounterpartyRules = strategy.builtInCounterpartyRules,
         signing = strategy.signing,
         peopleDownload = strategy.peopleDownload,
+        requestSigning = strategy.requestSigning,
+        dataEndpoints = strategy.dataEndpoints,
+        syntheticAccount = strategy.syntheticAccount,
+        internalTransferReconcile = strategy.internalTransferReconcile,
     )
 
 /** Reassembles an [ApiImportStrategy] from edited form state. The DB regenerates revisionId/configJson. */
@@ -103,6 +115,10 @@ fun buildStrategyFromApiFormState(
         signing = state.signing,
         peopleDownload = state.peopleDownload,
         personExternalIdAttribute = state.personExternalIdAttribute?.trim()?.ifBlank { null },
+        requestSigning = state.requestSigning,
+        dataEndpoints = state.dataEndpoints,
+        syntheticAccount = state.syntheticAccount,
+        internalTransferReconcile = state.internalTransferReconcile,
         createdAt = createdAt,
         updatedAt = updatedAt,
     )

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/EndpointsTab.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/EndpointsTab.kt
@@ -26,6 +26,22 @@ internal fun EndpointsTab(
     enabled: Boolean,
 ) {
     Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        SectionHeader("Synthetic account")
+        Text(
+            text =
+                "For exchanges that hold all assets in one account instead of an accounts endpoint. " +
+                    "When enabled, the accounts endpoint below is not fetched.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        SyntheticAccountEditor(
+            account = state.syntheticAccount,
+            onChange = { state.syntheticAccount = it },
+            enabled = enabled,
+        )
+
+        Spacer(Modifier.padding(top = 4.dp))
+        HorizontalDivider()
         SectionHeader("Accounts endpoint")
         EndpointEditor(
             endpoint = state.accountsEndpoint,
@@ -111,5 +127,21 @@ internal fun EndpointsTab(
             Spacer(Modifier.width(4.dp))
             Text("Add ancestor endpoint")
         }
+
+        Spacer(Modifier.padding(top = 4.dp))
+        HorizontalDivider()
+        SectionHeader("Data endpoints")
+        Text(
+            text =
+                "Additional endpoints an exchange exposes (trades, orders, deposits, withdrawals), each " +
+                    "producing a different kind of record.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        DataEndpointsEditor(
+            endpoints = state.dataEndpoints,
+            onChange = { state.dataEndpoints = it },
+            enabled = enabled,
+        )
     }
 }

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ExchangeDataEditors.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ExchangeDataEditors.kt
@@ -1,0 +1,485 @@
+package com.moneymanager.ui.screens.apistrategy.editor
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.moneymanager.domain.model.apistrategy.ApiAccountBridge
+import com.moneymanager.domain.model.apistrategy.ApiAmountFormat
+import com.moneymanager.domain.model.apistrategy.ApiDataEndpoint
+import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
+import com.moneymanager.domain.model.apistrategy.ApiEndpointKind
+import com.moneymanager.domain.model.apistrategy.ApiInternalTransferReconcile
+import com.moneymanager.domain.model.apistrategy.ApiSignSource
+import com.moneymanager.domain.model.apistrategy.ApiSyntheticAccount
+import com.moneymanager.domain.model.apistrategy.ApiTradeMappings
+import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
+import com.moneymanager.domain.model.apistrategy.InstrumentSplitMode
+import com.moneymanager.domain.model.apistrategy.TimestampFormat
+import com.moneymanager.domain.model.apistrategy.TransferDirection
+
+/** Kinds whose records are interpreted by [ApiTradeMappings]; the rest use [ApiTransactionMappings]. */
+private val TRADE_KINDS = setOf(ApiEndpointKind.TRADES, ApiEndpointKind.ORDERS)
+
+/** Kinds that carry a fixed movement direction + external counterparty account. */
+private val DIRECTIONAL_KINDS = setOf(ApiEndpointKind.DEPOSITS, ApiEndpointKind.WITHDRAWALS)
+
+/**
+ * Editor for the optional [ApiSyntheticAccount]: an exchange strategy imports into one fixed account
+ * holding all assets instead of enumerating an accounts endpoint.
+ */
+@Composable
+internal fun SyntheticAccountEditor(
+    account: ApiSyntheticAccount?,
+    onChange: (ApiSyntheticAccount?) -> Unit,
+    enabled: Boolean,
+) {
+    ToggleRow(
+        label = "Single synthetic account (exchanges)",
+        checked = account != null,
+        onCheckedChange = { on -> onChange(if (on) ApiSyntheticAccount(name = "", externalId = "") else null) },
+        enabled = enabled,
+    )
+    val a = account ?: return
+    TextFieldRow("Account name", a.name, { onChange(a.copy(name = it)) }, enabled, isError = a.name.isBlank())
+    TextFieldRow("External id", a.externalId, { onChange(a.copy(externalId = it)) }, enabled, isError = a.externalId.isBlank())
+}
+
+/**
+ * Editor for the strategy's [ApiDataEndpoint] list — exchanges expose several endpoints (trades,
+ * deposits, withdrawals, orders), each mapping to a different kind of imported record.
+ */
+@Composable
+internal fun DataEndpointsEditor(
+    endpoints: List<ApiDataEndpoint>,
+    onChange: (List<ApiDataEndpoint>) -> Unit,
+    enabled: Boolean,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        endpoints.forEachIndexed { index, dataEndpoint ->
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)),
+            ) {
+                Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    EditorCardHeader(
+                        title = "Data endpoint ${index + 1}",
+                        onRemove = { onChange(endpoints.filterIndexed { i, _ -> i != index }) },
+                        enabled = enabled,
+                    )
+                    DataEndpointEditor(
+                        dataEndpoint = dataEndpoint,
+                        onChange = { updated -> onChange(endpoints.mapIndexed { i, e -> if (i == index) updated else e }) },
+                        enabled = enabled,
+                    )
+                }
+            }
+        }
+        TextButton(
+            onClick = {
+                onChange(
+                    endpoints +
+                        ApiDataEndpoint(
+                            endpoint = ApiEndpointConfig(path = "", responseArrayKey = ""),
+                            kind = ApiEndpointKind.TRADES,
+                        ),
+                )
+            },
+            enabled = enabled,
+        ) {
+            Icon(Icons.Default.Add, contentDescription = null)
+            Spacer(Modifier.width(4.dp))
+            Text("Add data endpoint")
+        }
+    }
+}
+
+@Composable
+private fun DataEndpointEditor(
+    dataEndpoint: ApiDataEndpoint,
+    onChange: (ApiDataEndpoint) -> Unit,
+    enabled: Boolean,
+) {
+    EnumDropdown(
+        label = "Kind",
+        options = ApiEndpointKind.entries,
+        selected = dataEndpoint.kind,
+        onSelect = { onChange(dataEndpoint.copy(kind = it)) },
+        optionLabel = { it.name },
+        enabled = enabled,
+    )
+    EndpointEditor(
+        endpoint = dataEndpoint.endpoint,
+        onChange = { onChange(dataEndpoint.copy(endpoint = it)) },
+        enabled = enabled,
+    )
+
+    if (dataEndpoint.kind in TRADE_KINDS) {
+        Text("Trade mappings", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        TradeMappingsEditor(
+            mappings = dataEndpoint.tradeMappings ?: defaultTradeMappings(),
+            onChange = { onChange(dataEndpoint.copy(tradeMappings = it, transactionMappings = null)) },
+            enabled = enabled,
+        )
+    } else {
+        Text("Transaction mappings", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        TransactionMappingsFields(
+            mappings = dataEndpoint.transactionMappings ?: ApiTransactionMappings(),
+            onChange = { onChange(dataEndpoint.copy(transactionMappings = it, tradeMappings = null)) },
+            enabled = enabled,
+        )
+    }
+
+    if (dataEndpoint.kind in DIRECTIONAL_KINDS) {
+        EnumDropdown(
+            label = "Fixed direction",
+            options = TransferDirection.entries,
+            selected = dataEndpoint.fixedDirection ?: TransferDirection.IN,
+            onSelect = { onChange(dataEndpoint.copy(fixedDirection = it)) },
+            optionLabel = { it.name },
+            enabled = enabled,
+        )
+        TextFieldRow(
+            label = "Counterparty account name (optional)",
+            value = dataEndpoint.counterpartyAccountName.orEmpty(),
+            onValueChange = { onChange(dataEndpoint.copy(counterpartyAccountName = it.ifBlank { null })) },
+            enabled = enabled,
+        )
+    }
+}
+
+/**
+ * Structured editor for an [ApiTransactionMappings] on a data endpoint. Mirrors the fields exposed by
+ * the main Transactions tab, using plain text fields (data endpoints have no session sample to pick from).
+ */
+@Composable
+internal fun TransactionMappingsFields(
+    mappings: ApiTransactionMappings,
+    onChange: (ApiTransactionMappings) -> Unit,
+    enabled: Boolean,
+) {
+    val m = mappings
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        TextFieldRow("Amount field", m.amountField, { onChange(m.copy(amountField = it)) }, enabled, isError = m.amountField.isBlank())
+        TextFieldRow(
+            "Timestamp field",
+            m.timestampField,
+            { onChange(m.copy(timestampField = it)) },
+            enabled,
+            isError = m.timestampField.isBlank(),
+        )
+        TextFieldRow(
+            "Currency field",
+            m.currencyField,
+            { onChange(m.copy(currencyField = it)) },
+            enabled,
+            isError = m.currencyField.isBlank(),
+        )
+        TextFieldRow("Description field", m.descriptionField, {
+            onChange(m.copy(descriptionField = it))
+        }, enabled, isError = m.descriptionField.isBlank())
+        TextFieldRow("Transaction ID field", m.idField, { onChange(m.copy(idField = it)) }, enabled, isError = m.idField.isBlank())
+        EnumDropdown(
+            label = "Amount format",
+            options = ApiAmountFormat.entries,
+            selected = m.amountFormat,
+            onSelect = { onChange(m.copy(amountFormat = it)) },
+            optionLabel = { it.name },
+            enabled = enabled,
+        )
+        EnumDropdown(
+            label = "Timestamp format",
+            options = TimestampFormat.entries,
+            selected = m.timestampFormat,
+            onSelect = { onChange(m.copy(timestampFormat = it)) },
+            optionLabel = { it.name },
+            enabled = enabled,
+        )
+        EnumDropdown(
+            label = "Sign source",
+            options = ApiSignSource.entries,
+            selected = m.signSource,
+            onSelect = { onChange(m.copy(signSource = it)) },
+            optionLabel = { it.name },
+            enabled = enabled,
+        )
+        if (m.signSource == ApiSignSource.FIELD) {
+            TextFieldRow("Sign field", m.signField.orEmpty(), { onChange(m.copy(signField = it.ifBlank { null })) }, enabled)
+            StringSetEditor(
+                label = "Credit values (mean incoming/positive)",
+                values = m.creditValues,
+                onChange = { onChange(m.copy(creditValues = it)) },
+                enabled = enabled,
+            )
+        }
+        TextFieldRow(
+            "Fee amount field (optional)",
+            m.feeAmountField.orEmpty(),
+            { onChange(m.copy(feeAmountField = it.ifBlank { null })) },
+            enabled,
+        )
+        TextFieldRow("Fee currency field (optional)", m.feeCurrencyField.orEmpty(), {
+            onChange(m.copy(feeCurrencyField = it.ifBlank { null }))
+        }, enabled)
+        TextFieldRow(
+            "Counterparty name field (optional)",
+            m.counterpartyNameField.orEmpty(),
+            { onChange(m.copy(counterpartyNameField = it.ifBlank { null })) },
+            enabled,
+        )
+        TextFieldRow("Txid field (optional)", m.txidField.orEmpty(), { onChange(m.copy(txidField = it.ifBlank { null })) }, enabled)
+        TextFieldRow(
+            "Counterparty address field (optional)",
+            m.counterpartyAddressField.orEmpty(),
+            { onChange(m.copy(counterpartyAddressField = it.ifBlank { null })) },
+            enabled,
+        )
+        TextFieldRow(
+            "Counterparty network field (optional)",
+            m.counterpartyNetworkField.orEmpty(),
+            { onChange(m.copy(counterpartyNetworkField = it.ifBlank { null })) },
+            enabled,
+        )
+    }
+}
+
+/** Structured editor for an [ApiTradeMappings] on a TRADES/ORDERS data endpoint. */
+@Composable
+internal fun TradeMappingsEditor(
+    mappings: ApiTradeMappings,
+    onChange: (ApiTradeMappings) -> Unit,
+    enabled: Boolean,
+) {
+    val m = mappings
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        TextFieldRow("Instrument field", m.instrumentField, {
+            onChange(m.copy(instrumentField = it))
+        }, enabled, isError = m.instrumentField.isBlank())
+        EnumDropdown(
+            label = "Instrument split mode",
+            options = InstrumentSplitMode.entries,
+            selected = m.splitMode,
+            onSelect = { onChange(m.copy(splitMode = it)) },
+            optionLabel = { it.name },
+            enabled = enabled,
+        )
+        when (m.splitMode) {
+            InstrumentSplitMode.SEPARATOR ->
+                TextFieldRow("Instrument separator", m.instrumentSeparator, { onChange(m.copy(instrumentSeparator = it)) }, enabled)
+            InstrumentSplitMode.EXPLICIT_FIELDS -> {
+                TextFieldRow(
+                    "Base asset field",
+                    m.baseAssetField.orEmpty(),
+                    { onChange(m.copy(baseAssetField = it.ifBlank { null })) },
+                    enabled,
+                )
+                TextFieldRow(
+                    "Quote asset field",
+                    m.quoteAssetField.orEmpty(),
+                    { onChange(m.copy(quoteAssetField = it.ifBlank { null })) },
+                    enabled,
+                )
+            }
+            InstrumentSplitMode.QUOTE_SUFFIX ->
+                StringSetEditor(
+                    label = "Known quote assets (longest match wins)",
+                    values = m.quoteAssets.toSet(),
+                    onChange = { onChange(m.copy(quoteAssets = it.toList())) },
+                    enabled = enabled,
+                )
+        }
+        TextFieldRow("Side field", m.sideField, { onChange(m.copy(sideField = it)) }, enabled, isError = m.sideField.isBlank())
+        StringSetEditor(
+            label = "Buy values (mean BUY side)",
+            values = m.buyValues,
+            onChange = { onChange(m.copy(buyValues = it)) },
+            enabled = enabled,
+        )
+        TextFieldRow("Base quantity field", m.baseQuantityField, {
+            onChange(m.copy(baseQuantityField = it))
+        }, enabled, isError = m.baseQuantityField.isBlank())
+        TextFieldRow("Price field (optional)", m.priceField.orEmpty(), { onChange(m.copy(priceField = it.ifBlank { null })) }, enabled)
+        TextFieldRow("Quote quantity field (optional)", m.quoteQuantityField.orEmpty(), {
+            onChange(m.copy(quoteQuantityField = it.ifBlank { null }))
+        }, enabled)
+        TextFieldRow("Fee field (optional)", m.feeField.orEmpty(), { onChange(m.copy(feeField = it.ifBlank { null })) }, enabled)
+        TextFieldRow("Fee currency field (optional)", m.feeCurrencyField.orEmpty(), {
+            onChange(m.copy(feeCurrencyField = it.ifBlank { null }))
+        }, enabled)
+        TextFieldRow(
+            "Timestamp field",
+            m.timestampField,
+            { onChange(m.copy(timestampField = it)) },
+            enabled,
+            isError = m.timestampField.isBlank(),
+        )
+        EnumDropdown(
+            label = "Timestamp format",
+            options = TimestampFormat.entries,
+            selected = m.timestampFormat,
+            onSelect = { onChange(m.copy(timestampFormat = it)) },
+            optionLabel = { it.name },
+            enabled = enabled,
+        )
+        TextFieldRow("Trade ID field", m.idField, { onChange(m.copy(idField = it)) }, enabled, isError = m.idField.isBlank())
+        TextFieldRow(
+            "Order ID field (optional)",
+            m.orderIdField.orEmpty(),
+            { onChange(m.copy(orderIdField = it.ifBlank { null })) },
+            enabled,
+        )
+        TextFieldRow("Description field (optional)", m.descriptionField.orEmpty(), {
+            onChange(m.copy(descriptionField = it.ifBlank { null }))
+        }, enabled)
+        TextFieldRow(
+            "Order type field (optional)",
+            m.orderTypeField.orEmpty(),
+            { onChange(m.copy(orderTypeField = it.ifBlank { null })) },
+            enabled,
+        )
+        TextFieldRow("Order status field (optional)", m.orderStatusField.orEmpty(), {
+            onChange(m.copy(orderStatusField = it.ifBlank { null }))
+        }, enabled)
+        TextFieldRow("Limit price field (optional)", m.limitPriceField.orEmpty(), {
+            onChange(m.copy(limitPriceField = it.ifBlank { null }))
+        }, enabled)
+        TextFieldRow("Average price field (optional)", m.avgPriceField.orEmpty(), {
+            onChange(m.copy(avgPriceField = it.ifBlank { null }))
+        }, enabled)
+        TextFieldRow("Update timestamp field (optional)", m.updateTimestampField.orEmpty(), {
+            onChange(m.copy(updateTimestampField = it.ifBlank { null }))
+        }, enabled)
+        TextFieldRow("Client order id field (optional)", m.clientOidField.orEmpty(), {
+            onChange(m.copy(clientOidField = it.ifBlank { null }))
+        }, enabled)
+        TextFieldRow("Time-in-force field (optional)", m.timeInForceField.orEmpty(), {
+            onChange(m.copy(timeInForceField = it.ifBlank { null }))
+        }, enabled)
+    }
+}
+
+/**
+ * Editor for the optional [ApiInternalTransferReconcile]: collapses matching half-transfers recorded by
+ * this strategy's account and another owned account into one internal transfer.
+ */
+@Composable
+internal fun InternalTransferReconcileEditor(
+    config: ApiInternalTransferReconcile?,
+    onChange: (ApiInternalTransferReconcile?) -> Unit,
+    enabled: Boolean,
+) {
+    ToggleRow(
+        label = "Enable internal-transfer reconciliation",
+        checked = config != null,
+        onCheckedChange = { on ->
+            onChange(if (on) ApiInternalTransferReconcile(bridges = emptyList(), windowSeconds = 3600) else null)
+        },
+        enabled = enabled,
+    )
+    val c = config ?: return
+
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text("Bridged accounts", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        c.bridges.forEachIndexed { index, bridge ->
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)),
+            ) {
+                Column(modifier = Modifier.padding(8.dp)) {
+                    EditorCardHeader(
+                        title = "Bridge ${index + 1}",
+                        onRemove = { onChange(c.copy(bridges = c.bridges.filterIndexed { i, _ -> i != index })) },
+                        enabled = enabled,
+                    )
+                    TextFieldRow(
+                        label = "Other account name",
+                        value = bridge.otherAccountName,
+                        onValueChange = { updated ->
+                            onChange(
+                                c.copy(
+                                    bridges =
+                                        c.bridges.mapIndexed { i, b ->
+                                            if (i ==
+                                                index
+                                            ) {
+                                                b.copy(otherAccountName = updated)
+                                            } else {
+                                                b
+                                            }
+                                        },
+                                ),
+                            )
+                        },
+                        enabled = enabled,
+                        isError = bridge.otherAccountName.isBlank(),
+                    )
+                }
+            }
+        }
+        TextButton(onClick = { onChange(c.copy(bridges = c.bridges + ApiAccountBridge(otherAccountName = ""))) }, enabled = enabled) {
+            Icon(Icons.Default.Add, contentDescription = null)
+            Spacer(Modifier.width(4.dp))
+            Text("Add bridge")
+        }
+        IntFieldRow("Window (seconds)", c.windowSeconds.toInt(), { onChange(c.copy(windowSeconds = it.toLong())) }, enabled)
+        TextFieldRow(
+            label = "Amount tolerance percent",
+            value = c.amountTolerancePercent,
+            onValueChange = { onChange(c.copy(amountTolerancePercent = it)) },
+            enabled = enabled,
+            supportingText = "Decimal string, e.g. \"0.5\" (allowed amount difference as a percentage)",
+        )
+    }
+}
+
+private fun defaultTradeMappings(): ApiTradeMappings =
+    ApiTradeMappings(
+        instrumentField = "",
+        sideField = "",
+        baseQuantityField = "",
+        timestampField = "",
+        idField = "",
+    )
+
+/** Whether a data-endpoint list is complete enough to save (used for tab validation). */
+internal fun List<ApiDataEndpoint>.isValidForSave(): Boolean =
+    all { de ->
+        de.endpoint.path.isNotBlank() &&
+            if (de.kind in TRADE_KINDS) {
+                de.tradeMappings?.let {
+                    it.instrumentField.isNotBlank() &&
+                        it.sideField.isNotBlank() &&
+                        it.baseQuantityField.isNotBlank() &&
+                        it.timestampField.isNotBlank() &&
+                        it.idField.isNotBlank()
+                } ?: false
+            } else {
+                de.transactionMappings?.let {
+                    it.amountField.isNotBlank() &&
+                        it.timestampField.isNotBlank() &&
+                        it.currencyField.isNotBlank() &&
+                        it.descriptionField.isNotBlank() &&
+                        it.idField.isNotBlank()
+                } ?: false
+            }
+    }
+
+/** Whether an internal-transfer-reconcile config is complete enough to save. */
+internal fun ApiInternalTransferReconcile.isValidForSave(): Boolean =
+    bridges.isNotEmpty() && bridges.all { it.otherAccountName.isNotBlank() }
+
+/** Whether a synthetic-account config is complete enough to save. */
+internal fun ApiSyntheticAccount.isValidForSave(): Boolean = name.isNotBlank() && externalId.isNotBlank()

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ExchangeDataEditors.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ExchangeDataEditors.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.bigdecimal.BigDecimal
 import com.moneymanager.domain.model.apistrategy.ApiAccountBridge
 import com.moneymanager.domain.model.apistrategy.ApiAmountFormat
 import com.moneymanager.domain.model.apistrategy.ApiDataEndpoint
@@ -117,7 +118,12 @@ private fun DataEndpointEditor(
         label = "Kind",
         options = ApiEndpointKind.entries,
         selected = dataEndpoint.kind,
-        onSelect = { onChange(dataEndpoint.copy(kind = it)) },
+        // Persist the direction the UI shows by default (IN) when switching to a directional kind,
+        // so a saved deposit/withdrawal endpoint never keeps a null direction the UI rendered as IN.
+        onSelect = { newKind ->
+            val direction = dataEndpoint.fixedDirection ?: TransferDirection.IN.takeIf { newKind in DIRECTIONAL_KINDS }
+            onChange(dataEndpoint.copy(kind = newKind, fixedDirection = direction))
+        },
         optionLabel = { it.name },
         enabled = enabled,
     )
@@ -434,12 +440,20 @@ internal fun InternalTransferReconcileEditor(
             Spacer(Modifier.width(4.dp))
             Text("Add bridge")
         }
-        IntFieldRow("Window (seconds)", c.windowSeconds.toInt(), { onChange(c.copy(windowSeconds = it.toLong())) }, enabled)
+        LongFieldRow(
+            label = "Window (seconds)",
+            value = c.windowSeconds,
+            onValueChange = { onChange(c.copy(windowSeconds = it)) },
+            enabled = enabled,
+            isError = c.windowSeconds <= 0,
+            supportingText = "Must be a positive number of seconds",
+        )
         TextFieldRow(
             label = "Amount tolerance percent",
             value = c.amountTolerancePercent,
             onValueChange = { onChange(c.copy(amountTolerancePercent = it)) },
             enabled = enabled,
+            isError = !c.amountTolerancePercent.isNonNegativeDecimal(),
             supportingText = "Decimal string, e.g. \"0.5\" (allowed amount difference as a percentage)",
         )
     }
@@ -454,32 +468,52 @@ private fun defaultTradeMappings(): ApiTradeMappings =
         idField = "",
     )
 
+private fun ApiTradeMappings.isValidForSave(): Boolean =
+    instrumentField.isNotBlank() &&
+        sideField.isNotBlank() &&
+        baseQuantityField.isNotBlank() &&
+        timestampField.isNotBlank() &&
+        idField.isNotBlank() &&
+        // The base×price / explicit-quote-quantity derivation needs at least one of these.
+        (!priceField.isNullOrBlank() || !quoteQuantityField.isNullOrBlank()) &&
+        when (splitMode) {
+            InstrumentSplitMode.SEPARATOR -> instrumentSeparator.isNotBlank()
+            InstrumentSplitMode.EXPLICIT_FIELDS -> !baseAssetField.isNullOrBlank() && !quoteAssetField.isNullOrBlank()
+            InstrumentSplitMode.QUOTE_SUFFIX -> quoteAssets.isNotEmpty()
+        }
+
+private fun ApiTransactionMappings.isValidForSave(): Boolean =
+    amountField.isNotBlank() &&
+        timestampField.isNotBlank() &&
+        currencyField.isNotBlank() &&
+        descriptionField.isNotBlank() &&
+        idField.isNotBlank() &&
+        (signSource != ApiSignSource.FIELD || !signField.isNullOrBlank())
+
 /** Whether a data-endpoint list is complete enough to save (used for tab validation). */
 internal fun List<ApiDataEndpoint>.isValidForSave(): Boolean =
     all { de ->
         de.endpoint.path.isNotBlank() &&
+            (de.kind !in DIRECTIONAL_KINDS || de.fixedDirection != null) &&
             if (de.kind in TRADE_KINDS) {
-                de.tradeMappings?.let {
-                    it.instrumentField.isNotBlank() &&
-                        it.sideField.isNotBlank() &&
-                        it.baseQuantityField.isNotBlank() &&
-                        it.timestampField.isNotBlank() &&
-                        it.idField.isNotBlank()
-                } ?: false
+                de.tradeMappings?.isValidForSave() ?: false
             } else {
-                de.transactionMappings?.let {
-                    it.amountField.isNotBlank() &&
-                        it.timestampField.isNotBlank() &&
-                        it.currencyField.isNotBlank() &&
-                        it.descriptionField.isNotBlank() &&
-                        it.idField.isNotBlank()
-                } ?: false
+                de.transactionMappings?.isValidForSave() ?: false
             }
     }
 
 /** Whether an internal-transfer-reconcile config is complete enough to save. */
 internal fun ApiInternalTransferReconcile.isValidForSave(): Boolean =
-    bridges.isNotEmpty() && bridges.all { it.otherAccountName.isNotBlank() }
+    bridges.isNotEmpty() &&
+        bridges.all { it.otherAccountName.isNotBlank() } &&
+        windowSeconds > 0 &&
+        amountTolerancePercent.isNonNegativeDecimal()
 
 /** Whether a synthetic-account config is complete enough to save. */
 internal fun ApiSyntheticAccount.isValidForSave(): Boolean = name.isNotBlank() && externalId.isNotBlank()
+
+/**
+ * Whether [this] parses as an exact non-negative decimal. Uses [BigDecimal] (parsed from the string)
+ * rather than a Double, per the repository's monetary-parsing guideline.
+ */
+internal fun String.isNonNegativeDecimal(): Boolean = runCatching { BigDecimal(trim()) }.getOrNull()?.let { it >= BigDecimal.ZERO } ?: false

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/RequestSigningEditor.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/RequestSigningEditor.kt
@@ -332,6 +332,23 @@ private fun defaultRequestSigning(): ApiRequestSigningConfig =
         signature = FieldPlacement(SigFieldLocation.QUERY, "signature"),
     )
 
-/** Whether a request-signing config has its required fields set (used for tab validation). */
+/**
+ * Whether a message part is complete. Only the composite [SigPart.Sha256] can be incomplete — an empty
+ * nested list signs nothing — so it must have parts that are themselves valid; leaf parts are always OK.
+ */
+private fun SigPart.isValidForSave(): Boolean =
+    when (this) {
+        is SigPart.Sha256 -> parts.isNotEmpty() && parts.all { it.isValidForSave() }
+        else -> true
+    }
+
+/** Whether a request-signing config has every required (and enabled-conditional) field set. */
 internal fun ApiRequestSigningConfig.isValidForSave(): Boolean =
-    message.isNotEmpty() && apiKey.name.isNotBlank() && signature.name.isNotBlank() && nonce.placement.name.isNotBlank()
+    message.isNotEmpty() &&
+        message.all { it.isValidForSave() } &&
+        apiKey.name.isNotBlank() &&
+        signature.name.isNotBlank() &&
+        nonce.placement.name.isNotBlank() &&
+        (requestId?.placement?.name?.isNotBlank() ?: true) &&
+        (method?.name?.isNotBlank() ?: true) &&
+        (bodyFormat != BodyFormat.JSON_ENVELOPE || !paramsEnvelopeKey.isNullOrBlank())

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/RequestSigningEditor.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/RequestSigningEditor.kt
@@ -1,0 +1,337 @@
+package com.moneymanager.ui.screens.apistrategy.editor
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.moneymanager.domain.model.apistrategy.ApiRequestSigningConfig
+import com.moneymanager.domain.model.apistrategy.BodyFormat
+import com.moneymanager.domain.model.apistrategy.FieldPlacement
+import com.moneymanager.domain.model.apistrategy.NonceFormat
+import com.moneymanager.domain.model.apistrategy.NonceSpec
+import com.moneymanager.domain.model.apistrategy.ParamStringFormat
+import com.moneymanager.domain.model.apistrategy.RequestIdFormat
+import com.moneymanager.domain.model.apistrategy.RequestIdSpec
+import com.moneymanager.domain.model.apistrategy.SecretEncoding
+import com.moneymanager.domain.model.apistrategy.SigFieldLocation
+import com.moneymanager.domain.model.apistrategy.SigPart
+import com.moneymanager.domain.model.apistrategy.SignatureEncoding
+import com.moneymanager.domain.model.apistrategy.SigningAlgorithm
+
+/** The [SigPart] variants, used to drive a variant picker in [SigPartListEditor]. */
+private enum class SigPartKind(
+    val label: String,
+) {
+    LITERAL("Literal text"),
+    METHOD("API method name"),
+    REQUEST_ID("Request id"),
+    API_KEY("API key"),
+    NONCE("Nonce"),
+    PATH("Request path"),
+    QUERY_STRING("Query string"),
+    BODY("Request body"),
+    PARAM_STRING("Param string"),
+    SHA256("SHA-256 of parts"),
+}
+
+private fun SigPart.kind(): SigPartKind =
+    when (this) {
+        is SigPart.Literal -> SigPartKind.LITERAL
+        SigPart.Method -> SigPartKind.METHOD
+        SigPart.RequestId -> SigPartKind.REQUEST_ID
+        SigPart.ApiKey -> SigPartKind.API_KEY
+        SigPart.Nonce -> SigPartKind.NONCE
+        SigPart.Path -> SigPartKind.PATH
+        SigPart.QueryString -> SigPartKind.QUERY_STRING
+        SigPart.Body -> SigPartKind.BODY
+        is SigPart.ParamString -> SigPartKind.PARAM_STRING
+        is SigPart.Sha256 -> SigPartKind.SHA256
+    }
+
+private fun SigPartKind.defaultPart(): SigPart =
+    when (this) {
+        SigPartKind.LITERAL -> SigPart.Literal("")
+        SigPartKind.METHOD -> SigPart.Method
+        SigPartKind.REQUEST_ID -> SigPart.RequestId
+        SigPartKind.API_KEY -> SigPart.ApiKey
+        SigPartKind.NONCE -> SigPart.Nonce
+        SigPartKind.PATH -> SigPart.Path
+        SigPartKind.QUERY_STRING -> SigPart.QueryString
+        SigPartKind.BODY -> SigPart.Body
+        SigPartKind.PARAM_STRING -> SigPart.ParamString()
+        SigPartKind.SHA256 -> SigPart.Sha256(emptyList())
+    }
+
+/**
+ * Editor for a [FieldPlacement] (location + name) — where a signing field is written on the request.
+ */
+@Composable
+internal fun FieldPlacementEditor(
+    label: String,
+    placement: FieldPlacement,
+    onChange: (FieldPlacement) -> Unit,
+    enabled: Boolean,
+    nameRequired: Boolean = true,
+) {
+    Text(label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    EnumDropdown(
+        label = "Location",
+        options = SigFieldLocation.entries,
+        selected = placement.location,
+        onSelect = { onChange(placement.copy(location = it)) },
+        optionLabel = { it.name },
+        enabled = enabled,
+    )
+    TextFieldRow(
+        label = "Field name",
+        value = placement.name,
+        onValueChange = { onChange(placement.copy(name = it)) },
+        enabled = enabled,
+        isError = nameRequired && placement.name.isBlank(),
+    )
+}
+
+/**
+ * Editor for the ordered list of [SigPart]s that make up the signed message. Supports the recursive
+ * [SigPart.Sha256] variant by nesting another [SigPartListEditor].
+ */
+@Composable
+internal fun SigPartListEditor(
+    parts: List<SigPart>,
+    onChange: (List<SigPart>) -> Unit,
+    enabled: Boolean,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        parts.forEachIndexed { index, part ->
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)),
+            ) {
+                Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    EditorCardHeader(
+                        title = "Part ${index + 1}",
+                        onRemove = { onChange(parts.filterIndexed { i, _ -> i != index }) },
+                        enabled = enabled,
+                    )
+                    EnumDropdown(
+                        label = "Kind",
+                        options = SigPartKind.entries,
+                        selected = part.kind(),
+                        onSelect = { newKind ->
+                            if (newKind != part.kind()) {
+                                onChange(parts.mapIndexed { i, p -> if (i == index) newKind.defaultPart() else p })
+                            }
+                        },
+                        optionLabel = { it.label },
+                        enabled = enabled,
+                    )
+                    when (part) {
+                        is SigPart.Literal ->
+                            TextFieldRow(
+                                label = "Text",
+                                value = part.text,
+                                onValueChange = { updated ->
+                                    onChange(parts.mapIndexed { i, p -> if (i == index) SigPart.Literal(updated) else p })
+                                },
+                                enabled = enabled,
+                            )
+                        is SigPart.ParamString ->
+                            EnumDropdown(
+                                label = "Format",
+                                options = ParamStringFormat.entries,
+                                selected = part.format,
+                                onSelect = { fmt ->
+                                    onChange(parts.mapIndexed { i, p -> if (i == index) SigPart.ParamString(fmt) else p })
+                                },
+                                optionLabel = { it.name },
+                                enabled = enabled,
+                            )
+                        is SigPart.Sha256 -> {
+                            Text(
+                                "Nested parts",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            SigPartListEditor(
+                                parts = part.parts,
+                                onChange = { nested ->
+                                    onChange(parts.mapIndexed { i, p -> if (i == index) SigPart.Sha256(nested) else p })
+                                },
+                                enabled = enabled,
+                            )
+                        }
+                        else -> Unit
+                    }
+                }
+            }
+        }
+        TextButton(onClick = { onChange(parts + SigPart.Literal("")) }, enabled = enabled) {
+            Icon(Icons.Default.Add, contentDescription = null)
+            Spacer(Modifier.width(4.dp))
+            Text("Add part")
+        }
+    }
+}
+
+/**
+ * Editor for the optional proactive [ApiRequestSigningConfig] (used when `authType == SIGNED`): the
+ * complete provider-agnostic HMAC recipe (algorithm, message parts, field placements, body format).
+ */
+@Composable
+internal fun RequestSigningEditor(
+    config: ApiRequestSigningConfig?,
+    onChange: (ApiRequestSigningConfig?) -> Unit,
+    enabled: Boolean,
+) {
+    ToggleRow(
+        label = "Enable proactive request signing (exchanges)",
+        checked = config != null,
+        onCheckedChange = { on -> onChange(if (on) defaultRequestSigning() else null) },
+        enabled = enabled,
+    )
+    val c = config ?: return
+
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        EnumDropdown(
+            label = "Algorithm",
+            options = SigningAlgorithm.entries,
+            selected = c.algorithm,
+            onSelect = { onChange(c.copy(algorithm = it)) },
+            optionLabel = { it.name },
+            enabled = enabled,
+        )
+        EnumDropdown(
+            label = "Secret encoding",
+            options = SecretEncoding.entries,
+            selected = c.secretEncoding,
+            onSelect = { onChange(c.copy(secretEncoding = it)) },
+            optionLabel = { it.name },
+            enabled = enabled,
+        )
+        EnumDropdown(
+            label = "Signature encoding",
+            options = SignatureEncoding.entries,
+            selected = c.signatureEncoding,
+            onSelect = { onChange(c.copy(signatureEncoding = it)) },
+            optionLabel = { it.name },
+            enabled = enabled,
+        )
+
+        Text("Signed message parts", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        SigPartListEditor(parts = c.message, onChange = { onChange(c.copy(message = it)) }, enabled = enabled)
+
+        FieldPlacementEditor("API key placement", c.apiKey, { onChange(c.copy(apiKey = it)) }, enabled)
+        FieldPlacementEditor("Signature placement", c.signature, { onChange(c.copy(signature = it)) }, enabled)
+
+        Text("Nonce", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        EnumDropdown(
+            label = "Nonce format",
+            options = NonceFormat.entries,
+            selected = c.nonce.format,
+            onSelect = { onChange(c.copy(nonce = c.nonce.copy(format = it))) },
+            optionLabel = { it.name },
+            enabled = enabled,
+        )
+        FieldPlacementEditor(
+            label = "Nonce placement",
+            placement = c.nonce.placement,
+            onChange = { onChange(c.copy(nonce = c.nonce.copy(placement = it))) },
+            enabled = enabled,
+        )
+
+        ToggleRow(
+            label = "Include per-request id (Crypto.com)",
+            checked = c.requestId != null,
+            onCheckedChange = { on ->
+                onChange(
+                    c.copy(
+                        requestId =
+                            if (on) {
+                                RequestIdSpec(placement = FieldPlacement(SigFieldLocation.BODY_FIELD, "id"))
+                            } else {
+                                null
+                            },
+                    ),
+                )
+            },
+            enabled = enabled,
+        )
+        c.requestId?.let { rid ->
+            EnumDropdown(
+                label = "Request id format",
+                options = RequestIdFormat.entries,
+                selected = rid.format,
+                onSelect = { onChange(c.copy(requestId = rid.copy(format = it))) },
+                optionLabel = { it.name },
+                enabled = enabled,
+            )
+            FieldPlacementEditor(
+                label = "Request id placement",
+                placement = rid.placement,
+                onChange = { onChange(c.copy(requestId = rid.copy(placement = it))) },
+                enabled = enabled,
+            )
+        }
+
+        ToggleRow(
+            label = "Write API method name on the request",
+            checked = c.method != null,
+            onCheckedChange = { on ->
+                onChange(c.copy(method = if (on) FieldPlacement(SigFieldLocation.BODY_FIELD, "method") else null))
+            },
+            enabled = enabled,
+        )
+        c.method?.let { method ->
+            FieldPlacementEditor(
+                label = "Method placement",
+                placement = method,
+                onChange = { onChange(c.copy(method = it)) },
+                enabled = enabled,
+            )
+        }
+
+        EnumDropdown(
+            label = "Body format",
+            options = BodyFormat.entries,
+            selected = c.bodyFormat,
+            onSelect = { onChange(c.copy(bodyFormat = it)) },
+            optionLabel = { it.name },
+            enabled = enabled,
+        )
+        if (c.bodyFormat == BodyFormat.JSON_ENVELOPE) {
+            TextFieldRow(
+                label = "Params envelope key",
+                value = c.paramsEnvelopeKey.orEmpty(),
+                onValueChange = { onChange(c.copy(paramsEnvelopeKey = it.ifBlank { null })) },
+                enabled = enabled,
+                supportingText = "The JSON key request params are nested under (Crypto.com \"params\")",
+            )
+        }
+    }
+}
+
+private fun defaultRequestSigning(): ApiRequestSigningConfig =
+    ApiRequestSigningConfig(
+        algorithm = SigningAlgorithm.HMAC_SHA256,
+        message = emptyList(),
+        apiKey = FieldPlacement(SigFieldLocation.HEADER, ""),
+        nonce = NonceSpec(placement = FieldPlacement(SigFieldLocation.QUERY, "timestamp")),
+        signature = FieldPlacement(SigFieldLocation.QUERY, "signature"),
+    )
+
+/** Whether a request-signing config has its required fields set (used for tab validation). */
+internal fun ApiRequestSigningConfig.isValidForSave(): Boolean =
+    message.isNotEmpty() && apiKey.name.isNotBlank() && signature.name.isNotBlank() && nonce.placement.name.isNotBlank()

--- a/app/ui/imports/api/src/commonTest/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ApiStrategyEditorStateTest.kt
+++ b/app/ui/imports/api/src/commonTest/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ApiStrategyEditorStateTest.kt
@@ -3,23 +3,40 @@
 package com.moneymanager.ui.screens.apistrategy.editor
 
 import com.moneymanager.domain.model.ApiImportStrategyId
+import com.moneymanager.domain.model.apistrategy.ApiAccountBridge
 import com.moneymanager.domain.model.apistrategy.ApiAccountMappings
 import com.moneymanager.domain.model.apistrategy.ApiAmountFormat
 import com.moneymanager.domain.model.apistrategy.ApiAuthType
+import com.moneymanager.domain.model.apistrategy.ApiDataEndpoint
 import com.moneymanager.domain.model.apistrategy.ApiEndpointConfig
+import com.moneymanager.domain.model.apistrategy.ApiEndpointKind
 import com.moneymanager.domain.model.apistrategy.ApiImportStrategy
+import com.moneymanager.domain.model.apistrategy.ApiInternalTransferReconcile
 import com.moneymanager.domain.model.apistrategy.ApiPaginationConfig
 import com.moneymanager.domain.model.apistrategy.ApiPeopleMappings
 import com.moneymanager.domain.model.apistrategy.ApiPersonImportConfig
 import com.moneymanager.domain.model.apistrategy.ApiQueryParam
+import com.moneymanager.domain.model.apistrategy.ApiRequestSigningConfig
 import com.moneymanager.domain.model.apistrategy.ApiSignSource
 import com.moneymanager.domain.model.apistrategy.ApiSigningConfig
+import com.moneymanager.domain.model.apistrategy.ApiSyntheticAccount
+import com.moneymanager.domain.model.apistrategy.ApiTradeMappings
 import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
+import com.moneymanager.domain.model.apistrategy.BodyFormat
 import com.moneymanager.domain.model.apistrategy.BuiltInCounterpartyRule
+import com.moneymanager.domain.model.apistrategy.FieldPlacement
+import com.moneymanager.domain.model.apistrategy.NonceFormat
+import com.moneymanager.domain.model.apistrategy.NonceSpec
 import com.moneymanager.domain.model.apistrategy.PaginationMode
 import com.moneymanager.domain.model.apistrategy.PredicateOp
 import com.moneymanager.domain.model.apistrategy.RulePredicate
 import com.moneymanager.domain.model.apistrategy.RuleSign
+import com.moneymanager.domain.model.apistrategy.SecretEncoding
+import com.moneymanager.domain.model.apistrategy.SigFieldLocation
+import com.moneymanager.domain.model.apistrategy.SigPart
+import com.moneymanager.domain.model.apistrategy.SignatureEncoding
+import com.moneymanager.domain.model.apistrategy.SigningAlgorithm
+import com.moneymanager.domain.model.apistrategy.TransferDirection
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -100,6 +117,49 @@ class ApiStrategyEditorStateTest {
                     ownsAllAccounts = true,
                 ),
             personExternalIdAttribute = "example-external-id",
+            // A Kraken-style recipe: exercises the recursive Sha256 SigPart nesting.
+            requestSigning =
+                ApiRequestSigningConfig(
+                    algorithm = SigningAlgorithm.HMAC_SHA512,
+                    secretEncoding = SecretEncoding.BASE64,
+                    signatureEncoding = SignatureEncoding.BASE64,
+                    message = listOf(SigPart.Path, SigPart.Sha256(listOf(SigPart.Nonce, SigPart.Body))),
+                    apiKey = FieldPlacement(SigFieldLocation.HEADER, "API-Key"),
+                    nonce = NonceSpec(format = NonceFormat.EPOCH_MS, placement = FieldPlacement(SigFieldLocation.BODY_FIELD, "nonce")),
+                    signature = FieldPlacement(SigFieldLocation.HEADER, "API-Sign"),
+                    bodyFormat = BodyFormat.FORM_URLENCODED,
+                ),
+            dataEndpoints =
+                listOf(
+                    ApiDataEndpoint(
+                        endpoint = ApiEndpointConfig(path = "/private/get-trades", responseArrayKey = "result"),
+                        kind = ApiEndpointKind.TRADES,
+                        tradeMappings =
+                            ApiTradeMappings(
+                                instrumentField = "instrument_name",
+                                sideField = "side",
+                                baseQuantityField = "quantity",
+                                priceField = "price",
+                                timestampField = "create_time",
+                                idField = "trade_id",
+                                orderIdField = "order_id",
+                            ),
+                    ),
+                    ApiDataEndpoint(
+                        endpoint = ApiEndpointConfig(path = "/private/get-deposits", responseArrayKey = "result"),
+                        kind = ApiEndpointKind.DEPOSITS,
+                        transactionMappings = ApiTransactionMappings(amountField = "amount", currencyField = "currency"),
+                        fixedDirection = TransferDirection.IN,
+                        counterpartyAccountName = "Crypto.com Exchange Funding",
+                    ),
+                ),
+            syntheticAccount = ApiSyntheticAccount(name = "Crypto.com Exchange", externalId = "cryptocom-exchange"),
+            internalTransferReconcile =
+                ApiInternalTransferReconcile(
+                    bridges = listOf(ApiAccountBridge(otherAccountName = "Crypto.com")),
+                    windowSeconds = 3600,
+                    amountTolerancePercent = "0.5",
+                ),
             createdAt = now,
             updatedAt = now,
         )

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AdvancedTab.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/AdvancedTab.kt
@@ -1,13 +1,17 @@
 package com.moneymanager.ui.screens.csvstrategy.editor
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.Account
@@ -121,6 +125,38 @@ internal fun AdvancedTab(
         }
 
         Spacer(modifier = Modifier.height(16.dp))
+        Text("Cross-source Reconciliation (Optional)", style = MaterialTheme.typography.titleSmall)
+        Text(
+            "Import rows that fuzzy-match an existing transfer from another source (same accounts and " +
+                "amount, timestamps within this window) as excluded+reconciled instead of double-counting. " +
+                "Funding reconciliation above reuses this window.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Switch(
+                checked = state.crossSourceReconcileWindowSeconds != null,
+                onCheckedChange = { checked -> state.crossSourceReconcileWindowSeconds = if (checked) 60 else null },
+                enabled = enabled,
+            )
+            Text(
+                "Enable cross-source reconciliation",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(start = 8.dp),
+            )
+        }
+        state.crossSourceReconcileWindowSeconds?.let { window ->
+            Spacer(modifier = Modifier.height(4.dp))
+            LongField(
+                value = window,
+                onValueChange = { state.crossSourceReconcileWindowSeconds = it },
+                label = "Reconcile window (seconds)",
+                enabled = enabled,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
         Text("Row Preprocessing Rules (Optional)", style = MaterialTheme.typography.titleSmall)
         Text(
             "Swap column values and/or flip source/target accounts when conditions match",
@@ -146,6 +182,40 @@ internal fun AdvancedTab(
         CompanionTransactionRulesEditor(
             rules = state.companionTransactionRules,
             onRulesChanged = { state.companionTransactionRules = it },
+            enabled = enabled,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("Content Match Rules (Optional)", style = MaterialTheme.typography.titleSmall)
+        Text(
+            "Auto-detect this strategy from row content when the column set is fixed and can't " +
+                "distinguish formats (e.g. QIF). No rules means this strategy is the fallback.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        ContentMatchRulesEditor(
+            rules = state.contentMatchRules,
+            onRulesChanged = { state.contentMatchRules = it },
+            columns = csvColumns,
+            firstRow = firstRow,
+            enabled = enabled,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("Asset Conversions (Optional)", style = MaterialTheme.typography.titleSmall)
+        Text(
+            "For sources that express a conversion as separate debited/credited rows (e.g. crypto.com " +
+                "\"Convert Dust\"): route both legs through a shared account and link them as one event.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        ConversionConfigEditor(
+            config = state.conversionConfig,
+            onConfigChanged = { state.conversionConfig = it },
+            columns = csvColumns,
+            firstRow = firstRow,
             enabled = enabled,
         )
 

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/ConversionEditors.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/ConversionEditors.kt
@@ -1,0 +1,331 @@
+package com.moneymanager.ui.screens.csvstrategy.editor
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.moneymanager.domain.model.csv.CsvColumn
+import com.moneymanager.domain.model.csv.CsvRow
+import com.moneymanager.domain.model.csvstrategy.ContentMatchRule
+import com.moneymanager.domain.model.csvstrategy.ConversionAccountRule
+import com.moneymanager.domain.model.csvstrategy.ConversionConfig
+import com.moneymanager.ui.screens.csvstrategy.getSampleValue
+
+/**
+ * Editor for the strategy's list of [ContentMatchRule]s — content-based match rules that auto-detect
+ * this strategy from a sampled row when the column set is fixed and cannot distinguish formats (QIF).
+ */
+@Composable
+internal fun ContentMatchRulesEditor(
+    rules: List<ContentMatchRule>,
+    onRulesChanged: (List<ContentMatchRule>) -> Unit,
+    columns: List<CsvColumn>,
+    firstRow: CsvRow?,
+    enabled: Boolean,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        rules.forEachIndexed { index, rule ->
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)),
+            ) {
+                Column(modifier = Modifier.padding(8.dp)) {
+                    EditorCardHeader(
+                        title = "Rule ${index + 1}",
+                        removeContentDescription = "Remove content-match rule",
+                        onRemove = { onRulesChanged(rules.filterIndexed { i, _ -> i != index }) },
+                        enabled = enabled,
+                    )
+
+                    fun updateRule(transform: (ContentMatchRule) -> ContentMatchRule) {
+                        onRulesChanged(rules.mapIndexed { i, r -> if (i == index) transform(r) else r })
+                    }
+                    ColumnDropdown(
+                        columns = columns,
+                        selectedColumn = rule.columnName.takeIf { it.isNotBlank() },
+                        onColumnSelected = { selected -> updateRule { it.copy(columnName = selected) } },
+                        label = "Column",
+                        sampleValue = getSampleValue(columns, firstRow, rule.columnName),
+                        enabled = enabled,
+                        isError = rule.columnName.isBlank(),
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    OutlinedTextField(
+                        value = rule.pattern,
+                        onValueChange = { newValue -> updateRule { it.copy(pattern = newValue) } },
+                        label = { Text("Match pattern (regex, case-insensitive)") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        enabled = enabled,
+                        isError = rule.pattern.isBlank(),
+                        supportingText = { Text("A sampled row matching this value selects the strategy") },
+                    )
+                }
+            }
+        }
+        TextButton(
+            onClick = { onRulesChanged(rules + ContentMatchRule(columnName = "", pattern = "")) },
+            enabled = enabled,
+        ) {
+            Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.padding(end = 4.dp))
+            Text("Add Rule")
+        }
+    }
+}
+
+/**
+ * Editor for the optional [ConversionConfig]: a switch that creates/clears the config, and — when on —
+ * the full set of fields describing how debited/credited row pairs route through a shared conversion
+ * account and link as one conversion event.
+ */
+@Composable
+internal fun ConversionConfigEditor(
+    config: ConversionConfig?,
+    onConfigChanged: (ConversionConfig?) -> Unit,
+    columns: List<CsvColumn>,
+    firstRow: CsvRow?,
+    enabled: Boolean,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Switch(
+                checked = config != null,
+                onCheckedChange = { checked ->
+                    onConfigChanged(if (checked) defaultConversionConfig() else null)
+                },
+                enabled = enabled,
+            )
+            Text("Enable asset conversions", style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(start = 8.dp))
+        }
+
+        if (config == null) return
+
+        // Keep the model invariant (a name or at least one rule) so editing never throws.
+        fun update(transform: (ConversionConfig) -> ConversionConfig) {
+            val next = transform(config)
+            onConfigChanged(
+                if (next.conversionAccountName == null && next.conversionAccountRules.isEmpty()) {
+                    next.copy(conversionAccountName = "")
+                } else {
+                    next
+                },
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        ColumnDropdown(
+            columns = columns,
+            selectedColumn = config.signalColumn.takeIf { it.isNotBlank() },
+            onColumnSelected = { selected -> update { it.copy(signalColumn = selected) } },
+            label = "Signal column",
+            sampleValue = getSampleValue(columns, firstRow, config.signalColumn),
+            enabled = enabled,
+            isError = config.signalColumn.isBlank(),
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        OutlinedTextField(
+            value = config.debitPattern,
+            onValueChange = { newValue -> update { it.copy(debitPattern = newValue) } },
+            label = { Text("Debit pattern (regex)") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = enabled,
+            isError = config.debitPattern.isBlank(),
+            supportingText = { Text("Matches the signal column of the leg leaving the owner account") },
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        OutlinedTextField(
+            value = config.creditPattern,
+            onValueChange = { newValue -> update { it.copy(creditPattern = newValue) } },
+            label = { Text("Credit pattern (regex)") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = enabled,
+            isError = config.creditPattern.isBlank(),
+            supportingText = { Text("Matches the signal column of the leg received into the owner account") },
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        OutlinedTextField(
+            value = config.conversionAccountName.orEmpty(),
+            onValueChange = { newValue -> update { it.copy(conversionAccountName = newValue) } },
+            label = { Text("Conversion account name") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = enabled,
+            isError = config.conversionAccountName.isNullOrBlank() && config.conversionAccountRules.isEmpty(),
+            supportingText = {
+                Text("Shared counterparty account the legs route through. Leave blank only if the rules below cover every leg.")
+            },
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Text("Per-value account routing (optional)", style = MaterialTheme.typography.labelMedium)
+        Text(
+            "Override the conversion account for legs whose column matches a pattern; first match wins.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        ConversionAccountRulesEditor(
+            rules = config.conversionAccountRules,
+            onRulesChanged = { updated -> update { it.copy(conversionAccountRules = updated) } },
+            columns = columns,
+            firstRow = firstRow,
+            enabled = enabled,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            value = config.pairingKeyPattern.orEmpty(),
+            onValueChange = { newValue -> update { it.copy(pairingKeyPattern = newValue.ifBlank { null }) } },
+            label = { Text("Pairing key pattern (optional regex)") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = enabled,
+            supportingText = { Text("First capture group on the signal column becomes the pairing key") },
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        LongField(
+            value = config.pairingWindowSeconds,
+            onValueChange = { newValue -> update { it.copy(pairingWindowSeconds = newValue) } },
+            label = "Pairing window (seconds)",
+            enabled = enabled,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        OutlinedTextField(
+            value = config.relationshipTypeName,
+            onValueChange = { newValue -> update { it.copy(relationshipTypeName = newValue) } },
+            label = { Text("Relationship type name") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = enabled,
+            isError = config.relationshipTypeName.isBlank(),
+            supportingText = { Text("Links each debit leg to its credit leg (e.g. \"conversion\")") },
+        )
+    }
+}
+
+@Composable
+private fun ConversionAccountRulesEditor(
+    rules: List<ConversionAccountRule>,
+    onRulesChanged: (List<ConversionAccountRule>) -> Unit,
+    columns: List<CsvColumn>,
+    firstRow: CsvRow?,
+    enabled: Boolean,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        rules.forEachIndexed { index, rule ->
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)),
+            ) {
+                Column(modifier = Modifier.padding(8.dp)) {
+                    EditorCardHeader(
+                        title = "Route ${index + 1}",
+                        removeContentDescription = "Remove routing rule",
+                        onRemove = { onRulesChanged(rules.filterIndexed { i, _ -> i != index }) },
+                        enabled = enabled,
+                    )
+
+                    fun updateRule(transform: (ConversionAccountRule) -> ConversionAccountRule) {
+                        onRulesChanged(rules.mapIndexed { i, r -> if (i == index) transform(r) else r })
+                    }
+                    ColumnDropdown(
+                        columns = columns,
+                        selectedColumn = rule.column.takeIf { it.isNotBlank() },
+                        onColumnSelected = { selected -> updateRule { it.copy(column = selected) } },
+                        label = "Column",
+                        sampleValue = getSampleValue(columns, firstRow, rule.column),
+                        enabled = enabled,
+                        isError = rule.column.isBlank(),
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    OutlinedTextField(
+                        value = rule.pattern,
+                        onValueChange = { newValue -> updateRule { it.copy(pattern = newValue) } },
+                        label = { Text("Pattern (regex)") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        enabled = enabled,
+                        isError = rule.pattern.isBlank(),
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    OutlinedTextField(
+                        value = rule.accountName,
+                        onValueChange = { newValue -> updateRule { it.copy(accountName = newValue) } },
+                        label = { Text("Account name") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        enabled = enabled,
+                        isError = rule.accountName.isBlank(),
+                    )
+                }
+            }
+        }
+        TextButton(
+            onClick = { onRulesChanged(rules + ConversionAccountRule(column = "", pattern = "", accountName = "")) },
+            enabled = enabled,
+        ) {
+            Icon(Icons.Filled.Add, contentDescription = null, modifier = Modifier.padding(end = 4.dp))
+            Text("Add Route")
+        }
+    }
+}
+
+/**
+ * A numeric [OutlinedTextField] bound to a [Long]. Keeps its own text buffer so intermediate
+ * empty/invalid input is shown without corrupting the model; commits only parseable values.
+ */
+@Composable
+internal fun LongField(
+    value: Long,
+    onValueChange: (Long) -> Unit,
+    label: String,
+    enabled: Boolean,
+) {
+    var text by remember { mutableStateOf(value.toString()) }
+    OutlinedTextField(
+        value = text,
+        onValueChange = {
+            text = it
+            it.trim().toLongOrNull()?.let(onValueChange)
+        },
+        label = { Text(label) },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+        enabled = enabled,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        isError = text.trim().toLongOrNull() == null,
+    )
+}
+
+private fun defaultConversionConfig(): ConversionConfig =
+    ConversionConfig(
+        signalColumn = "",
+        debitPattern = "",
+        creditPattern = "",
+        conversionAccountName = "",
+        pairingWindowSeconds = 60,
+        relationshipTypeName = "conversion",
+    )

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/ConversionEditors.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/ConversionEditors.kt
@@ -304,7 +304,9 @@ internal fun LongField(
     label: String,
     enabled: Boolean,
 ) {
-    var text by remember { mutableStateOf(value.toString()) }
+    // Keyed on value so an external change to the backing Long resyncs the buffer, while
+    // intermediate invalid input (which doesn't change value) is preserved.
+    var text by remember(value) { mutableStateOf(value.toString()) }
     OutlinedTextField(
         value = text,
         onValueChange = {

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorState.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyEditorState.kt
@@ -103,9 +103,12 @@ internal class CsvStrategyEditorState(
     var fundingMatchAttributeTypeName by
         mutableStateOf(initial?.fundingAttributeMatch?.attributeTypeName ?: WellKnownIds.ACCOUNT_CARD_LAST4_ATTR_TYPE_NAME)
 
-    // Not yet editable in the UI; carried through so saving never drops them.
     var contentMatchRules by mutableStateOf(initial?.contentMatchRules.orEmpty())
     var crossSourceReconcileWindowSeconds by mutableStateOf(initial?.crossSourceReconcileWindowSeconds)
+
+    // Conversion config: pairs debited/credited rows into transfers routed through a shared account.
+    // Edited via ConversionConfigEditor (Advanced tab); null when the source has no such conversions.
+    var conversionConfig by mutableStateOf(initial?.conversionConfig)
 
     // Initial primary columns, used to avoid clobbering saved fallbacks on edit-mode load.
     val initialTargetAccountColumnName: String? = initial?.targetAccountColumnName
@@ -149,6 +152,24 @@ internal class CsvStrategyEditorState(
                 it.name.isNotBlank() && it.matchAttributeName.isNotBlank() && it.matchValuePattern.isNotBlank()
             }
 
+    private val contentMatchValid: Boolean
+        get() = contentMatchRules.all { it.columnName.isNotBlank() && it.pattern.isNotBlank() }
+
+    // A conversion config is opt-in: valid when absent, otherwise its required scalars must be set, at
+    // least one of name/rules must resolve, and every routing rule must be fully specified.
+    private val conversionConfigValid: Boolean
+        get() =
+            conversionConfig?.let { c ->
+                c.signalColumn.isNotBlank() &&
+                    c.debitPattern.isNotBlank() &&
+                    c.creditPattern.isNotBlank() &&
+                    c.relationshipTypeName.isNotBlank() &&
+                    (!c.conversionAccountName.isNullOrBlank() || c.conversionAccountRules.isNotEmpty()) &&
+                    c.conversionAccountRules.all {
+                        it.column.isNotBlank() && it.pattern.isNotBlank() && it.accountName.isNotBlank()
+                    }
+            } ?: true
+
     private val currencyValid: Boolean
         get() =
             when (currencyMode) {
@@ -186,7 +207,12 @@ internal class CsvStrategyEditorState(
 
     /** Whether the Advanced tab has an unsatisfied required field. */
     val advancedHasError: Boolean
-        get() = !rowPreprocessingValid || !companionRulesValid || !fundingMatchValid
+        get() =
+            !rowPreprocessingValid ||
+                !companionRulesValid ||
+                !fundingMatchValid ||
+                !contentMatchValid ||
+                !conversionConfigValid
 
     fun tabHasError(tab: EditorTab): Boolean =
         when (tab) {
@@ -210,6 +236,8 @@ internal class CsvStrategyEditorState(
                 rowPreprocessingValid &&
                 companionRulesValid &&
                 fundingMatchValid &&
+                contentMatchValid &&
+                conversionConfigValid &&
                 currencyValid &&
                 timezoneValid
 
@@ -266,6 +294,7 @@ internal class CsvStrategyEditorState(
                         AttributeAccountMatch(column = column, attributeTypeName = type)
                     }
                 },
+            conversionConfig = conversionConfig,
         )
 }
 

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyFormState.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csvstrategy/editor/CsvStrategyFormState.kt
@@ -18,6 +18,7 @@ import com.moneymanager.domain.model.csvstrategy.AttributeMatchAccountMapping
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
 import com.moneymanager.domain.model.csvstrategy.ContentMatchRule
+import com.moneymanager.domain.model.csvstrategy.ConversionConfig
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
 import com.moneymanager.domain.model.csvstrategy.DateTimeParsingMapping
@@ -200,6 +201,7 @@ internal data class StrategyFormState(
     val fileNamePattern: String?,
     val crossSourceReconcileWindowSeconds: Long?,
     val fundingAttributeMatch: AttributeAccountMatch?,
+    val conversionConfig: ConversionConfig?,
 )
 
 /**
@@ -485,6 +487,9 @@ internal fun extractFormStateFromStrategy(
         fileNamePattern = strategy.fileNamePattern,
         crossSourceReconcileWindowSeconds = strategy.crossSourceReconcileWindowSeconds,
         fundingAttributeMatch = strategy.fundingAttributeMatch,
+        // Carried through verbatim (like content-match/companion rules): its column references may
+        // name columns absent from the uploaded sample, but dropping them would corrupt the strategy.
+        conversionConfig = strategy.conversionConfig,
     )
 }
 
@@ -652,6 +657,7 @@ internal fun buildStrategyFromFormState(
         fileNamePattern = state.fileNamePattern?.takeIf { it.isNotBlank() },
         crossSourceReconcileWindowSeconds = state.crossSourceReconcileWindowSeconds,
         fundingAttributeMatch = state.fundingAttributeMatch,
+        conversionConfig = state.conversionConfig,
         createdAt = createdAt,
         updatedAt = updatedAt,
     )

--- a/app/ui/imports/csv/src/commonTest/kotlin/com/moneymanager/ui/screens/csvstrategy/StrategyFormRoundTripTest.kt
+++ b/app/ui/imports/csv/src/commonTest/kotlin/com/moneymanager/ui/screens/csvstrategy/StrategyFormRoundTripTest.kt
@@ -255,7 +255,7 @@ class StrategyFormRoundTripTest {
     }
 
     @Test
-    fun `conversion config, content-match rules and cross-source window round-trip`() {
+    fun `conversion config plus content-match rules and cross-source window round-trip`() {
         val original =
             advancedStrategy().copy(
                 contentMatchRules =

--- a/app/ui/imports/csv/src/commonTest/kotlin/com/moneymanager/ui/screens/csvstrategy/StrategyFormRoundTripTest.kt
+++ b/app/ui/imports/csv/src/commonTest/kotlin/com/moneymanager/ui/screens/csvstrategy/StrategyFormRoundTripTest.kt
@@ -14,6 +14,9 @@ import com.moneymanager.domain.model.csvstrategy.AttributeMatchAccountMapping
 import com.moneymanager.domain.model.csvstrategy.ColumnPairSwap
 import com.moneymanager.domain.model.csvstrategy.CompanionTransactionRule
 import com.moneymanager.domain.model.csvstrategy.ConditionalAccountMapping
+import com.moneymanager.domain.model.csvstrategy.ContentMatchRule
+import com.moneymanager.domain.model.csvstrategy.ConversionAccountRule
+import com.moneymanager.domain.model.csvstrategy.ConversionConfig
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.model.csvstrategy.CurrencyLookupMapping
 import com.moneymanager.domain.model.csvstrategy.DateTimeParsingMapping
@@ -249,6 +252,42 @@ class StrategyFormRoundTripTest {
         assertIs<AttributeMatchAccountMapping>(target)
         assertEquals("card-last4", target.attributeTypeName)
         assertEquals("Target name", target.columnName)
+    }
+
+    @Test
+    fun `conversion config, content-match rules and cross-source window round-trip`() {
+        val original =
+            advancedStrategy().copy(
+                contentMatchRules =
+                    listOf(
+                        ContentMatchRule(columnName = "Direction", pattern = "OUT"),
+                        ContentMatchRule(columnName = "Reference", pattern = "CRV\\*"),
+                    ),
+                crossSourceReconcileWindowSeconds = 120,
+                conversionConfig =
+                    ConversionConfig(
+                        signalColumn = "Direction",
+                        debitPattern = "(?i)_debited$",
+                        creditPattern = "(?i)_credited$",
+                        conversionAccountName = "Crypto.com Conversions",
+                        conversionAccountRules =
+                            listOf(
+                                ConversionAccountRule(column = "Source currency", pattern = "(?i)^DUST$", accountName = "Dust"),
+                            ),
+                        pairingKeyPattern = "(?i)^(.*)_(?:debited|credited)$",
+                        pairingKeyColumns = listOf("Reference"),
+                        pairingWindowSeconds = 60,
+                        relationshipTypeName = "conversion",
+                    ),
+            )
+        val availableColumns = columns.map { it.originalName }.toSet()
+
+        val state = extractFormStateFromStrategy(original, availableColumns)
+        val rebuilt = buildStrategyFromFormState(state, original.id, original.createdAt, original.updatedAt)
+
+        assertEquals(original.contentMatchRules, rebuilt.contentMatchRules)
+        assertEquals(original.crossSourceReconcileWindowSeconds, rebuilt.crossSourceReconcileWindowSeconds)
+        assertEquals(original.conversionConfig, rebuilt.conversionConfig)
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,3 +40,6 @@ org.gradle.caching=true
 
 # Parallel execution for faster builds
 org.gradle.parallel=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
## What

Exposes — and stops silently dropping — several persisted strategy config features that the CSV and API strategy editors did not handle.

### The bug
Some live config fields were **dropped on save** because the editor form-state round-trip omitted them. Opening a built-in strategy (a crypto.com CSV strategy, or a crypto.com/Binance/Kraken exchange API strategy), making an unrelated edit, and hitting Save would write back a strategy with those fields defaulted away — breaking import.

### Fixes (round-trip) + new editors

**CSV** (`CsvImportStrategy`)
- `conversionConfig` — was dropped on save; now round-trips and has a full Advanced-tab editor (signal/debit/credit patterns, per-value account routing rules, pairing config). The model's name-or-rules invariant is kept crash-safe during editing.
- `contentMatchRules`, `crossSourceReconcileWindowSeconds` — round-tripped but had no widget; now editable on the Advanced tab.

**API** (`ApiImportStrategy`)
- `requestSigning`, `dataEndpoints`, `syntheticAccount`, `internalTransferReconcile` — all four were dropped on save; now round-trip with structured editors.
  - **Endpoints tab**: synthetic-account section + data-endpoints list (each reuses the shared `EndpointEditor` + kind dropdown + full trade/transaction mapping sub-forms + fixed direction / counterparty).
  - **Advanced tab**: the complete provider-agnostic HMAC recipe editor, including a **recursive `SigPart` list editor** (Literal / ParamString / nested Sha256), field placements, nonce/request-id specs; plus internal-transfer reconciliation.

Per-tab validation is extended so incomplete new configs flag their tab and block save.

## Tests
Both round-trip regression tests are extended to populate the previously-defaulted fields — the API fixture left all four at defaults, which is exactly why it never caught the data loss. The new API fixture includes a Kraken-style `requestSigning` with a nested `Sha256` to exercise the recursive path.

## Scope
No model, DB, or importer changes — every field already persisted via the JSON codecs. This is purely UI + form-state wiring in `app/ui/imports/csv` and `app/ui/imports/api`.

## Verification
- `./gradlew build buildHealth detekt` + ktlint: green.
- Drove the real desktop app (read-only, no Save on a real DB) to confirm the new API editor sections render with correct validation: synthetic account, data endpoints, the request-signing recipe (algorithm/encodings/message-part cards/placements), and internal-transfer reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advanced API strategy options for request signing, synthetic accounts, data endpoints, and internal-transfer reconciliation.
  * Added CSV strategy options for cross-source reconciliation, content-match rules, and asset conversions.
  * Added editors for configuring mappings, patterns, endpoints, signing behavior, and reconciliation rules.
* **Bug Fixes**
  * Improved validation so incomplete advanced configurations prevent saving.
  * Preserved new configuration settings when editing and saving strategies.
* **Tests**
  * Added coverage for configuration round-trip persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->