### PR TITLE
Add account-grouped Timeline view with search/owner filters

### DIFF
--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/timeline/TimelineSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/timeline/TimelineSelect.sq
@@ -88,3 +88,147 @@ WHERE entity_source.entity_type_id = 7
       FROM entity_source creation
       WHERE creation.entity_type_id = 7 AND creation.entity_id = entity_source.entity_id
   );
+
+-- Account-grouped counterparts below: every transfer touches two accounts (source_account_id and
+-- target_account_id, both NOT NULL FKs to account), so each import/session/manual transfer is
+-- unpivoted into two rows (one per leg) before grouping. A file/session whose transfers touch
+-- several accounts therefore contributes a bar to each of those accounts' rows, exactly mirroring
+-- how the same transfer already appears on both accounts' ledgers.
+selectCsvImportAccountRanges:
+SELECT
+    import_id,
+    file_name,
+    ignored,
+    account_id,
+    MIN(timestamp) AS earliest_ms,
+    MAX(timestamp) AS latest_ms,
+    COUNT(DISTINCT transfer_id) AS transaction_count
+FROM (
+    SELECT
+        csv_import_metadata.id AS import_id,
+        csv_import_metadata.original_file_name AS file_name,
+        csv_import_metadata.ignored AS ignored,
+        transfer.id AS transfer_id,
+        transfer.source_account_id AS account_id,
+        transfer.timestamp AS timestamp
+    FROM csv_import_metadata
+    JOIN csv_entity_source ON csv_entity_source.csv_import_id = csv_import_metadata.id
+    JOIN entity_source ON entity_source.id = csv_entity_source.id AND entity_source.entity_type_id = 7
+    JOIN transfer ON transfer.id = entity_source.entity_id
+    UNION ALL
+    SELECT
+        csv_import_metadata.id,
+        csv_import_metadata.original_file_name,
+        csv_import_metadata.ignored,
+        transfer.id,
+        transfer.target_account_id,
+        transfer.timestamp
+    FROM csv_import_metadata
+    JOIN csv_entity_source ON csv_entity_source.csv_import_id = csv_import_metadata.id
+    JOIN entity_source ON entity_source.id = csv_entity_source.id AND entity_source.entity_type_id = 7
+    JOIN transfer ON transfer.id = entity_source.entity_id
+)
+GROUP BY import_id, account_id;
+
+selectQifImportAccountRanges:
+SELECT
+    import_id,
+    file_name,
+    ignored,
+    account_id,
+    MIN(timestamp) AS earliest_ms,
+    MAX(timestamp) AS latest_ms,
+    COUNT(DISTINCT transfer_id) AS transaction_count
+FROM (
+    SELECT
+        qif_import_metadata.id AS import_id,
+        qif_import_metadata.original_file_name AS file_name,
+        qif_import_metadata.ignored AS ignored,
+        transfer.id AS transfer_id,
+        transfer.source_account_id AS account_id,
+        transfer.timestamp AS timestamp
+    FROM qif_import_metadata
+    JOIN qif_entity_source ON qif_entity_source.qif_import_id = qif_import_metadata.id
+    JOIN entity_source ON entity_source.id = qif_entity_source.id AND entity_source.entity_type_id = 7
+    JOIN transfer ON transfer.id = entity_source.entity_id
+    UNION ALL
+    SELECT
+        qif_import_metadata.id,
+        qif_import_metadata.original_file_name,
+        qif_import_metadata.ignored,
+        transfer.id,
+        transfer.target_account_id,
+        transfer.timestamp
+    FROM qif_import_metadata
+    JOIN qif_entity_source ON qif_entity_source.qif_import_id = qif_import_metadata.id
+    JOIN entity_source ON entity_source.id = qif_entity_source.id AND entity_source.entity_type_id = 7
+    JOIN transfer ON transfer.id = entity_source.entity_id
+)
+GROUP BY import_id, account_id;
+
+selectApiSessionAccountRanges:
+SELECT
+    session_id,
+    account_id,
+    MIN(timestamp) AS earliest_ms,
+    MAX(timestamp) AS latest_ms,
+    COUNT(DISTINCT transfer_id) AS transaction_count
+FROM (
+    SELECT
+        api_session.id AS session_id,
+        transfer.id AS transfer_id,
+        transfer.source_account_id AS account_id,
+        transfer.timestamp AS timestamp
+    FROM api_session
+    JOIN api_entity_source ON api_entity_source.api_session_id = api_session.id
+    JOIN entity_source ON entity_source.id = api_entity_source.id AND entity_source.entity_type_id = 7
+    JOIN transfer ON transfer.id = entity_source.entity_id
+    UNION ALL
+    SELECT
+        api_session.id,
+        transfer.id,
+        transfer.target_account_id,
+        transfer.timestamp
+    FROM api_session
+    JOIN api_entity_source ON api_entity_source.api_session_id = api_session.id
+    JOIN entity_source ON entity_source.id = api_entity_source.id AND entity_source.entity_type_id = 7
+    JOIN transfer ON transfer.id = entity_source.entity_id
+)
+GROUP BY session_id, account_id;
+
+selectManualAccountRanges:
+SELECT
+    account_id,
+    MIN(timestamp) AS earliest_ms,
+    MAX(timestamp) AS latest_ms,
+    COUNT(DISTINCT transfer_id) AS transaction_count
+FROM (
+    SELECT
+        transfer.id AS transfer_id,
+        transfer.source_account_id AS account_id,
+        transfer.timestamp AS timestamp
+    FROM entity_source
+    JOIN transfer ON transfer.id = entity_source.entity_id
+    WHERE entity_source.entity_type_id = 7
+      AND entity_source.source_type_id = 1
+      AND entity_source.revision_id = (
+          SELECT MIN(creation.revision_id)
+          FROM entity_source creation
+          WHERE creation.entity_type_id = 7 AND creation.entity_id = entity_source.entity_id
+      )
+    UNION ALL
+    SELECT
+        transfer.id,
+        transfer.target_account_id,
+        transfer.timestamp
+    FROM entity_source
+    JOIN transfer ON transfer.id = entity_source.entity_id
+    WHERE entity_source.entity_type_id = 7
+      AND entity_source.source_type_id = 1
+      AND entity_source.revision_id = (
+          SELECT MIN(creation.revision_id)
+          FROM entity_source creation
+          WHERE creation.entity_type_id = 7 AND creation.entity_id = entity_source.entity_id
+      )
+)
+GROUP BY account_id;

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/ImportTimelineReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/ImportTimelineReadRepositoryImpl.kt
@@ -6,6 +6,7 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.coroutines.mapToOne
 import com.moneymanager.database.sql.read.MoneyManagerDatabase
