### PR TITLE
Fix API strategy editor Save button staying disabled for directional endpoints

### DIFF
--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ApiStrategyEditorState.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ApiStrategyEditorState.kt
@@ -14,6 +14,7 @@ import com.moneymanager.domain.model.apistrategy.ApiQueryParam
 import com.moneymanager.domain.model.apistrategy.ApiSignSource
 import com.moneymanager.domain.model.apistrategy.ApiTransactionMappings
 import com.moneymanager.domain.model.apistrategy.PredicateOp
+import com.moneymanager.domain.model.apistrategy.TransferDirection
 
 /** Tabs of the API strategy editor screen. */
 internal enum class EditorTab(
@@ -83,7 +84,22 @@ internal class ApiStrategyEditorState(
     // edited on the Endpoints tab (synthetic account, data endpoints) and Advanced tab (request
     // signing, internal-transfer reconciliation).
     var requestSigning by mutableStateOf(initial?.requestSigning)
-    var dataEndpoints by mutableStateOf(initial?.dataEndpoints.orEmpty())
+
+    // A directional (deposit/withdrawal) endpoint with a null fixedDirection displays as "IN" in the
+    // Endpoints tab (a rendering fallback), but that fallback is never persisted on its own — so a
+    // strategy saved before this field existed, or otherwise missing it, would show a fully-filled-in
+    // form yet fail isValidForSave and permanently disable Save. Backfill it here, at load time, so the
+    // fix applies without the user ever having to visit the Endpoints tab.
+    var dataEndpoints by
+        mutableStateOf(
+            initial?.dataEndpoints.orEmpty().map { endpoint ->
+                if (endpoint.kind in DIRECTIONAL_KINDS && !endpoint.enrichesTransfers && endpoint.fixedDirection == null) {
+                    endpoint.copy(fixedDirection = TransferDirection.IN)
+                } else {
+                    endpoint
+                }
+            },
+        )
     var syntheticAccount by mutableStateOf(initial?.syntheticAccount)
     var internalTransferReconcile by mutableStateOf(initial?.internalTransferReconcile)
     var assetAliases by mutableStateOf(initial?.assetAliases.orEmpty())

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ExchangeDataEditors.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/editor/ExchangeDataEditors.kt
@@ -45,7 +45,7 @@ import kotlinx.coroutines.launch
 private val TRADE_KINDS = setOf(ApiEndpointKind.TRADES, ApiEndpointKind.ORDERS)
 
 /** Kinds that carry a fixed movement direction + external counterparty account. */
-private val DIRECTIONAL_KINDS = setOf(ApiEndpointKind.DEPOSITS, ApiEndpointKind.WITHDRAWALS)
+internal val DIRECTIONAL_KINDS = setOf(ApiEndpointKind.DEPOSITS, ApiEndpointKind.WITHDRAWALS)
 
 /**
  * Editor for the optional [ApiSyntheticAccount]: an exchange strategy imports into one fixed account
@@ -464,19 +464,26 @@ internal fun InternalTransferReconcileEditor(
                     AccountPicker(
                         selectedAccountId = accounts.firstOrNull { it.name == bridge.otherAccountName }?.id,
                         onAccountSelected = { accountId ->
-                            // Resolve by id directly rather than through the (possibly stale, just after
-                            // an inline creation) `accounts` snapshot: the picker can return the new
-                            // account's id before this composable's collected list re-emits with it.
-                            scope.launch {
-                                val selectedName = accountRepository.getAccountById(accountId).first()?.name ?: return@launch
+                            fun applyName(name: String) =
                                 onChange(
                                     c.copy(
                                         bridges =
                                             c.bridges.mapIndexed { i, b ->
-                                                if (i == index) b.copy(otherAccountName = selectedName) else b
+                                                if (i == index) b.copy(otherAccountName = name) else b
                                             },
                                     ),
                                 )
+                            // Update synchronously from the already-collected snapshot whenever possible, like
+                            // every other field on this tab, so the Save button reacts immediately. Only fall
+                            // back to a DB lookup for a just-created account this snapshot hasn't re-emitted yet.
+                            val cachedName = accounts.firstOrNull { it.id == accountId }?.name
+                            if (cachedName != null) {
+                                applyName(cachedName)
+                            } else {
+                                scope.launch {
+                                    val selectedName = accountRepository.getAccountById(accountId).first()?.name ?: return@launch
+                                    applyName(selectedName)
+                                }
                             }
                         },
                         label = "Other account",


### PR DESCRIPTION
## Summary
- The Endpoints tab's "Fixed direction" dropdown for a directional (deposit/withdrawal) data endpoint fell back to displaying "IN" when the underlying `fixedDirection` was `null`, but that display fallback was never written back into state.
- `ApiStrategyEditorState.isValid` requires a non-null `fixedDirection` on directional, non-enrichment endpoints, so any endpoint missing it (e.g. Kraken's Ledgers endpoint on an existing strategy) looked fully configured yet permanently kept the Save button disabled, no matter what else was edited elsewhere in the form.
- Backfill `fixedDirection` to `IN` for any directional, non-enrichment endpoint missing it at editor-state load time, so the fix applies immediately on opening the editor rather than requiring a visit to the Endpoints tab.

## Test plan
- [x] `./gradlew --console=plain build`
- [x] `./gradlew --console=plain buildHealth`
- [x] Manually verified against the real Kraken strategy (JVM desktop app on a nested X display): before the fix, Save stayed disabled until visiting Endpoints and re-selecting "Fixed direction"; after the fix, Save is enabled immediately on opening the editor, without visiting Endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when editing older API strategies with directional endpoints.
  * Automatically fills in missing transfer direction details so valid strategies can be saved successfully.
  * Improved bridge account name updates by displaying available account information immediately and loading missing details as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->