### PR TITLE
Fix Kraken import balance reconciliation

### DIFF
--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ExchangeApiImportService.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ExchangeApiImportService.kt
@@ -401,6 +401,14 @@ private data class ParsedExchangeTransfer(
     val aliasAccount: String?,
     /** Value looked up against an [ApiDataEndpoint.enrichesTransfers] index (e.g. Kraken Ledgers `refid`). */
     val joinKey: String?,
+    /**
+     * When true, this movement is booked straight to the fee account (exchange -> Fees), never to
+     * the counterparty/funding side. Produced by [ApiTransactionMappings.feeAmountField] on a ledger row
+     * whose main [ApiTransactionMappings.amountField] was skipped as an excluded duplicate (Kraken's
+     * `type=trade` ledger rows carry a same-asset settlement fee TradesHistory never reports, alongside
+     * an `amount` that duplicates the trade TradesHistory already supplied).
+     */
+    val isFeeOnly: Boolean = false,
 )
 
 private data class ParsedOrder(
@@ -430,12 +438,27 @@ private data class ParsedEnrichment(
     val txid: String?,
 )
 
+/**
+ * One leg of a trade-type ledger row excluded from [ParsedExchangeData.transfers] as a duplicate of a
+ * `TradesHistory` trade (see [ApiTransactionMappings.reconcileTradeAmountsField]) — kept so the trade's
+ * booked amount can be reconciled against what the ledger actually settled.
+ */
+private data class ParsedLedgerTradeLeg(
+    val refid: String,
+    val assetCode: String,
+    val signedAmount: BigDecimal,
+    val timestamp: Instant,
+    val requestId: ApiRequestId,
+    val jsonPath: String,
+)
+
 /** Accumulator for parsed items across all of a session's responses. */
 private class ParsedExchangeData {
     val trades = mutableListOf<ParsedTrade>()
     val transfers = mutableListOf<ParsedExchangeTransfer>()
     val orders = mutableListOf<ParsedOrder>()
     val enrichments = mutableListOf<ParsedEnrichment>()
+    val ledgerTradeLegs = mutableListOf<ParsedLedgerTradeLeg>()
 }
 
 /** Parses one response item into [into] according to its endpoint kind. */
@@ -457,12 +480,12 @@ private fun parseExchangeItem(
             dataEndpoint.tradeMappings?.let { parseOrder(obj, it, requestId, jsonPath) }?.let(into.orders::add)
         ApiEndpointKind.DEPOSITS ->
             dataEndpoint.transactionMappings
-                ?.let { parseExchangeTransfer(obj, it, TransferDirection.IN, requestId, jsonPath) }
-                ?.let(into.transfers::add)
+                ?.let { parseExchangeTransfer(obj, it, TransferDirection.IN, requestId, jsonPath, into) }
+                ?.let(into.transfers::addAll)
         ApiEndpointKind.WITHDRAWALS ->
             dataEndpoint.transactionMappings
-                ?.let { parseExchangeTransfer(obj, it, TransferDirection.OUT, requestId, jsonPath) }
-                ?.let(into.transfers::add)
+                ?.let { parseExchangeTransfer(obj, it, TransferDirection.OUT, requestId, jsonPath, into) }
+                ?.let(into.transfers::addAll)
         ApiEndpointKind.BANK_TRANSACTIONS -> Unit
     }
 }
