### PR TITLE
Re-extract the correct worksheet when an XLSX strategy names a non-default sheet

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/CsvImportApplier.kt
@@ -51,6 +51,8 @@ import com.moneymanager.importengineapi.createAccountMappings
 import com.moneymanager.importengineapi.createAccounts
 import com.moneymanager.importengineapi.createCrypto
 import com.moneymanager.importengineapi.getOrCreateAttributeTypes
+import com.moneymanager.importengineapi.restageXlsxImport
+import com.moneymanager.xlsx.createXlsxParser
 import kotlinx.coroutines.flow.first
 import org.lighthousegames.logging.logging
 import kotlin.time.Clock
@@ -330,7 +332,12 @@ suspend fun applyStagedCsv(
     cryptoRepository: CryptoReadRepository? = null,
     attributeAccountMatchers: Map<String, AttributeAccountMatcher> = emptyMap(),
 ): CsvImportResult? {
-    val allRows = csvImportRepository.getImportRows(csvImport.id, limit = csvImport.rowCount.coerceAtLeast(1), offset = 0)
+    // An Excel import is initially staged from the workbook's FIRST worksheet, but the matched strategy
+    // may target a different sheet. Re-extract + re-stage the correct sheet before reading rows so the
+    // staged data (and everything downstream) reflects the sheet the strategy actually imports.
+    val stagedImport = restageXlsxForStrategy(csvImport, strategy, csvImportRepository, importEngine)
+
+    val allRows = csvImportRepository.getImportRows(stagedImport.id, limit = stagedImport.rowCount.coerceAtLeast(1), offset = 0)
     val rows = allRows.filter { it.importStatus == null || it.importStatus == ImportStatus.ERROR }
     if (rows.isEmpty()) {
         // A genuinely empty file (a header-only export with no data rows) has nothing to import, but
@@ -338,8 +345,8 @@ suspend fun applyStagedCsv(
         // Record the strategy application once (the lastAppliedAt guard keeps repeated runs a no-op).
         // Scoped to allRows.isEmpty() so it never fires on re-import, which always has rows and whose
         // "nothing new to import" outcome must stay a null result.
-        if (allRows.isEmpty() && csvImport.lastAppliedAt == null) {
-            recordCsvApplication(importEngine, csvImport.id, strategy)
+        if (allRows.isEmpty() && stagedImport.lastAppliedAt == null) {
+            recordCsvApplication(importEngine, stagedImport.id, strategy)
             return CsvImportResult(successCount = 0, failedRows = emptyList())
         }
         return null
@@ -352,7 +359,7 @@ suspend fun applyStagedCsv(
     // On-demand: create a crypto asset for every non-fiat ticker appearing in the strategy's currency
     // column, so rows denominated in crypto resolve to a real crypto asset (upsert = idempotent on
     // re-import). No-op unless a CryptoReadRepository is supplied and the currency column carries crypto.
-    val cryptoAssets = ensureCryptoAssets(strategy, csvImport.columns, rows, currencies, importEngine, cryptoRepository)
+    val cryptoAssets = ensureCryptoAssets(strategy, stagedImport.columns, rows, currencies, importEngine, cryptoRepository)
 
     // Re-fetch accounts so payee accounts created by earlier files in the same scan are seen.
     val accounts = accountRepository.getAllAccounts().first()
@@ -361,7 +368,7 @@ suspend fun applyStagedCsv(
     val basePrep =
         buildCsvMapper(
             strategy,
-            csvImport.columns,
+            stagedImport.columns,
             accounts,
             currencies,
             mappings,
@@ -374,9 +381,9 @@ suspend fun applyStagedCsv(
 
     return runCsvImport(
         cryptoAssets = cryptoAssets,
-        csvImport = csvImport,
+        csvImport = stagedImport,
         rows = rows,
-        columns = csvImport.columns,
+        columns = stagedImport.columns,
         strategy = strategy,
         basePrep = basePrep,
         selectedExistingAccounts = emptyMap(),
@@ -393,6 +400,31 @@ suspend fun applyStagedCsv(
         engineBatchSize = engineBatchSize,
         attributeAccountMatchers = attributeAccountMatchers,
     )
+}
+
+/**
+ * If [strategy] is an Excel strategy naming a worksheet other than the one [csvImport] was staged from,
+ * re-extracts that sheet from the stored workbook bytes and re-stages the import's rows/columns in
+ * place, returning the reloaded import. Otherwise returns [csvImport] unchanged — for CSV/QIF imports,
+ * Excel strategies with no worksheet name, a staged sheet that already matches, or a missing workbook
+ * blob (a CSV file matched by an Excel strategy, or an import staged before Excel support). Excel
+ * parsing is JVM-only, but this stays a no-op on Android because such imports never have a blob, so the
+ * JVM-only [createXlsxParser] is only reached once a blob is present.
+ */
+suspend fun restageXlsxForStrategy(
+    csvImport: CsvImport,
+    strategy: CsvImportStrategy,
+    csvImportRepository: CsvImportReadRepository,
+    importEngine: ImportEngine,
+): CsvImport {
+    val targetSheet = strategy.worksheetName ?: return csvImport
+    val blob = csvImportRepository.getXlsxBlob(csvImport.id) ?: return csvImport
+    if (blob.worksheetName == targetSheet) return csvImport
+
+    val parsed = createXlsxParser().parse(blob.fileBytes, targetSheet)
+    importEngine.restageXlsxImport(csvImport.id, parsed.headers, parsed.rows, targetSheet)
+    logger.info { "Re-staged Excel import ${csvImport.id.id} from sheet '${blob.worksheetName}' to '$targetSheet'" }
+    return csvImportRepository.getImport(csvImport.id).first() ?: csvImport
 }
 
 /**

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/XlsxRestageDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/csv/XlsxRestageDbTest.kt
@@ -1,0 +1,72 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.moneymanager.database.csv
+
+import com.moneymanager.test.database.DbTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+/**
+ * Verifies the in-place re-staging of an Excel import: [restageImport] replaces the staged rows/columns
+ * with a different worksheet's data (keeping the import id and its stored workbook bytes), which is what
+ * lets the applier switch to the sheet a matched strategy actually targets.
+ */
+class XlsxRestageDbTest : DbTest() {
+    private val lastModified = Instant.fromEpochMilliseconds(1_700_000_000_000)
+    private val workbookBytes = byteArrayOf(0x50, 0x4B, 0x03, 0x04, 1, 2, 3, 4) // arbitrary stand-in for a .xlsx
+
+    @Test
+    fun restageReplacesSheetRowsColumnsAndBlobWorksheet() =
+        runTest {
+            val repo = repositories.csvImportRepository
+
+            val sheet1Headers = listOf("Date", "Amount")
+            val sheet1Rows = listOf(listOf("2024-01-01", "10.00"), listOf("2024-01-02", "20.00"))
+            val id =
+                repo.createImport(
+                    fileName = "book.xlsx",
+                    headers = sheet1Headers,
+                    rows = sheet1Rows,
+                    fileChecksum = "checksum",
+                    fileLastModified = lastModified,
+                    xlsxBytes = workbookBytes,
+                    xlsxWorksheetName = "Sheet1",
+                )
+
+            // Staged from the first sheet.
+            val staged = repo.getImport(id).first()!!
+            assertEquals(listOf("Date", "Amount"), staged.columns.map { it.originalName })
+            assertEquals(2L, staged.rowCount.toLong())
+            assertEquals("Sheet1", repo.getXlsxBlob(id)!!.worksheetName)
+
+            // Re-stage the second sheet: different column shape and rows.
+            val sheet2Headers = listOf("Timestamp", "Description", "Value")
+            val sheet2Rows =
+                listOf(
+                    listOf("2024-02-01", "Coffee", "3.50"),
+                    listOf("2024-02-02", "Lunch", "12.00"),
+                    listOf("2024-02-03", "Books", "40.00"),
+                )
+            repo.restageImport(id, sheet2Headers, sheet2Rows, "Sheet2")
+
+            val restaged = repo.getImport(id).first()!!
+            assertEquals(id, restaged.id, "id must stay stable across re-staging")
+            assertEquals(listOf("Timestamp", "Description", "Value"), restaged.columns.map { it.originalName })
+            assertEquals(3L, restaged.rowCount.toLong())
+
+            val rows = repo.getImportRows(id, limit = 10, offset = 0)
+            assertEquals(3, rows.size)
+            assertContentEquals(listOf("2024-02-01", "Coffee", "3.50"), rows[0].values)
+            assertContentEquals(listOf("2024-02-03", "Books", "40.00"), rows[2].values)
+
+            // The blob records the new worksheet but keeps the original workbook bytes.
+            val blob = repo.getXlsxBlob(id)!!
+            assertEquals("Sheet2", blob.worksheetName)
+            assertTrue(blob.fileBytes.contentEquals(workbookBytes), "workbook bytes must be preserved")
+        }
+}

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/CsvImportWriteRepositoryImpl.kt
@@ -83,6 +83,48 @@ class CsvImportWriteRepositoryImpl(
             }
         }
 
+    override suspend fun restageImport(
+        id: CsvImportId,
+        headers: List<String>,
+        rows: List<List<String>>,
+        worksheetName: String,
+    ): Unit =
+        withContext(coroutineContext) {
+            database.transaction {
+                val import =
+                    csvImportSelectQueries.selectImportById(id.id.toString()).executeAsOneOrNull()
+                        ?: return@transaction
+                val columnCount = headers.size
+
+                // Recreate the dynamic table with the new column shape and rows. The row_index sequence
+                // restarts, so any previously written per-row errors are stale — clear them.
+                tableManager.dropCsvTable(import.table_name)
+                tableManager.createCsvTable(import.table_name, columnCount)
+                tableManager.insertRowsBatch(import.table_name, rows, columnCount)
+
+                csvImportWriteQueries.deleteColumnsByImportId(id.id.toString())
+                headers.forEachIndexed { index, header ->
+                    csvImportWriteQueries.insertColumn(
+                        id = Uuid.random().toString(),
+                        import_id = id.id.toString(),
+                        column_index = index.toLong(),
+                        original_name = header,
+                    )
+                }
+
+                csvImportWriteQueries.deleteErrorsByImportId(id.id.toString())
+                csvImportWriteQueries.updateImportCounts(
+                    row_count = rows.size.toLong(),
+                    column_count = columnCount.toLong(),
+                    id = id.id.toString(),
+                )
+                csvImportWriteQueries.updateXlsxBlobWorksheet(
+                    worksheet_name = worksheetName,
+                    csv_import_id = id.id.toString(),
+                )
+            }
+        }
+
     override suspend fun deleteImport(id: CsvImportId): Unit =
         withContext(coroutineContext) {
             val import =

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImport/CsvImportWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/csvImport/CsvImportWrite.sq
@@ -5,6 +5,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
 deleteImport:
 DELETE FROM csv_import_metadata WHERE id = ?;
 
+updateImportCounts:
+UPDATE csv_import_metadata SET row_count = ?, column_count = ? WHERE id = ?;
+
 setImportIgnored:
 UPDATE csv_import_metadata SET ignored = ? WHERE id = ?;
 
@@ -27,7 +30,13 @@ VALUES (?, ?, ?, ?);
 deleteError:
 DELETE FROM csv_import_error WHERE csv_import_id = ? AND row_index = ?;
 
+deleteErrorsByImportId:
+DELETE FROM csv_import_error WHERE csv_import_id = ?;
+
 -- xlsx_import_blob queries
 insertXlsxBlob:
 INSERT INTO xlsx_import_blob (csv_import_id, file_bytes, worksheet_name)
 VALUES (?, ?, ?);
+
+updateXlsxBlobWorksheet:
+UPDATE xlsx_import_blob SET worksheet_name = ? WHERE csv_import_id = ?;

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportConfigIntents.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportConfigIntents.kt
@@ -148,6 +148,18 @@ sealed interface CsvImportMutation {
         val id: CsvImportId,
     ) : CsvImportMutation
 
+    /**
+     * Replaces an already-staged Excel import's rows/columns in place (keeping its id) with a different
+     * worksheet re-parsed from the stored workbook bytes. Used when the matched strategy names a sheet
+     * other than the one initially staged (the first sheet).
+     */
+    data class Restage(
+        val id: CsvImportId,
+        val headers: List<String>,
+        val rows: List<List<String>>,
+        val worksheetName: String,
+    ) : CsvImportMutation
+
     /** Toggles the "ignored" flag; ignored files are hidden from the actionable lists. */
     data class SetIgnored(
         val id: CsvImportId,

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportEngineConfigActions.kt
@@ -182,6 +182,20 @@ suspend fun ImportEngine.createXlsxImport(
         ).createdCsvImportIds[fileName],
     )
 
+/**
+ * Re-stages an already-created Excel import [id] in place with a different worksheet's [headers]/[rows],
+ * recording [worksheetName] on the stored workbook blob. The caller (JVM-side) has re-parsed the sheet
+ * from the blob's raw bytes into the same headers/rows shape a CSV file would produce.
+ */
+suspend fun ImportEngine.restageXlsxImport(
+    id: CsvImportId,
+    headers: List<String>,
+    rows: List<List<String>>,
+    worksheetName: String,
+) {
+    import(ImportBatch(csvImportMutations = listOf(CsvImportMutation.Restage(id, headers, rows, worksheetName))))
+}
+
 suspend fun ImportEngine.deleteCsvImport(id: CsvImportId) {
     import(ImportBatch(csvImportMutations = listOf(CsvImportMutation.Delete(id))))
 }

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -1579,6 +1579,7 @@ class ImportEngineImpl(
                         ),
                         "CsvImport",
                     )
+                is CsvImportMutation.Restage -> csvImportRepository.restageImport(m.id, m.headers, m.rows, m.worksheetName)
                 is CsvImportMutation.Delete -> csvImportRepository.deleteImport(m.id)
                 is CsvImportMutation.SetIgnored -> csvImportRepository.setImportIgnored(m.id, m.ignored)
                 is CsvImportMutation.UpdateRowTransferId -> csvImportRepository.updateRowTransferId(m.id, m.rowIndex, m.transferId)

--- a/app/model/repository/write/src/commonMain/kotlin/com/moneymanager/domain/repository/write/CsvImportWriteRepository.kt
+++ b/app/model/repository/write/src/commonMain/kotlin/com/moneymanager/domain/repository/write/CsvImportWriteRepository.kt
@@ -32,6 +32,22 @@ interface CsvImportWriteRepository : CsvImportReadRepository {
     ): CsvImportId
 
     /**
+     * Replaces the staged rows and columns of an existing Excel import in place, keeping its id (and
+     * therefore its directory-file link and history) stable. Used when the matched strategy names a
+     * different worksheet than the one initially staged: the correct sheet is re-parsed from the stored
+     * workbook bytes and re-staged. Recreates the dynamic table, replaces the column metadata, updates
+     * the row/column counts, and records the new [worksheetName] on the workbook blob. Any previously
+     * written per-row statuses/errors are discarded along with the old rows (the old sheet's rows were
+     * never validly imported under this strategy).
+     */
+    suspend fun restageImport(
+        id: CsvImportId,
+        headers: List<String>,
+        rows: List<List<String>>,
+        worksheetName: String,
+    )
+
+    /**
      * Deletes an import, including its metadata, columns, and dynamic table.
      */
     suspend fun deleteImport(id: CsvImportId)


### PR DESCRIPTION
## Summary
- Fixes #701: an Excel (`.xlsx`) import is always staged from the workbook's **first** worksheet, and neither `ImportDirectoryScanner.stageXlsx` nor the `CsvImportsScreen` upload handler re-checked the matched strategy's `worksheetName` afterward — a strategy targeting a different sheet silently imported the wrong one.
- `applyStagedCsv` (shared by Import All, directory-scan imports, and re-import) now calls a new `restageXlsxForStrategy` helper: if the matched strategy names a worksheet other than the one staged, it re-extracts that sheet from the stored `xlsx_import_blob.file_bytes` via `XlsxParser` and re-stages the import **in place** (same `CsvImportId`, so directory-file links and history stay intact), replacing the rows/columns and updating the blob's `worksheet_name`.
- The re-stage write goes through a new `CsvImportMutation.Restage` intent on the sole-writer `ImportEngine`, per this repo's "every DB mutation goes through the ImportEngine" rule.
- No-op (and therefore safe on Android, where Excel parsing is unavailable) for CSV/QIF imports, an Excel strategy with no worksheet name, an already-matching sheet, or an import staged before Excel support (no blob).

## Test plan
- [x] `./gradlew build` passes locally
- [x] New `XlsxRestageDbTest` (commonTest, runs on JVM+Android) verifies re-staging swaps rows/columns/worksheet name in place while preserving the import id and original workbook bytes
- [x] Existing `CryptoComCardXlsxMapperTest` and CSV import tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excel imports now correctly use the worksheet selected by the matched import strategy.
  * Re-staged imports preserve their import identity while refreshing rows, columns, counts, and worksheet information.
  * Previous row-level errors are cleared when an Excel import is re-staged.

* **Reliability**
  * Improved handling of empty Excel imports and imports targeting non-default worksheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->