### PR TITLE
Add Excel (.xlsx) import strategy support

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -15,6 +15,7 @@
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/ui/imports/money-manager.app.ui.imports.iml" filepath="$PROJECT_DIR$/.idea/modules/app/ui/imports/money-manager.app.ui.imports.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/test/app/money-manager.test.app.iml" filepath="$PROJECT_DIR$/.idea/modules/test/app/money-manager.test.app.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/utils/localsettings/money-manager.utils.localsettings.iml" filepath="$PROJECT_DIR$/.idea/modules/utils/localsettings/money-manager.utils.localsettings.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/utils/parsers/money-manager.utils.parsers.iml" filepath="$PROJECT_DIR$/.idea/modules/utils/parsers/money-manager.utils.parsers.iml" />
     </modules>
   </component>
 </project>

--- a/app/csvimporter/build.gradle.kts
+++ b/app/csvimporter/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
                 implementation(projects.utils.bigdecimal)
                 implementation(projects.utils.parsers.csv)
                 implementation(projects.utils.parsers.qif)
+                implementation(projects.utils.parsers.xlsx)
                 implementation(libs.diamondedge.logging)
                 implementation(libs.kotlinx.coroutines.core)
             }
@@ -51,6 +52,7 @@ kotlin {
                 implementation(projects.utils.bigdecimal)
                 implementation(projects.utils.parsers.csv)
                 implementation(projects.utils.parsers.qif)
+                implementation(projects.utils.parsers.xlsx)
                 implementation(libs.diamondedge.logging)
                 implementation(libs.kotlinx.coroutines.core)
             }

--- a/app/csvimporter/src/androidMain/kotlin/com/moneymanager/csvimporter/Sha256.android.kt
+++ b/app/csvimporter/src/androidMain/kotlin/com/moneymanager/csvimporter/Sha256.android.kt
@@ -2,8 +2,10 @@ package com.moneymanager.csvimporter
 
 import java.security.MessageDigest
 
-internal actual fun sha256Hex(input: String): String =
+internal actual fun sha256Hex(input: String): String = sha256Hex(input.toByteArray(Charsets.UTF_8))
+
+internal actual fun sha256Hex(bytes: ByteArray): String =
     MessageDigest
         .getInstance("SHA-256")
-        .digest(input.toByteArray(Charsets.UTF_8))
+        .digest(bytes)
         .joinToString("") { byte -> "%02x".format(byte) }

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/ImportDirectoryScanner.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/ImportDirectoryScanner.kt
@@ -13,10 +13,13 @@ import com.moneymanager.domain.repository.QifImportReadRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.createCsvImport
 import com.moneymanager.importengineapi.createQifImport
+import com.moneymanager.importengineapi.createXlsxImport
 import com.moneymanager.importengineapi.recordDirectoryFileImported
 import com.moneymanager.importfilesource.ImportFileEntry
 import com.moneymanager.importfilesource.ImportFileSource
 import com.moneymanager.qif.QifParser
+import com.moneymanager.xlsx.XlsxUnsupportedPlatformException
+import com.moneymanager.xlsx.createXlsxParser
 import org.lighthousegames.logging.logging
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Clock
@@ -25,22 +28,25 @@ import kotlin.time.Instant
 private val scanLogger = logging()
 
 /** File types the scanner can stage. Others (e.g. .pdf) are skipped. */
-private enum class SupportedKind { CSV, QIF }
+private enum class SupportedKind { CSV, QIF, XLSX }
 
 private fun supportedKind(fileName: String): SupportedKind? =
     when (fileName.substringAfterLast('.', "").lowercase()) {
         "csv" -> SupportedKind.CSV
         "qif" -> SupportedKind.QIF
+        "xlsx" -> SupportedKind.XLSX
         else -> null
     }
 
-/** True if [fileName] is an importable file (.csv/.qif). Used by directory discovery. */
+/** True if [fileName] is an importable file (.csv/.qif/.xlsx). Used by directory discovery. */
 internal fun isSupportedImportFile(fileName: String): Boolean = supportedKind(fileName) != null
 
 /**
  * Scans one configured [directory]: lists its files and DOWNLOADS new/changed **supported** files
- * (.csv → CSV staging, .qif → QIF staging) into the Imports section. Unsupported files (e.g. .pdf) are
- * skipped without downloading. It does NOT apply a strategy — the user runs the existing "Import All".
+ * (.csv → CSV staging, .qif → QIF staging, .xlsx → CSV staging of its first worksheet) into the
+ * Imports section. Unsupported files (e.g. .pdf) are skipped without downloading. Excel parsing (Apache
+ * POI) is JVM-only; on Android an .xlsx file is recorded as a per-file scan failure rather than crashing
+ * the scan. It does NOT apply a strategy — the user runs the existing "Import All".
  * Change detection: a matching server-provided content hash (e.g. Drive md5Checksum) skips the download
  * entirely; otherwise the file is downloaded and sha256-confirmed. A changed file produces a fresh
  * staging row; a bad file is recorded as a failure and does not abort the scan.
@@ -99,8 +105,11 @@ suspend fun scanImportDirectory(
 
             // Always hash the content: a provider that preserves/backdates the timestamp on an edit
             // would otherwise hide a real content change forever. The checksum below decides re-staging.
-            val content = fileSource.download(entry.ref).decodeToString()
-            val checksum = sha256Hex(content)
+            // Excel is binary and must be hashed/staged from raw bytes; decoding it as UTF-8 text (like
+            // CSV/QIF) would both corrupt the checksum and lose data, so it branches before decoding.
+            val rawBytes = fileSource.download(entry.ref)
+            val content = if (kind == SupportedKind.XLSX) null else rawBytes.decodeToString()
+            val checksum = content?.let(::sha256Hex) ?: sha256Hex(rawBytes)
 
             // Content unchanged despite a moved timestamp: advance the cursor, don't re-stage.
             if (tracked?.checksum == checksum) {
@@ -125,14 +134,20 @@ suspend fun scanImportDirectory(
                 SupportedKind.CSV -> {
                     csvImportId =
                         csvImportRepository.findImportsByChecksum(checksum).firstOrNull()?.id
-                            ?: stageCsv(importEngine, entry, content, checksum, lastModified)
+                            ?: stageCsv(importEngine, entry, checkNotNull(content), checksum, lastModified)
                     csvDownloaded++
                 }
                 SupportedKind.QIF -> {
                     qifImportId =
                         qifImportRepository.findImportsByChecksum(checksum).firstOrNull()?.id
-                            ?: stageQif(importEngine, entry, content, checksum, lastModified)
+                            ?: stageQif(importEngine, entry, checkNotNull(content), checksum, lastModified)
                     qifDownloaded++
+                }
+                SupportedKind.XLSX -> {
+                    csvImportId =
+                        csvImportRepository.findImportsByChecksum(checksum).firstOrNull()?.id
+                            ?: stageXlsx(importEngine, entry, rawBytes, checksum, lastModified)
+                    csvDownloaded++
                 }
             }
 
@@ -186,6 +201,33 @@ private suspend fun stageCsv(
         rows = parsed.rows,
         fileChecksum = checksum,
         fileLastModified = lastModified,
+    )
+}
+
+/**
+ * Stages an Excel workbook's first worksheet exactly like [stageCsv] (header row + data rows), plus the
+ * raw workbook bytes so a strategy naming a different worksheet can re-extract it later. Throws
+ * [XlsxUnsupportedPlatformException] on Android (Apache POI is JVM-only); the caller's generic
+ * exception handler records that as a per-file scan failure.
+ */
+private suspend fun stageXlsx(
+    importEngine: ImportEngine,
+    entry: ImportFileEntry,
+    bytes: ByteArray,
+    checksum: String,
+    lastModified: Instant,
+): CsvImportId {
+    val parser = createXlsxParser()
+    val sheetName = parser.sheetNames(bytes).firstOrNull() ?: ""
+    val parsed = parser.parse(bytes, sheetName)
+    return importEngine.createXlsxImport(
+        fileName = entry.name,
+        headers = parsed.headers,
+        rows = parsed.rows,
+        fileChecksum = checksum,
+        fileLastModified = lastModified,
+        xlsxBytes = bytes,
+        xlsxWorksheetName = sheetName,
     )
 }
 

--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/Sha256.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/Sha256.kt
@@ -2,3 +2,6 @@ package com.moneymanager.csvimporter
 
 /** Hex-encoded SHA-256 of [input], used as the file checksum for change detection / dedup. */
 internal expect fun sha256Hex(input: String): String