@@ -546,14 +569,7 @@ suspend fun importApiSessionExchange(
             ?: code
 
     fun canonicalAsset(code: String): String = stripAssetSuffix(code).let { aliases[it.uppercase()] ?: it }
-    val trades =
-        parsed.trades.map {
-            it.copy(
-                baseCode = canonicalAsset(it.baseCode),
-                quoteCode = canonicalAsset(it.quoteCode),
-                feeCode = it.feeCode?.let(::canonicalAsset),
-            )
-        }
+    val trades = reconcileTradesAgainstLedger(parsed.trades, parsed.ledgerTradeLegs, ::canonicalAsset)
     // Enrichment endpoints (e.g. Kraken DepositStatus/WithdrawStatus) supply on-chain address/network/
     // txid for transfers built from a different endpoint (Ledgers), matched by joinKey; a transfer's own
     // fields win when present.
@@ -748,16 +764,28 @@ suspend fun importApiSessionExchange(
     for (tx in transfers) {
         val txAsset = asset(tx.currencyCode) ?: continue // single jump — allowed
         val money = Money.fromDisplayValue(tx.amount, txAsset)
-        // Only look up a wallet account for a crypto-denominated transfer — see the minting comment
-        // above. Guarded explicitly (not just relying on accountKeys missing the entry) so a fiat
-        // transfer can never resolve a wallet account that a same-valued crypto address happened to mint.
-        val counterpartyKey =
-            tx.aliasAccount?.let { accountKeys[it] }
-                ?: tx.counterpartyAddress
-                    ?.takeIf { txAsset is CryptoAsset && it.isNotBlank() }
-                    ?.let { accountKeys[it] }
-        val counterparty = counterpartyKey?.let { AccountRef.Local(it) } ?: AccountRef.Existing(fundingId)
-        val (from, to) = if (tx.direction == TransferDirection.IN) counterparty to exchangeRef else exchangeRef to counterparty
+        val (from, to) =
+            if (tx.isFeeOnly) {
+                // A refund (negated ledger fee, e.g. crediting back a failed withdrawal's charge) runs the
+                // opposite way: Fees -> exchange, not exchange -> Fees.
+                if (tx.direction == TransferDirection.IN) {
+                    AccountRef.Existing(feeAccountId) to exchangeRef
+                } else {
+                    exchangeRef to AccountRef.Existing(feeAccountId)
+                }
+            } else {
+                // Only look up a wallet account for a crypto-denominated transfer — see the minting
+                // comment above. Guarded explicitly (not just relying on accountKeys missing the entry)
+                // so a fiat transfer can never resolve a wallet account a same-valued crypto address
+                // happened to mint.
+                val counterpartyKey =
+                    tx.aliasAccount?.let { accountKeys[it] }
+                        ?: tx.counterpartyAddress
+                            ?.takeIf { txAsset is CryptoAsset && it.isNotBlank() }
+                            ?.let { accountKeys[it] }
+                val counterparty = counterpartyKey?.let { AccountRef.Local(it) } ?: AccountRef.Existing(fundingId)
+                if (tx.direction == TransferDirection.IN) counterparty to exchangeRef else exchangeRef to counterparty
+            }
         transferIntents +=
             exchangeTransfer(
                 id = tx.id,
@@ -965,8 +993,18 @@ private fun splitInstrument(
         // EXPLICIT_FIELDS is resolved directly in parseTrade from the base/quote asset fields.
         InstrumentSplitMode.EXPLICIT_FIELDS -> null
         InstrumentSplitMode.QUOTE_SUFFIX -> {
-            val quote = tm.quoteAssets.filter { instrument.endsWith(it) }.maxByOrNull { it.length }
-            quote?.let { instrument.removeSuffix(it) to it }
+            // Kraken marks some crypto/crypto pairs as "synthetic_pair" and reports them
+            // slash-separated (e.g. "SUI/BTC") instead of concatenated like its usual pairs
+            // ("XXBTZGBP") — an explicit separator always wins over suffix matching.
+            val slashIndex = instrument.indexOf('/')
+            if (slashIndex >= 0) {
+                val base = instrument.substring(0, slashIndex)
+                val quote = instrument.substring(slashIndex + 1)
+                if (base.isNotEmpty() && quote.isNotEmpty()) base to quote else null
+            } else {
+                val quote = tm.quoteAssets.filter { instrument.endsWith(it) }.maxByOrNull { it.length }
+                quote?.let { instrument.removeSuffix(it) to it }
+            }
         }
     }
 
@@ -976,29 +1014,175 @@ private fun parseExchangeTransfer(
     direction: TransferDirection,
     requestId: ApiRequestId,
     jsonPath: String,
-): ParsedExchangeTransfer? {
-    val amount = obj.str(tm.amountField)?.let { runCatching { BigDecimal(it).abs() }.getOrNull() } ?: return null
-    val currency = obj.str(tm.currencyField) ?: return null
-    val timestamp = obj.str(tm.timestampField)?.let { parseApiTimestamp(it, tm.timestampFormat) } ?: return null
-    val id = obj.str(tm.idField) ?: return null
-    val description =
-        obj.str(tm.descriptionField)?.takeIf { it.isNotBlank() }
-            ?: if (direction == TransferDirection.IN) "Deposit $currency" else "Withdraw $currency"
-    return ParsedExchangeTransfer(
-        id = id,
-        timestamp = timestamp,
-        currencyCode = currency,
-        amount = amount,
-        direction = direction,
-        description = description,
-        requestId = requestId,
-        jsonPath = jsonPath,
-        counterpartyAddress = tm.counterpartyAddressField?.let { obj.str(it) }?.takeIf { it.isNotBlank() },
-        network = tm.counterpartyNetworkField?.let { obj.str(it) }?.takeIf { it.isNotBlank() },
-        txid = tm.txidField?.let { obj.str(it) }?.takeIf { it.isNotBlank() },
-        aliasAccount = tm.counterpartyAliasField?.let { obj.str(it) }?.let { tm.counterpartyAccountAliases[it] },
-        joinKey = tm.joinKeyField?.let { obj.str(it) },
-    )
+    into: ParsedExchangeData,
+): List<ParsedExchangeTransfer> {
+    val currency = obj.str(tm.currencyField) ?: return emptyList()
+    val timestamp = obj.str(tm.timestampField)?.let { parseApiTimestamp(it, tm.timestampFormat) } ?: return emptyList()
+    val id = obj.str(tm.idField) ?: return emptyList()
+    val excludeField = tm.excludeField
+    val excluded = excludeField != null && obj.str(excludeField) in tm.excludeValues
+    val rawAmount = obj.str(tm.amountField)?.let { runCatching { BigDecimal(it) }.getOrNull() }
+
+    val result = mutableListOf<ParsedExchangeTransfer>()
+    if (excluded) {
+        val refField = tm.reconcileTradeAmountsField
+        val refid = refField?.let { obj.str(it) }
+        if (refid != null && rawAmount != null) {
+            into.ledgerTradeLegs +=
+                ParsedLedgerTradeLeg(
+                    refid = refid,
+                    assetCode = currency,
+                    signedAmount = rawAmount,
+                    timestamp = timestamp,
+                    requestId = requestId,
+                    jsonPath = jsonPath,
+                )
+        }
+    } else if (rawAmount != null) {
+        // Some exchanges (Kraken) book a failed/cancelled deposit or withdrawal as a second ledger
+        // entry sharing the same id with the opposite sign of the original debit/credit, netting to
+        // zero; deriving direction from the sign instead of trusting the endpoint's fixed direction
+        // preserves that net-zero.
+        val resolvedDirection =
+            if (tm.directionFromAmountSign) {
+                if (rawAmount < BigDecimal.ZERO) TransferDirection.OUT else TransferDirection.IN
+            } else {
+                direction
+            }
+        val amount = rawAmount.abs()
+        val description =
+            obj.str(tm.descriptionField)?.takeIf { it.isNotBlank() }
+                ?: if (resolvedDirection == TransferDirection.IN) "Deposit $currency" else "Withdraw $currency"
+        result +=
+            ParsedExchangeTransfer(
+                id = id,
+                timestamp = timestamp,
+                currencyCode = currency,
+                amount = amount,
+                direction = resolvedDirection,
+                description = description,
+                requestId = requestId,
+                jsonPath = jsonPath,
+                counterpartyAddress = tm.counterpartyAddressField?.let { obj.str(it) }?.takeIf { it.isNotBlank() },
+                network = tm.counterpartyNetworkField?.let { obj.str(it) }?.takeIf { it.isNotBlank() },
+                txid = tm.txidField?.let { obj.str(it) }?.takeIf { it.isNotBlank() },
+                aliasAccount = tm.counterpartyAliasField?.let { obj.str(it) }?.let { tm.counterpartyAccountAliases[it] },
+                joinKey = tm.joinKeyField?.let { obj.str(it) },
+            )
+    }
+
+    // Kraken's ledger charges a same-asset settlement fee on some rows (visible only here, never in
+    // TradesHistory's own quote-currency fee) — extracted unconditionally, even when the row's main
+    // amount was excluded as a trade-type duplicate, since the fee itself is not a duplicate of anything.
+    // A failed/reversed deposit or withdrawal's reversal row carries the *negated* fee (a refund of the
+    // original charge) — abs()-ing it would book the refund as a second charge instead of crediting it
+    // back, so the sign decides direction: negative -> refund (Fees -> exchange), positive -> charge
+    // (exchange -> Fees).
+    val rawFeeAmount = tm.feeAmountField?.let { obj.str(it)?.let { v -> runCatching { BigDecimal(v) }.getOrNull() } }
+    if (rawFeeAmount != null && rawFeeAmount != BigDecimal.ZERO) {
+        val isRefund = rawFeeAmount < BigDecimal.ZERO
+        result +=
+            ParsedExchangeTransfer(
+                id = "$id-fee",
+                timestamp = timestamp,
+                currencyCode = currency,
+                amount = rawFeeAmount.abs(),
+                direction = if (isRefund) TransferDirection.IN else TransferDirection.OUT,
+                description =
+                    tm.feeDescriptionField?.let { obj.str(it) }?.takeIf { it.isNotBlank() }
+                        ?: if (isRefund) "$currency fee refund" else "$currency fee",
+                requestId = requestId,
+                jsonPath = jsonPath,
+                counterpartyAddress = null,
+                network = null,
+                txid = null,
+                aliasAccount = null,
+                joinKey = null,
+                isFeeOnly = true,
+            )
+    }
+    return result
+}
+
+/**
+ * Reconciles parsed trades against their authoritative ledger legs (see
+ * [ApiTransactionMappings.reconcileTradeAmountsField]): a trade's leg amounts are overridden by the
+ * matching ledger group's signed amounts where present, and any ledger group matching no trade at all
+ * is booked as its own trade — Kraken's Ledgers `balance` is ground truth, so no movement it reports
+ * may be silently dropped or left at a TradesHistory amount it disagrees with.
+ */
+private fun reconcileTradesAgainstLedger(
+    rawTrades: List<ParsedTrade>,
+    ledgerLegs: List<ParsedLedgerTradeLeg>,
+    canonicalAsset: (String) -> String,
+): List<ParsedTrade> {
+    val trades =
+        rawTrades.map {
+            it.copy(
+                baseCode = canonicalAsset(it.baseCode),
+                quoteCode = canonicalAsset(it.quoteCode),
+                feeCode = it.feeCode?.let(canonicalAsset),
+            )
+        }
+    val legsByRefid = ledgerLegs.map { it.copy(assetCode = canonicalAsset(it.assetCode)) }.groupBy { it.refid }
+    if (legsByRefid.isEmpty()) return trades
+
+    val consumedRefids = mutableSetOf<String>()
+
+    // A trade's own id equals its ledger refid for an ordinary fill; a Kraken "synthetic_pair"
+    // crypto/crypto trade's id never appears as a ledger refid at all, so fall back to the only other
+    // thing that reliably ties them together: the same second and the same {base, quote} asset pair.
+    fun legsFor(trade: ParsedTrade): List<ParsedLedgerTradeLeg>? {
+        legsByRefid[trade.id]?.let {
+            consumedRefids += trade.id
+            return it
+        }
+        val tradeSecond = trade.timestamp.epochSeconds
+        val assets = setOf(trade.baseCode, trade.quoteCode)
+        val match =
+            legsByRefid.entries.firstOrNull { (refid, legs) ->
+                refid !in consumedRefids &&
+                    legs.any { it.timestamp.epochSeconds == tradeSecond } &&
+                    legs.map { it.assetCode }.toSet() == assets
+            }
+        match?.let { consumedRefids += it.key }
+        return match?.value
+    }
+
+    val reconciled =
+        trades.map { trade ->
+            val legs = legsFor(trade) ?: return@map trade
+            val baseLeg = legs.firstOrNull { it.assetCode == trade.baseCode }
+            val quoteLeg = legs.firstOrNull { it.assetCode == trade.quoteCode }
+            trade.copy(
+                baseQuantity = baseLeg?.signedAmount?.abs() ?: trade.baseQuantity,
+                quoteAmount = quoteLeg?.signedAmount?.abs() ?: trade.quoteAmount,
+            )
+        }
+
+    val orphanTrades =
+        legsByRefid.entries
+            .filterNot { it.key in consumedRefids }
+            .mapNotNull { (refid, legs) ->
+                if (legs.size != 2) return@mapNotNull null
+                val outLeg = legs.firstOrNull { it.signedAmount < BigDecimal.ZERO } ?: return@mapNotNull null
+                val inLeg = legs.firstOrNull { it.signedAmount > BigDecimal.ZERO } ?: return@mapNotNull null
+                ParsedTrade(
+                    id = refid,
+                    timestamp = outLeg.timestamp,
+                    isBuy = false,
+                    baseCode = outLeg.assetCode,
+                    quoteCode = inLeg.assetCode,
+                    baseQuantity = outLeg.signedAmount.abs(),
+                    quoteAmount = inLeg.signedAmount.abs(),
+                    feeAmount = null,
+                    feeCode = null,
+                    orderId = null,
+                    requestId = outLeg.requestId,
+                    jsonPath = outLeg.jsonPath,
+                )
+            }
+    return reconciled + orphanTrades
 }
 
 /** Converts an exchange-reported display value exactly; throws if the asset's scale can't

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/api/KrakenExchangeApiE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/api/KrakenExchangeApiE2ETest.kt
@@ -46,10 +46,12 @@ class KrakenExchangeApiE2ETest : DbTest() {
         },"count":1}}
         """.trimIndent()
 
+    // Kraken reports a withdrawal's "amount" as negative; direction is derived from that sign
+    // (directionFromAmountSign), not just from which Ledgers endpoint the entry came from.
     private val withdrawalLedgerJson =
         """
         {"error":[],"result":{"ledger":{
-          "LG2":{"refid":"REF2","time":1700000002.5,"asset":"ZUSD","amount":"100.00","fee":"0.10"}
+          "LG2":{"refid":"REF2","time":1700000002.5,"asset":"ZUSD","amount":"-100.00","fee":"0.0000"}
         },"count":1}}
         """.trimIndent()
 
@@ -182,7 +184,7 @@ class KrakenExchangeApiE2ETest : DbTest() {
             val fiatWithdrawalLedgerJson =
                 """
                 {"error":[],"result":{"ledger":{
-                  "LG3":{"refid":"REF3","time":1700000003.5,"asset":"ZGBP","amount":"1998.05","fee":"1.95"}
+                  "LG3":{"refid":"REF3","time":1700000003.5,"asset":"ZGBP","amount":"-1998.05","fee":"0.0000"}
                 },"count":1}}
                 """.trimIndent()
             val withdrawStatusJson =
@@ -211,5 +213,478 @@ class KrakenExchangeApiE2ETest : DbTest() {
                     ).first()
                     .first { it.sourceAccountId == exchange.id && it.amount.asset.code == "GBP" }
             assertEquals(funding.id, withdrawal.targetAccountId, "fiat withdrawal should book against the funding account")
+        }
+
+    // Kraken marks some crypto/crypto pairs as "synthetic_pair" and reports them slash-separated
+    // ("SUI/BTC") instead of concatenated ("XXBTZGBP"); others use the concatenated form but with the
+    // short quote code instead of the legacy long one ("ETHWETH" is ETHW/ETH, not a fiat pair). Both
+    // used to fall through splitInstrument's suffix match (only "XXBT"/"XETH" were listed) and get
+    // silently dropped — the trade's assets never moved, permanently corrupting the BTC/ETH balance.
+    @Test
+    fun `imports crypto-quoted pairs instead of silently dropping them`() =
+        runTest {
+            val trades =
+                """
+                {"error":[],"result":{"trades":{
+                  "T1":{"ordertxid":"O1","pair":"SUI/BTC","time":1700000000.100,"type":"sell",
+                   "price":"0.0000129","cost":"0.36347453","vol":"28176.32013","fee":"0.00145390","trade_id":"t1"},
+                  "T2":{"ordertxid":"O2","pair":"ETHWETH","time":1700000000.200,"type":"sell",
+                   "price":"0.00143","cost":"0.04445562","vol":"31.06611900","fee":"0.00004446","trade_id":"t2"}
+                },"count":2}}
+                """.trimIndent()
+
+            stageSessionAndImport(trades = trades)
+
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken" }
+            val trs = repositories.tradeRepository.getTradesByAccount(exchange.id).first()
+            assertEquals(2, trs.size, "both crypto-quoted trades should be imported, not dropped")
+
+            val suiBtc = trs.first { it.from.asset.code == "SUI" }
+            assertEquals("BTC", suiBtc.to.asset.code, "SUI/BTC slash-separated pair resolves base SUI / quote BTC")
+            assertEquals("28176.32013", suiBtc.from.toDisplayValue().toString())
+
+            val ethwEth = trs.first { it.from.asset.code == "ETHW" }
+            assertEquals("ETH", ethwEth.to.asset.code, "ETHWETH concatenated pair resolves base ETHW / quote ETH (short code)")
+        }
+
+    // "XBTPYUSD" (XBT quoted in PayPal USD) used to match the shorter listed suffix "USD" before
+    // "PYUSD" was added, splitting as base "XBTPY" / quote "USD" and auto-creating a bogus "XBTPY"
+    // crypto asset that siphoned BTC balance away from the real "BTC" asset.
+    @Test
+    fun `splits a multi-character stablecoin quote suffix correctly`() =
+        runTest {
+            val trades =
+                """
+                {"error":[],"result":{"trades":{
+                  "T1":{"ordertxid":"O1","pair":"XBTPYUSD","time":1700000000.100,"type":"buy",
+                   "price":"29984.1","cost":"342.05623","vol":"0.00360168","fee":"0.47888","trade_id":"t1"}
+                },"count":1}}
+                """.trimIndent()
+
+            stageSessionAndImport(trades = trades)
+
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken" }
+            val trade =
+                repositories.tradeRepository
+                    .getTradesByAccount(exchange.id)
+                    .first()
+                    .single()
+            assertEquals("BTC", trade.to.asset.code, "base asset resolves to BTC, not a bogus XBTPY asset")
+            assertEquals("PYUSD", trade.from.asset.code, "quote asset resolves to PYUSD, not plain USD")
+            assertEquals("0.00360168", trade.to.toDisplayValue().toString())
+
+            assertEquals(null, repositories.cryptoRepository.getCryptoAssetByCode("XBTPY").first(), "no bogus XBTPY asset created")
+        }
+
+    // Kraken books a failed/cancelled deposit or withdrawal as two ledger rows sharing one refid with
+    // opposite-signed amounts (the debit and its reversal), netting to zero. The endpoint's fixed
+    // direction ignored the sign and treated both as real outgoing withdrawals, double-booking a
+    // reversed withdrawal attempt as an actual loss of funds.
+    @Test
+    fun `nets a reversed withdrawal to zero instead of double-booking it`() =
+        runTest {
+            val withdrawals =
+                """
+                {"error":[],"result":{"ledger":{
+                  "LG1":{"refid":"REFX","time":1700000002.0,"asset":"TRUMP","amount":"33.827200","fee":"0.0000"},
+                  "LG2":{"refid":"REFX","time":1700000002.5,"asset":"TRUMP","amount":"-33.827200","fee":"0.0000"}
+                },"count":2}}
+                """.trimIndent()
+
+            stageSessionAndImport(withdrawals = withdrawals, deposits = """{"error":[],"result":{"ledger":{},"count":0}}""")
+
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken" }
+            val transfers =
+                repositories.transactionRepository
+                    .getTransactionsByDateRange(
+                        startDate = Instant.fromEpochMilliseconds(1_700_000_001_900L),
+                        endDate = Instant.fromEpochMilliseconds(1_700_000_003_000L),
+                    ).first()
+                    .filter { it.amount.asset.code == "TRUMP" }
+            assertEquals(2, transfers.size, "both ledger rows of the reversed withdrawal are recorded")
+            val netTrump =
+                transfers.sumOf {
+                    val signed = if (it.targetAccountId == exchange.id) 1 else -1
+                    signed * it.amount.toDisplayValue().toDouble()
+                }
+            assertEquals(0.0, netTrump, "a debit + its reversal must net to zero, not double-book as a withdrawal")
+        }
+
+    // Ledgers is now requested with type=all (not just deposit/withdrawal/reward/staking), so any other
+    // balance-affecting ledger type (transfer, margin, adjustment, rollover, credit, settled, sale,
+    // nft_rebate, ...) is no longer silently invisible to the importer. type=all also returns "trade"
+    // entries, which duplicate TradesHistory and must be excluded rather than double-booked.
+    @Test
+    fun `imports non-standard ledger types from type=all and excludes duplicate trade entries`() =
+        runTest {
+            val deposits =
+                """
+                {"error":[],"result":{"ledger":{
+                  "LG1":{"refid":"REF1","time":1700000001.5,"asset":"XXBT","amount":"0.05","fee":"0.0000","type":"transfer"},
+                  "LG2":{"refid":"REF2","time":1700000002.5,"asset":"XXBT","amount":"0.36347453","fee":"0.00145390","type":"trade"}
+                },"count":2}}
+                """.trimIndent()
+
+            stageSessionAndImport(deposits = deposits, withdrawals = """{"error":[],"result":{"ledger":{},"count":0}}""")
+
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken" }
+            val transfers =
+                repositories.transactionRepository
+                    .getTransactionsByDateRange(
+                        startDate = Instant.fromEpochMilliseconds(1_700_000_001_000L),
+                        endDate = Instant.fromEpochMilliseconds(1_700_000_003_000L),
+                    ).first()
+                    .filter { it.amount.asset.code == "BTC" }
+            // The type=transfer row's amount ("0.05") is booked in full; the type=trade row's amount
+            // ("0.36347453") is excluded as a TradesHistory duplicate, but its fee ("0.00145390") is
+            // still real BTC that left the account and must still be booked — see the next test.
+            val mainTransfer = transfers.singleOrNull { it.amount.toDisplayValue().toString() == "0.05" }
+            assertNotNull(mainTransfer, "the type=transfer ledger row is imported; the type=trade row's amount is excluded")
+            assertEquals(exchange.id, mainTransfer.targetAccountId)
+        }
+
+    // Kraken sometimes charges a same-asset settlement fee on a trade-type ledger row that never appears
+    // in TradesHistory's own (quote-currency) fee field — confirmed against real account data by summing
+    // every raw ledger row's (amount - fee) and matching it exactly to Kraken's own running "balance"
+    // checkpoint. Because feeAmountField previously wasn't read by the exchange engine at all, and the
+    // row's excluded main amount discarded the whole row anyway, this fee was silently dropped, leaving a
+    // small but real balance short by exactly the missed fee — see ledgerMappings' feeAmountField.
+    @Test
+    fun `books a same-asset settlement fee from an excluded trade-type ledger row without duplicating its amount`() =
+        runTest {
+            val deposits =
+                """
+                {"error":[],"result":{"ledger":{
+                  "LG1":{"refid":"REF1","time":1700000002.5,"asset":"XXBT","amount":"0.36347453","fee":"0.00145390","type":"trade"}
+                },"count":1}}
+                """.trimIndent()
+
+            stageSessionAndImport(deposits = deposits, withdrawals = """{"error":[],"result":{"ledger":{},"count":0}}""")
+
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken" }
+            val fees =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken Fees" }
+            val transfers =
+                repositories.transactionRepository
+                    .getTransactionsByDateRange(
+                        startDate = Instant.fromEpochMilliseconds(1_700_000_002_000L),
+                        endDate = Instant.fromEpochMilliseconds(1_700_000_003_000L),
+                    ).first()
+                    .filter { it.amount.asset.code == "BTC" }
+            assertEquals(1, transfers.size, "only the fee is booked; the trade-duplicate amount is excluded")
+            val feeTransfer = transfers.single()
+            assertEquals("0.0014539", feeTransfer.amount.toDisplayValue().toString())
+            assertEquals(exchange.id, feeTransfer.sourceAccountId)
+            assertEquals(fees.id, feeTransfer.targetAccountId)
+        }
+
+    // TradesHistory's own "fee" is a quote-currency report that can duplicate (or, for a base-asset
+    // settlement fee, wrongly report the fee in the wrong asset entirely) the fee the Ledgers `type=all`
+    // feed already books authoritatively (see the two tests above). The trade path must never book a fee
+    // of its own from TradesHistory — confirmed here by a trade whose "fee" is nonzero but which has no
+    // matching ledger group staged at all, so no fee transfer should exist regardless.
+    @Test
+    fun `a trade's TradesHistory fee never books its own fee transfer`() =
+        runTest {
+            val trades =
+                """
+                {"error":[],"result":{"trades":{
+                  "T1":{"ordertxid":"O1","pair":"XXBTZUSD","time":1700000000.100,"type":"buy",
+                   "price":"40000.00","cost":"20000.00","vol":"0.5","fee":"52.00","trade_id":"t1"}
+                },"count":1}}
+                """.trimIndent()
+
+            stageSessionAndImport(trades = trades)
+
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken" }
+            val fees =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken Fees" }
+            val feeTransfers =
+                repositories.transactionRepository
+                    .getTransactionsByDateRange(
+                        startDate = Instant.fromEpochMilliseconds(1_699_999_999_000L),
+                        endDate = Instant.fromEpochMilliseconds(1_700_000_001_000L),
+                    ).first()
+                    .filter { it.sourceAccountId == exchange.id && it.targetAccountId == fees.id }
+            assertEquals(emptyList(), feeTransfers, "no fee transfer should be booked from TradesHistory's own fee field")
+        }
+
+    // Kraken's Ledgers `type=all` also returns the two legs of every trade (excluded from booking a
+    // transfer since TradesHistory already supplies the trade — see excludeField/excludeValues), but
+    // those legs are the actual settled amounts; TradesHistory's own cost/vol can disagree (confirmed
+    // against real account data on synthetic crypto/crypto pairs). A ledger row's refid equals the
+    // matching TradesHistory trade's own response-object key (spliced over "trade_id" by itemKeyField),
+    // so the two are joined by that shared identifier.
+    @Test
+    fun `overrides a trade's leg amounts with its matching ledger group when they disagree`() =
+        runTest {
+            val trades =
+                """
+                {"error":[],"result":{"trades":{
+                  "TMATCH1":{"ordertxid":"O1","pair":"XXBTZUSD","time":1700000000.100,"type":"sell",
+                   "price":"40000.00","cost":"20000.00","vol":"0.500000","fee":"0.00","trade_id":"t1"}
+                },"count":1}}
+                """.trimIndent()
+            val deposits =
+                """
+                {"error":[],"result":{"ledger":{
+                  "LG1":{"refid":"TMATCH1","time":1700000000.100,"asset":"XXBT","amount":"-0.500123","fee":"0.0000","type":"trade"},
+                  "LG2":{"refid":"TMATCH1","time":1700000000.100,"asset":"ZUSD","amount":"20000.45","fee":"0.0000","type":"trade"}
+                },"count":2}}
+                """.trimIndent()
+
+            stageSessionAndImport(trades = trades, deposits = deposits, withdrawals = """{"error":[],"result":{"ledger":{},"count":0}}""")
+
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken" }
+            val trade =
+                repositories.tradeRepository
+                    .getTradesByAccount(exchange.id)
+                    .first()
+                    .single()
+            assertEquals("BTC", trade.from.asset.code)
+            assertEquals(
+                "0.500123",
+                trade.from.toDisplayValue().toString(),
+                "BTC leg overridden by the ledger's amount, not TradesHistory's vol",
+            )
+            assertEquals(
+                "20000.45",
+                trade.to.toDisplayValue().toString(),
+                "USD leg overridden by the ledger's amount, not TradesHistory's cost",
+            )
+        }
+
+    // A Kraken "synthetic_pair" crypto/crypto trade's own key never appears as a ledger refid at all (its
+    // ledger legs share a DIFFERENT, unrelated refid) — the fallback join is the same second plus the
+    // same {base, quote} asset pair, which is unambiguous in practice.
+    @Test
+    fun `overrides a synthetic-pair trade's leg amounts via the timestamp and asset-pair fallback`() =
+        runTest {
+            val trades =
+                """
+                {"error":[],"result":{"trades":{
+                  "STVCTCR-ERSZJ-HBXQB2":{"ordertxid":"O1","pair":"SUI/BTC","time":1700000000.778,"type":"sell",
+                   "price":"0.0000129","cost":"0.3634745296","vol":"28176.32013","fee":"0.00145390","trade_id":"t1"}
+                },"count":1}}
+                """.trimIndent()
+            val deposits =
+                """
+                {"error":[],"result":{"ledger":{
+                  "LG1":{"refid":"T4BBJL-WDAFB-KWYHT6","time":1700000000.100,"asset":"SUI","amount":"-28176.32013","fee":"0.00000","type":"trade"},
+                  "LG2":{"refid":"T4BBJL-WDAFB-KWYHT6","time":1700000000.900,"asset":"XXBT","amount":"0.3636702500","fee":"0.0014538981","type":"trade"}
+                },"count":2}}
+                """.trimIndent()
+
+            stageSessionAndImport(trades = trades, deposits = deposits, withdrawals = """{"error":[],"result":{"ledger":{},"count":0}}""")
+
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken" }
+            val trade =
+                repositories.tradeRepository
+                    .getTradesByAccount(exchange.id)
+                    .first()
+                    .single { it.from.asset.code == "SUI" }
+            assertEquals("BTC", trade.to.asset.code)
+            assertEquals(
+                "0.36367025",
+                trade.to.toDisplayValue().toString(),
+                "BTC leg overridden by the ledger's actually-settled amount via the timestamp+asset fallback",
+            )
+        }
+
+    // A ledger trade-type group matching no TradesHistory trade at all (Kraken omitted a fill from
+    // TradesHistory entirely) must still be booked — the ledger's own balance is ground truth, so no
+    // movement it reports may be silently dropped.
+    @Test
+    fun `books a ledger trade group with no matching TradesHistory trade at all as its own trade`() =
+        runTest {
+            val deposits =
+                """
+                {"error":[],"result":{"ledger":{
+                  "LG1":{"refid":"TORPHAN1","time":1700000005.0,"asset":"XXBT","amount":"-0.01","fee":"0.0000","type":"trade"},
+                  "LG2":{"refid":"TORPHAN1","time":1700000005.0,"asset":"ZUSD","amount":"410.00","fee":"0.0000","type":"trade"}
+                },"count":2}}
+                """.trimIndent()
+
+            stageSessionAndImport(
+                trades = """{"error":[],"result":{"trades":{},"count":0}}""",
+                deposits = deposits,
+                withdrawals = """{"error":[],"result":{"ledger":{},"count":0}}""",
+            )
+
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken" }
+            val trade =
+                repositories.tradeRepository
+                    .getTradesByAccount(exchange.id)
+                    .first()
+                    .single()
+            assertEquals("BTC", trade.from.asset.code, "the ledger-only group is booked as a trade from its two legs")
+            assertEquals("0.01", trade.from.toDisplayValue().toString())
+            assertEquals("USD", trade.to.asset.code)
+            assertEquals("410", trade.to.toDisplayValue().toString())
+        }
+
+    // Kraken books each spot<->Earn move as two same-refid `type=transfer, subtype=autoallocation`
+    // ledger rows at the same timestamp (a debit from spot, a credit into Earn, or vice versa). After
+    // ".F" suffix-stripping both legs are the same asset/amount/account-pair, differing only in
+    // direction — the direction-symmetric fuzzy-dedupe fallback used to treat the second leg (which
+    // carries its own distinct ledger_id) as a duplicate of the first, silently dropping half of every
+    // autoallocation and leaving the exchange balance overstated by the full deposited amount.
+    @Test
+    fun `books both legs of an earn autoallocation pair instead of fuzzy-deduping one against the other`() =
+        runTest {
+            val deposits =
+                """
+                {"error":[],"result":{"ledger":{
+                  "LG1":{"refid":"RAUTO","time":1700000004.0,"asset":"XETH","amount":"-5.0000000000","fee":"0.0000","type":"transfer","subtype":"autoallocation"},
+                  "LG2":{"refid":"RAUTO","time":1700000004.0,"asset":"XETH.F","amount":"5.0000000000","fee":"0.0000","type":"transfer","subtype":"autoallocation"}
+                },"count":2}}
+                """.trimIndent()
+
+            stageSessionAndImport(deposits = deposits, withdrawals = """{"error":[],"result":{"ledger":{},"count":0}}""")
+
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken" }
+            val transfers =
+                repositories.transactionRepository
+                    .getTransactionsByDateRange(
+                        startDate = Instant.fromEpochMilliseconds(1_700_000_003_900L),
+                        endDate = Instant.fromEpochMilliseconds(1_700_000_004_100L),
+                    ).first()
+                    .filter { it.amount.asset.code == "ETH" }
+            assertEquals(2, transfers.size, "both autoallocation legs must be booked, not fuzzy-deduped against each other")
+            val net =
+                transfers.sumOf {
+                    val signed = if (it.targetAccountId == exchange.id) 1 else -1
+                    signed * it.amount.toDisplayValue().toDouble()
+                }
+            assertEquals(0.0, net, "the spot debit and its Earn-side credit must net to zero on the exchange account")
+        }
+
+    // Kraken can split one order into several fills that, after ms-truncation, are byte-identical (same
+    // timestamp, pair, vol, cost) — createTrade's exact-tuple idempotency used to treat the second
+    // identical fill as a re-import of the first and silently drop it, when both are genuinely distinct
+    // real trades. N identical fills must book as N trades, while re-importing the same N fills must
+    // still dedupe to those same N rows rather than creating N more. The fills' float timestamps differ
+    // only below the millisecond (as Kraken's real ones do), so occurrence counting must group them by
+    // the persisted ms value, not the full-precision Instant.
+    @Test
+    fun `books each of several byte-identical fills as its own trade, but stays idempotent on re-import`() =
+        runTest {
+            val trades =
+                """
+                {"error":[],"result":{"trades":{
+                  "T1":{"ordertxid":"O1","pair":"XXBTZUSD","time":1700000000.500684,"type":"sell",
+                   "price":"40000.00","cost":"219.60","vol":"0.1012","fee":"0.00","trade_id":"t1"},
+                  "T2":{"ordertxid":"O1","pair":"XXBTZUSD","time":1700000000.500309,"type":"sell",
+                   "price":"40000.00","cost":"219.60","vol":"0.1012","fee":"0.00","trade_id":"t2"}
+                },"count":2}}
+                """.trimIndent()
+            val noLedger = """{"error":[],"result":{"ledger":{},"count":0}}"""
+
+            stageSessionAndImport(trades = trades, deposits = noLedger, withdrawals = noLedger)
+
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken" }
+            val tradesAfterFirst = repositories.tradeRepository.getTradesByAccount(exchange.id).first()
+            assertEquals(2, tradesAfterFirst.size, "two byte-identical fills must book as two trades, not collapse to one")
+
+            // Re-import the same session: still exactly two trades (multiset idempotency), not four.
+            stageSessionAndImport(trades = trades, deposits = noLedger, withdrawals = noLedger)
+            val tradesAfterSecond = repositories.tradeRepository.getTradesByAccount(exchange.id).first()
+            assertEquals(2, tradesAfterSecond.size, "re-importing the same two identical fills must not create two more")
+        }
+
+    // A failed/cancelled withdrawal's reversal ledger row refunds the fee too: the debit row carries
+    // fee "0.03" and the reversal row carries fee "-0.03". abs()-ing the negative fee used to book the
+    // refund as a second charge instead of crediting it back, leaving the Fees account permanently
+    // overstated (and the exchange balance understated) by double the fee on every reversed withdrawal.
+    @Test
+    fun `nets a refunded ledger fee to zero instead of booking it as a second charge`() =
+        runTest {
+            val withdrawals =
+                """
+                {"error":[],"result":{"ledger":{
+                  "LG1":{"refid":"REFFEE","time":1700000002.0,"asset":"XXBT","amount":"-33.827200","fee":"0.03","type":"withdrawal"},
+                  "LG2":{"refid":"REFFEE","time":1700000002.5,"asset":"XXBT","amount":"33.827200","fee":"-0.03","type":"withdrawal"}
+                },"count":2}}
+                """.trimIndent()
+
+            stageSessionAndImport(withdrawals = withdrawals, deposits = """{"error":[],"result":{"ledger":{},"count":0}}""")
+
+            val exchange =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken" }
+            val fees =
+                repositories.accountRepository
+                    .getAllAccounts()
+                    .first()
+                    .first { it.name == "Kraken Fees" }
+            val feeTransfers =
+                repositories.transactionRepository
+                    .getTransactionsByDateRange(
+                        startDate = Instant.fromEpochMilliseconds(1_700_000_001_900L),
+                        endDate = Instant.fromEpochMilliseconds(1_700_000_003_000L),
+                    ).first()
+                    .filter {
+                        (it.sourceAccountId == exchange.id && it.targetAccountId == fees.id) ||
+                            (it.sourceAccountId == fees.id && it.targetAccountId == exchange.id)
+                    }
+            assertEquals(2, feeTransfers.size, "both the original fee charge and its refund are recorded")
+            val netFee =
+                feeTransfers.sumOf {
+                    val signed = if (it.targetAccountId == fees.id) 1 else -1
+                    signed * it.amount.toDisplayValue().toDouble()
+                }
+            assertEquals(0.0, netFee, "a fee charge and its refund must net to zero, not double-charge")
         }
 }

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/api/KrakenReimportE2ETest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/api/KrakenReimportE2ETest.kt
@@ -59,7 +59,7 @@ class KrakenReimportE2ETest : DbTest() {
     private val withdrawalLedgerJson =
         """
         {"error":[],"result":{"ledger":{
-          "LG1":{"refid":"REF1","time":1700000003.5,"asset":"ZGBP","amount":"1998.05","fee":"1.95"}
+          "LG1":{"refid":"REF1","time":1700000003.5,"asset":"ZGBP","amount":"-1998.05","fee":"0.0000"}
         },"count":1}}
         """.trimIndent()
     private val withdrawStatusJson =

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/trade/TradeSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/trade/TradeSelect.sq
@@ -24,12 +24,13 @@ JOIN asset_details fa ON trade.from_asset_id = fa.id
 JOIN asset_details ta ON trade.to_asset_id = ta.id
 WHERE trade.id = ?;
 
--- Finds every existing trade identical on every field, for re-import dedup (so re-running the same
--- CSV/API session doesn't double-book a conversion) while still allowing N genuinely-repeated
--- identical fills (e.g. an exchange order split into several byte-identical fills) to book as N rows.
--- Ordered by id so callers can consume the k-th occurrence deterministically. Amounts are the
--- canonical decimal strings.
-selectMatchingTradeIds:
+-- Finds the occurrence-th existing trade identical on every field, for re-import dedup (so
+-- re-running the same CSV/API session doesn't double-book a conversion) while still allowing N
+-- genuinely-repeated identical fills (e.g. an exchange order split into several byte-identical
+-- fills) to book as N rows. Ordered by id so callers consume the k-th occurrence deterministically
+-- via :occurrence, without materializing every matching row. Amounts are the canonical decimal
+-- strings.
+selectMatchingTradeId:
 SELECT id FROM trade
 WHERE timestamp = ?
   AND description = ?
@@ -39,7 +40,8 @@ WHERE timestamp = ?
   AND to_account_id = ?
   AND to_asset_id = ?
   AND to_amount = ?
-ORDER BY id;
+ORDER BY id
+LIMIT 1 OFFSET :occurrence;
 
 selectByAccount:
 SELECT

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/trade/TradeSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/trade/TradeSelect.sq
@@ -24,9 +24,12 @@ JOIN asset_details fa ON trade.from_asset_id = fa.id
 JOIN asset_details ta ON trade.to_asset_id = ta.id
 WHERE trade.id = ?;
 
--- Finds an existing trade identical on every field, for re-import dedup (so re-running the same CSV
--- doesn't double-book a conversion). Amounts are the canonical decimal strings.
-selectMatchingTradeId:
+-- Finds every existing trade identical on every field, for re-import dedup (so re-running the same
+-- CSV/API session doesn't double-book a conversion) while still allowing N genuinely-repeated
+-- identical fills (e.g. an exchange order split into several byte-identical fills) to book as N rows.
+-- Ordered by id so callers can consume the k-th occurrence deterministically. Amounts are the
+-- canonical decimal strings.
+selectMatchingTradeIds:
 SELECT id FROM trade
 WHERE timestamp = ?
   AND description = ?
@@ -36,7 +39,7 @@ WHERE timestamp = ?
   AND to_account_id = ?
   AND to_asset_id = ?
   AND to_amount = ?
-LIMIT 1;
+ORDER BY id;
 
 selectByAccount:
 SELECT

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/TradeWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/TradeWriteRepositoryImpl.kt
@@ -35,6 +35,7 @@ class TradeWriteRepositoryImpl(
         toAccountId: AccountId,
         toAmount: Money,
         source: Source,
+        occurrence: Int,
     ): TradeCreateResult {
         // A trade is a cross-asset exchange; a same-asset movement is a transfer. The DB CHECK only
         // blocks the same-account+same-asset degenerate case, so enforce the cross-asset rule here.
@@ -43,11 +44,12 @@ class TradeWriteRepositoryImpl(
         }
         return withContext(Dispatchers.Default) {
             writeQueries.transactionWithResult {
-                // Idempotency: re-importing the same conversion must not double-book. If an identical
-                // trade already exists, return it instead of inserting a duplicate.
+                // Multiset idempotency: re-importing the same conversion must not double-book, but N
+                // genuinely-repeated identical fills must book as N rows. Reuse the occurrence-th existing
+                // identical trade (0-based, ordered by id); once exhausted, fall through to insert.
                 val existing =
                     selectQueries
-                        .selectMatchingTradeId(
+                        .selectMatchingTradeIds(
                             timestamp = timestamp.toEpochMilliseconds(),
                             description = description,
                             from_account_id = fromAccountId.id,
@@ -56,7 +58,8 @@ class TradeWriteRepositoryImpl(
                             to_account_id = toAccountId.id,
                             to_asset_id = toAmount.asset.id.id,
                             to_amount = toAmount.amount.toString(),
-                        ).executeAsOneOrNull()
+                        ).executeAsList()
+                        .getOrNull(occurrence)
                 if (existing != null) {
                     return@transactionWithResult TradeCreateResult(TradeId(existing), created = false)
                 }

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/TradeWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/TradeWriteRepositoryImpl.kt
@@ -49,7 +49,7 @@ class TradeWriteRepositoryImpl(
                 // identical trade (0-based, ordered by id); once exhausted, fall through to insert.
                 val existing =
                     selectQueries
-                        .selectMatchingTradeIds(
+                        .selectMatchingTradeId(
                             timestamp = timestamp.toEpochMilliseconds(),
                             description = description,
                             from_account_id = fromAccountId.id,
@@ -58,8 +58,8 @@ class TradeWriteRepositoryImpl(
                             to_account_id = toAccountId.id,
                             to_asset_id = toAmount.asset.id.id,
                             to_amount = toAmount.amount.toString(),
-                        ).executeAsList()
-                        .getOrNull(occurrence)
+                            occurrence = occurrence.toLong(),
+                        ).executeAsOneOrNull()
                 if (existing != null) {
                     return@transactionWithResult TradeCreateResult(TradeId(existing), created = false)
                 }

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportDeduper.kt
@@ -183,9 +183,22 @@ class ImportDeduper(
     // the reconcile candidates by that triple.
     private val reconcileCandidatesByDirectedAmount: Map<DirectedAmountKey, List<Pair<TransferId, Transfer>>> =
         reconcileCandidates.groupBy { (_, t) -> DirectedAmountKey(t.sourceAccountId, t.targetAccountId, t.amount) }
+
+    // Transfer id -> apiId, for the same non-conflict check applied to in-batch candidates below.
+    private val existingApiIdByTransferId: Map<TransferId, String> =
+        existing.mapNotNull { info -> info.apiId?.let { info.transferId to it } }.toMap()
+
     private val batchApiId = mutableMapOf<String, Int>()
     private val batchUniqueKey = mutableMapOf<Map<String, String>, Int>()
-    private val batchMatchCandidates = mutableListOf<Pair<Int, Transfer>>()
+
+    /** A fuzzy-match candidate from earlier in this batch, keeping its own apiId (see [apiIdConflict]). */
+    private data class BatchCandidate(
+        val index: Int,
+        val transfer: Transfer,
+        val apiId: String?,
+    )
+
+    private val batchMatchCandidates = mutableListOf<BatchCandidate>()
 
     // Existing legs already claimed by an earlier funding-card or internal-transfer reconcile in this
     // batch. Unlike plain cross-source reconcile (which deliberately doesn't consume), both of these rules
@@ -222,7 +235,9 @@ class ImportDeduper(
         val existingId =
             transfer.apiId?.let { existingApiId[it] }
                 ?: transfer.uniqueKey?.takeIf { it.isNotEmpty() }?.let { existingUniqueKeyId[it] }
-                ?: apiMatchCandidatesFor(transfer).firstOrNull { (_, e) -> apiMatches(transfer, e) }?.first
+                ?: apiMatchCandidatesFor(transfer)
+                    .firstOrNull { (id, e) -> apiMatches(transfer, e) && !apiIdConflict(transfer.apiId, existingApiIdByTransferId[id]) }
+                    ?.first
         if (existingId != null) return Classified(transfer, ImportStatus.DUPLICATE, existingId)
 
         // Cross-source reconciliation: the same real movement seen from another provider. Keep this
@@ -242,7 +257,9 @@ class ImportDeduper(
         val batchMatchIndex =
             transfer.apiId?.let { batchApiId[it] }
                 ?: transfer.uniqueKey?.takeIf { it.isNotEmpty() }?.let { batchUniqueKey[it] }
-                ?: batchMatchCandidates.firstOrNull { (_, e) -> apiMatches(transfer, e) }?.first
+                ?: batchMatchCandidates
+                    .firstOrNull { c -> apiMatches(transfer, c.transfer) && !apiIdConflict(transfer.apiId, c.apiId) }
+                    ?.index
         if (batchMatchIndex != null) {
             return Classified(transfer, ImportStatus.DUPLICATE, existing = null, inBatchMatchIndex = batchMatchIndex)
         }
@@ -250,9 +267,21 @@ class ImportDeduper(
         // Accepted: register this transfer so later items in the batch dedupe against it.
         transfer.apiId?.let { batchApiId[it] = index }
         transfer.uniqueKey?.takeIf { it.isNotEmpty() }?.let { batchUniqueKey[it] = index }
-        batchMatchCandidates += index to transfer.toComparableTransfer(TransferId(0))
+        batchMatchCandidates += BatchCandidate(index, transfer.toComparableTransfer(TransferId(0)), transfer.apiId)
         return Classified(transfer, ImportStatus.IMPORTED, null)
     }
+
+    /**
+     * True when both sides carry a provider-native id and they differ — e.g. Kraken's Earn
+     * autoallocation books a spot-debit and Earn-credit leg as two distinct ledger rows, same
+     * timestamp/amount/account-pair but opposite direction; each has its own unique `ledger_id`. Fuzzy
+     * (timestamp+amount+either-direction) matching exists only for legacy/no-apiId records, so it must
+     * never treat two differently-identified real movements as the same one.
+     */
+    private fun apiIdConflict(
+        incoming: String?,
+        existing: String?,
+    ): Boolean = incoming != null && existing != null && incoming != existing
 
     /**
      * Classifies [transfer] as a cross-source reconciliation of an existing transfer when the policy

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -160,7 +160,34 @@ class ImportEngineImpl(
         }
         val createdTradeIds = mutableMapOf<LocalTradeKey, TradeId>()
         val dedupedTradeKeys = mutableSetOf<LocalTradeKey>()
+
+        // Multiset idempotency (see TradeWriteRepository.createTrade): N intents sharing the exact same
+        // field tuple (e.g. an exchange order split into several byte-identical fills) must book as N
+        // trades, not collapse to one. Count how many identical tuples this pass has already claimed and
+        // pass that count as the occurrence index, so each one reuses a distinct existing row (re-import)
+        // or inserts a distinct new one (first import). The key must group exactly the intents that
+        // createTrade cannot tell apart, so the timestamp is the persisted millisecond value — an Instant
+        // can carry sub-ms precision (e.g. Kraken's float epoch-seconds) that the trade row does not.
+        data class TradeTupleKey(
+            val timestampMs: Long?,
+            val description: String?,
+            val fromAccountId: AccountId?,
+            val fromAmount: Money?,
+            val toAccountId: AccountId?,
+            val toAmount: Money?,
+        )
+        val tradeOccurrences = mutableMapOf<TradeTupleKey, Int>()
         for (intent in batch.trades.creates()) {
+            val tupleKey =
+                TradeTupleKey(
+                    intent.timestamp?.toEpochMilliseconds(),
+                    intent.description,
+                    intent.fromAccountId,
+                    intent.fromAmount,
+                    intent.toAccountId,
+                    intent.toAmount,
+                )
+            val occurrence = tradeOccurrences.getOrDefault(tupleKey, 0)
             val tradeResult =
                 tradeRepository.createTrade(
                     timestamp = requireNotNull(intent.timestamp),
@@ -170,7 +197,9 @@ class ImportEngineImpl(
                     toAccountId = requireNotNull(intent.toAccountId),
                     toAmount = requireNotNull(intent.toAmount),
                     source = intent.source,
+                    occurrence = occurrence,
                 )
+            tradeOccurrences[tupleKey] = occurrence + 1
             createdTradeIds[intent.key] = tradeResult.id
             if (!tradeResult.created) dedupedTradeKeys += intent.key
         }

--- a/app/model/apistrategy/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
+++ b/app/model/apistrategy/src/commonMain/kotlin/com/moneymanager/domain/model/apistrategy/ApiStrategyConfig.kt
@@ -334,6 +334,32 @@ data class ApiTransactionMappings(
      * [counterpartyNetworkField] from the enrichment item. Null disables enrichment for this mapping.
      */
     val joinKeyField: String? = null,
+    /**
+     * When true, the endpoint's fixed direction (IN for DEPOSITS, OUT for WITHDRAWALS) is overridden
+     * by the sign of the raw [amountField] value: negative -> OUT, non-negative -> IN. Some exchanges
+     * (Kraken) report a failed/cancelled deposit or withdrawal as a second ledger entry sharing the
+     * same id with the opposite sign, so the movement nets to zero; treating every ledger row as
+     * unsigned and direction-by-endpoint double-books the reversal as an additional real movement.
+     */
+    val directionFromAmountSign: Boolean = false,
+    /**
+     * Dot-path to a field whose value, if present in [excludeValues], causes the item to be skipped
+     * entirely (no transfer, no enrichment). Used when a single endpoint's response mixes record kinds
+     * that must be dropped — e.g. Kraken's Ledgers `type=all` includes `"trade"` entries that duplicate
+     * the trades already sourced from `TradesHistory`.
+     */
+    val excludeField: String? = null,
+    val excludeValues: Set<String> = emptySet(),
+    /**
+     * Dot-path to a field identifying the trade this row belongs to (e.g. Kraken Ledgers `refid`, which
+     * equals the matching `TradesHistory` trade's own id). When set on a row excluded via
+     * [excludeField]/[excludeValues] (a duplicate trade-type ledger entry), the row's signed amount is
+     * kept as an authoritative leg for reconciling that trade's booked amount — Kraken's TradesHistory
+     * `cost` is a display-rounded price*volume for synthetic crypto/crypto pairs and can disagree with
+     * what the ledger actually settled. A ledger group with no matching trade at all is booked as its
+     * own trade from the two legs, so no movement the ledger reports is ever silently dropped.
+     */
+    val reconcileTradeAmountsField: String? = null,
 )
 
 @Serializable

--- a/app/model/repository/write/src/commonMain/kotlin/com/moneymanager/domain/repository/write/TradeWriteRepository.kt
+++ b/app/model/repository/write/src/commonMain/kotlin/com/moneymanager/domain/repository/write/TradeWriteRepository.kt
@@ -23,8 +23,14 @@ interface TradeWriteRepository : TradeReadRepository {
     /**
      * Creates a cross-asset trade: [fromAmount] leaves [fromAccountId], [toAmount] enters
      * [toAccountId] (the two [Money] legs may be denominated in different assets). Allocates a
-     * `transaction_id`, inserts the trade, and records provenance. Idempotent: if an identical
-     * trade already exists it is returned with [TradeCreateResult.created] = false.
+     * `transaction_id`, inserts the trade, and records provenance.
+     *
+     * Idempotent as a **multiset**, not a set: [occurrence] (0-based) is the caller's count of how
+     * many earlier trades in this same create pass already matched this exact field tuple (e.g. an
+     * exchange order split into several byte-identical fills). The occurrence-th existing identical
+     * trade is reused ([TradeCreateResult.created] = false); once existing matches are exhausted, a
+     * new row is inserted. This lets N genuinely-repeated identical fills book as N distinct trades
+     * while re-importing the same N fills still dedupes to the same N rows instead of only one.
      */
     @Suppress("LongParameterList")
     suspend fun createTrade(
@@ -35,6 +41,7 @@ interface TradeWriteRepository : TradeReadRepository {
         toAccountId: AccountId,
         toAmount: Money,
         source: Source,
+        occurrence: Int = 0,
     ): TradeCreateResult
 
     suspend fun deleteTrade(id: TradeId)

--- a/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInApiStrategies.kt
+++ b/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInApiStrategies.kt
@@ -41,7 +41,6 @@ import com.moneymanager.domain.model.apistrategy.SigPart
 import com.moneymanager.domain.model.apistrategy.SignatureEncoding
 import com.moneymanager.domain.model.apistrategy.SigningAlgorithm
 import com.moneymanager.domain.model.apistrategy.TimestampFormat
-import com.moneymanager.domain.model.apistrategy.TransferDirection
 import com.moneymanager.domain.model.apistrategy.WindowBoundFormat
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
@@ -620,8 +619,12 @@ object BuiltInApiStrategies {
                 splitMode = InstrumentSplitMode.QUOTE_SUFFIX,
                 // The longest matching suffix always wins (see splitInstrument), so shorter codes that
                 // are also suffixes of longer ones (e.g. "ZUSD" ends with "USD") are listed safely.
-                // "XXBT"/"XETH" cover crypto/crypto pairs quoted in BTC or ETH (e.g. "XETHXXBT" is
-                // ETH/BTC, not a BTC/USD-style fiat pair).
+                // "XXBT"/"XETH" cover crypto/crypto pairs quoted in BTC or ETH using Kraken's legacy long
+                // codes (e.g. "XETHXXBT" is ETH/BTC); "BTC"/"ETH" cover the same case for pairs that use
+                // the short code instead (e.g. "ETHWETH" is ETHW/ETH, "PAXGETH" is PAXG/ETH) — Kraken is
+                // inconsistent about which form a given pair uses. "PYUSD" (and other multi-char
+                // stablecoins) must be listed or a pair like "XBTPYUSD" wrongly matches the shorter "USD"
+                // suffix, splitting as XBTPY/USD instead of XBT/PYUSD.
                 quoteAssets =
                     listOf(
                         "XXBT",
@@ -633,9 +636,17 @@ object BuiltInApiStrategies {
                         "ZJPY",
                         "ZCHF",
                         "ZAUD",
+                        "PYUSD",
                         "USDT",
                         "USDC",
+                        "USDG",
+                        "RLUSD",
+                        "TUSD",
+                        "EURT",
                         "DAI",
+                        "XBT",
+                        "BTC",
+                        "ETH",
                         "USD",
                         "EUR",
                         "GBP",
@@ -644,7 +655,11 @@ object BuiltInApiStrategies {
                 buyValues = setOf("buy"),
                 baseQuantityField = "vol",
                 quoteQuantityField = "cost",
-                feeField = "fee",
+                // No feeField: TradesHistory's own fee is a quote-currency report that can disagree with
+                // (or duplicate) what was actually charged — sometimes in a different asset entirely (a
+                // base-asset settlement fee Kraken bills separately). The Ledgers `type=all` feed already
+                // supplies every fee authoritatively (see ledgerMappings' feeAmountField), so the trade
+                // path books none of its own.
                 timestampField = "time",
                 timestampFormat = TimestampFormat.EPOCH_S_FLOAT,
                 idField = "trade_id",
@@ -663,6 +678,14 @@ object BuiltInApiStrategies {
                 amountFormat = ApiAmountFormat.DECIMAL_MAJOR_UNITS,
                 feeAmountField = "fee",
                 joinKeyField = joinKey,
+                // A failed/cancelled deposit or withdrawal appears as two ledger rows sharing one refid
+                // with opposite-signed amounts (the debit and its reversal), netting to zero. Kraken's
+                // "amount" is signed (negative = out), so trust that sign instead of the endpoint's fixed
+                // direction, or the reversal double-books as a second real movement in the same direction.
+                directionFromAmountSign = true,
+                // Only meaningful on the excluded `type=trade` rows (see excludeField/excludeValues
+                // below) — refid equals the matching TradesHistory trade's own id.
+                reconcileTradeAmountsField = "refid",
             )
 
         // DepositStatus/WithdrawStatus supply no money movement of their own — they only enrich the
@@ -698,60 +721,44 @@ object BuiltInApiStrategies {
             dataEndpoints =
                 listOf(
                     ApiDataEndpoint(
-                        signed("0/private/TradesHistory", "result.trades", responseObjectValues = true),
+                        // Splice the response object's own key (e.g. "STVCTCR-ERSZJ-HBXQB2") over the
+                        // "trade_id" field before mapping: the native `trade_id` is a small per-fill
+                        // sequence number that collides across unrelated trades (observed repeatedly as
+                        // 0), whereas the key is unique and — critically — is the same identifier
+                        // Kraken's Ledgers rows carry as `refid`, letting reconcileTradeAmountsField join
+                        // a trade to its authoritative ledger legs (see ledgerMappings).
+                        signed(
+                            "0/private/TradesHistory",
+                            "result.trades",
+                            responseObjectValues = true,
+                            itemKeyField = "trade_id",
+                        ),
                         ApiEndpointKind.TRADES,
                         tradeMappings = tradeMappings,
                     ),
+                    // Every non-trade ledger movement in one pass. Kraken's Ledgers `type` enum is
+                    // `all, trade, deposit, withdrawal, transfer, margin, adjustment, rollover, credit,
+                    // settled, staking, dividend, sale, nft_rebate` (default "all") — earlier revisions
+                    // of this strategy only requested deposit/withdrawal/reward/staking, so any balance
+                    // movement Kraken books under transfer/margin/adjustment/rollover/credit/settled/
+                    // sale/nft_rebate (Earn subscribe/unsubscribe, internal moves, fee rebates, etc.) was
+                    // invisible to the importer — the account balance would silently drift from the true
+                    // Kraken balance by exactly the missed amount. `type=all` also returns `trade`-type
+                    // entries that duplicate what TradesHistory already supplies, so those are dropped via
+                    // excludeField/excludeValues. Direction comes from the signed `amount` field
+                    // (directionFromAmountSign), not the ledger `type`, so this single endpoint covers
+                    // every type without per-type direction mapping — including the historical "reward"
+                    // vs "staking" naming inconsistency between Kraken account vintages.
                     ApiDataEndpoint(
                         signed(
                             "0/private/Ledgers",
                             "result.ledger",
                             responseObjectValues = true,
                             itemKeyField = "ledger_id",
-                            queryParams = listOf(ApiQueryParam(name = "type", value = "deposit")),
+                            queryParams = listOf(ApiQueryParam(name = "type", value = "all")),
                         ),
                         ApiEndpointKind.DEPOSITS,
-                        fixedDirection = TransferDirection.IN,
-                        transactionMappings = ledgerMappings("refid"),
-                    ),
-                    ApiDataEndpoint(
-                        signed(
-                            "0/private/Ledgers",
-                            "result.ledger",
-                            responseObjectValues = true,
-                            itemKeyField = "ledger_id",
-                            queryParams = listOf(ApiQueryParam(name = "type", value = "withdrawal")),
-                        ),
-                        ApiEndpointKind.WITHDRAWALS,
-                        fixedDirection = TransferDirection.OUT,
-                        transactionMappings = ledgerMappings("refid"),
-                    ),
-                    // Earn/staking reward payouts. Kraken's own docs disagree on the ledger type value
-                    // ("reward" vs "staking") between endpoints — both are requested; whichever the
-                    // account doesn't use simply returns an empty ledger.
-                    ApiDataEndpoint(
-                        signed(
-                            "0/private/Ledgers",
-                            "result.ledger",
-                            responseObjectValues = true,
-                            itemKeyField = "ledger_id",
-                            queryParams = listOf(ApiQueryParam(name = "type", value = "reward")),
-                        ),
-                        ApiEndpointKind.DEPOSITS,
-                        fixedDirection = TransferDirection.IN,
-                        transactionMappings = ledgerMappings("refid"),
-                    ),
-                    ApiDataEndpoint(
-                        signed(
-                            "0/private/Ledgers",
-                            "result.ledger",
-                            responseObjectValues = true,
-                            itemKeyField = "ledger_id",
-                            queryParams = listOf(ApiQueryParam(name = "type", value = "staking")),
-                        ),
-                        ApiEndpointKind.DEPOSITS,
-                        fixedDirection = TransferDirection.IN,
-                        transactionMappings = ledgerMappings("refid"),
+                        transactionMappings = ledgerMappings("refid").copy(excludeField = "type", excludeValues = setOf("trade")),
                     ),
                     // Known limitation: Kraken paginates these funding-status endpoints with an opaque
                     // cursor token (not the offset/date-window shapes the generic engine implements), so


### PR DESCRIPTION
## Summary

Every Kraken exchange asset balance now reconciles exactly against Kraken's own ledger ground truth. This fixes six compounding bugs in the generic signed-exchange API importer, found by comparing the app's computed balances against the raw stored Kraken `Ledgers`/`TradesHistory` API responses (`sum(amount) − sum(fee)` per asset, checked against Kraken's own running `balance` field).

- **Ledgers `type=all`**: the strategy only requested 4 of Kraken's ~14 ledger types; movements under the others (Earn, internal transfers, rebates…) were invisible.
- **Ledger-authoritative fees**: `feeAmountField` was wired into config but never read by the exchange engine; fees are now extracted independently of whether the row's main amount is excluded (trade-type rows).
- **Trade leg reconciliation**: trade amounts are now overridden from the matching ledger group (keyed by refid, falling back to timestamp+asset-pair for Kraken's synthetic-pair trades) instead of trusting TradesHistory's display-rounded `cost`; TradesHistory's own fee (sometimes reported in the wrong asset) is no longer separately booked.
- **Fuzzy dedupe direction-symmetry bug**: a transfer carrying a distinct provider id could get fuzzy-matched (by timestamp+amount+account-pair, either direction) against a *different* transfer's distinct provider id — e.g. Kraken's paired spot-debit/Earn-credit autoallocation rows — silently dropping one leg.
- **Trade multiset idempotency**: Kraken can split one order into several genuinely-identical fills. `createTrade`'s exact-tuple dedupe collapsed them into one row; it now takes an occurrence/skip-count so N identical fills book as N trades, while re-importing the same N still dedupes to N (not 2N). The occurrence key uses millisecond precision to match what's persisted, since Kraken's float timestamps carry sub-ms precision that would otherwise make every fill look unique.
- **Signed ledger fees**: a refunded (negative) ledger fee was `abs()`'d into a second charge instead of crediting back the original.

All fixes are import-engine code, not exchange-specific config, so they benefit any exchange the generic engine covers.

## Test plan
- [x] `./gradlew --console=plain build` passes
- [x] `KrakenExchangeApiE2ETest` (14 tests) covers each bug with a dedicated fixture
- [x] Verified end-to-end against the real production database: every Kraken asset balance now matches Kraken's own ledger ground truth exactly after re-importing the existing session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kraken imports for crypto-quoted pairs, stablecoin symbols, withdrawals, refunds, fees, rewards, and staking transactions.
  * Reconciled trade amounts with authoritative ledger data, including trades missing from trade history.
  * Prevented duplicate fees, transfers, and trades during imports and re-imports.
  * Preserved multiple identical fills as separate trades while maintaining idempotency.
  * Improved handling of earn autoallocations and reversed withdrawal entries.

* **Improvements**
  * Kraken ledger processing now derives transfer direction from signed amounts and recognizes more quote assets.
  * Added support for configurable transaction exclusions and ledger-based trade reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->