+import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.timeline.ImportFileDateRange
 import com.moneymanager.domain.model.timeline.TimelineSourceKind
 import com.moneymanager.domain.repository.ImportTimelineReadRepository
@@ -111,6 +112,98 @@ class ImportTimelineReadRepositoryImpl(
             csv + qif + api + listOfNotNull(manual)
         }
 
+    override fun getCsvImportAccountRanges(): Flow<List<ImportFileDateRange>> =
+        queries
+            .selectCsvImportAccountRanges()
+            .asFlow()
+            .mapToList(coroutineContext)
+            .map { rows ->
+                rows.map { row ->
+                    fileRange(
+                        kind = TimelineSourceKind.CSV,
+                        fileId = row.import_id,
+                        fileName = row.file_name,
+                        ignored = row.ignored,
+                        strategyName = null,
+                        earliestMs = row.earliest_ms,
+                        latestMs = row.latest_ms,
+                        transactionCount = row.transaction_count,
+                        accountId = AccountId(row.account_id),
+                    )
+                }
+            }
+
+    override fun getQifImportAccountRanges(): Flow<List<ImportFileDateRange>> =
+        queries
+            .selectQifImportAccountRanges()
+            .asFlow()
+            .mapToList(coroutineContext)
+            .map { rows ->
+                rows.map { row ->
+                    fileRange(
+                        kind = TimelineSourceKind.QIF,
+                        fileId = row.import_id,
+                        fileName = row.file_name,
+                        ignored = row.ignored,
+                        strategyName = null,
+                        earliestMs = row.earliest_ms,
+                        latestMs = row.latest_ms,
+                        transactionCount = row.transaction_count,
+                        accountId = AccountId(row.account_id),
+                    )
+                }
+            }
+
+    override fun getApiSessionAccountRanges(): Flow<List<ImportFileDateRange>> =
+        queries
+            .selectApiSessionAccountRanges()
+            .asFlow()
+            .mapToList(coroutineContext)
+            .map { rows ->
+                rows.map { row ->
+                    ImportFileDateRange(
+                        kind = TimelineSourceKind.API,
+                        fileId = row.session_id.toString(),
+                        fileName = "Session ${row.session_id}",
+                        strategyName = null,
+                        earliest = Instant.fromEpochMilliseconds(requireNotNull(row.earliest_ms)),
+                        latest = Instant.fromEpochMilliseconds(requireNotNull(row.latest_ms)),
+                        transactionCount = row.transaction_count,
+                        accountId = AccountId(row.account_id),
+                    )
+                }
+            }
+
+    override fun getManualAccountRanges(): Flow<List<ImportFileDateRange>> =
+        queries
+            .selectManualAccountRanges()
+            .asFlow()
+            .mapToList(coroutineContext)
+            .map { rows ->
+                rows.map { row ->
+                    ImportFileDateRange(
+                        kind = TimelineSourceKind.MANUAL,
+                        fileId = "",
+                        fileName = "Manual entries",
+                        strategyName = null,
+                        earliest = Instant.fromEpochMilliseconds(requireNotNull(row.earliest_ms)),
+                        latest = Instant.fromEpochMilliseconds(requireNotNull(row.latest_ms)),
+                        transactionCount = row.transaction_count,
+                        accountId = AccountId(row.account_id),
+                    )
+                }
+            }
+
+    override fun getAllAccountRanges(): Flow<List<ImportFileDateRange>> =
+        combine(
+            getCsvImportAccountRanges(),
+            getQifImportAccountRanges(),
+            getApiSessionAccountRanges(),
+            getManualAccountRanges(),
+        ) { csv, qif, api, manual ->
+            csv + qif + api + manual
+        }
+
     @Suppress("LongParameterList")
     private fun fileRange(
         kind: TimelineSourceKind,
@@ -121,6 +214,7 @@ class ImportTimelineReadRepositoryImpl(
         earliestMs: Long?,
         latestMs: Long?,
         transactionCount: Long,
+        accountId: AccountId? = null,
     ): ImportFileDateRange =
         ImportFileDateRange(
             kind = kind,
@@ -131,5 +225,6 @@ class ImportTimelineReadRepositoryImpl(
             earliest = Instant.fromEpochMilliseconds(requireNotNull(earliestMs)),
             latest = Instant.fromEpochMilliseconds(requireNotNull(latestMs)),
             transactionCount = transactionCount,
+            accountId = accountId,
         )
 }

--- a/app/model/repository/read/src/commonMain/kotlin/com/moneymanager/domain/repository/ImportTimelineReadRepository.kt
+++ b/app/model/repository/read/src/commonMain/kotlin/com/moneymanager/domain/repository/ImportTimelineReadRepository.kt
@@ -22,4 +22,19 @@ interface ImportTimelineReadRepository {
 
     /** All of the above combined — the timeline screen's single input. */
     fun getAllDateRanges(): Flow<List<ImportFileDateRange>>
+
+    /** One entry per (CSV import, touched account) pair — a file touching several accounts repeats. */
+    fun getCsvImportAccountRanges(): Flow<List<ImportFileDateRange>>
+
+    /** One entry per (QIF import, touched account) pair. */
+    fun getQifImportAccountRanges(): Flow<List<ImportFileDateRange>>
+
+    /** One entry per (API session, touched account) pair. */
+    fun getApiSessionAccountRanges(): Flow<List<ImportFileDateRange>>
+
+    /** One entry per account touched by manually created transactions. */
+    fun getManualAccountRanges(): Flow<List<ImportFileDateRange>>
+
+    /** All of the above combined — the timeline screen's input for the account-grouped view. */
+    fun getAllAccountRanges(): Flow<List<ImportFileDateRange>>
 }

--- a/app/model/timeline/build.gradle.kts
+++ b/app/model/timeline/build.gradle.kts
@@ -3,3 +3,19 @@ plugins {
     id("moneymanager.android-convention")
     id("moneymanager.kotlin-multiplatform-convention")
 }
+
+kotlin {
+    sourceSets {
+        getByName("commonMain") {
+            dependencies {
+                api(projects.app.model.core)
+            }
+        }
+
+        getByName("jvmMain") {
+            dependencies {
+                api(projects.app.model.core)
+            }
+        }
+    }
+}

--- a/app/model/timeline/src/commonMain/kotlin/com/moneymanager/domain/model/timeline/ImportTimeline.kt
+++ b/app/model/timeline/src/commonMain/kotlin/com/moneymanager/domain/model/timeline/ImportTimeline.kt
@@ -2,6 +2,7 @@
 
 package com.moneymanager.domain.model.timeline
 
+import com.moneymanager.domain.model.AccountId
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -28,4 +29,6 @@ data class ImportFileDateRange(
     val earliest: Instant,
     val latest: Instant,
     val transactionCount: Long,
+    /** Set only for account-grouped ranges: one of the two accounts a transfer leg touched. */
+    val accountId: AccountId? = null,
 )

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/MoneyManagerApp.kt
@@ -621,6 +621,7 @@ fun MoneyManagerApp(
                                                 tradeRepository = services.transactions.tradeRepository,
                                                 maintenance = services.imports.maintenance,
                                                 personRepository = services.people.personRepository,
+                                                personAccountOwnershipRepository = services.people.personAccountOwnershipRepository,
                                                 importEngine = services.transactions.importEngine,
                                                 deviceId = services.deviceId,
                                                 onCsvImportClick = { importId ->

--- a/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
+++ b/app/ui/core/src/commonMain/kotlin/com/moneymanager/ui/screens/ImportsScreen.kt
@@ -34,6 +34,7 @@ import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.domain.repository.ImportDirectoryReadRepository
 import com.moneymanager.domain.repository.ImportTimelineReadRepository
 import com.moneymanager.domain.repository.PassThroughAccountReadRepository
+import com.moneymanager.domain.repository.PersonAccountOwnershipReadRepository
 import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.domain.repository.QifImportReadRepository
 import com.moneymanager.domain.repository.SettingsReadRepository
@@ -82,6 +83,7 @@ fun ImportsScreen(
     tradeRepository: TradeReadRepository,
     maintenance: Maintenance,
     personRepository: PersonReadRepository,
+    personAccountOwnershipRepository: PersonAccountOwnershipReadRepository,
     importEngine: ImportEngine,
     deviceId: DeviceId,
     onCsvImportClick: (CsvImportId) -> Unit,
@@ -225,6 +227,9 @@ fun ImportsScreen(
             ImportTab.TIMELINE ->
                 ImportTimelineScreen(
                     importTimelineRepository = importTimelineRepository,
+                    accountRepository = accountRepository,
+                    personRepository = personRepository,
+                    personAccountOwnershipRepository = personAccountOwnershipRepository,
                     onOpenFile = onTimelineFileClick,
                 )
         }

--- a/app/ui/imports/timeline/build.gradle.kts
+++ b/app/ui/imports/timeline/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
         }
         getByName("androidMain") {
             dependencies {
+                api(projects.app.model.core)
                 api(libs.androidx.compose.foundation.layout)
                 api(libs.androidx.compose.runtime)
                 api(libs.androidx.compose.ui)
@@ -37,6 +38,7 @@ kotlin {
         }
         getByName("jvmMain") {
             dependencies {
+                api(projects.app.model.core)
                 api(projects.app.model.repository.read)
                 api(projects.app.model.timeline)
                 api(libs.androidx.compose.runtime.desktop)
@@ -54,6 +56,7 @@ kotlin {
         }
         getByName("jvmTest") {
             dependencies {
+                implementation(projects.app.model.core)
                 implementation(kotlin("test"))
                 implementation(libs.compose.ui.test.desktop)
                 implementation(libs.kotlinx.coroutines.core)
@@ -63,6 +66,7 @@ kotlin {
         }
         getByName("androidDeviceTest") {
             dependencies {
+                implementation(projects.app.model.core)
                 implementation(projects.test.app.ui)
                 implementation(libs.androidx.compose.ui.test)
                 implementation(libs.kotlinx.coroutines.core)
@@ -70,6 +74,7 @@ kotlin {
         }
         getByName("androidHostTest") {
             dependencies {
+                implementation(projects.app.model.core)
                 implementation(libs.kotlinx.coroutines.core)
             }
         }

--- a/app/ui/imports/timeline/src/commonMain/kotlin/com/moneymanager/ui/screens/timeline/ImportTimelineScreen.kt
+++ b/app/ui/imports/timeline/src/commonMain/kotlin/com/moneymanager/ui/screens/timeline/ImportTimelineScreen.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.time.ExperimentalTime::class)
+@file:OptIn(kotlin.time.ExperimentalTime::class, androidx.compose.material3.ExperimentalMaterial3Api::class)
 
 package com.moneymanager.ui.screens.timeline
 
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -19,10 +20,17 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -45,9 +53,13 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
+import com.moneymanager.domain.model.Person
 import com.moneymanager.domain.model.timeline.ImportFileDateRange
 import com.moneymanager.domain.model.timeline.TimelineSourceKind
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.ImportTimelineReadRepository
+import com.moneymanager.domain.repository.PersonAccountOwnershipReadRepository
+import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.util.displayDate
 import kotlinx.datetime.LocalDate
@@ -61,76 +73,156 @@ private val ROW_BAR_HEIGHT = 24.dp
 private val TOOLTIP_OFFSET = 12.dp
 
 /**
- * Matrix of import coverage: one row per import strategy (plus manual entries), a shared time
- * axis spanning the earliest to the latest imported transaction. Gaps in a row are periods no
- * file covers; darker stretches are covered by more than one file. Hovering a row (desktop) or
- * tapping it (touch) lists the files covering that day; clicking a covered spot opens the file
- * (with a chooser when several files overlap). A table of every gap sits under the timeline.
+ * Matrix of import coverage: one row per import strategy or per account (toggled by the tabs at
+ * the top), sharing a time axis spanning the earliest to the latest imported transaction. Gaps in
+ * a row are periods no file covers; darker stretches are covered by more than one file. Hovering a
+ * row (desktop) or tapping it (touch) lists the files covering that day; clicking a covered spot
+ * opens the file (with a chooser when several files overlap). A table of every gap sits under the
+ * timeline.
  */
 @Composable
 fun ImportTimelineScreen(
     importTimelineRepository: ImportTimelineReadRepository,
+    accountRepository: AccountReadRepository,
+    personRepository: PersonReadRepository,
+    personAccountOwnershipRepository: PersonAccountOwnershipReadRepository,
     onOpenFile: (ImportFileDateRange) -> Unit = {},
 ) {
-    val ranges by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+    var groupMode by remember { mutableStateOf(TimelineGroupMode.STRATEGY) }
+    var accountNameFilter by remember { mutableStateOf("") }
+    var selectedOwnerIds by remember { mutableStateOf<Set<Long>>(emptySet()) }
+
+    val strategyRanges by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
         importTimelineRepository.getAllDateRanges()
     }
+    val accountRanges by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        importTimelineRepository.getAllAccountRanges()
+    }
+    val accounts by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        accountRepository.getAllAccounts()
+    }
+    val people by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        personRepository.getAllPeople()
+    }
+    val ownerships by rememberFlowAsStateWithSchemaErrorHandling(initial = emptyList()) {
+        personAccountOwnershipRepository.getAllOwnerships()
+    }
+    val accountNameById = remember(accounts) { accounts.associate { it.id to it.name } }
+    val ownerIdsByAccount =
+        remember(ownerships) {
+            ownerships.groupBy({ it.accountId }, { it.personId.id }).mapValues { it.value.toSet() }
+        }
+
     val timeZone = remember { TimeZone.currentSystemDefault() }
     val matrix =
-        remember(ranges) {
+        remember(groupMode, strategyRanges, accountRanges, accountNameById, accountNameFilter, selectedOwnerIds, ownerIdsByAccount) {
             val todayDay =
                 Clock.System
                     .now()
                     .toLocalDateTime(timeZone)
                     .date
                     .toEpochDays()
-            buildTimelineMatrix(ranges, timeZone, todayDay)
+            when (groupMode) {
+                TimelineGroupMode.STRATEGY -> buildTimelineMatrix(strategyRanges, timeZone, todayDay, groupMode)
+                TimelineGroupMode.ACCOUNT -> {
+                    val filtered =
+                        filterAccountRanges(
+                            accountRanges,
+                            accountNameById,
+                            accountNameFilter,
+                            selectedOwnerIds,
+                            ownerIdsByAccount,
+                        )
+                    buildTimelineMatrix(filtered, timeZone, todayDay, groupMode, accountNameById)
+                }
+            }
         }
 
-    if (matrix == null) {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(
-                text = "No imported transactions yet",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+    Column(modifier = Modifier.fillMaxSize()) {
+        SecondaryTabRow(selectedTabIndex = groupMode.ordinal) {
+            Tab(
+                selected = groupMode == TimelineGroupMode.STRATEGY,
+                onClick = { groupMode = TimelineGroupMode.STRATEGY },
+                text = { Text("By strategy") },
+            )
+            Tab(
+                selected = groupMode == TimelineGroupMode.ACCOUNT,
+                onClick = { groupMode = TimelineGroupMode.ACCOUNT },
+                text = { Text("By account") },
             )
         }
-        return
-    }
 
-    Column(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(16.dp),
-    ) {
-        TimelineLegend()
-        Spacer(modifier = Modifier.height(12.dp))
-        matrix.rows.forEach { row ->
-            TimelineRowItem(row = row, minDay = matrix.minDay, maxDay = matrix.maxDay, onOpenFile = onOpenFile)
-            Spacer(modifier = Modifier.height(8.dp))
+        if (groupMode == TimelineGroupMode.ACCOUNT) {
+            Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                OutlinedTextField(
+                    value = accountNameFilter,
+                    onValueChange = { accountNameFilter = it },
+                    label = { Text("Search accounts") },
+                    placeholder = { Text("Type to search...") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+                if (people.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OwnerFilterDropdown(
+                        people = people,
+                        selectedOwnerIds = selectedOwnerIds,
+                        onSelectionChange = { selectedOwnerIds = it },
+                    )
+                }
+            }
         }
-        TimelineAxis(minDay = matrix.minDay, maxDay = matrix.maxDay)
-        Spacer(modifier = Modifier.height(24.dp))
-        GapsTable(matrix)
+
+        if (matrix == null) {
+            val filtersActive = groupMode == TimelineGroupMode.ACCOUNT && (accountNameFilter.isNotBlank() || selectedOwnerIds.isNotEmpty())
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                    text = if (filtersActive) "No accounts match the current filters." else "No imported transactions yet",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            return@Column
+        }
+
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+        ) {
+            TimelineLegend()
+            Spacer(modifier = Modifier.height(12.dp))
+            matrix.rows.forEach { row ->
+                TimelineRowItem(row = row, minDay = matrix.minDay, maxDay = matrix.maxDay, onOpenFile = onOpenFile)
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+            TimelineAxis(minDay = matrix.minDay, maxDay = matrix.maxDay)
+            Spacer(modifier = Modifier.height(24.dp))
+            GapsTable(matrix, groupMode)
+        }
     }
 }
 
 @Composable
-private fun GapsTable(matrix: TimelineMatrix) {
+private fun GapsTable(
+    matrix: TimelineMatrix,
+    groupMode: TimelineGroupMode,
+) {
     val gaps = matrix.rows.flatMap { row -> row.gaps.map { gap -> row.label to gap } }
+    val columnLabel = if (groupMode == TimelineGroupMode.ACCOUNT) "Account" else "Strategy"
     Text(text = "Gaps", style = MaterialTheme.typography.titleSmall)
     Spacer(modifier = Modifier.height(4.dp))
     if (gaps.isEmpty()) {
         Text(
-            text = "No gaps — every strategy is fully covered up to today.",
+            text = "No gaps — every ${columnLabel.lowercase()} is fully covered up to today.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         return
     }
-    GapsTableRow(strategy = "Strategy", from = "From", to = "To", days = "Days", header = true)
+    GapsTableRow(strategy = columnLabel, from = "From", to = "To", days = "Days", header = true)
     gaps.forEach { (label, gap) ->
         GapsTableRow(
             strategy = label,
@@ -428,6 +520,79 @@ private fun TimelineAxis(
                         maxLines = 1,
                     )
                 }
+            }
+        }
+    }
+}
+
+/** Multi-select owner filter, matching the one on the Accounts screen. */
+@Composable
+private fun OwnerFilterDropdown(
+    people: List<Person>,
+    selectedOwnerIds: Set<Long>,
+    onSelectionChange: (Set<Long>) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("") }
+
+    val selectionLabel =
+        when (selectedOwnerIds.size) {
+            0 -> "All owners"
+            1 -> people.find { it.id.id in selectedOwnerIds }?.fullName ?: "1 owner"
+            else -> "${selectedOwnerIds.size} owners"
+        }
+
+    val filteredPeople =
+        remember(people, searchQuery) {
+            if (searchQuery.isBlank()) people else people.filter { it.fullName.contains(searchQuery, ignoreCase = true) }
+        }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded },
+    ) {
+        OutlinedTextField(
+            value = if (expanded) searchQuery else selectionLabel,
+            onValueChange = { searchQuery = it },
+            label = { Text("Filter by owner") },
+            placeholder = { Text("Type to search...") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.fillMaxWidth().menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable),
+            singleLine = true,
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = {
+                expanded = false
+                searchQuery = ""
+            },
+        ) {
+            DropdownMenuItem(
+                text = { Text("All owners") },
+                onClick = { onSelectionChange(emptySet()) },
+            )
+            filteredPeople.forEach { person ->
+                DropdownMenuItem(
+                    text = {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Checkbox(
+                                checked = selectedOwnerIds.contains(person.id.id),
+                                onCheckedChange = null,
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(person.fullName)
+                        }
+                    },
+                    onClick = {
+                        onSelectionChange(
+                            if (selectedOwnerIds.contains(person.id.id)) {
+                                selectedOwnerIds - person.id.id
+                            } else {
+                                selectedOwnerIds + person.id.id
+                            },
+                        )
+                    },
+                )
             }
         }
     }

--- a/app/ui/imports/timeline/src/commonMain/kotlin/com/moneymanager/ui/screens/timeline/TimelineModel.kt
+++ b/app/ui/imports/timeline/src/commonMain/kotlin/com/moneymanager/ui/screens/timeline/TimelineModel.kt
@@ -2,6 +2,7 @@
 
 package com.moneymanager.ui.screens.timeline
 
+import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.timeline.ImportFileDateRange
 import com.moneymanager.domain.model.timeline.TimelineSourceKind
 import kotlinx.datetime.LocalDate
@@ -9,6 +10,38 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.number
 import kotlinx.datetime.toLocalDateTime
 import kotlin.time.Instant
+
+/** Which dimension timeline rows are grouped by. */
+enum class TimelineGroupMode {
+    STRATEGY,
+    ACCOUNT,
+}
+
+/**
+ * Narrows account-grouped ranges (see [TimelineGroupMode.ACCOUNT]) to those whose account matches
+ * both [nameFilter] (case-insensitive substring of the account name) and [selectedOwnerIds] (a
+ * range's account must have at least one of the selected owners; an empty selection matches
+ * everything) — the same two filters as the Accounts screen. A range whose account is unknown
+ * (missing from [accountNameById]) never matches a non-blank [nameFilter] or a non-empty owner
+ * selection.
+ */
+fun filterAccountRanges(
+    ranges: List<ImportFileDateRange>,
+    accountNameById: Map<AccountId, String>,
+    nameFilter: String,
+    selectedOwnerIds: Set<Long>,
+    ownerIdsByAccount: Map<AccountId, Set<Long>>,
+): List<ImportFileDateRange> =
+    ranges.filter { range ->
+        val accountId = range.accountId
+        val matchesName =
+            nameFilter.isBlank() ||
+                (accountId != null && accountNameById[accountId]?.contains(nameFilter, ignoreCase = true) == true)
+        val matchesOwner =
+            selectedOwnerIds.isEmpty() ||
+                (accountId != null && ownerIdsByAccount[accountId].orEmpty().any { it in selectedOwnerIds })
+        matchesName && matchesOwner
+    }
 
 /** One file/session bar inside a timeline row, in local epoch days (inclusive on both ends). */
 data class TimelineFile(
@@ -47,14 +80,24 @@ data class TimelineMatrix(
 
 private const val MANUAL_ROW_LABEL = "Manual entries"
 private const val UNKNOWN_STRATEGY_LABEL = "Unknown strategy"
+private const val UNKNOWN_ACCOUNT_LABEL = "Unknown account"
 
 /**
- * Groups per-file date ranges into timeline rows keyed by strategy name. CSV and QIF files that
- * share a strategy land in the same row (QIF reuses CSV strategies — one strategy is one logical
- * source, and a CSV+QIF export of the same period should show up as overlap, not as two rows).
- * Strategy names are per-application snapshots, so files imported before and after a strategy
- * rename split into separate rows. API sessions group by API strategy name, falling back to the
- * session type for legacy strategy-less sessions. The manual aggregate gets its own last row.
+ * Groups per-file date ranges into timeline rows keyed by strategy name ([TimelineGroupMode.STRATEGY])
+ * or by account name ([TimelineGroupMode.ACCOUNT]).
+ *
+ * In [TimelineGroupMode.STRATEGY]: CSV and QIF files that share a strategy land in the same row
+ * (QIF reuses CSV strategies — one strategy is one logical source, and a CSV+QIF export of the
+ * same period should show up as overlap, not as two rows). Strategy names are per-application
+ * snapshots, so files imported before and after a strategy rename split into separate rows. API
+ * sessions group by API strategy name, falling back to the session type for legacy strategy-less
+ * sessions. The manual aggregate gets its own last row.
+ *
+ * In [TimelineGroupMode.ACCOUNT]: every transfer touches two accounts, so [ranges] is expected to
+ * already be the account-unpivoted form (one entry per file/session/manual *and* touched account —
+ * see `ImportTimelineReadRepository.getAllAccountRanges`), and rows are keyed by [accountNameById]
+ * looked up from `range.accountId`. A file whose transfers touch several accounts naturally lands
+ * in several rows, one per account.
  *
  * The axis spans the earliest transaction anywhere up to [todayDay]. A row whose coverage starts
  * later than the axis gets a leading gap, and one whose coverage stops before today gets a
@@ -64,6 +107,8 @@ fun buildTimelineMatrix(
     ranges: List<ImportFileDateRange>,
     timeZone: TimeZone,
     todayDay: Long,
+    groupMode: TimelineGroupMode = TimelineGroupMode.STRATEGY,
+    accountNameById: Map<AccountId, String> = emptyMap(),
 ): TimelineMatrix? {
     if (ranges.isEmpty()) return null
     val files =
@@ -80,7 +125,7 @@ fun buildTimelineMatrix(
     val maxDay = maxOf(files.maxOf { it.endDay }, todayDay)
     val rows =
         files
-            .groupBy { rowLabel(it.range) }
+            .groupBy { rowLabel(it.range, groupMode, accountNameById) }
             .map { (label, rowFiles) ->
                 val segments = mergeIntervals(rowFiles)
                 TimelineRow(
@@ -90,7 +135,10 @@ fun buildTimelineMatrix(
                     gaps = leadingGap(segments, minDay) + gapsBetween(segments) + trailingGap(segments, maxDay),
                 )
             }.sortedWith(
-                compareBy({ it.files.first().kind == TimelineSourceKind.MANUAL }, { it.label.lowercase() }),
+                compareBy(
+                    { groupMode == TimelineGroupMode.STRATEGY && it.files.first().kind == TimelineSourceKind.MANUAL },
+                    { it.label.lowercase() },
+                ),
             )
     return TimelineMatrix(
         minDay = minDay,
@@ -125,11 +173,19 @@ private fun trailingGap(
     }
 }
 
-private fun rowLabel(range: ImportFileDateRange): String =
-    when (range.kind) {
-        TimelineSourceKind.MANUAL -> MANUAL_ROW_LABEL
-        TimelineSourceKind.API -> range.strategyName ?: UNKNOWN_STRATEGY_LABEL
-        TimelineSourceKind.CSV, TimelineSourceKind.QIF -> range.strategyName ?: UNKNOWN_STRATEGY_LABEL
+private fun rowLabel(
+    range: ImportFileDateRange,
+    groupMode: TimelineGroupMode,
+    accountNameById: Map<AccountId, String>,
+): String =
+    when (groupMode) {
+        TimelineGroupMode.ACCOUNT -> accountNameById[range.accountId] ?: UNKNOWN_ACCOUNT_LABEL
+        TimelineGroupMode.STRATEGY ->
+            when (range.kind) {
+                TimelineSourceKind.MANUAL -> MANUAL_ROW_LABEL
+                TimelineSourceKind.API -> range.strategyName ?: UNKNOWN_STRATEGY_LABEL
+                TimelineSourceKind.CSV, TimelineSourceKind.QIF -> range.strategyName ?: UNKNOWN_STRATEGY_LABEL
+            }
     }
 
 private fun fileLabel(

--- a/app/ui/imports/timeline/src/commonTest/kotlin/com/moneymanager/ui/screens/timeline/ImportTimelineScreenTest.kt
+++ b/app/ui/imports/timeline/src/commonTest/kotlin/com/moneymanager/ui/screens/timeline/ImportTimelineScreenTest.kt
@@ -7,9 +7,22 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithText
+import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountId
+import com.moneymanager.domain.model.AccountMerge
+import com.moneymanager.domain.model.AccountMergeContext
+import com.moneymanager.domain.model.MergeId
+import com.moneymanager.domain.model.MergeMovedTransfer
+import com.moneymanager.domain.model.Person
+import com.moneymanager.domain.model.PersonAccountOwnership
+import com.moneymanager.domain.model.PersonId
+import com.moneymanager.domain.model.Transfer
 import com.moneymanager.domain.model.timeline.ImportFileDateRange
 import com.moneymanager.domain.model.timeline.TimelineSourceKind
+import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.ImportTimelineReadRepository
+import com.moneymanager.domain.repository.PersonAccountOwnershipReadRepository
+import com.moneymanager.domain.repository.PersonReadRepository
 import com.moneymanager.ui.error.ProvideSchemaAwareScope
 import com.moneymanager.ui.test.runMoneyManagerComposeUiTest
 import kotlinx.coroutines.flow.Flow
@@ -30,6 +43,64 @@ class ImportTimelineScreenTest {
             override fun getManualDateRange(): Flow<ImportFileDateRange?> = flowOf(null)
 
             override fun getAllDateRanges(): Flow<List<ImportFileDateRange>> = flowOf(ranges)
+
+            override fun getCsvImportAccountRanges(): Flow<List<ImportFileDateRange>> = flowOf(emptyList())
+
+            override fun getQifImportAccountRanges(): Flow<List<ImportFileDateRange>> = flowOf(emptyList())
+
+            override fun getApiSessionAccountRanges(): Flow<List<ImportFileDateRange>> = flowOf(emptyList())
+
+            override fun getManualAccountRanges(): Flow<List<ImportFileDateRange>> = flowOf(emptyList())
+
+            override fun getAllAccountRanges(): Flow<List<ImportFileDateRange>> = flowOf(emptyList())
+        }
+
+    private fun createAccountRepository(accounts: List<Account> = emptyList()): AccountReadRepository =
+        object : AccountReadRepository {
+            override fun getAllAccounts(): Flow<List<Account>> = flowOf(accounts)
+
+            override fun getAccountById(id: AccountId): Flow<Account?> = flowOf(accounts.find { it.id == id })
+
+            override suspend fun getPreviousAccountNames(): Map<String, AccountId> = emptyMap()
+
+            override suspend fun countTransfersByAccount(accountId: AccountId): Long = 0
+
+            override suspend fun accountsWithTransfers(accountIds: Collection<AccountId>): Set<AccountId> = emptySet()
+
+            override suspend fun getTransfersBetweenAccounts(
+                accountA: AccountId,
+                accountB: AccountId,
+            ): List<Transfer> = emptyList()
+
+            override fun getReversibleMerges(): Flow<List<AccountMerge>> = flowOf(emptyList())
+
+            override fun getMergesForSurvivingAccount(accountId: AccountId): Flow<List<AccountMerge>> = flowOf(emptyList())
+
+            override suspend fun getMergesForDeletedAccount(accountId: AccountId): List<AccountMergeContext> = emptyList()
+
+            override suspend fun getMergeMovedTransfers(mergeId: MergeId): List<MergeMovedTransfer> = emptyList()
+        }
+
+    private fun createPersonRepository(people: List<Person> = emptyList()): PersonReadRepository =
+        object : PersonReadRepository {
+            override fun getAllPeople(): Flow<List<Person>> = flowOf(people)
+
+            override fun getPersonById(id: PersonId): Flow<Person?> = flowOf(people.find { it.id == id })
+        }
+
+    private fun createPersonAccountOwnershipRepository(
+        ownerships: List<PersonAccountOwnership> = emptyList(),
+    ): PersonAccountOwnershipReadRepository =
+        object : PersonAccountOwnershipReadRepository {
+            override fun getOwnershipsByPerson(personId: PersonId): Flow<List<PersonAccountOwnership>> =
+                flowOf(ownerships.filter { it.personId == personId })
+
+            override fun getOwnershipsByAccount(accountId: AccountId): Flow<List<PersonAccountOwnership>> =
+                flowOf(ownerships.filter { it.accountId == accountId })
+
+            override fun getAllOwnerships(): Flow<List<PersonAccountOwnership>> = flowOf(ownerships)
+
+            override fun getOwnershipById(id: Long): Flow<PersonAccountOwnership?> = flowOf(ownerships.find { it.id == id })
         }
 
     private fun range(
@@ -52,7 +123,12 @@ class ImportTimelineScreenTest {
         runMoneyManagerComposeUiTest {
             setContent {
                 ProvideSchemaAwareScope {
-                    ImportTimelineScreen(importTimelineRepository = createRepository(emptyList()))
+                    ImportTimelineScreen(
+                        importTimelineRepository = createRepository(emptyList()),
+                        accountRepository = createAccountRepository(),
+                        personRepository = createPersonRepository(),
+                        personAccountOwnershipRepository = createPersonAccountOwnershipRepository(),
+                    )
                 }
             }
 
@@ -72,7 +148,12 @@ class ImportTimelineScreenTest {
 
             setContent {
                 ProvideSchemaAwareScope {
-                    ImportTimelineScreen(importTimelineRepository = createRepository(ranges))
+                    ImportTimelineScreen(
+                        importTimelineRepository = createRepository(ranges),
+                        accountRepository = createAccountRepository(),
+                        personRepository = createPersonRepository(),
+                        personAccountOwnershipRepository = createPersonAccountOwnershipRepository(),
+                    )
                 }
             }
 

--- a/app/ui/imports/timeline/src/commonTest/kotlin/com/moneymanager/ui/screens/timeline/TimelineModelTest.kt
+++ b/app/ui/imports/timeline/src/commonTest/kotlin/com/moneymanager/ui/screens/timeline/TimelineModelTest.kt
@@ -2,6 +2,7 @@
 
 package com.moneymanager.ui.screens.timeline
 
+import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.timeline.ImportFileDateRange
 import com.moneymanager.domain.model.timeline.TimelineSourceKind
 import kotlinx.datetime.LocalDate
@@ -29,6 +30,7 @@ class TimelineModelTest {
         strategyName: String? = "Strategy A",
         ignored: Boolean = false,
         count: Long = 10,
+        accountId: AccountId? = null,
     ): ImportFileDateRange =
         ImportFileDateRange(
             kind = kind,
@@ -39,6 +41,7 @@ class TimelineModelTest {
             earliest = instant(start),
             latest = instant(end),
             transactionCount = count,
+            accountId = accountId,
         )
 
     private fun file(
@@ -172,6 +175,97 @@ class TimelineModelTest {
                 todayDay = day("2024-01-31"),
             )!!
         assertEquals(listOf("Zebra Bank", "Manual entries"), matrix.rows.map { it.label })
+    }
+
+    @Test
+    fun filterAccountRangesMatchesByNameCaseInsensitively() {
+        val checking = AccountId(1)
+        val savings = AccountId(2)
+        val ranges = listOf(range("2024-01-01", "2024-01-31", accountId = checking), range("2024-01-01", "2024-01-31", accountId = savings))
+        val filtered =
+            filterAccountRanges(
+                ranges,
+                accountNameById = mapOf(checking to "Checking", savings to "Savings"),
+                nameFilter = "check",
+                selectedOwnerIds = emptySet(),
+                ownerIdsByAccount = emptyMap(),
+            )
+        assertEquals(listOf(checking), filtered.map { it.accountId })
+    }
+
+    @Test
+    fun filterAccountRangesMatchesByOwner() {
+        val checking = AccountId(1)
+        val savings = AccountId(2)
+        val ranges = listOf(range("2024-01-01", "2024-01-31", accountId = checking), range("2024-01-01", "2024-01-31", accountId = savings))
+        val filtered =
+            filterAccountRanges(
+                ranges,
+                accountNameById = mapOf(checking to "Checking", savings to "Savings"),
+                nameFilter = "",
+                selectedOwnerIds = setOf(42L),
+                ownerIdsByAccount = mapOf(savings to setOf(42L)),
+            )
+        assertEquals(listOf(savings), filtered.map { it.accountId })
+    }
+
+    @Test
+    fun filterAccountRangesWithBlankFilterAndNoOwnersSelectedKeepsEverything() {
+        val checking = AccountId(1)
+        val ranges = listOf(range("2024-01-01", "2024-01-31", accountId = checking))
+        val filtered =
+            filterAccountRanges(
+                ranges,
+                accountNameById = mapOf(checking to "Checking"),
+                nameFilter = "",
+                selectedOwnerIds = emptySet(),
+                ownerIdsByAccount = emptyMap(),
+            )
+        assertEquals(ranges, filtered)
+    }
+
+    @Test
+    fun accountModeGroupsByAccountNameAndAFileTouchingTwoAccountsAppearsInBoth() {
+        val checking = AccountId(1)
+        val savings = AccountId(2)
+        val matrix =
+            buildTimelineMatrix(
+                listOf(
+                    range("2024-01-01", "2024-01-31", fileId = "csv-1", accountId = checking),
+                    range("2024-01-01", "2024-01-31", fileId = "csv-1", accountId = savings),
+                    range("2024-02-01", "2024-02-28", fileId = "csv-2", accountId = checking),
+                ),
+                timeZone,
+                todayDay = day("2024-02-28"),
+                groupMode = TimelineGroupMode.ACCOUNT,
+                accountNameById = mapOf(checking to "Checking", savings to "Savings"),
+            )!!
+        assertEquals(listOf("Checking", "Savings"), matrix.rows.map { it.label })
+        assertEquals(
+            2,
+            matrix.rows
+                .single { it.label == "Checking" }
+                .files.size,
+        )
+        assertEquals(
+            1,
+            matrix.rows
+                .single { it.label == "Savings" }
+                .files.size,
+        )
+    }
+
+    @Test
+    fun accountModeFallsBackToUnknownAccountLabel() {
+        val matrix =
+            buildTimelineMatrix(
+                listOf(range("2024-01-01", "2024-01-31", accountId = AccountId(99))),
+                timeZone,
+                todayDay = day("2024-01-31"),
+                groupMode = TimelineGroupMode.ACCOUNT,
+                accountNameById = emptyMap(),
+            )!!
+        assertEquals(listOf("Unknown account"), matrix.rows.map { it.label })
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add a "By strategy" / "By account" toggle to the Import Timeline screen. The account view groups coverage rows by account instead of import strategy, unpivoting each transfer's `source_account_id`/`target_account_id` legs (same technique already used for balance/ledger queries), so a file whose transactions touch several accounts contributes a bar to each account's row.
- Add a name search box and a multi-select "Filter by owner" dropdown to the account view, narrowing the visible accounts — mirroring the existing filter UX on the Accounts screen exactly (same `ExposedDropdownMenuBox` + checkbox-list pattern, same `PersonAccountOwnership` join).
- New SQLDelight queries (`selectCsvImportAccountRanges`, `selectQifImportAccountRanges`, `selectApiSessionAccountRanges`, `selectManualAccountRanges`) and repository methods (`get*AccountRanges()`, `getAllAccountRanges()`) back the account view; `ImportFileDateRange` gained an optional `accountId` field populated only by these.

## Test plan
- [x] `./gradlew build buildHealth` passes locally
- [x] Unit tests for `buildTimelineMatrix` in `ACCOUNT` mode (a file touching two accounts appears in both rows) and for the new `filterAccountRanges` (name filter, owner filter, no-op when both are empty)
- [x] Compose UI tests for `ImportTimelineScreen` updated for the new repository params
- [ ] Manually verify in the running JVM app: switch to "By account", search by name, filter by owner, confirm gaps/tooltips/click-to-open still work per row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an account-based timeline view alongside the existing strategy view.
  * Added account-name filtering and multi-select owner filtering.
  * Timeline rows now display account names, with an “Unknown account” fallback when needed.
  * Import timeline data now supports account-specific date ranges across all transaction sources.
* **Tests**
  * Added coverage for account grouping, filtering, owner selection, and missing account names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->