+
+/** Hex-encoded SHA-256 of raw [bytes] (binary files, e.g. `.xlsx`, that can't be checksummed as text). */
+internal expect fun sha256Hex(bytes: ByteArray): String

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoComCardXlsxMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoComCardXlsxMapperTest.kt
@@ -1,0 +1,226 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class, kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.moneymanager.csvimporter
+
+import com.moneymanager.bigdecimal.BigDecimal
+import com.moneymanager.builtin.BuiltInCsvStrategies
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.Category
+import com.moneymanager.domain.model.Currency
+import com.moneymanager.domain.model.CurrencyId
+import com.moneymanager.domain.model.Money
+import com.moneymanager.domain.model.csv.CsvColumn
+import com.moneymanager.domain.model.csv.CsvColumnId
+import com.moneymanager.domain.model.csv.CsvRow
+import com.moneymanager.domain.model.passthrough.PassThroughAccount
+import com.moneymanager.domain.model.passthrough.PassThroughAccountId
+import com.moneymanager.domain.model.passthrough.PassThroughRule
+import com.moneymanager.importengineapi.PassThroughDetector
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+/**
+ * Exercises the built-in "Crypto.com Card (Excel)" strategy ([BuiltInCsvStrategies]) — pure config —
+ * against row shapes from the real "Card Transaction History" workbook. Unlike the CSV export, its
+ * `Amount Processed` column is already signed (negative = spend, positive = load/refund), so direction
+ * comes entirely from the standard positive-amount source/target flip plus a Service Abbreviation
+ * check that routes card loads to Cash instead of a merchant lookup.
+ */
+class CryptoComCardXlsxMapperTest {
+    private val now = Clock.System.now()
+    private val strategy = BuiltInCsvStrategies.buildCryptoComCardXlsxStrategy(now)
+
+    private val gbp = Currency(id = CurrencyId(1), code = "GBP", name = "British Pound")
+    private val card = Account(id = AccountId(1), name = "Crypto.com Card", openingDate = now)
+    private val cash = Account(id = AccountId(2), name = "Crypto.com Cash", openingDate = now)
+
+    private val columns =
+        listOf(
+            "Transaction Date",
+            "Transaction Time",
+            "Service Abbreviation",
+            "Card Acceptor Name",
+            "Description",
+            "Merchant Category Code",
+            "Amount Processed",
+            "Available Balance",
+            "Currency ",
+            "Amount Requested",
+        ).mapIndexed { index, name -> CsvColumn(CsvColumnId(Uuid.random()), index, name) }
+
+    private val curve =
+        PassThroughAccount(
+            id = PassThroughAccountId(1),
+            name = "Curve",
+            conduitAccountName = "Curve",
+            rules =
+                listOf(
+                    PassThroughRule(
+                        detectionPattern = "(?i)^(?:Refund: )?CRV\\*",
+                        merchantPattern = "(?i)^(?:Refund: )?CRV\\*\\s*(.+?)(?:\\s{2,}.*)?$",
+                    ),
+                ),
+        )
+
+    private val mapper =
+        CsvTransferMapper(
+            strategy = strategy,
+            columns = columns,
+            existingAccounts = mapOf(card.name to card, cash.name to cash),
+            existingCurrencies = mapOf(gbp.id to gbp),
+            existingCurrenciesByCode = mapOf(gbp.code to gbp),
+            existingCryptoByCode = emptyMap(),
+            passThroughDetector = PassThroughDetector(listOf(curve)),
+        )
+
+    @Suppress("LongParameterList")
+    private fun row(
+        date: String,
+        time: String,
+        serviceAbbreviation: String,
+        cardAcceptorName: String,
+        description: String,
+        amountProcessed: String,
+        currency: String,
+    ): CsvRow =
+        CsvRow(
+            rowIndex = 1,
+            values =
+                listOf(
+                    date,
+                    time,
+                    serviceAbbreviation,
+                    cardAcceptorName,
+                    description,
+                    "5411.0",
+                    amountProcessed,
+                    "0.0",
+                    currency,
+                    amountProcessed,
+                ),
+        )
+
+    private fun map(row: CsvRow): MappingResult.Success {
+        val result = mapper.mapRow(row)
+        if (result is MappingResult.Error) throw AssertionError("mapping failed: ${result.errorMessage}")
+        return assertIs<MappingResult.Success>(result, "mapping failed")
+    }
+
+    @Test
+    fun `identification columns match the real workbook headers, including the trailing space`() {
+        assertEquals(columns.map { it.originalName }.toSet(), strategy.identificationColumns)
+    }
+
+    @Test
+    fun `a negative purchase debits the card and credits a merchant account`() {
+        val r =
+            map(
+                row(
+                    date = "11/27/2021",
+                    time = "09:12:00",
+                    serviceAbbreviation = "POS Signature Purchase",
+                    cardAcceptorName = "Spotify UK               Stockholm      SWE",
+                    description = "POS Signature Purchase",
+                    amountProcessed = "-4.5",
+                    currency = "GBP",
+                ),
+            )
+
+        assertEquals(card.id, r.transfer.sourceAccountId)
+        assertEquals(Money.fromDisplayValue(BigDecimal("4.5"), gbp), r.transfer.amount)
+        // The fixed-width padding + city/country ("               Stockholm      SWE") must be trimmed
+        // off, both for a clean account name and because pass-through detection depends on it.
+        assertEquals(listOf(NewAccount("Spotify UK", Category.UNCATEGORIZED_ID)), r.newAccounts)
+        assertNull(r.passThrough)
+    }
+
+    @Test
+    fun `a CRV_ card acceptor name is routed through the Curve pass-through, not a raw junk account`() {
+        val r =
+            map(
+                row(
+                    date = "11/27/2021",
+                    time = "10:00:00",
+                    serviceAbbreviation = "POS Signature Purchase",
+                    cardAcceptorName = "CRV*Card verification    London         GBR",
+                    description = "POS Signature Purchase",
+                    amountProcessed = "-1.5",
+                    currency = "GBP",
+                ),
+            )
+
+        val passThrough = r.passThrough
+        checkNotNull(passThrough) { "expected the CRV* card acceptor name to match the Curve pass-through" }
+        assertEquals(listOf("Curve"), passThrough.conduitNames)
+        assertEquals("Card verification", passThrough.merchantName)
+        // The conduit becomes the target, not a raw "CRV*Card verification    London         GBR" account.
+        assertEquals(card.id, r.transfer.sourceAccountId)
+        assertEquals(setOf("Curve", "Card verification"), r.newAccounts.map { it.name }.toSet())
+    }
+
+    @Test
+    fun `a blank card acceptor name routes to Cash instead of failing to resolve an empty account`() {
+        val r =
+            map(
+                row(
+                    date = "12/03/2021",
+                    time = "06:20:49",
+                    serviceAbbreviation = "Batch Credit Funds Transfer",
+                    cardAcceptorName = "",
+                    description = "Batch Credit Funds Transfer",
+                    amountProcessed = "245.86",
+                    currency = "GBP",
+                ),
+            )
+
+        // Positive amount flips: Cash (this branch's mapped account) becomes the source, Card the target.
+        assertEquals(cash.id, r.transfer.sourceAccountId)
+        assertEquals(card.id, r.transfer.targetAccountId)
+        assertEquals(emptyList(), r.newAccounts)
+    }
+
+    @Test
+    fun `a positive card load credits the card from Cash, not a merchant lookup`() {
+        val r =
+            map(
+                row(
+                    date = "11/26/2021",
+                    time = "14:34:00",
+                    serviceAbbreviation = "LdExtDbCr",
+                    cardAcceptorName = "                                        GBR",
+                    description = "GBP/200.0-Card Load",
+                    amountProcessed = "200.0",
+                    currency = "GBP",
+                ),
+            )
+
+        // Positive amount flips source/target: Cash (this branch's mapped account) becomes the source.
+        assertEquals(cash.id, r.transfer.sourceAccountId)
+        assertEquals(card.id, r.transfer.targetAccountId)
+        assertEquals(Money.fromDisplayValue(BigDecimal("200.0"), gbp), r.transfer.amount)
+        assertEquals(emptyList(), r.newAccounts)
+    }
+
+    @Test
+    fun `timestamp combines the date and time columns`() {
+        val r =
+            map(
+                row(
+                    date = "11/26/2021",
+                    time = "14:21:29",
+                    serviceAbbreviation = "POS Signature Purchase",
+                    cardAcceptorName = "CRV*Card verification    London         GBR",
+                    description = "Account Verification Transaction",
+                    amountProcessed = "0.0",
+                    currency = "GBP",
+                ),
+            )
+
+        assertEquals("2021-11-26T14:21:29Z", r.transfer.timestamp.toString())
+    }
+}

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoComCardXlsxMapperTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/CryptoComCardXlsxMapperTest.kt
@@ -204,6 +204,10 @@ class CryptoComCardXlsxMapperTest {
         assertEquals(card.id, r.transfer.targetAccountId)
         assertEquals(Money.fromDisplayValue(BigDecimal("200.0"), gbp), r.transfer.amount)
         assertEquals(emptyList(), r.newAccounts)
+        // Card Acceptor Name here is pure padding + a country code ("                    GBR", no real
+        // merchant): the trim regex must skip past the leading whitespace rather than capturing just a
+        // single leading space, or the description ends up blank/whitespace-only.
+        assertEquals("GBR", r.transfer.description)
     }
 
     @Test

--- a/app/csvimporter/src/jvmMain/kotlin/com/moneymanager/csvimporter/Sha256.jvm.kt
+++ b/app/csvimporter/src/jvmMain/kotlin/com/moneymanager/csvimporter/Sha256.jvm.kt
@@ -2,8 +2,10 @@ package com.moneymanager.csvimporter
 
 import java.security.MessageDigest
 
-internal actual fun sha256Hex(input: String): String =
+internal actual fun sha256Hex(input: String): String = sha256Hex(input.toByteArray(Charsets.UTF_8))
+
+internal actual fun sha256Hex(bytes: ByteArray): String =
     MessageDigest
         .getInstance("SHA-256")
-        .digest(input.toByteArray(Charsets.UTF_8))
+        .digest(bytes)
         .joinToString("") { byte -> "%02x".format(byte) }

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/CsvStrategyExportService.kt
@@ -420,6 +420,7 @@ class CsvStrategyExportService(
                 crossSourceReconcileWindowSeconds = export.crossSourceReconcileWindowSeconds,
                 conversionConfig = export.conversionConfig,
                 fundingAttributeMatch = export.fundingAttributeMatch,
+                worksheetName = export.worksheetName,
                 createdAt = now,
                 updatedAt = now,
             )

--- a/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/StrategyLibraryService.kt
+++ b/app/db/core/src/commonMain/kotlin/com/moneymanager/database/service/StrategyLibraryService.kt
@@ -9,6 +9,7 @@ import com.moneymanager.domain.model.AppVersion
 import com.moneymanager.domain.model.Source
 import com.moneymanager.domain.model.csvstrategy.export.CsvStrategyExport
 import com.moneymanager.domain.model.csvstrategy.isQifStrategy
+import com.moneymanager.domain.model.csvstrategy.isXlsxStrategy
 import com.moneymanager.domain.model.passthrough.PassThroughAccount
 import com.moneymanager.domain.model.passthrough.PassThroughAccountId
 import com.moneymanager.domain.model.passthrough.export.PassThroughExport
@@ -55,7 +56,12 @@ class StrategyLibraryService(
 
         for (strategy in csvStrategyRepository.getAllStrategies().first()) {
             val json = CsvStrategyExportCodec.encode(csvStrategyExportService.toExport(strategy, appVersion))
-            val kind = if (strategy.isQifStrategy()) StrategyKind.QIF else StrategyKind.CSV
+            val kind =
+                when {
+                    strategy.isQifStrategy() -> StrategyKind.QIF
+                    strategy.isXlsxStrategy() -> StrategyKind.XLSX
+                    else -> StrategyKind.CSV
+                }
             entries += entry(StrategyKey(kind, strategy.name), json)
         }
 
@@ -83,7 +89,7 @@ class StrategyLibraryService(
         json: String,
     ): StrategyParseResult =
         when (key.kind) {
-            StrategyKind.CSV, StrategyKind.QIF -> {
+            StrategyKind.CSV, StrategyKind.QIF, StrategyKind.XLSX -> {
                 val export = CsvStrategyExportCodec.decode(json)
                 val refs = csvStrategyExportService.parseExport(export).unresolvedReferences.map { it.toDomain() }
                 StrategyParseResult(key, refs)
@@ -106,7 +112,7 @@ class StrategyLibraryService(
         resolutions: Map<CsvUnresolvedReference, CsvResolution>,
     ) {
         when (key.kind) {
-            StrategyKind.CSV, StrategyKind.QIF -> applyCsv(key.name, json, resolutions)
+            StrategyKind.CSV, StrategyKind.QIF, StrategyKind.XLSX -> applyCsv(key.name, json, resolutions)
             StrategyKind.API -> applyApi(key.name, json)
             StrategyKind.PASS_THROUGH -> applyPassThrough(key.name, json)
             StrategyKind.GLOBAL_MAPPINGS -> applyGlobalMappings(json, resolutions)

--- a/app/db/read/src/commonMain/kotlin/com/moneymanager/database/json/StrategyArtifactCodec.kt
+++ b/app/db/read/src/commonMain/kotlin/com/moneymanager/database/json/StrategyArtifactCodec.kt
@@ -23,7 +23,7 @@ object StrategyArtifactCodec {
     ): String {
         val canonical =
             when (kind) {
-                StrategyKind.CSV, StrategyKind.QIF ->
+                StrategyKind.CSV, StrategyKind.QIF, StrategyKind.XLSX ->
                     CsvStrategyExportCodec.encode(CsvStrategyExportCodec.decode(json).copy(version = ""))
                 StrategyKind.API ->
                     ApiStrategyExportCodec.encode(ApiStrategyExportCodec.decode(json).copy(version = ""))
@@ -44,7 +44,7 @@ object StrategyArtifactCodec {
         json: String,
     ): String =
         when (kind) {
-            StrategyKind.CSV, StrategyKind.QIF -> CsvStrategyExportCodec.decode(json).name
+            StrategyKind.CSV, StrategyKind.QIF, StrategyKind.XLSX -> CsvStrategyExportCodec.decode(json).name
             StrategyKind.API -> ApiStrategyExportCodec.decode(json).name
             StrategyKind.GLOBAL_MAPPINGS -> StrategyFileNaming.GLOBAL_MAPPINGS_NAME
             StrategyKind.PASS_THROUGH -> PassThroughExportCodec.decode(json).name

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImport/CsvImportSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImport/CsvImportSelect.sq
@@ -129,3 +129,7 @@ ORDER BY csv_import_metadata.import_timestamp DESC;
 -- csv_column_metadata queries
 selectColumnsByImportId:
 SELECT * FROM csv_column_metadata WHERE import_id = ? ORDER BY column_index;
+
+-- xlsx_import_blob queries
+selectXlsxBlob:
+SELECT file_bytes, worksheet_name FROM xlsx_import_blob WHERE csv_import_id = ?;

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategySelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategySelect.sq
@@ -1,11 +1,20 @@
 -- Select all strategies ordered by name
 selectAll:
-SELECT * FROM csv_import_strategy ORDER BY name;
+SELECT csv_import_strategy.*, xlsx_import_strategy.worksheet_name AS worksheet_name
+FROM csv_import_strategy
+LEFT JOIN xlsx_import_strategy ON xlsx_import_strategy.csv_import_strategy_id = csv_import_strategy.id
+ORDER BY csv_import_strategy.name;
 
 -- Select a strategy by ID
 selectById:
-SELECT * FROM csv_import_strategy WHERE id = ?;
+SELECT csv_import_strategy.*, xlsx_import_strategy.worksheet_name AS worksheet_name
+FROM csv_import_strategy
+LEFT JOIN xlsx_import_strategy ON xlsx_import_strategy.csv_import_strategy_id = csv_import_strategy.id
+WHERE csv_import_strategy.id = ?;
 
 -- Select a strategy by name
 selectByName:
-SELECT * FROM csv_import_strategy WHERE name = ?;
+SELECT csv_import_strategy.*, xlsx_import_strategy.worksheet_name AS worksheet_name
+FROM csv_import_strategy
+LEFT JOIN xlsx_import_strategy ON xlsx_import_strategy.csv_import_strategy_id = csv_import_strategy.id
+WHERE csv_import_strategy.name = ?;

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyReadRepositoryImpl.kt
@@ -58,6 +58,7 @@ class CsvImportStrategyReadRepositoryImpl(
             crossSourceReconcileWindowSeconds = entity.cross_source_reconcile_window_seconds,
             conversionConfig = FieldMappingJsonCodec.decodeConversionConfig(entity.conversion_config_json),
             fundingAttributeMatch = FieldMappingJsonCodec.decodeAttributeAccountMatch(entity.funding_attribute_match_json),
+            worksheetName = entity.worksheet_name,
             createdAt = Instant.fromEpochMilliseconds(entity.created_at),
             updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
         )

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/CsvImportStrategyReadRepositoryImpl.kt
@@ -12,7 +12,6 @@ import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 import com.moneymanager.domain.repository.CsvImportStrategyReadRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
@@ -25,41 +24,58 @@ class CsvImportStrategyReadRepositoryImpl(
 
     override fun getAllStrategies(): Flow<List<CsvImportStrategy>> =
         selectQueries
-            .selectAll()
+            .selectAll(::toDomain)
             .asFlow()
             .mapToList(coroutineContext)
-            .map { strategies -> strategies.map(::toDomain) }
 
     override fun getStrategyById(id: CsvImportStrategyId): Flow<CsvImportStrategy?> =
         selectQueries
-            .selectById(id.id.toString())
+            .selectById(id.id.toString(), ::toDomain)
             .asFlow()
             .mapToOneOrNull(coroutineContext)
-            .map { it?.let(::toDomain) }
 
     override fun getStrategyByName(name: String): Flow<CsvImportStrategy?> =
         selectQueries
-            .selectByName(name)
+            .selectByName(name, ::toDomain)
             .asFlow()
             .mapToOneOrNull(coroutineContext)
-            .map { it?.let(::toDomain) }
 
-    private fun toDomain(entity: com.moneymanager.database.sql.csvImportStrategy.Csv_import_strategy): CsvImportStrategy =
+    // revisionId is part of the query's column set (needed to keep this a positional match for the
+    // generated mapper) but isn't part of the domain model.
+    @Suppress("LongParameterList", "UnusedParameter")
+    private fun toDomain(
+        id: String,
+        revisionId: Long,
+        name: String,
+        identificationColumnsJson: String,
+        fieldMappingsJson: String,
+        attributeMappingsJson: String,
+        rowRulesJson: String,
+        companionRulesJson: String,
+        contentMatchRulesJson: String,
+        fileNamePattern: String?,
+        crossSourceReconcileWindowSeconds: Long?,
+        conversionConfigJson: String?,
+        fundingAttributeMatchJson: String?,
+        createdAt: Long,
+        updatedAt: Long,
+        worksheetName: String?,
+    ): CsvImportStrategy =
         CsvImportStrategy(
-            id = CsvImportStrategyId(Uuid.parse(entity.id)),
-            name = entity.name,
-            identificationColumns = FieldMappingJsonCodec.decodeColumns(entity.identification_columns_json),
-            fieldMappings = FieldMappingJsonCodec.decode(entity.field_mappings_json),
-            attributeMappings = FieldMappingJsonCodec.decodeAttributeMappings(entity.attribute_mappings_json),
-            rowPreprocessingRules = FieldMappingJsonCodec.decodeRowRules(entity.row_rules_json),
-            companionTransactionRules = FieldMappingJsonCodec.decodeCompanionRules(entity.companion_rules_json),
-            contentMatchRules = FieldMappingJsonCodec.decodeContentRules(entity.content_match_rules_json),
-            fileNamePattern = entity.file_name_pattern,
-            crossSourceReconcileWindowSeconds = entity.cross_source_reconcile_window_seconds,
-            conversionConfig = FieldMappingJsonCodec.decodeConversionConfig(entity.conversion_config_json),
-            fundingAttributeMatch = FieldMappingJsonCodec.decodeAttributeAccountMatch(entity.funding_attribute_match_json),
-            worksheetName = entity.worksheet_name,
-            createdAt = Instant.fromEpochMilliseconds(entity.created_at),
-            updatedAt = Instant.fromEpochMilliseconds(entity.updated_at),
+            id = CsvImportStrategyId(Uuid.parse(id)),
+            name = name,
+            identificationColumns = FieldMappingJsonCodec.decodeColumns(identificationColumnsJson),
+            fieldMappings = FieldMappingJsonCodec.decode(fieldMappingsJson),
+            attributeMappings = FieldMappingJsonCodec.decodeAttributeMappings(attributeMappingsJson),
+            rowPreprocessingRules = FieldMappingJsonCodec.decodeRowRules(rowRulesJson),
+            companionTransactionRules = FieldMappingJsonCodec.decodeCompanionRules(companionRulesJson),
+            contentMatchRules = FieldMappingJsonCodec.decodeContentRules(contentMatchRulesJson),
+            fileNamePattern = fileNamePattern,
+            crossSourceReconcileWindowSeconds = crossSourceReconcileWindowSeconds,
+            conversionConfig = FieldMappingJsonCodec.decodeConversionConfig(conversionConfigJson),
+            fundingAttributeMatch = FieldMappingJsonCodec.decodeAttributeAccountMatch(fundingAttributeMatchJson),
+            worksheetName = worksheetName,
+            createdAt = Instant.fromEpochMilliseconds(createdAt),
+            updatedAt = Instant.fromEpochMilliseconds(updatedAt),
         )
 }

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImport/CsvImport.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImport/CsvImport.sq
@@ -54,3 +54,13 @@ CREATE TABLE csv_import_error (
 );
 
 CREATE INDEX idx_csv_import_error_import ON csv_import_error(csv_import_id);
+
+-- Raw bytes of an imported Excel workbook, kept alongside its staged rows (in the dynamic
+-- csv_import_<uuid> table referenced by csv_import_metadata) so the worksheet can be re-parsed if the
+-- matched strategy names a different sheet than the one initially staged.
+CREATE TABLE xlsx_import_blob (
+    csv_import_id TEXT PRIMARY KEY NOT NULL,
+    file_bytes BLOB NOT NULL,
+    worksheet_name TEXT NOT NULL,
+    FOREIGN KEY (csv_import_id) REFERENCES csv_import_metadata(id) ON DELETE CASCADE
+);

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategy.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategy.sq
@@ -13,6 +13,7 @@ CREATE TABLE csv_import_strategy (
     cross_source_reconcile_window_seconds INTEGER,
     conversion_config_json TEXT,
     funding_attribute_match_json TEXT,
+    worksheet_name TEXT,
     created_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000),
     updated_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000)
 );

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategy.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategy.sq
@@ -13,12 +13,22 @@ CREATE TABLE csv_import_strategy (
     cross_source_reconcile_window_seconds INTEGER,
     conversion_config_json TEXT,
     funding_attribute_match_json TEXT,
-    worksheet_name TEXT,
     created_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000),
     updated_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000)
 );
 
 CREATE INDEX idx_csv_import_strategy_name ON csv_import_strategy(name);
+
+-- Marks a csv_import_strategy as targeting an Excel worksheet rather than a CSV file (like QIF, an
+-- XLSX strategy is an ordinary csv_import_strategy row that rides the CSV engine). Split into its own
+-- table rather than a nullable column: unlike the optional per-strategy features above (file name
+-- pattern, conversion config, funding match), worksheet_name is a kind discriminator, not a feature
+-- any strategy may opt into.
+CREATE TABLE xlsx_import_strategy (
+    csv_import_strategy_id TEXT PRIMARY KEY NOT NULL,
+    worksheet_name TEXT NOT NULL,
+    FOREIGN KEY (csv_import_strategy_id) REFERENCES csv_import_strategy(id) ON DELETE CASCADE
+);
 
 -- Source attribution for csv_import_strategy revisions.
 -- Uses TEXT strategy_id because csv_import_strategy.id is a UUID, unlike the INTEGER entity_id

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportReadRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportReadRepositoryImpl.kt
@@ -15,6 +15,7 @@ import com.moneymanager.domain.model.csv.CsvColumn
 import com.moneymanager.domain.model.csv.CsvColumnId
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csv.CsvRow
+import com.moneymanager.domain.model.csv.XlsxImportBlob
 import com.moneymanager.domain.repository.CsvImportReadRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -106,6 +107,13 @@ class CsvImportReadRepositoryImpl(
         withContext(coroutineContext) {
             csvImportSelectQueries.selectImportsByChecksum(checksum, ::toCsvImportRecord).executeAsList().map { import ->
                 toCsvImport(import)
+            }
+        }
+
+    override suspend fun getXlsxBlob(id: CsvImportId): XlsxImportBlob? =
+        withContext(coroutineContext) {
+            csvImportSelectQueries.selectXlsxBlob(id.id.toString()).executeAsOneOrNull()?.let { blob ->
+                XlsxImportBlob(fileBytes = blob.file_bytes, worksheetName = blob.worksheet_name)
             }
         }
 

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportStrategyWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportStrategyWriteRepositoryImpl.kt
@@ -65,6 +65,7 @@ class CsvImportStrategyWriteRepositoryImpl(
                     cross_source_reconcile_window_seconds = strategy.crossSourceReconcileWindowSeconds,
                     conversion_config_json = FieldMappingJsonCodec.encodeConversionConfig(strategy.conversionConfig),
                     funding_attribute_match_json = FieldMappingJsonCodec.encodeAttributeAccountMatch(strategy.fundingAttributeMatch),
+                    worksheet_name = strategy.worksheetName,
                     updated_at = now.toEpochMilliseconds(),
                     id = strategy.id.id.toString(),
                 )

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportStrategyWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportStrategyWriteRepositoryImpl.kt
@@ -65,10 +65,18 @@ class CsvImportStrategyWriteRepositoryImpl(
                     cross_source_reconcile_window_seconds = strategy.crossSourceReconcileWindowSeconds,
                     conversion_config_json = FieldMappingJsonCodec.encodeConversionConfig(strategy.conversionConfig),
                     funding_attribute_match_json = FieldMappingJsonCodec.encodeAttributeAccountMatch(strategy.fundingAttributeMatch),
-                    worksheet_name = strategy.worksheetName,
                     updated_at = now.toEpochMilliseconds(),
                     id = strategy.id.id.toString(),
                 )
+                val worksheetName = strategy.worksheetName
+                if (worksheetName != null) {
+                    writeQueries.insertOrReplaceXlsxWorksheet(
+                        csv_import_strategy_id = strategy.id.id.toString(),
+                        worksheet_name = worksheetName,
+                    )
+                } else {
+                    writeQueries.deleteXlsxWorksheet(strategy.id.id.toString())
+                }
                 val persistedRevisionId =
                     selectQueries.selectById(strategy.id.id.toString()).executeAsOne().revision_id
                 writeQueries.insertSource(

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportWriteRepositoryImpl.kt
@@ -36,6 +36,8 @@ class CsvImportWriteRepositoryImpl(
         rows: List<List<String>>,
         fileChecksum: String,
         fileLastModified: Instant,
+        xlsxBytes: ByteArray?,
+        xlsxWorksheetName: String?,
     ): CsvImportId =
         withContext(coroutineContext) {
             database.transactionWithResult {
@@ -66,6 +68,14 @@ class CsvImportWriteRepositoryImpl(
                         import_id = importId.id.toString(),
                         column_index = index.toLong(),
                         original_name = header,
+                    )
+                }
+
+                if (xlsxBytes != null && xlsxWorksheetName != null) {
+                    csvImportWriteQueries.insertXlsxBlob(
+                        csv_import_id = importId.id.toString(),
+                        file_bytes = xlsxBytes,
+                        worksheet_name = xlsxWorksheetName,
                     )
                 }
 

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/CsvImportStrategyInsert.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/CsvImportStrategyInsert.kt
@@ -7,7 +7,8 @@ import com.moneymanager.database.sql.csvImportStrategy.CsvImportStrategyWriteQue
 import com.moneymanager.domain.model.csvstrategy.CsvImportStrategy
 
 /**
- * Inserts a [CsvImportStrategy] row, serialising its config sections to JSON. Shared by the runtime
+ * Inserts a [CsvImportStrategy] row, serialising its config sections to JSON, plus its
+ * `xlsx_import_strategy` satellite row when it targets an Excel worksheet. Shared by the runtime
  * repository (user-created strategies) and the seeder (built-in strategies) so the column/encoder list
  * lives in one place. created_at/updated_at are filled by the table's DEFAULT (current time).
  */
@@ -25,6 +26,11 @@ fun CsvImportStrategyWriteQueries.insertStrategy(strategy: CsvImportStrategy) {
         cross_source_reconcile_window_seconds = strategy.crossSourceReconcileWindowSeconds,
         conversion_config_json = FieldMappingJsonCodec.encodeConversionConfig(strategy.conversionConfig),
         funding_attribute_match_json = FieldMappingJsonCodec.encodeAttributeAccountMatch(strategy.fundingAttributeMatch),
-        worksheet_name = strategy.worksheetName,
     )
+    strategy.worksheetName?.let { worksheetName ->
+        insertOrReplaceXlsxWorksheet(
+            csv_import_strategy_id = strategy.id.id.toString(),
+            worksheet_name = worksheetName,
+        )
+    }
 }

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/CsvImportStrategyInsert.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/CsvImportStrategyInsert.kt
@@ -25,5 +25,6 @@ fun CsvImportStrategyWriteQueries.insertStrategy(strategy: CsvImportStrategy) {
         cross_source_reconcile_window_seconds = strategy.crossSourceReconcileWindowSeconds,
         conversion_config_json = FieldMappingJsonCodec.encodeConversionConfig(strategy.conversionConfig),
         funding_attribute_match_json = FieldMappingJsonCodec.encodeAttributeAccountMatch(strategy.fundingAttributeMatch),
+        worksheet_name = strategy.worksheetName,
     )
 }

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/MoneyManagerDatabaseWrapper.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/MoneyManagerDatabaseWrapper.kt
@@ -369,6 +369,7 @@ class MoneyManagerDatabaseWrapper(
             "csv_import_error",
             "csv_import_metadata",
             "csv_import_strategy",
+            "xlsx_import_blob",
             "transaction_id",
             "source_type",
             "entity_source",

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/MoneyManagerDatabaseWrapper.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/MoneyManagerDatabaseWrapper.kt
@@ -370,6 +370,7 @@ class MoneyManagerDatabaseWrapper(
             "csv_import_metadata",
             "csv_import_strategy",
             "xlsx_import_blob",
+            "xlsx_import_strategy",
             "transaction_id",
             "source_type",
             "entity_source",

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImport/CsvImportWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImport/CsvImportWrite.sq
@@ -26,3 +26,8 @@ VALUES (?, ?, ?, ?);
 
 deleteError:
 DELETE FROM csv_import_error WHERE csv_import_id = ? AND row_index = ?;
+
+-- xlsx_import_blob queries
+insertXlsxBlob:
+INSERT INTO xlsx_import_blob (csv_import_id, file_bytes, worksheet_name)
+VALUES (?, ?, ?);

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategyWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategyWrite.sq
@@ -1,12 +1,12 @@
 -- Insert a new strategy. created_at/updated_at are filled by their column DEFAULTs (current time).
 insert:
-INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json, file_name_pattern, cross_source_reconcile_window_seconds, conversion_config_json, funding_attribute_match_json)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json, file_name_pattern, cross_source_reconcile_window_seconds, conversion_config_json, funding_attribute_match_json, worksheet_name)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- Update an existing strategy
 update:
 UPDATE csv_import_strategy
-SET revision_id = revision_id + 1, name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, content_match_rules_json = ?, file_name_pattern = ?, cross_source_reconcile_window_seconds = ?, conversion_config_json = ?, funding_attribute_match_json = ?, updated_at = ?
+SET revision_id = revision_id + 1, name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, content_match_rules_json = ?, file_name_pattern = ?, cross_source_reconcile_window_seconds = ?, conversion_config_json = ?, funding_attribute_match_json = ?, worksheet_name = ?, updated_at = ?
 WHERE id = ?;
 
 -- Delete a strategy by ID

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategyWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImportStrategy/CsvImportStrategyWrite.sq
@@ -1,12 +1,12 @@
 -- Insert a new strategy. created_at/updated_at are filled by their column DEFAULTs (current time).
 insert:
-INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json, file_name_pattern, cross_source_reconcile_window_seconds, conversion_config_json, funding_attribute_match_json, worksheet_name)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+INSERT INTO csv_import_strategy (id, name, identification_columns_json, field_mappings_json, attribute_mappings_json, row_rules_json, companion_rules_json, content_match_rules_json, file_name_pattern, cross_source_reconcile_window_seconds, conversion_config_json, funding_attribute_match_json)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- Update an existing strategy
 update:
 UPDATE csv_import_strategy
-SET revision_id = revision_id + 1, name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, content_match_rules_json = ?, file_name_pattern = ?, cross_source_reconcile_window_seconds = ?, conversion_config_json = ?, funding_attribute_match_json = ?, worksheet_name = ?, updated_at = ?
+SET revision_id = revision_id + 1, name = ?, identification_columns_json = ?, field_mappings_json = ?, attribute_mappings_json = ?, row_rules_json = ?, companion_rules_json = ?, content_match_rules_json = ?, file_name_pattern = ?, cross_source_reconcile_window_seconds = ?, conversion_config_json = ?, funding_attribute_match_json = ?, updated_at = ?
 WHERE id = ?;
 
 -- Delete a strategy by ID
@@ -16,3 +16,11 @@ DELETE FROM csv_import_strategy WHERE id = ?;
 insertSource:
 INSERT OR IGNORE INTO csv_import_strategy_source (strategy_id, revision_id, source_type_id, device_id)
 VALUES (?, ?, ?, ?);
+
+-- xlsx_import_strategy queries
+insertOrReplaceXlsxWorksheet:
+INSERT OR REPLACE INTO xlsx_import_strategy (csv_import_strategy_id, worksheet_name)
+VALUES (?, ?);
+
+deleteXlsxWorksheet:
+DELETE FROM xlsx_import_strategy WHERE csv_import_strategy_id = ?;

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportConfigIntents.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportConfigIntents.kt
@@ -114,7 +114,35 @@ sealed interface CsvImportMutation {
         // different worksheet is later selected.
         val xlsxBytes: ByteArray? = null,
         val xlsxWorksheetName: String? = null,
-    ) : CsvImportMutation
+    ) : CsvImportMutation {
+        // ByteArray uses reference equality by default; override with structural (contentEquals)
+        // comparison so this mutation compares correctly in tests/state diffing.
+        override fun equals(other: Any?): Boolean =
+            this === other ||
+                (
+                    other is Create &&
+                        key == other.key &&
+                        fileName == other.fileName &&
+                        headers == other.headers &&
+                        rows == other.rows &&
+                        fileChecksum == other.fileChecksum &&
+                        fileLastModified == other.fileLastModified &&
+                        xlsxBytes.contentEquals(other.xlsxBytes) &&
+                        xlsxWorksheetName == other.xlsxWorksheetName
+                )
+
+        override fun hashCode(): Int {
+            var result = key.hashCode()
+            result = 31 * result + fileName.hashCode()
+            result = 31 * result + headers.hashCode()
+            result = 31 * result + rows.hashCode()
+            result = 31 * result + fileChecksum.hashCode()
+            result = 31 * result + fileLastModified.hashCode()
+            result = 31 * result + (xlsxBytes?.contentHashCode() ?: 0)
+            result = 31 * result + (xlsxWorksheetName?.hashCode() ?: 0)
+            return result
+        }
+    }
 
     data class Delete(
         val id: CsvImportId,

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportConfigIntents.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportConfigIntents.kt
@@ -109,6 +109,11 @@ sealed interface CsvImportMutation {
         val rows: List<List<String>>,
         val fileChecksum: String,
         val fileLastModified: Instant,
+        // Non-null only for an Excel import: the raw workbook bytes + the worksheet [headers]/[rows]
+        // were parsed from, stored alongside the staged rows so the sheet can be re-extracted if a
+        // different worksheet is later selected.
+        val xlsxBytes: ByteArray? = null,
+        val xlsxWorksheetName: String? = null,
     ) : CsvImportMutation
 
     data class Delete(

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
@@ -147,6 +147,41 @@ suspend fun ImportEngine.createCsvImport(
         ).createdCsvImportIds[fileName],
     )
 
+/**
+ * Stages an Excel worksheet exactly like [createCsvImport], additionally storing the raw workbook
+ * [xlsxBytes] and the [xlsxWorksheetName] [headers]/[rows] were parsed from, so the sheet can be
+ * re-extracted later if a different worksheet is selected. The caller (JVM-side, via the injected
+ * `XlsxParser`) has already parsed the sheet into the same headers/rows shape a CSV file would produce.
+ */
+suspend fun ImportEngine.createXlsxImport(
+    fileName: String,
+    headers: List<String>,
+    rows: List<List<String>>,
+    fileChecksum: String,
+    fileLastModified: Instant,
+    xlsxBytes: ByteArray,
+    xlsxWorksheetName: String,
+): CsvImportId =
+    requireNotNull(
+        import(
+            ImportBatch(
+                csvImportMutations =
+                    listOf(
+                        CsvImportMutation.Create(
+                            fileName,
+                            fileName,
+                            headers,
+                            rows,
+                            fileChecksum,
+                            fileLastModified,
+                            xlsxBytes,
+                            xlsxWorksheetName,
+                        ),
+                    ),
+            ),
+        ).createdCsvImportIds[fileName],
+    )
+
 suspend fun ImportEngine.deleteCsvImport(id: CsvImportId) {
     import(ImportBatch(csvImportMutations = listOf(CsvImportMutation.Delete(id))))
 }

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -1568,7 +1568,15 @@ class ImportEngineImpl(
                 is CsvImportMutation.Create ->
                     csvImportIds.putUnique(
                         m.key,
-                        csvImportRepository.createImport(m.fileName, m.headers, m.rows, m.fileChecksum, m.fileLastModified),
+                        csvImportRepository.createImport(
+                            m.fileName,
+                            m.headers,
+                            m.rows,
+                            m.fileChecksum,
+                            m.fileLastModified,
+                            m.xlsxBytes,
+                            m.xlsxWorksheetName,
+                        ),
                         "CsvImport",
                     )
                 is CsvImportMutation.Delete -> csvImportRepository.deleteImport(m.id)

--- a/app/model/csv/src/commonMain/kotlin/com/moneymanager/domain/model/csv/XlsxImportBlob.kt
+++ b/app/model/csv/src/commonMain/kotlin/com/moneymanager/domain/model/csv/XlsxImportBlob.kt
@@ -1,0 +1,21 @@
+package com.moneymanager.domain.model.csv
+
+/**
+ * The raw bytes of an Excel workbook staged as a [CsvImport], kept alongside its staged rows so the
+ * worksheet can be re-extracted if the matched strategy names a different sheet than the one initially
+ * staged. Absent for CSV/QIF imports.
+ */
+data class XlsxImportBlob(
+    val fileBytes: ByteArray,
+    val worksheetName: String,
+) {
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            (
+                other is XlsxImportBlob &&
+                    fileBytes.contentEquals(other.fileBytes) &&
+                    worksheetName == other.worksheetName
+            )
+
+    override fun hashCode(): Int = 31 * fileBytes.contentHashCode() + worksheetName.hashCode()
+}

--- a/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategy.kt
+++ b/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/CsvImportStrategy.kt
@@ -75,6 +75,11 @@ data class AttributeAccountMatch(
  *                             against an unconsumed funding leg into the row's source account (same
  *                             amount+currency within [crossSourceReconcileWindowSeconds]), ignoring the
  *                             merchant. Null disables funding reconciliation.
+ * @property worksheetName When set, this strategy targets an Excel worksheet by this name rather than a
+ *                          CSV file (like QIF, an XLSX strategy is an ordinary [CsvImportStrategy] that
+ *                          rides the CSV engine — see [isXlsxStrategy]). The named worksheet's first row
+ *                          is treated as headers and the rest as data, exactly like a CSV. Null for CSV
+ *                          and QIF strategies.
  * @property createdAt Timestamp when this strategy was created
  * @property updatedAt Timestamp when this strategy was last modified
  */
@@ -91,6 +96,7 @@ data class CsvImportStrategy(
     val crossSourceReconcileWindowSeconds: Long? = null,
     val conversionConfig: ConversionConfig? = null,
     val fundingAttributeMatch: AttributeAccountMatch? = null,
+    val worksheetName: String? = null,
     val createdAt: Instant,
     val updatedAt: Instant,
 ) {

--- a/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/XlsxStrategyClassification.kt
+++ b/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/XlsxStrategyClassification.kt
@@ -1,0 +1,8 @@
+package com.moneymanager.domain.model.csvstrategy
+
+/**
+ * Whether this strategy targets an Excel worksheet rather than a CSV file. Like QIF, an XLSX strategy
+ * is an ordinary [CsvImportStrategy] row (it rides the CSV engine); [worksheetName] being set is the
+ * only signal, since it has no meaning for a real CSV/QIF strategy.
+ */
+fun CsvImportStrategy.isXlsxStrategy(): Boolean = worksheetName != null

--- a/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExport.kt
+++ b/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExport.kt
@@ -43,6 +43,8 @@ import kotlinx.serialization.Serializable
  * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.conversionConfig])
  * @property fundingAttributeMatch Attribute-based funding-account match (already portable, no IDs)
  * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.fundingAttributeMatch])
+ * @property worksheetName When set, this is an Excel strategy targeting this worksheet
+ * (see [com.moneymanager.domain.model.csvstrategy.CsvImportStrategy.worksheetName])
  */
 @Serializable
 data class CsvStrategyExport(
@@ -75,6 +77,10 @@ data class CsvStrategyExport(
     // strategies changed" on catalog/Drive sync. See StrategyArtifactCodec.canonicalHash.
     @EncodeDefault(EncodeDefault.Mode.NEVER)
     val fundingAttributeMatch: AttributeAccountMatch? = null,
+    // Same NEVER-encode rationale as fundingAttributeMatch above: only strategies that actually set a
+    // worksheet name (XLSX strategies) rehash when this field is added.
+    @EncodeDefault(EncodeDefault.Mode.NEVER)
+    val worksheetName: String? = null,
 )
 
 /**

--- a/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExportMapper.kt
+++ b/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/model/csvstrategy/export/CsvStrategyExportMapper.kt
@@ -51,6 +51,7 @@ object CsvStrategyExportMapper {
             crossSourceReconcileWindowSeconds = strategy.crossSourceReconcileWindowSeconds,
             conversionConfig = strategy.conversionConfig,
             fundingAttributeMatch = strategy.fundingAttributeMatch,
+            worksheetName = strategy.worksheetName,
         )
 
     private fun FieldMapping.toExport(

--- a/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/strategy/StrategyLibrary.kt
+++ b/app/model/csvstrategy/src/commonMain/kotlin/com/moneymanager/domain/strategy/StrategyLibrary.kt
@@ -4,14 +4,15 @@ import com.moneymanager.domain.model.AppVersion
 
 /**
  * The kinds of strategy artifact stored in the shared library, one file per artifact on the remote.
- * CSV and QIF are both `csv_import_strategy` rows (QIF rides the CSV engine); they are separated here
- * only so the filename suffix records which kind a file is. [GLOBAL_MAPPINGS] is the single combined
- * file holding all global account mappings. [PASS_THROUGH] is one pass-through (conduit) account
- * definition per file.
+ * CSV, QIF and XLSX are all `csv_import_strategy` rows (QIF and XLSX both ride the CSV engine); they
+ * are separated here only so the filename suffix records which kind a file is. [GLOBAL_MAPPINGS] is
+ * the single combined file holding all global account mappings. [PASS_THROUGH] is one pass-through
+ * (conduit) account definition per file.
  */
 enum class StrategyKind {
     CSV,
     QIF,
+    XLSX,
     API,
     GLOBAL_MAPPINGS,
     PASS_THROUGH,
@@ -51,6 +52,7 @@ object StrategyFileNaming {
     private const val SUFFIX = ".json"
     private const val CSV_INFIX = ".csv"
     private const val QIF_INFIX = ".qif"
+    private const val XLSX_INFIX = ".xlsx"
     private const val API_INFIX = ".api"
     private const val PASS_THROUGH_INFIX = ".passthrough"
 
@@ -58,6 +60,7 @@ object StrategyFileNaming {
         when (key.kind) {
             StrategyKind.CSV -> "${key.name}$CSV_INFIX$SUFFIX"
             StrategyKind.QIF -> "${key.name}$QIF_INFIX$SUFFIX"
+            StrategyKind.XLSX -> "${key.name}$XLSX_INFIX$SUFFIX"
             StrategyKind.API -> "${key.name}$API_INFIX$SUFFIX"
             StrategyKind.GLOBAL_MAPPINGS -> "$GLOBAL_MAPPINGS_NAME$SUFFIX"
             StrategyKind.PASS_THROUGH -> "${key.name}$PASS_THROUGH_INFIX$SUFFIX"
@@ -71,6 +74,7 @@ object StrategyFileNaming {
             return StrategyKey(StrategyKind.GLOBAL_MAPPINGS, GLOBAL_MAPPINGS_NAME)
         }
         return when {
+            stem.endsWith(XLSX_INFIX) -> StrategyKey(StrategyKind.XLSX, stem.removeSuffix(XLSX_INFIX))
             stem.endsWith(CSV_INFIX) -> StrategyKey(StrategyKind.CSV, stem.removeSuffix(CSV_INFIX))
             stem.endsWith(QIF_INFIX) -> StrategyKey(StrategyKind.QIF, stem.removeSuffix(QIF_INFIX))
             stem.endsWith(API_INFIX) -> StrategyKey(StrategyKind.API, stem.removeSuffix(API_INFIX))

--- a/app/model/repository/read/src/commonMain/kotlin/com/moneymanager/domain/repository/CsvImportReadRepository.kt
+++ b/app/model/repository/read/src/commonMain/kotlin/com/moneymanager/domain/repository/CsvImportReadRepository.kt
@@ -6,6 +6,7 @@ import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.CsvImportId
 import com.moneymanager.domain.model.csv.CsvImport
 import com.moneymanager.domain.model.csv.CsvRow
+import com.moneymanager.domain.model.csv.XlsxImportBlob
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.ExperimentalTime
 
@@ -47,4 +48,7 @@ interface CsvImportReadRepository {
      * @return List of matching imports, ordered by timestamp descending
      */
     suspend fun findImportsByChecksum(checksum: String): List<CsvImport>
+
+    /** The raw workbook bytes for an Excel-backed import, or null for a CSV/QIF import. */
+    suspend fun getXlsxBlob(id: CsvImportId): XlsxImportBlob?
 }

--- a/app/model/repository/write/src/commonMain/kotlin/com/moneymanager/domain/repository/write/CsvImportWriteRepository.kt
+++ b/app/model/repository/write/src/commonMain/kotlin/com/moneymanager/domain/repository/write/CsvImportWriteRepository.kt
@@ -11,8 +11,10 @@ import kotlin.time.Instant
 
 interface CsvImportWriteRepository : CsvImportReadRepository {
     /**
-     * Creates a new CSV import from parsed data.
-     * Creates the metadata, column definitions, and dynamic table with data.
+     * Creates a new CSV (or Excel) import from parsed data. Creates the metadata, column definitions,
+     * and dynamic table with data. When [xlsxBytes] is non-null, also stores the raw workbook bytes
+     * (and the worksheet they were parsed from) so the sheet can be re-extracted later if a different
+     * worksheet is chosen.
      *
      * @param fileName The original file name
      * @param headers The column headers
@@ -25,6 +27,8 @@ interface CsvImportWriteRepository : CsvImportReadRepository {
         rows: List<List<String>>,
         fileChecksum: String,
         fileLastModified: Instant,
+        xlsxBytes: ByteArray? = null,
+        xlsxWorksheetName: String? = null,
     ): CsvImportId
 
     /**

--- a/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
+++ b/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
@@ -59,8 +59,12 @@ object BuiltInCsvStrategies {
      * `Card Acceptor Name` field (e.g. `"Spotify UK               Stockholm      SWE"` ->
      * `"Spotify UK"`, `"CRV*Card verification    London         GBR"` -> `"CRV*Card verification"`),
      * while leaving any leading marker (like "CRV*") untouched for [BuiltInPassThroughs] to detect.
+     * Anchors on the first non-space character (`\s*(\S.*?)`) rather than a bare lazy `(.+?)`: for a
+     * value that's pure padding + a trailing country code (e.g. "                    GBR", no real
+     * merchant name), a bare `(.+?)` backtracks to a single leading space instead of skipping to "GBR",
+     * producing a blank/whitespace-only description.
      */
-    private const val CARD_ACCEPTOR_NAME_TRIM_PATTERN = "^(.+?)(?:\\s{2,}.*)?$"
+    private const val CARD_ACCEPTOR_NAME_TRIM_PATTERN = "^\\s*(\\S.*?)(?:\\s{2,}.*)?$"
 
     /**
      * The Crypto.com Exchange account (also created by the Exchange API strategy). Routing the App's

--- a/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
+++ b/app/strategies/src/commonMain/kotlin/com/moneymanager/builtin/BuiltInCsvStrategies.kt
@@ -45,6 +45,7 @@ object BuiltInCsvStrategies {
     val cryptoComFiatStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-000000000008")
     val cryptoComCryptoStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-000000000009")
     val curveCsvStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-00000000000a")
+    val cryptoComCardXlsxStrategyId: Uuid = Uuid.parse("00000000-0000-0000-0000-00000000000b")
 
     /** Fixed account names shared by the crypto.com Card and Fiat strategies, so both files resolve the same accounts. */
     private const val CRYPTO_COM_CARD_ACCOUNT = "Crypto.com Card"
@@ -52,6 +53,14 @@ object BuiltInCsvStrategies {
 
     /** Single account that holds every crypto.com crypto balance (one per-asset balance, not per account). */
     private const val CRYPTO_COM_CRYPTO_ACCOUNT = "Crypto.com"
+
+    /**
+     * Trims the trailing city/country padding from the xlsx card export's fixed-width
+     * `Card Acceptor Name` field (e.g. `"Spotify UK               Stockholm      SWE"` ->
+     * `"Spotify UK"`, `"CRV*Card verification    London         GBR"` -> `"CRV*Card verification"`),
+     * while leaving any leading marker (like "CRV*") untouched for [BuiltInPassThroughs] to detect.
+     */
+    private const val CARD_ACCEPTOR_NAME_TRIM_PATTERN = "^(.+?)(?:\\s{2,}.*)?$"
 
     /**
      * The Crypto.com Exchange account (also created by the Exchange API strategy). Routing the App's
@@ -127,6 +136,8 @@ object BuiltInCsvStrategies {
 
     private fun curveCsvMappingId(index: Int): FieldMappingId = builtInCsvMappingId(strategyGroup = 8, index = index)
 
+    private fun cryptoComCardXlsxMappingId(index: Int): FieldMappingId = builtInCsvMappingId(strategyGroup = 9, index = index)
+
     /**
      * All built-in CSV import strategies seeded into a fresh database. [qifCurrencyId] is the fixed
      * currency the QIF strategies carry (the default the QIF import dialog pre-selects); it is resolved
@@ -145,6 +156,7 @@ object BuiltInCsvStrategies {
             buildCryptoComFiatStrategy(now),
             buildCryptoComCryptoStrategy(now),
             buildCurveCsvStrategy(now),
+            buildCryptoComCardXlsxStrategy(now),
         )
 
     /**
@@ -259,6 +271,151 @@ object BuiltInCsvStrategies {
             contentMatchRules = listOf(ContentMatchRule(columnName = "Transaction Kind", pattern = "^$")),
             fileNamePattern = "^card_transactions_record_",
             crossSourceReconcileWindowSeconds = CRYPTO_COM_RECONCILE_WINDOW_SECONDS,
+            createdAt = now,
+            updatedAt = now,
+        )
+    }
+
+    /**
+     * Built-in strategy for crypto.com's older "Card Transaction History" Excel export (an .xlsx
+     * workbook of the same Visa card, before crypto.com switched to the card_transactions_record_*.csv
+     * format above — same source account, entirely different columns and header names). Every row's
+     * `Amount Processed` is already signed (negative = spend, positive = card load/refund), so no
+     * per-row direction logic is needed beyond the standard positive-amount source/target flip.
+     *
+     * v1 limitation: multi-currency FX rows (Service Abbreviation "POS Sig Pur Multi Curr" etc.) are
+     * imported using `Amount Processed`/`Currency ` as-is (the settlement currency), not the original
+     * `Amount Requested` foreign-currency amount — a future refinement could split these into a trade.
+     */
+    fun buildCryptoComCardXlsxStrategy(now: Instant): CsvImportStrategy {
+        val fieldMappings =
+            mapOf(
+                // Fixed-name source so this strategy resolves the same Card account as the CSV
+                // strategy above (both are exports of the same physical card).
+                TransferField.SOURCE_ACCOUNT to
+                    RegexAccountMapping(
+                        id = cryptoComCardXlsxMappingId(1),
+                        fieldType = TransferField.SOURCE_ACCOUNT,
+                        columnName = "Service Abbreviation",
+                        rules = listOf(RegexRule(pattern = "^", accountName = CRYPTO_COM_CARD_ACCOUNT)),
+                    ),
+                TransferField.TARGET_ACCOUNT to
+                    // Rows with no card acceptor name at all ("Batch Credit Funds Transfer", "Balance
+                    // transfer", …) are account-level credits, not merchant purchases — a raw AccountLookup
+                    // would fail to resolve an empty name and error the row, so route them to Cash first.
+                    ConditionalAccountMapping(
+                        id = cryptoComCardXlsxMappingId(10),
+                        fieldType = TransferField.TARGET_ACCOUNT,
+                        conditions = listOf(RowCondition("Card Acceptor Name", RowConditionOperator.IS_BLANK)),
+                        whenTrue =
+                            RegexAccountMapping(
+                                id = cryptoComCardXlsxMappingId(11),
+                                fieldType = TransferField.TARGET_ACCOUNT,
+                                columnName = "Service Abbreviation",
+                                rules = listOf(RegexRule(pattern = "^", accountName = CRYPTO_COM_CASH_ACCOUNT)),
+                            ),
+                        whenFalse =
+                            ConditionalAccountMapping(
+                                id = cryptoComCardXlsxMappingId(2),
+                                fieldType = TransferField.TARGET_ACCOUNT,
+                                conditions =
+                                    listOf(
+                                        RowCondition("Service Abbreviation", RowConditionOperator.EQUALS_VALUE, value = "LdExtDbCr"),
+                                    ),
+                                // Card loads ("GBP/200.0-Card Load") come from the Cash account.
+                                whenTrue =
+                                    RegexAccountMapping(
+                                        id = cryptoComCardXlsxMappingId(3),
+                                        fieldType = TransferField.TARGET_ACCOUNT,
+                                        columnName = "Service Abbreviation",
+                                        rules = listOf(RegexRule(pattern = "^", accountName = CRYPTO_COM_CASH_ACCOUNT)),
+                                    ),
+                                // Everything else looks up/creates a merchant account from the card acceptor
+                                // name, stripped of its trailing city/country padding (the field is
+                                // fixed-width, e.g. "Spotify UK               Stockholm      SWE") via the
+                                // same trim regex as DESCRIPTION below, so "CRV*" pass-through rows still
+                                // resolve to the conduit instead of a raw junk account (pass-through
+                                // detection matches on DESCRIPTION, so both mappings must derive from the
+                                // same trimmed text).
+                                whenFalse =
+                                    RegexAccountMapping(
+                                        id = cryptoComCardXlsxMappingId(4),
+                                        fieldType = TransferField.TARGET_ACCOUNT,
+                                        columnName = "Card Acceptor Name",
+                                        rules =
+                                            listOf(
+                                                RegexRule(
+                                                    pattern = CARD_ACCEPTOR_NAME_TRIM_PATTERN,
+                                                    accountName = "Unknown Merchant",
+                                                    accountNameTemplate = "$1",
+                                                ),
+                                            ),
+                                    ),
+                            ),
+                    ),
+                TransferField.TIMESTAMP to
+                    DateTimeParsingMapping(
+                        id = cryptoComCardXlsxMappingId(5),
+                        fieldType = TransferField.TIMESTAMP,
+                        dateColumnName = "Transaction Date",
+                        dateFormat = "MM/dd/yyyy",
+                        timeColumnName = "Transaction Time",
+                        timeFormat = "HH:mm:ss",
+                    ),
+                // Card Acceptor Name (not the near-constant Description column) carries the real
+                // merchant/CRV* marker; pass-through detection ([PassThroughDetector]) matches against
+                // this field, so it must be the source here, trimmed of trailing city/country padding
+                // but with any "CRV*" prefix left intact for the detector to peel.
+                TransferField.DESCRIPTION to
+                    DirectColumnMapping(
+                        id = cryptoComCardXlsxMappingId(6),
+                        fieldType = TransferField.DESCRIPTION,
+                        columnName = "Card Acceptor Name",
+                        fallbackColumns = listOf("Description"),
+                        extraction = ColumnExtraction(pattern = CARD_ACCEPTOR_NAME_TRIM_PATTERN, outputTemplate = "$1"),
+                    ),
+                // Already signed: negative = spend, positive (loads/refunds) flows in, so flip.
+                TransferField.AMOUNT to
+                    AmountParsingMapping(
+                        id = cryptoComCardXlsxMappingId(7),
+                        fieldType = TransferField.AMOUNT,
+                        mode = AmountMode.SINGLE_COLUMN,
+                        amountColumnName = "Amount Processed",
+                        flipAccountsOnPositive = true,
+                    ),
+                // Column header has a trailing space in the source workbook.
+                TransferField.CURRENCY to
+                    CurrencyLookupMapping(
+                        id = cryptoComCardXlsxMappingId(8),
+                        fieldType = TransferField.CURRENCY,
+                        columnName = "Currency ",
+                    ),
+                TransferField.TIMEZONE to
+                    HardCodedTimezoneMapping(
+                        id = cryptoComCardXlsxMappingId(9),
+                        fieldType = TransferField.TIMEZONE,
+                        timezoneId = "UTC",
+                    ),
+            )
+        return CsvImportStrategy(
+            id = CsvImportStrategyId(cryptoComCardXlsxStrategyId),
+            name = "Crypto.com Card (Excel)",
+            identificationColumns =
+                setOf(
+                    "Transaction Date",
+                    "Transaction Time",
+                    "Service Abbreviation",
+                    "Card Acceptor Name",
+                    "Description",
+                    "Merchant Category Code",
+                    "Amount Processed",
+                    "Available Balance",
+                    "Currency ",
+                    "Amount Requested",
+                ),
+            fieldMappings = fieldMappings,
+            fileNamePattern = "Card Transaction History",
+            worksheetName = "Sheet1",
             createdAt = now,
             updatedAt = now,
         )

--- a/app/ui/categories/build.gradle.kts
+++ b/app/ui/categories/build.gradle.kts
@@ -71,6 +71,7 @@ kotlin {
             dependencies {
                 implementation(projects.app.model.accountmapping)
                 implementation(projects.app.model.apistrategy)
+                implementation(projects.app.model.csv)
                 implementation(projects.app.model.csvstrategy)
                 implementation(projects.app.model.importdirectory)
                 implementation(projects.app.model.passthrough)
@@ -86,6 +87,7 @@ kotlin {
                 implementation(projects.app.importer)
                 implementation(projects.app.model.accountmapping)
                 implementation(projects.app.model.apistrategy)
+                implementation(projects.app.model.csv)
                 implementation(projects.app.model.csvstrategy)
                 implementation(projects.app.model.importdirectory)
                 implementation(projects.app.model.passthrough)
@@ -99,6 +101,7 @@ kotlin {
             dependencies {
                 implementation(projects.app.model.accountmapping)
                 implementation(projects.app.model.apistrategy)
+                implementation(projects.app.model.csv)
                 implementation(projects.app.model.csvstrategy)
                 implementation(projects.app.model.importdirectory)
                 implementation(projects.app.model.passthrough)

--- a/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/util/Sha256.kt
+++ b/app/ui/foundation/src/commonMain/kotlin/com/moneymanager/ui/util/Sha256.kt
@@ -1,3 +1,6 @@
 package com.moneymanager.ui.util
 
 expect fun sha256Hex(input: String): String
+
+/** Hex-encoded SHA-256 of raw [bytes] (binary files, e.g. `.xlsx`, that can't be checksummed as text). */
+expect fun sha256Hex(bytes: ByteArray): String

--- a/app/ui/foundation/src/jvmAndroidMain/kotlin/com/moneymanager/ui/util/Sha256.jvmAndroid.kt
+++ b/app/ui/foundation/src/jvmAndroidMain/kotlin/com/moneymanager/ui/util/Sha256.jvmAndroid.kt
@@ -2,9 +2,11 @@ package com.moneymanager.ui.util
 
 import java.security.MessageDigest
 
-actual fun sha256Hex(input: String): String {
+actual fun sha256Hex(input: String): String = sha256Hex(input.toByteArray(Charsets.UTF_8))
+
+actual fun sha256Hex(bytes: ByteArray): String {
     val digest = MessageDigest.getInstance("SHA-256")
-    return digest.digest(input.toByteArray(Charsets.UTF_8)).toHexString()
+    return digest.digest(bytes).toHexString()
 }
 
 private fun ByteArray.toHexString(): String = joinToString("") { byte -> "%02x".format(byte) }

--- a/app/ui/imports/csv/build.gradle.kts
+++ b/app/ui/imports/csv/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
                 implementation(projects.utils.compose.filePicker)
                 implementation(projects.utils.compose.scrollbar)
                 implementation(projects.utils.parsers.csv)
+                implementation(projects.utils.parsers.xlsx)
                 implementation(libs.human.readable)
                 implementation(libs.kmlogging)
                 implementation(libs.kotlinx.coroutines.core)

--- a/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportsScreen.kt
+++ b/app/ui/imports/csv/src/commonMain/kotlin/com/moneymanager/ui/screens/csv/CsvImportsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.moneymanager.compose.filepicker.rememberBinaryFilePicker
 import com.moneymanager.compose.filepicker.rememberMultipleFilePicker
 import com.moneymanager.csv.CsvParseOptions
 import com.moneymanager.csv.CsvParser
@@ -56,6 +57,7 @@ import com.moneymanager.domain.repository.TransferRelationshipReadRepository
 import com.moneymanager.domain.repository.TransferSourceReadRepository
 import com.moneymanager.importengineapi.ImportEngine
 import com.moneymanager.importengineapi.createCsvImport
+import com.moneymanager.importengineapi.createXlsxImport
 import com.moneymanager.importengineapi.setCsvImportIgnored
 import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -64,6 +66,7 @@ import com.moneymanager.ui.screens.csv.CsvReimportAllDialog
 import com.moneymanager.ui.util.displayDate
 import com.moneymanager.ui.util.displayDateTime
 import com.moneymanager.ui.util.sha256Hex
+import com.moneymanager.xlsx.createXlsxParser
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
@@ -155,6 +158,44 @@ fun CsvImportsScreen(
             }
         }
 
+    val xlsxFilePicker =
+        rememberBinaryFilePicker(
+            mimeTypes = listOf("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+        ) { result ->
+            if (result != null) {
+                isImporting = true
+                importMessage = null
+                scope.launch {
+                    importMessageIsError = false
+                    importMessage =
+                        try {
+                            val checksum = sha256Hex(result.bytes)
+                            if (csvImportRepository.findImportsByChecksum(checksum).isNotEmpty()) {
+                                "Skipped ${result.fileName}: already imported"
+                            } else {
+                                val parser = createXlsxParser()
+                                val sheetName = parser.sheetNames(result.bytes).firstOrNull() ?: ""
+                                val parsed = parser.parse(result.bytes, sheetName)
+                                importEngine.createXlsxImport(
+                                    fileName = result.fileName,
+                                    headers = parsed.headers,
+                                    rows = parsed.rows,
+                                    fileChecksum = checksum,
+                                    fileLastModified = result.lastModified ?: Clock.System.now(),
+                                    xlsxBytes = result.bytes,
+                                    xlsxWorksheetName = sheetName,
+                                )
+                                "Imported ${result.fileName}"
+                            }
+                        } catch (expected: Exception) {
+                            importMessageIsError = true
+                            "${result.fileName}: ${expected.message}"
+                        }
+                    isImporting = false
+                }
+            }
+        }
+
     Column(
         modifier =
             Modifier
@@ -189,6 +230,12 @@ fun CsvImportsScreen(
                     } else {
                         Text("+ Import CSV")
                     }
+                }
+                TextButton(
+                    onClick = { xlsxFilePicker.launch() },
+                    enabled = !isImporting,
+                ) {
+                    Text("+ Import Excel")
                 }
             }
         }

--- a/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/settings/StrategyCatalogScreen.kt
+++ b/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/settings/StrategyCatalogScreen.kt
@@ -367,6 +367,7 @@ private val kindFilterChips =
     listOf(
         StrategyKind.CSV to "CSV",
         StrategyKind.QIF to "QIF",
+        StrategyKind.XLSX to "Excel",
         StrategyKind.API to "API",
         StrategyKind.PASS_THROUGH to "Pass-through",
     )
@@ -375,6 +376,7 @@ private fun StrategyKind.displayName(): String =
     when (this) {
         StrategyKind.CSV -> "CSV import strategy"
         StrategyKind.QIF -> "QIF import strategy"
+        StrategyKind.XLSX -> "Excel import strategy"
         StrategyKind.API -> "API import strategy"
         StrategyKind.PASS_THROUGH -> "Pass-through definition"
         StrategyKind.GLOBAL_MAPPINGS -> "Global account mappings"

--- a/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/settings/StrategyCloudCard.kt
+++ b/app/ui/settings/src/commonMain/kotlin/com/moneymanager/ui/screens/settings/StrategyCloudCard.kt
@@ -423,6 +423,7 @@ private fun StrategyKey.displayLabel(): String =
         StrategyKind.GLOBAL_MAPPINGS -> "Global account mappings"
         StrategyKind.CSV -> "$name (CSV)"
         StrategyKind.QIF -> "$name (QIF)"
+        StrategyKind.XLSX -> "$name (Excel)"
         StrategyKind.API -> "$name (API)"
         StrategyKind.PASS_THROUGH -> "$name (Pass-through)"
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ ktor = "3.5.1"
 log4j = "2.26.1"
 mappie = "2.4.0-2.4.1"
 module-graph = "0.13.0"
+poi = "5.5.1"
 proguard = "7.8.2"
 metro = "1.3.2"
 mokkery = "3.4.2"
@@ -168,6 +169,8 @@ kover-gradle-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", ve
 ktlint-gradle-plugin = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint" }
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+poi = { module = "org.apache.poi:poi", version.ref = "poi" }
+poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "poi" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -169,8 +169,6 @@ kover-gradle-plugin = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", ve
 ktlint-gradle-plugin = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint" }
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
-poi = { module = "org.apache.poi:poi", version.ref = "poi" }
-poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "poi" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
@@ -183,6 +181,8 @@ metro-gradle-plugin = { module = "dev.zacsweers.metro:dev.zacsweers.metro.gradle
 metro-runtime = { module = "dev.zacsweers.metro:runtime", version.ref = "metro" }
 mokkery-core = { module = "dev.mokkery:mokkery-core", version.ref = "mokkery" }
 mokkery-runtime = { module = "dev.mokkery:mokkery-runtime", version.ref = "mokkery" }
+poi = { module = "org.apache.poi:poi", version.ref = "poi" }
+poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "poi" }
 schemaspy = { module = "org.schemaspy:schemaspy", version.ref = "schemaspy" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 sort-dependencies-gradle-plugin = { module = "com.squareup.sort-dependencies:com.squareup.sort-dependencies.gradle.plugin", version.ref = "sort-dependencies" }

--- a/tools/strategy-catalog/src/main/kotlin/com/moneymanager/tools/strategycatalog/StrategyCatalogTool.kt
+++ b/tools/strategy-catalog/src/main/kotlin/com/moneymanager/tools/strategycatalog/StrategyCatalogTool.kt
@@ -13,6 +13,7 @@ import com.moneymanager.domain.model.CurrencyId
 import com.moneymanager.domain.model.apistrategy.export.ApiStrategyExportMapper
 import com.moneymanager.domain.model.csvstrategy.export.CsvStrategyExportMapper
 import com.moneymanager.domain.model.csvstrategy.isQifStrategy
+import com.moneymanager.domain.model.csvstrategy.isXlsxStrategy
 import com.moneymanager.domain.model.passthrough.PassThroughAccount
 import com.moneymanager.domain.model.passthrough.export.PassThroughExport
 import com.moneymanager.domain.strategy.StrategyFileNaming
@@ -56,7 +57,12 @@ internal fun builtInArtifacts(): Map<StrategyKey, String> {
                 currencyCodeById = { id -> GBP_CURRENCY_CODE.takeIf { id == GBP_CURRENCY_ID } },
                 categoryNameById = { null },
             )
-        val kind = if (strategy.isQifStrategy()) StrategyKind.QIF else StrategyKind.CSV
+        val kind =
+            when {
+                strategy.isQifStrategy() -> StrategyKind.QIF
+                strategy.isXlsxStrategy() -> StrategyKind.XLSX
+                else -> StrategyKind.CSV
+            }
         artifacts[StrategyKey(kind, strategy.name)] = CsvStrategyExportCodec.encode(export)
     }
 

--- a/tools/strategy-catalog/src/test/kotlin/com/moneymanager/tools/strategycatalog/StrategyCatalogToolTest.kt
+++ b/tools/strategy-catalog/src/test/kotlin/com/moneymanager/tools/strategycatalog/StrategyCatalogToolTest.kt
@@ -48,7 +48,7 @@ class StrategyCatalogToolTest {
     @Test
     fun `the catalog covers all built-in kinds`() {
         val kinds = builtInArtifacts().keys.map { it.kind }.toSet()
-        assertEquals(setOf(StrategyKind.CSV, StrategyKind.QIF, StrategyKind.API, StrategyKind.PASS_THROUGH), kinds)
+        assertEquals(setOf(StrategyKind.CSV, StrategyKind.QIF, StrategyKind.XLSX, StrategyKind.API, StrategyKind.PASS_THROUGH), kinds)
     }
 
     @Test

--- a/utils/compose/filePicker/src/androidMain/kotlin/com/moneymanager/compose/filepicker/FilePicker.kt
+++ b/utils/compose/filePicker/src/androidMain/kotlin/com/moneymanager/compose/filepicker/FilePicker.kt
@@ -65,6 +65,28 @@ actual fun rememberMultipleFilePicker(
     }
 }
 
+@Composable
+actual fun rememberBinaryFilePicker(
+    mimeTypes: List<String>,
+    onResult: (BinaryFilePickerResult?) -> Unit,
+): BinaryFilePickerLauncher {
+    val context = LocalContext.current
+
+    val launcher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.OpenDocument(),
+        ) { uri: Uri? ->
+            onResult(uri?.let { readBinaryFileContent(context, it) })
+        }
+
+    return remember(launcher, mimeTypes) {
+        BinaryFilePickerLauncher(
+            mimeTypes = mimeTypes.toTypedArray(),
+            launcher = { types -> launcher.launch(types) },
+        )
+    }
+}
+
 private fun readFileContent(
     context: Context,
     uri: Uri,
@@ -75,6 +97,21 @@ private fun readFileContent(
         val inputStream = context.contentResolver.openInputStream(uri) ?: return null
         val content = readStreamAsString(inputStream)
         FilePickerResult(fileName = fileName, content = content, lastModified = lastModified)
+    } catch (_: Exception) {
+        null
+    }
+}
+
+private fun readBinaryFileContent(
+    context: Context,
+    uri: Uri,
+): BinaryFilePickerResult? {
+    return try {
+        val fileName = getFileName(context, uri) ?: "unknown.xlsx"
+        val lastModified = getLastModified(context, uri)
+        val inputStream = context.contentResolver.openInputStream(uri) ?: return null
+        val bytes = inputStream.use { it.readBytes() }
+        BinaryFilePickerResult(fileName = fileName, bytes = bytes, lastModified = lastModified)
     } catch (_: Exception) {
         null
     }

--- a/utils/compose/filePicker/src/androidMain/kotlin/com/moneymanager/compose/filepicker/FilePickerLauncher.kt
+++ b/utils/compose/filePicker/src/androidMain/kotlin/com/moneymanager/compose/filepicker/FilePickerLauncher.kt
@@ -17,3 +17,12 @@ actual class MultipleFilePickerLauncher(
         launcher(mimeTypes)
     }
 }
+
+actual class BinaryFilePickerLauncher(
+    private val mimeTypes: Array<String>,
+    private val launcher: (Array<String>) -> Unit,
+) {
+    actual fun launch() {
+        launcher(mimeTypes)
+    }
+}

--- a/utils/compose/filePicker/src/commonMain/kotlin/com/moneymanager/compose/filepicker/FilePicker.kt
+++ b/utils/compose/filePicker/src/commonMain/kotlin/com/moneymanager/compose/filepicker/FilePicker.kt
@@ -31,3 +31,17 @@ expect fun rememberMultipleFilePicker(
 expect class MultipleFilePickerLauncher {
     fun launch()
 }
+
+/**
+ * Creates and remembers a file picker launcher that reads the selection as raw bytes rather than text
+ * (e.g. `.xlsx`, where decoding as UTF-8 like [rememberFilePicker] would corrupt the file).
+ *
+ * @param mimeTypes List of MIME types to filter files
+ * @param onResult Callback invoked with the selected file result, or null if cancelled
+ * @return A launcher that can be used to open the file picker dialog
+ */
+@Composable
+expect fun rememberBinaryFilePicker(
+    mimeTypes: List<String>,
+    onResult: (BinaryFilePickerResult?) -> Unit,
+): BinaryFilePickerLauncher

--- a/utils/compose/filePicker/src/commonMain/kotlin/com/moneymanager/compose/filepicker/FilePickerLauncher.kt
+++ b/utils/compose/filePicker/src/commonMain/kotlin/com/moneymanager/compose/filepicker/FilePickerLauncher.kt
@@ -9,3 +9,11 @@ expect class FilePickerLauncher {
      */
     fun launch()
 }
+
+/** Platform-specific file picker launcher that reads the selection as raw bytes (e.g. `.xlsx`). */
+expect class BinaryFilePickerLauncher {
+    /**
+     * Opens the file picker dialog.
+     */
+    fun launch()
+}

--- a/utils/compose/filePicker/src/commonMain/kotlin/com/moneymanager/compose/filepicker/FilePickerResult.kt
+++ b/utils/compose/filePicker/src/commonMain/kotlin/com/moneymanager/compose/filepicker/FilePickerResult.kt
@@ -16,3 +16,28 @@ data class FilePickerResult(
     val content: String,
     val lastModified: Instant? = null,
 )
+
+/**
+ * Result of a binary file picker operation (e.g. `.xlsx`), where decoding the bytes as UTF-8 text
+ * (like [FilePickerResult]) would corrupt the file.
+ *
+ * @property fileName The name of the selected file
+ * @property bytes The raw content of the file
+ * @property lastModified The last-modified timestamp of the file, if available
+ */
+data class BinaryFilePickerResult(
+    val fileName: String,
+    val bytes: ByteArray,
+    val lastModified: Instant? = null,
+) {
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            (
+                other is BinaryFilePickerResult &&
+                    fileName == other.fileName &&
+                    bytes.contentEquals(other.bytes) &&
+                    lastModified == other.lastModified
+            )
+
+    override fun hashCode(): Int = 31 * (31 * fileName.hashCode() + bytes.contentHashCode()) + (lastModified?.hashCode() ?: 0)
+}

--- a/utils/compose/filePicker/src/jvmMain/kotlin/com/moneymanager/compose/filepicker/FilePicker.kt
+++ b/utils/compose/filePicker/src/jvmMain/kotlin/com/moneymanager/compose/filepicker/FilePicker.kt
@@ -42,3 +42,22 @@ actual fun rememberMultipleFilePicker(
         )
     }
 }
+
+@Composable
+actual fun rememberBinaryFilePicker(
+    mimeTypes: List<String>,
+    onResult: (BinaryFilePickerResult?) -> Unit,
+): BinaryFilePickerLauncher {
+    val scope = rememberCoroutineScope()
+
+    return remember(mimeTypes, onResult) {
+        BinaryFilePickerLauncher(
+            mimeTypes = mimeTypes,
+            onResult = { result ->
+                scope.launch {
+                    onResult(result)
+                }
+            },
+        )
+    }
+}

--- a/utils/compose/filePicker/src/jvmMain/kotlin/com/moneymanager/compose/filepicker/FilePickerLauncher.kt
+++ b/utils/compose/filePicker/src/jvmMain/kotlin/com/moneymanager/compose/filepicker/FilePickerLauncher.kt
@@ -37,6 +37,17 @@ actual class MultipleFilePickerLauncher(
     }
 }
 
+actual class BinaryFilePickerLauncher(
+    private val mimeTypes: List<String>,
+    private val onResult: (BinaryFilePickerResult?) -> Unit,
+) {
+    actual fun launch() {
+        val files = showLoadDialog("Select a file", mimeTypes, multiple = false)
+        files.firstOrNull()?.parent?.let { localSettings.putString(KEY_LAST_DIRECTORY, it) }
+        onResult(files.firstOrNull()?.let { readFileAsBinaryResult(it) })
+    }
+}
+
 /**
  * Shows a native load dialog filtered by [mimeTypes], opened at the last-used directory, and returns
  * the selected files (empty if the user cancelled).
@@ -78,6 +89,7 @@ internal fun mimeTypesToExtensions(mimeTypes: List<String>): List<String> =
                 "application/qif", "application/x-qif" -> listOf(".qif")
                 "text/tab-separated-values" -> listOf(".tsv")
                 "application/vnd.ms-excel" -> listOf(".csv", ".xls")
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" -> listOf(".xlsx")
                 else -> emptyList()
             }
         }.distinct()
@@ -98,6 +110,18 @@ internal fun readFileAsResult(file: File): FilePickerResult? =
         val content = file.readText(Charsets.UTF_8)
         val lastModified = file.lastModified().takeIf { it > 0 }?.let { Instant.fromEpochMilliseconds(it) }
         FilePickerResult(fileName = file.name, content = content, lastModified = lastModified)
+    } catch (_: Exception) {
+        null
+    }
+
+/**
+ * Reads a file as raw bytes and returns a BinaryFilePickerResult, or null if reading fails.
+ */
+internal fun readFileAsBinaryResult(file: File): BinaryFilePickerResult? =
+    try {
+        val bytes = file.readBytes()
+        val lastModified = file.lastModified().takeIf { it > 0 }?.let { Instant.fromEpochMilliseconds(it) }
+        BinaryFilePickerResult(fileName = file.name, bytes = bytes, lastModified = lastModified)
     } catch (_: Exception) {
         null
     }

--- a/utils/parsers/xlsx/build.gradle.kts
+++ b/utils/parsers/xlsx/build.gradle.kts
@@ -1,0 +1,41 @@
+plugins {
+    id("moneymanager.kotlin-multiplatform-convention")
+    id("moneymanager.android-convention")
+}
+
+// Excel parsing uses Apache POI, which is JVM-only (not Android-friendly: large, reflection-heavy,
+// and not designed for the Android runtime). commonMain declares the parsing contract; jvmMain
+// implements it with POI; androidMain's actual reports the platform as unsupported.
+kotlin {
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(projects.utils.parsers.csv)
+            }
+        }
+
+        getByName("jvmMain") {
+            dependencies {
+                // WorkbookFactory/DataFormatter/Row/Sheet are org.apache.poi:poi (core) API; poi-ooxml
+                // is only needed at runtime so WorkbookFactory can dispatch to the XSSF (.xlsx) reader.
+                api(projects.utils.parsers.csv)
+                implementation(libs.poi)
+                runtimeOnly(libs.poi.ooxml)
+            }
+        }
+
+        getByName("commonTest") {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+
+        getByName("jvmTest") {
+            dependencies {
+                // The test fixture builds workbooks directly with XSSFWorkbook (poi-ooxml).
+                implementation(libs.poi)
+                implementation(libs.poi.ooxml)
+            }
+        }
+    }
+}

--- a/utils/parsers/xlsx/src/androidMain/kotlin/com/moneymanager/xlsx/XlsxParser.android.kt
+++ b/utils/parsers/xlsx/src/androidMain/kotlin/com/moneymanager/xlsx/XlsxParser.android.kt
@@ -1,0 +1,18 @@
+package com.moneymanager.xlsx
+
+import com.moneymanager.csv.CsvParseResult
+
+/** Excel parsing (Apache POI) is JVM-only; Android reports the platform as unsupported. */
+private class UnsupportedXlsxParser : XlsxParser {
+    override fun sheetNames(bytes: ByteArray): List<String> = throw unsupported()
+
+    override fun parse(
+        bytes: ByteArray,
+        sheetName: String?,
+    ): CsvParseResult = throw unsupported()
+
+    private fun unsupported() = XlsxUnsupportedPlatformException("Excel import is desktop-only")
+}
+
+@Suppress("ktlint:standard:function-naming")
+actual fun createXlsxParser(): XlsxParser = UnsupportedXlsxParser()

--- a/utils/parsers/xlsx/src/commonMain/kotlin/com/moneymanager/xlsx/XlsxParser.kt
+++ b/utils/parsers/xlsx/src/commonMain/kotlin/com/moneymanager/xlsx/XlsxParser.kt
@@ -1,0 +1,31 @@
+package com.moneymanager.xlsx
+
+import com.moneymanager.csv.CsvParseResult
+
+/**
+ * Reads `.xlsx` (and legacy `.xls`) workbooks as tabular data, so a worksheet can be treated exactly
+ * like a CSV file: first row = headers, remaining rows = data. Implemented with Apache POI on JVM only;
+ * the Android [actual] reports the platform as unsupported (see [createXlsxParser]).
+ */
+interface XlsxParser {
+    /** Worksheet names in workbook order. */
+    fun sheetNames(bytes: ByteArray): List<String>
+
+    /**
+     * Parses one worksheet into headers + rows. [sheetName] null selects the first sheet.
+     *
+     * @throws IllegalArgumentException if [sheetName] doesn't name a sheet in the workbook.
+     */
+    fun parse(
+        bytes: ByteArray,
+        sheetName: String? = null,
+    ): CsvParseResult
+}
+
+/** Thrown by the Android [XlsxParser] actual: Excel parsing is desktop-only (Apache POI is JVM-only). */
+class XlsxUnsupportedPlatformException(
+    message: String,
+) : UnsupportedOperationException(message)
+
+@Suppress("ktlint:standard:function-naming")
+expect fun createXlsxParser(): XlsxParser

--- a/utils/parsers/xlsx/src/jvmMain/kotlin/com/moneymanager/xlsx/XlsxParser.jvm.kt
+++ b/utils/parsers/xlsx/src/jvmMain/kotlin/com/moneymanager/xlsx/XlsxParser.jvm.kt
@@ -1,0 +1,58 @@
+package com.moneymanager.xlsx
+
+import com.moneymanager.csv.CsvParseResult
+import org.apache.poi.ss.usermodel.DataFormatter
+import org.apache.poi.ss.usermodel.Row
+import org.apache.poi.ss.usermodel.Sheet
+import org.apache.poi.ss.usermodel.WorkbookFactory
+import java.io.ByteArrayInputStream
+import java.util.Locale
+
+/** Apache POI-backed [XlsxParser]. Reads `.xlsx` (OOXML) and legacy `.xls` (HSSF) workbooks. */
+private class PoiXlsxParser : XlsxParser {
+    override fun sheetNames(bytes: ByteArray): List<String> =
+        WorkbookFactory.create(ByteArrayInputStream(bytes)).use { workbook ->
+            (0 until workbook.numberOfSheets).map { workbook.getSheetName(it) }
+        }
+
+    override fun parse(
+        bytes: ByteArray,
+        sheetName: String?,
+    ): CsvParseResult =
+        WorkbookFactory.create(ByteArrayInputStream(bytes)).use { workbook ->
+            val sheet: Sheet =
+                if (sheetName == null) {
+                    workbook.getSheetAt(0)
+                } else {
+                    workbook.getSheet(sheetName)
+                        ?: throw IllegalArgumentException("No worksheet named \"$sheetName\" in this workbook")
+                }
+            val formatter = DataFormatter(Locale.ROOT)
+            val rowIterator = sheet.rowIterator()
+            if (!rowIterator.hasNext()) {
+                return CsvParseResult(headers = emptyList(), rows = emptyList())
+            }
+
+            val headerRow = rowIterator.next()
+            val columnCount = headerRow.lastCellNum.coerceAtLeast(0).toInt()
+            val headers = rowValues(headerRow, columnCount, formatter)
+
+            val rows = mutableListOf<List<String>>()
+            while (rowIterator.hasNext()) {
+                rows.add(rowValues(rowIterator.next(), columnCount, formatter))
+            }
+            CsvParseResult(headers = headers, rows = rows)
+        }
+
+    private fun rowValues(
+        row: Row,
+        columnCount: Int,
+        formatter: DataFormatter,
+    ): List<String> =
+        (0 until columnCount).map { columnIndex ->
+            row.getCell(columnIndex)?.let { formatter.formatCellValue(it) }.orEmpty()
+        }
+}
+
+@Suppress("ktlint:standard:function-naming")
+actual fun createXlsxParser(): XlsxParser = PoiXlsxParser()

--- a/utils/parsers/xlsx/src/jvmTest/kotlin/com/moneymanager/xlsx/XlsxParserTest.kt
+++ b/utils/parsers/xlsx/src/jvmTest/kotlin/com/moneymanager/xlsx/XlsxParserTest.kt
@@ -1,0 +1,120 @@
+package com.moneymanager.xlsx
+
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import java.io.ByteArrayOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class XlsxParserTest {
+    private val parser = createXlsxParser()
+
+    @Test
+    fun parse_singleSheetWorkbook_readsHeadersAndRows() {
+        val bytes =
+            workbookBytes {
+                sheet("Sheet1") {
+                    row("Transaction Date", "Description", "Amount Processed", "Currency ")
+                    row("11/26/2021", "Card Load", "200", "GBP")
+                    row("11/27/2021", "Coffee Shop", "-4.5", "GBP")
+                }
+            }
+
+        val result = parser.parse(bytes)
+
+        assertEquals(listOf("Transaction Date", "Description", "Amount Processed", "Currency "), result.headers)
+        assertEquals(2, result.rows.size)
+        assertEquals(listOf("11/26/2021", "Card Load", "200", "GBP"), result.rows[0])
+        assertEquals(listOf("11/27/2021", "Coffee Shop", "-4.5", "GBP"), result.rows[1])
+    }
+
+    @Test
+    fun sheetNames_multiSheetWorkbook_returnsAllInOrder() {
+        val bytes =
+            workbookBytes {
+                sheet("First") { row("a") }
+                sheet("Second") { row("b") }
+            }
+
+        assertEquals(listOf("First", "Second"), parser.sheetNames(bytes))
+    }
+
+    @Test
+    fun parse_namedSheet_selectsThatSheetNotTheFirst() {
+        val bytes =
+            workbookBytes {
+                sheet("First") { row("wrong") }
+                sheet("Second") {
+                    row("header")
+                    row("value")
+                }
+            }
+
+        val result = parser.parse(bytes, sheetName = "Second")
+
+        assertEquals(listOf("header"), result.headers)
+        assertEquals(listOf(listOf("value")), result.rows)
+    }
+
+    @Test
+    fun parse_unknownSheetName_throws() {
+        val bytes = workbookBytes { sheet("Sheet1") { row("a") } }
+
+        assertFailsWith<IllegalArgumentException> { parser.parse(bytes, sheetName = "NoSuchSheet") }
+    }
+
+    @Test
+    fun parse_emptySheet_returnsEmptyResult() {
+        val bytes = workbookBytes { sheet("Sheet1") {} }
+
+        val result = parser.parse(bytes)
+
+        assertEquals(emptyList(), result.headers)
+        assertEquals(emptyList(), result.rows)
+    }
+
+    @Test
+    fun parse_shortRow_padsMissingTrailingCellsAsEmptyStrings() {
+        val bytes =
+            workbookBytes {
+                sheet("Sheet1") {
+                    row("a", "b", "c")
+                    row("1", "2")
+                }
+            }
+
+        val result = parser.parse(bytes)
+
+        assertEquals(listOf("1", "2", ""), result.rows[0])
+    }
+
+    private class WorkbookBuilder(
+        private val workbook: XSSFWorkbook,
+    ) {
+        fun sheet(
+            name: String,
+            block: SheetBuilder.() -> Unit,
+        ) {
+            SheetBuilder(workbook.createSheet(name)).block()
+        }
+    }
+
+    private class SheetBuilder(
+        private val sheet: org.apache.poi.ss.usermodel.Sheet,
+    ) {
+        private var rowIndex = 0
+
+        fun row(vararg values: String) {
+            val row = sheet.createRow(rowIndex++)
+            values.forEachIndexed { columnIndex, value -> row.createCell(columnIndex).setCellValue(value) }
+        }
+    }
+
+    private fun workbookBytes(block: WorkbookBuilder.() -> Unit): ByteArray {
+        val workbook = XSSFWorkbook()
+        WorkbookBuilder(workbook).block()
+        val out = ByteArrayOutputStream()
+        workbook.use { it.write(out) }
+        return out.toByteArray()
+    }
+}


### PR DESCRIPTION
## Summary

Crypto.com's older "Card Transaction History" export is an Excel workbook in a different layout than their usual CSV files, so a dedicated strategy type is needed. Rather than build a parallel pipeline, XLSX rides the existing CSV strategy engine end to end (the same way QIF does): an `.xlsx` worksheet is parsed into the same headers/rows shape a CSV produces, then flows through the unchanged `StrategySelector`, `CsvTransferMapper`, `CsvImportApplier`, and re-import machinery.

- New `utils/parsers/xlsx` module: Apache POI on the JVM behind an expect/actual seam (Android reports the platform unsupported — POI is JVM-only, not Android-friendly)
- Binary file picker (`utils/compose/filePicker`) alongside the existing text-only one, since decoding `.xlsx` bytes as UTF-8 would corrupt the file
- `xlsx_import_blob` table stores the raw workbook bytes next to the existing staged-row table, so a strategy naming a different worksheet can re-extract it later
- `CsvImportStrategy.worksheetName` + `StrategyKind.XLSX` thread an Excel strategy through the catalog/sync codecs the same way QIF does
- `ImportDirectoryScanner` stages `.xlsx` files (JVM-only; Android records a per-file scan failure rather than crashing)
- Built-in "Crypto.com Card (Excel)" strategy, tuned against the real workbook: signed `Amount Processed` for direction, `Card Acceptor Name` trimmed of its fixed-width city/country padding for both the account name and Curve pass-through detection, and a Cash-account fallback for rows with no card acceptor name (e.g. "Batch Credit Funds Transfer")

## Test plan
- [x] `./gradlew build` passes locally (all modules, all tests)
- [x] `./gradlew buildHealth` passes
- [x] New unit tests: `XlsxParserTest` (parsing, multi-sheet selection, edge cases) and `CryptoComCardXlsxMapperTest` (field mapping, Curve pass-through routing, blank-acceptor-name handling) against real row shapes
- [x] Verified against the real workbook via the default local database: import succeeds, Curve pass-through correctly collapses `CRV*` merchant rows instead of creating junk accounts, and the two previously-failing "Batch Credit Funds Transfer" rows now resolve to the Cash account

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import and stage `.xlsx` files from the Imports screen, selecting a worksheet and converting it into importable rows.
  * Save and manage worksheet-specific Excel import strategies, including Excel labeling and filtering in the strategy catalog.
  * Added a binary file picker to read workbook bytes safely.
* **Bug Fixes**
  * Improved duplicate detection by hashing raw workbook bytes for Excel imports; preserved original workbook data for later worksheet re-extraction.
* **Tests**
  * Added XLSX parser and Crypto.com Card Excel strategy test coverage.
* **Platform Support**
  * Excel parsing is available on desktop; Android reports XLSX imports as unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->