### PR TITLE
Let accounts own multiple bank identities via attribute groups

### DIFF
--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiReimport.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiReimport.kt
@@ -213,7 +213,6 @@ suspend fun executeApiReimport(
                 if (strategy.peopleDownload != null) {
                     importApiSessionPeople(
                         apiSessionRepository = apiSessionRepository,
-                        accountRepository = accountRepository,
                         accountAttributeRepository = accountAttributeRepository,
                         importEngine = importEngine,
                         sessionId = session.id,

--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
@@ -2587,13 +2587,17 @@ private class BatchAccountResolver {
     private fun externalIdAttr(value: String) = NewAttribute(typeId = ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID, value = value)
 
     /**
-     * The sort-code + account-number pair for one bank identity, tagged with a shared group key so the two
-     * halves stay bound together. An account can legitimately own several identities (Crypto.com moved its
-     * fiat destination to a new sort code), and without the group the engine would be free to pair one
-     * identity's sort code with another's account number.
+     * The sort-code + account-number pair for one bank identity, always emitted TOGETHER under one shared
+     * grouping tag. This is the sole point that produces bank details, so the invariant "an API import
+     * never stores a sort code and account number separately" holds here: both halves carry the same tag,
+     * and the engine maps stored `group_key`s by tag, so both land under the same UUID — even if bank-key
+     * derivation ever returned null, because the grouping follows the tag, not the derived value. An account
+     * can legitimately own several identities (Crypto.com moved its fiat destination to a new sort code);
+     * the tag keeps each identity's two halves bound so the engine never pairs one identity's sort code
+     * with another's account number.
      *
-     * The group is SEEDED with the identity's own natural key so a re-import upserts the same group instead
-     * of minting a duplicate; nothing ever reads it back to recover the sort code.
+     * The tag is the identity's natural key. It is transient — it only groups the attributes within this
+     * batch and is never persisted; the engine translates it to an opaque UUID on write.
      */
     private fun bankAttrs(
         sortCode: String,

--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
@@ -39,7 +39,6 @@ import com.moneymanager.domain.model.apistrategy.TimestampFormat
 import com.moneymanager.domain.model.csv.ImportStatus
 import com.moneymanager.domain.model.passthrough.PassThroughAccount
 import com.moneymanager.domain.repository.AccountAttributeReadRepository
-import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.ApiSessionReadRepository
 import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.importengineapi.AccountMatchKey
@@ -490,7 +489,6 @@ private fun validatePeopleOwnershipConfig(config: ApiPersonImportConfig) {
  */
 suspend fun importApiSessionPeople(
     apiSessionRepository: ApiSessionReadRepository,
-    accountRepository: AccountReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
     importEngine: ImportEngine,
     sessionId: ApiSessionId,
@@ -509,12 +507,12 @@ suspend fun importApiSessionPeople(
     // The own accounts these people own already exist in the DB; resolve their ids by external id (a
     // read, not a write) so they can be referenced via AccountRef.Existing.
     val ownedAccountsByProfile =
-        buildProfileAccountMap(apiSessionRepository, accountRepository, accountAttributeRepository, accountsSessionId, strategy, config)
+        buildProfileAccountMap(apiSessionRepository, accountAttributeRepository, accountsSessionId, strategy, config)
     // Flat providers with a single global account holder (no ancestor hierarchy) link that holder to
     // every account imported in the session.
     val allSessionAccountIds =
         if (config.ownsAllAccounts) {
-            loadSessionAccountIds(apiSessionRepository, accountRepository, accountAttributeRepository, accountsSessionId, strategy)
+            loadSessionAccountIds(apiSessionRepository, accountAttributeRepository, accountsSessionId, strategy)
         } else {
             emptyList()
         }
@@ -566,7 +564,6 @@ suspend fun importApiSessionPeople(
 /** Builds a map of profile external id → the [AccountId]s fetched under that profile. */
 private suspend fun buildProfileAccountMap(
     apiSessionRepository: ApiSessionReadRepository,
-    accountRepository: AccountReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
     accountsSessionId: ApiSessionId?,
     strategy: ApiImportStrategy,
@@ -574,7 +571,7 @@ private suspend fun buildProfileAccountMap(
 ): Map<String, List<AccountId>> {
     val ancestorExpr = config.accountOwnerAncestorExpr ?: return emptyMap()
     if (accountsSessionId == null) return emptyMap()
-    val accountIdByExternalId = loadAccountExternalIdIndex(accountRepository, accountAttributeRepository)
+    val accountIdByExternalId = loadAccountExternalIdIndex(accountAttributeRepository)
     val requestsById = apiSessionRepository.getRequestsBySession(accountsSessionId).associateBy { it.id }
     val result = mutableMapOf<String, MutableList<AccountId>>()
     for (response in apiSessionRepository.getResponsesBySession(accountsSessionId)) {
@@ -595,13 +592,12 @@ private suspend fun buildProfileAccountMap(
 /** Returns every [AccountId] imported under [accountsSessionId] (used for [ApiPersonImportConfig.ownsAllAccounts]). */
 private suspend fun loadSessionAccountIds(
     apiSessionRepository: ApiSessionReadRepository,
-    accountRepository: AccountReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
     accountsSessionId: ApiSessionId?,
     strategy: ApiImportStrategy,
 ): List<AccountId> {
     if (accountsSessionId == null) return emptyList()
-    val accountIdByExternalId = loadAccountExternalIdIndex(accountRepository, accountAttributeRepository)
+    val accountIdByExternalId = loadAccountExternalIdIndex(accountAttributeRepository)
     val requestsById = apiSessionRepository.getRequestsBySession(accountsSessionId).associateBy { it.id }
     val result = mutableListOf<AccountId>()
     for (response in apiSessionRepository.getResponsesBySession(accountsSessionId)) {
@@ -677,7 +673,7 @@ suspend fun importApiSessionTransactions(
     onProgress(ApiSessionImportProgress(detail = "Transactions prepared. Processing people...", progress = 0.6f))
     addCustomAccountFieldAttributes(setup)
     buildPeopleAndOwnershipIntents(setup)
-    onProgress(ApiSessionImportProgress(detail = "Importing...", progress = 0.7f))
+    onProgress(ApiSessionImportProgress(detail = "Saving to database...", progress = 0.7f))
     val importResult = runImportEngine(setup, preparedTransfers)
     onProgress(ApiSessionImportProgress(detail = "Import finalized.", progress = 0.98f))
     return ApiSessionImportResult(
@@ -1049,17 +1045,18 @@ private suspend fun resolveOwnAccountKey(
 
 suspend fun discoverApiCounterpartiesToCreate(
     apiSessionRepository: ApiSessionReadRepository,
-    accountRepository: AccountReadRepository,
     accountAttributeRepository: AccountAttributeReadRepository,
     sessionId: ApiSessionId,
     strategy: ApiImportStrategy,
+    onProgress: (ApiSessionImportProgress) -> Unit = {},
 ): List<ApiCounterpartySuggestion> {
     val counterpartyIdField = strategy.transactionMappings.counterpartyIdField ?: return emptyList()
-    val existingCounterpartyIds =
-        loadCounterpartyIdIndex(
-            accountRepository = accountRepository,
-            accountAttributeRepository = accountAttributeRepository,
-        ).keys
+    // Reported as sub-steps so the (potentially slow) preparation phase shows what it is doing rather than
+    // a single opaque "Preparing import…". Left indeterminate (no fraction) so the bar does not fill and
+    // then reset when the engine phases take over with their own 0–100% progress.
+    onProgress(ApiSessionImportProgress(detail = "Scanning existing accounts...", progress = null))
+    val existingCounterpartyIds = loadCounterpartyIdIndex(accountAttributeRepository).keys
+    onProgress(ApiSessionImportProgress(detail = "Reading downloaded transactions...", progress = null))
     val requestsById = apiSessionRepository.getRequestsBySession(sessionId).associateBy { it.id }
     val transactionResponses =
         apiSessionRepository
@@ -1071,6 +1068,9 @@ suspend fun discoverApiCounterpartiesToCreate(
         strategy = strategy,
         counterpartyIdField = counterpartyIdField,
         nameMappings = CounterpartyNameMappings.from(strategy),
+        onResponseProcessed = { done, total ->
+            onProgress(ApiSessionImportProgress(detail = "Finding new counterparties ($done/$total)...", progress = null))
+        },
     ).filterKeys { it !in existingCounterpartyIds }
         .map { (counterpartyId, names) ->
             ApiCounterpartySuggestion(
@@ -1149,9 +1149,11 @@ private fun collectCounterpartiesFromResponses(
     strategy: ApiImportStrategy,
     counterpartyIdField: String,
     nameMappings: CounterpartyNameMappings,
+    onResponseProcessed: (done: Int, total: Int) -> Unit = { _, _ -> },
 ): Map<String, List<String>> =
     responses
-        .flatMap { response ->
+        .flatMapIndexed { index, response ->
+            onResponseProcessed(index + 1, responses.size)
             parseTransactionsWithPath(response.json, strategy).mapNotNull { item ->
                 // Skip transactions handled by built-in type logic — their counterpartyId is
                 // irrelevant because they all route to a single built-in account.
@@ -1172,22 +1174,17 @@ private fun collectCounterpartiesFromResponses(
             valueTransform = { it.second },
         ).mapValues { (_, names) -> names.filterNotNull() }
 
-private suspend fun loadCounterpartyIdIndex(
-    accountRepository: AccountReadRepository,
-    accountAttributeRepository: AccountAttributeReadRepository,
-): Map<String, AccountId> = loadAccountExternalIdIndex(accountRepository, accountAttributeRepository)
+private suspend fun loadCounterpartyIdIndex(accountAttributeRepository: AccountAttributeReadRepository): Map<String, AccountId> =
+    loadAccountExternalIdIndex(accountAttributeRepository)
 
-private suspend fun loadAccountExternalIdIndex(
-    accountRepository: AccountReadRepository,
-    accountAttributeRepository: AccountAttributeReadRepository,
-): Map<String, AccountId> {
+private suspend fun loadAccountExternalIdIndex(accountAttributeRepository: AccountAttributeReadRepository): Map<String, AccountId> {
+    // One query for every account's attributes rather than a per-account read: this used to be an N+1
+    // over the whole account table, which dominated the "Preparing import…" phase on a large database.
     val index = mutableMapOf<String, AccountId>()
-    for (account in accountRepository.getAllAccounts().first()) {
-        accountAttributeRepository
-            .getByAccount(account.id)
-            .first()
-            .firstOrNull { it.attributeType.id == ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID }
-            ?.let { index[it.value] = account.id }
+    for (attr in accountAttributeRepository.getAll().first()) {
+        if (attr.attributeType.id == ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID) {
+            index[attr.value] = attr.accountId
+        }
     }
     return index
 }

--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
@@ -1054,9 +1054,9 @@ suspend fun discoverApiCounterpartiesToCreate(
     // Reported as sub-steps so the (potentially slow) preparation phase shows what it is doing rather than
     // a single opaque "Preparing import…". Left indeterminate (no fraction) so the bar does not fill and
     // then reset when the engine phases take over with their own 0–100% progress.
-    onProgress(ApiSessionImportProgress(detail = "Scanning existing accounts...", progress = null))
+    onProgress(ApiSessionImportProgress(detail = "Scanning existing accounts..."))
     val existingCounterpartyIds = loadCounterpartyIdIndex(accountAttributeRepository).keys
-    onProgress(ApiSessionImportProgress(detail = "Reading downloaded transactions...", progress = null))
+    onProgress(ApiSessionImportProgress(detail = "Reading downloaded transactions..."))
     val requestsById = apiSessionRepository.getRequestsBySession(sessionId).associateBy { it.id }
     val transactionResponses =
         apiSessionRepository
@@ -1069,7 +1069,7 @@ suspend fun discoverApiCounterpartiesToCreate(
         counterpartyIdField = counterpartyIdField,
         nameMappings = CounterpartyNameMappings.from(strategy),
         onResponseProcessed = { done, total ->
-            onProgress(ApiSessionImportProgress(detail = "Finding new counterparties ($done/$total)...", progress = null))
+            onProgress(ApiSessionImportProgress(detail = "Finding new counterparties ($done/$total)..."))
         },
     ).filterKeys { it !in existingCounterpartyIds }
         .map { (counterpartyId, names) ->

--- a/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
+++ b/app/apiimporter/src/commonMain/kotlin/com/moneymanager/apiimporter/ApiSessionImportService.kt
@@ -45,6 +45,7 @@ import com.moneymanager.domain.repository.CurrencyReadRepository
 import com.moneymanager.importengineapi.AccountMatchKey
 import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.ApiSessionMutation
+import com.moneymanager.importengineapi.AttributeSlot
 import com.moneymanager.importengineapi.DedupePolicy
 import com.moneymanager.importengineapi.ExistingApiIdExtractor
 import com.moneymanager.importengineapi.ExistingUniqueKeyExtractor
@@ -62,6 +63,7 @@ import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.importengineapi.PassThroughDetector
 import com.moneymanager.importengineapi.PersonMatchKey
+import com.moneymanager.importengineapi.bankKeysFrom
 import com.moneymanager.importengineapi.getOrCreateAttributeType
 import com.moneymanager.importengineapi.normalizeNameKey
 import com.moneymanager.importengineapi.personalCounterpartyKey
@@ -708,13 +710,26 @@ private suspend fun ensureSourceAccounts(setup: ImportSetup) {
  * The own account's bank details (sort code, account number), taken from the account itself (filled
  * directly from the accounts response or from the account-identifiers endpoint) or, failing that, from
  * its owners. Either element is null when absent.
+ *
+ * The pair is preferred from a SINGLE source — the account's own fields, else the first owner supplying
+ * both — before falling back to mixing an account-level sort code with an owner-level account number.
+ * A mixed pair is a bank identity that belongs to no real account, and now that the pair also seeds an
+ * attribute group key, a bogus one would persist as a group and be upserted on every later import
+ * rather than merely mis-keying a single match.
  */
 private fun ApiImportAccount.bankDetails(): Pair<String?, String?> {
-    val sortCode =
-        sortCode?.takeIf { it.isNotBlank() } ?: owners.firstOrNull { !it.sortCode.isNullOrBlank() }?.sortCode
-    val accountNumber =
-        accountNumber?.takeIf { it.isNotBlank() } ?: owners.firstOrNull { !it.accountNumber.isNullOrBlank() }?.accountNumber
-    return sortCode to accountNumber
+    val ownSortCode = sortCode?.takeIf { it.isNotBlank() }
+    val ownAccountNumber = accountNumber?.takeIf { it.isNotBlank() }
+    if (ownSortCode != null && ownAccountNumber != null) return ownSortCode to ownAccountNumber
+
+    val completeOwner =
+        owners.firstOrNull { !it.sortCode.isNullOrBlank() && !it.accountNumber.isNullOrBlank() }
+    if (completeOwner != null) return completeOwner.sortCode to completeOwner.accountNumber
+
+    // Last resort: neither the account nor any single owner has a complete pair, so fill each half
+    // independently and accept that they may come from different objects.
+    return (ownSortCode ?: owners.firstOrNull { !it.sortCode.isNullOrBlank() }?.sortCode) to
+        (ownAccountNumber ?: owners.firstOrNull { !it.accountNumber.isNullOrBlank() }?.accountNumber)
 }
 
 /** Mutable progress counters shared between the setup, parallel import, and progress callback. */
@@ -1260,8 +1275,10 @@ private data class PersonalCounterpartyIdentity(
     val sortCode: String,
     val accountNumber: String,
 ) {
+    // Built with the shared helper so this dedupe key, the engine's match key and the attribute group key
+    // seeded by [bankAttrs] are the same string by construction rather than by coincidence.
     val dedupeKey: String
-        get() = "$sortCode|$accountNumber"
+        get() = personalCounterpartyKey(sortCode, accountNumber)
 }
 
 private fun ApiImportAccountOwner.personalCounterpartyIdentity(): PersonalCounterpartyIdentity? {
@@ -2569,16 +2586,27 @@ private class BatchAccountResolver {
 
     private fun externalIdAttr(value: String) = NewAttribute(typeId = ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID, value = value)
 
+    /**
+     * The sort-code + account-number pair for one bank identity, tagged with a shared group key so the two
+     * halves stay bound together. An account can legitimately own several identities (Crypto.com moved its
+     * fiat destination to a new sort code), and without the group the engine would be free to pair one
+     * identity's sort code with another's account number.
+     *
+     * The group is SEEDED with the identity's own natural key so a re-import upserts the same group instead
+     * of minting a duplicate; nothing ever reads it back to recover the sort code.
+     */
     private fun bankAttrs(
         sortCode: String,
         accountNumber: String,
-    ): List<NewAttribute> =
-        listOf(
-            NewAttribute(typeId = ACCOUNT_SORT_CODE_ATTR_TYPE_ID, value = sortCode),
-            NewAttribute(typeId = ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID, value = accountNumber),
+    ): List<NewAttribute> {
+        val group = personalCounterpartyKey(sortCode, accountNumber)
+        return listOf(
+            NewAttribute(typeId = ACCOUNT_SORT_CODE_ATTR_TYPE_ID, value = sortCode, groupKey = group),
+            NewAttribute(typeId = ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID, value = accountNumber, groupKey = group),
         )
+    }
 
-    /** Adds attributes (deduped by type+value) onto an already-allocated intent. */
+    /** Adds attributes (deduped by type+value+group) onto an already-allocated intent. */
     private fun mergeAttributes(
         key: LocalAccountKey,
         newAttrs: List<NewAttribute>,
@@ -2588,15 +2616,17 @@ private class BatchAccountResolver {
         val existing = intent.attributes
         val merged =
             existing +
-                newAttrs.filter { attr -> existing.none { it.typeId == attr.typeId && it.value == attr.value } }
+                newAttrs.filter { attr ->
+                    existing.none { it.typeId == attr.typeId && it.value == attr.value && it.groupKey == attr.groupKey }
+                }
         if (merged.size != existing.size) intents[key] = intent.copy(attributes = merged)
-        // Register any bank attributes on the personal-key index so a later personal-counterparty
-        // match (or a source account with the same bank key) collapses onto this same intent.
-        val sortCode = merged.firstOrNull { it.typeId == ACCOUNT_SORT_CODE_ATTR_TYPE_ID }?.value
-        val accountNumber = merged.firstOrNull { it.typeId == ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID }?.value
-        if (!sortCode.isNullOrBlank() && !accountNumber.isNullOrBlank()) {
-            byPersonalKey.getOrPut(personalCounterpartyKey(sortCode, accountNumber)) { key }
-        }
+        // Register EVERY bank identity on the personal-key index so a later personal-counterparty match (or
+        // a source account with any of these bank keys) collapses onto this same intent. This is where one
+        // intent accumulates a second identity, so scanning per group matters twice over: keying off the
+        // first sort code alone would leave the second identity unregistered, and pairing across groups
+        // would invent a key belonging to no real account.
+        bankKeysFrom(merged.map { AttributeSlot(it.typeId.id, it.value, it.groupKey) })
+            .forEach { bankKey -> byPersonalKey.getOrPut(bankKey) { key } }
     }
 
     /**
@@ -3188,7 +3218,11 @@ private fun JsonObject.bankIdentity(peopleMappings: ApiPeopleMappings): String? 
 private fun bankDedupeKeyFromCounterpartyId(counterpartyId: String?): String? {
     if (counterpartyId == null || !counterpartyId.startsWith("bank:")) return null
     val (sortCode, accountNumber) = counterpartyId.removePrefix("bank:").split(":").takeIf { it.size == 2 } ?: return null
-    return if (sortCode.isNotBlank() && accountNumber.isNotBlank()) "$sortCode|$accountNumber" else null
+    return if (sortCode.isNotBlank() && accountNumber.isNotBlank()) {
+        personalCounterpartyKey(sortCode, accountNumber)
+    } else {
+        null
+    }
 }
 
 /**

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -39,6 +39,7 @@ import com.moneymanager.importengineapi.createAccounts
 import com.moneymanager.importengineapi.createCrypto
 import com.moneymanager.importengineapi.createTrade
 import com.moneymanager.importengineapi.getOrCreateAttributeType
+import com.moneymanager.importengineapi.personalCounterpartyKey
 import com.moneymanager.importer.ImportEngineImpl
 import com.moneymanager.test.database.DbTest
 import com.moneymanager.test.database.createAccount
@@ -147,8 +148,7 @@ class ImportEngineDbTest : DbTest() {
         val externalIdType = AttributeTypeId(WellKnownIds.ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID)
         val attributes = mutableListOf(NewAttribute(externalIdType, externalId))
         if (sortCode != null && accountNumber != null) {
-            attributes += NewAttribute(AttributeTypeId(WellKnownIds.ACCOUNT_SORT_CODE_ATTR_TYPE_ID), sortCode)
-            attributes += NewAttribute(AttributeTypeId(WellKnownIds.ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID), accountNumber)
+            attributes += bankIdentityAttrs(sortCode, accountNumber)
         }
         return ImportAccountIntent(
             key = key,
@@ -157,6 +157,18 @@ class ImportEngineDbTest : DbTest() {
             openingDate = baseTime,
             source = Source.SampleGenerator,
             attributes = attributes,
+        )
+    }
+
+    /** A bank identity as the API importer writes it: both halves sharing the natural-key group. */
+    private fun bankIdentityAttrs(
+        sortCode: String,
+        accountNumber: String,
+    ): List<NewAttribute> {
+        val group = personalCounterpartyKey(sortCode, accountNumber)
+        return listOf(
+            NewAttribute(AttributeTypeId(WellKnownIds.ACCOUNT_SORT_CODE_ATTR_TYPE_ID), sortCode, group),
+            NewAttribute(AttributeTypeId(WellKnownIds.ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID), accountNumber, group),
         )
     }
 
@@ -219,6 +231,204 @@ class ImportEngineDbTest : DbTest() {
             assertEquals(2, result.accountsCreated)
             assertEquals(1, accountsNamed("Nikolay Metchev"))
             assertEquals(1, accountsNamed("Nikolay Metchev (6361)"))
+        }
+
+    /**
+     * An account can own several bank identities: Crypto.com moved its fiat destination from one sort
+     * code to another, so payments to the same account arrive under two. Both must resolve to it, or the
+     * second one forks a duplicate account that money flows into and never out of.
+     */
+    @Test
+    fun accountWithTwoBankIdentities_matchesOnEither() =
+        runTest {
+            val key = LocalAccountKey("cash")
+            val externalIdType = AttributeTypeId(WellKnownIds.ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID)
+            val created =
+                engine().import(
+                    ImportBatch(
+                        accountsToCreate =
+                            listOf(
+                                ImportAccountIntent(
+                                    key = key,
+                                    match = AccountMatchKey.ByExternalId(externalIdType, "crypto-com-cash"),
+                                    name = "Crypto.com Cash",
+                                    openingDate = baseTime,
+                                    source = Source.SampleGenerator,
+                                    attributes =
+                                        listOf(NewAttribute(externalIdType, "crypto-com-cash")) +
+                                            bankIdentityAttrs("040541", "00002490") +
+                                            bankIdentityAttrs("040736", "01311504"),
+                                ),
+                            ),
+                    ),
+                )
+            val cashId = created.createdAccountIds.getValue(key)
+
+            // A later import knows the account only by its bank details — once by the old identity, once by
+            // the new one. Neither may create an account.
+            val second =
+                engine().import(
+                    ImportBatch(
+                        accountsToCreate =
+                            listOf(
+                                counterpartyByExternalId(
+                                    LocalAccountKey("old"),
+                                    "FORIS MT LIMITED",
+                                    "bank:040541:00002490",
+                                    sortCode = "040541",
+                                    accountNumber = "00002490",
+                                ),
+                                counterpartyByExternalId(
+                                    LocalAccountKey("new"),
+                                    "NIKOLAY IVANOV METCHEV",
+                                    "bank:040736:01311504",
+                                    sortCode = "040736",
+                                    accountNumber = "01311504",
+                                ),
+                            ),
+                    ),
+                )
+
+            assertEquals(0, second.accountsCreated)
+            assertEquals(cashId, second.createdAccountIds.getValue(LocalAccountKey("old")))
+            assertEquals(cashId, second.createdAccountIds.getValue(LocalAccountKey("new")))
+        }
+
+    /**
+     * Re-importing an account that already holds both identities must upsert the same two groups rather
+     * than duplicate them — the group key is seeded from the identity's own values precisely so this is a
+     * no-op.
+     */
+    @Test
+    fun reimportOfBothBankIdentities_isIdempotent() =
+        runTest {
+            val externalIdType = AttributeTypeId(WellKnownIds.ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID)
+
+            fun batch() =
+                ImportBatch(
+                    accountsToCreate =
+                        listOf(
+                            ImportAccountIntent(
+                                key = LocalAccountKey("cash"),
+                                match = AccountMatchKey.ByExternalId(externalIdType, "crypto-com-cash"),
+                                name = "Crypto.com Cash",
+                                openingDate = baseTime,
+                                source = Source.SampleGenerator,
+                                adoptOnBankMatch = true,
+                                attributes =
+                                    listOf(NewAttribute(externalIdType, "crypto-com-cash")) +
+                                        bankIdentityAttrs("040541", "00002490") +
+                                        bankIdentityAttrs("040736", "01311504"),
+                            ),
+                        ),
+                )
+
+            val cashId = engine().import(batch()).createdAccountIds.getValue(LocalAccountKey("cash"))
+            val afterFirst = repositories.accountAttributeRepository.getByAccount(cashId).first()
+            engine().import(batch())
+            val afterSecond = repositories.accountAttributeRepository.getByAccount(cashId).first()
+
+            assertEquals(5, afterFirst.size)
+            assertEquals(
+                afterFirst.map { Triple(it.attributeType.id, it.value, it.groupKey) }.toSet(),
+                afterSecond.map { Triple(it.attributeType.id, it.value, it.groupKey) }.toSet(),
+            )
+            // Both identities remain distinct groups rather than collapsing into one.
+            assertEquals(2, afterSecond.count { it.groupKey.isNotEmpty() } / 2)
+        }
+
+    /**
+     * The headline regression. Merging the duplicate account away must CARRY its bank identity onto the
+     * survivor; otherwise the cascade delete drops the identity and the next import sees an unknown sort
+     * code / account number pair and re-creates the very account just merged away.
+     */
+    @Test
+    fun mergedAwayBankIdentity_doesNotResurrectTheAccountOnReimport() =
+        runTest {
+            fun incoming() =
+                ImportBatch(
+                    accountsToCreate =
+                        listOf(
+                            counterpartyByExternalId(
+                                LocalAccountKey("old"),
+                                "Crypto.com Cash",
+                                "bank:040541:00002490",
+                                sortCode = "040541",
+                                accountNumber = "00002490",
+                            ),
+                            counterpartyByExternalId(
+                                LocalAccountKey("new"),
+                                "NIKOLAY IVANOV METCHEV",
+                                "bank:040736:01311504",
+                                sortCode = "040736",
+                                accountNumber = "01311504",
+                            ),
+                        ),
+                )
+
+            val created = engine().import(incoming())
+            assertEquals(2, created.accountsCreated)
+            val keepId = created.createdAccountIds.getValue(LocalAccountKey("old"))
+            val dropId = created.createdAccountIds.getValue(LocalAccountKey("new"))
+
+            engine().import(
+                ImportBatch.manualEdits(accountMerges = listOf(AccountMergeRequest(deletedId = dropId, survivingId = keepId))),
+            )
+            assertNull(repositories.accountRepository.getAccountById(dropId).first())
+
+            // The survivor now owns both identities, so re-importing the same data creates nothing.
+            val second = engine().import(incoming())
+            assertEquals(0, second.accountsCreated)
+            assertEquals(0, accountsNamed("NIKOLAY IVANOV METCHEV"))
+            assertEquals(keepId, second.createdAccountIds.getValue(LocalAccountKey("new")))
+        }
+
+    /** Unmerging must hand the carried identity back, leaving neither account holding both. */
+    @Test
+    fun unmergingReturnsTheCarriedBankIdentityToTheRestoredAccount() =
+        runTest {
+            val created =
+                engine().import(
+                    ImportBatch(
+                        accountsToCreate =
+                            listOf(
+                                counterpartyByExternalId(
+                                    LocalAccountKey("keep"),
+                                    "Crypto.com Cash",
+                                    "bank:040541:00002490",
+                                    sortCode = "040541",
+                                    accountNumber = "00002490",
+                                ),
+                                counterpartyByExternalId(
+                                    LocalAccountKey("drop"),
+                                    "NIKOLAY IVANOV METCHEV",
+                                    "bank:040736:01311504",
+                                    sortCode = "040736",
+                                    accountNumber = "01311504",
+                                ),
+                            ),
+                    ),
+                )
+            val keepId = created.createdAccountIds.getValue(LocalAccountKey("keep"))
+            val dropId = created.createdAccountIds.getValue(LocalAccountKey("drop"))
+            val keepBefore = repositories.accountAttributeRepository.getByAccount(keepId).first()
+            val dropBefore = repositories.accountAttributeRepository.getByAccount(dropId).first()
+
+            engine().import(
+                ImportBatch.manualEdits(accountMerges = listOf(AccountMergeRequest(deletedId = dropId, survivingId = keepId))),
+            )
+            val merge =
+                repositories.accountRepository
+                    .getReversibleMerges()
+                    .first()
+                    .first()
+            engine().import(ImportBatch.manualEdits(accountUnmerges = listOf(merge.id)))
+
+            fun signature(attrs: List<com.moneymanager.domain.model.AccountAttribute>) =
+                attrs.map { Triple(it.attributeType.id, it.value, it.groupKey) }.toSet()
+
+            assertEquals(signature(keepBefore), signature(repositories.accountAttributeRepository.getByAccount(keepId).first()))
+            assertEquals(signature(dropBefore), signature(repositories.accountAttributeRepository.getByAccount(dropId).first()))
         }
 
     @Test

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/importer/ImportEngineDbTest.kt
@@ -52,6 +52,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Instant
+import kotlin.uuid.Uuid
 
 class ImportEngineDbTest : DbTest() {
     private val baseTime = Instant.fromEpochMilliseconds(1_700_000_000_000)
@@ -335,6 +336,48 @@ class ImportEngineDbTest : DbTest() {
             )
             // Both identities remain distinct groups rather than collapsing into one.
             assertEquals(2, afterSecond.count { it.groupKey.isNotEmpty() } / 2)
+            // Stored group keys are opaque UUIDs (minted by the engine), not the natural key seeded by the
+            // intent — and stable across the re-import, which is what keeps it idempotent.
+            afterSecond.filter { it.groupKey.isNotEmpty() }.forEach { Uuid.parse(it.groupKey) }
+        }
+
+    /**
+     * The invariant the API import relies on: a sort code and account number always land in ONE non-empty
+     * group, so the two halves of an identity can never be paired with another identity's.
+     */
+    @Test
+    fun importedBankIdentity_storesSortCodeAndAccountNumberInOneUuidGroup() =
+        runTest {
+            val result =
+                engine().import(
+                    ImportBatch(
+                        accountsToCreate =
+                            listOf(
+                                counterpartyByExternalId(
+                                    LocalAccountKey("cp"),
+                                    "NIKOLAY IVANOV METCHEV",
+                                    "bank:040736:01311504",
+                                    sortCode = "040736",
+                                    accountNumber = "01311504",
+                                ),
+                            ),
+                    ),
+                )
+            val id = result.createdAccountIds.getValue(LocalAccountKey("cp"))
+            val bankAttrs =
+                repositories.accountAttributeRepository
+                    .getByAccount(id)
+                    .first()
+                    .filter {
+                        it.attributeType.id.id == WellKnownIds.ACCOUNT_SORT_CODE_ATTR_TYPE_ID ||
+                            it.attributeType.id.id == WellKnownIds.ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID
+                    }
+            assertEquals(2, bankAttrs.size)
+            val groupKeys = bankAttrs.map { it.groupKey }.toSet()
+            assertEquals(1, groupKeys.size)
+            val groupKey = groupKeys.single()
+            assertTrue(groupKey.isNotEmpty())
+            Uuid.parse(groupKey)
         }
 
     /**

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/AccountRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/AccountRepositoryImplTest.kt
@@ -413,7 +413,7 @@ class AccountRepositoryImplTest : DbTest() {
         }
 
     @Test
-    fun `mergeAccounts carries the deleted account's identity groups onto the survivor`() =
+    fun `mergeAccounts carries the deleted accounts identity groups onto the survivor`() =
         runTest {
             val now = Clock.System.now()
             val keep =

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/AccountRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/AccountRepositoryImplTest.kt
@@ -45,11 +45,17 @@ class AccountRepositoryImplTest : DbTest() {
         runTest {
             val now = Clock.System.now()
             // Account A held "Shared" then was renamed away (audit row: name="Shared", account_id=A).
-            val a = repositories.accountRepository.createAccount(Account(id = AccountId(0), name = "Shared", openingDate = now))
+            val a =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Shared", openingDate = now),
+                )
             repositories.accountRepository.updateAccount(Account(id = a, name = "A Renamed", openingDate = now))
 
             // Account B later also held "Shared" (a MORE RECENT audit row) then was deleted.
-            val b = repositories.accountRepository.createAccount(Account(id = AccountId(0), name = "Shared", openingDate = now))
+            val b =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Shared", openingDate = now),
+                )
             repositories.accountRepository.updateAccount(Account(id = b, name = "B Renamed", openingDate = now))
             repositories.accountRepository.deleteAccount(b)
 
@@ -66,7 +72,9 @@ class AccountRepositoryImplTest : DbTest() {
                     Person(id = PersonId(0), firstName = "Owner", middleName = null, lastName = "One"),
                 )
             val accountId =
-                repositories.accountRepository.createAccount(Account(id = AccountId(0), name = "Acct", openingDate = now))
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Acct", openingDate = now),
+                )
             val manual = Source.Manual
 
             // Adding an owner is a change to the account: it must become a new revision.
@@ -95,7 +103,9 @@ class AccountRepositoryImplTest : DbTest() {
                     Person(id = PersonId(0), firstName = "Owner", middleName = null, lastName = "One"),
                 )
             val accountId =
-                repositories.accountRepository.createAccount(Account(id = AccountId(0), name = "Acct", openingDate = now))
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Acct", openingDate = now),
+                )
 
             // Default test provenance is SampleGenerator (a bulk/non-manual source): no revision bump.
             repositories.personAccountOwnershipRepository.createOwnership(person, accountId)
@@ -400,6 +410,100 @@ class AccountRepositoryImplTest : DbTest() {
                     .first()
                     .size,
             )
+        }
+
+    @Test
+    fun `mergeAccounts carries the deleted account's identity groups onto the survivor`() =
+        runTest {
+            val now = Clock.System.now()
+            val keep =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Crypto.com Cash", openingDate = now),
+                )
+            val drop =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "NIKOLAY IVANOV METCHEV", openingDate = now),
+                )
+            val sortCode = repositories.attributeTypeRepository.getOrCreate("account-sort-code")
+            val accountNumber = repositories.attributeTypeRepository.getOrCreate("account-account-number")
+
+            repositories.accountAttributeRepository.insert(keep, sortCode, "040541", "040541|00002490")
+            repositories.accountAttributeRepository.insert(keep, accountNumber, "00002490", "040541|00002490")
+            repositories.accountAttributeRepository.insert(drop, sortCode, "040736", "040736|01311504")
+            repositories.accountAttributeRepository.insert(drop, accountNumber, "01311504", "040736|01311504")
+
+            repositories.accountRepository.mergeAccounts(deletedAccount = drop, survivingAccount = keep)
+
+            // The survivor owns BOTH identities, each still a distinct group. Without the carry, the
+            // cascade delete would have dropped the second one and the next import would re-create it.
+            val attrs = repositories.accountAttributeRepository.getByAccount(keep).first()
+            assertEquals(
+                setOf("040541|00002490", "040736|01311504"),
+                attrs.map { it.groupKey }.toSet(),
+            )
+            assertEquals(
+                setOf("040541", "00002490", "040736", "01311504"),
+                attrs.map { it.value }.toSet(),
+            )
+        }
+
+    @Test
+    fun `mergeAccounts skips an identity the survivor already holds`() =
+        runTest {
+            val now = Clock.System.now()
+            val keep =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Keep", openingDate = now),
+                )
+            val drop =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Drop", openingDate = now),
+                )
+            val sortCode = repositories.attributeTypeRepository.getOrCreate("account-sort-code")
+            val accountNumber = repositories.attributeTypeRepository.getOrCreate("account-account-number")
+
+            // Both accounts describe the SAME real bank account, so both groups carry the same key and the
+            // same contents — the merge must not duplicate them onto the survivor.
+            listOf(keep, drop).forEach { account ->
+                repositories.accountAttributeRepository.insert(account, sortCode, "040541", "040541|00002490")
+                repositories.accountAttributeRepository.insert(account, accountNumber, "00002490", "040541|00002490")
+            }
+
+            repositories.accountRepository.mergeAccounts(deletedAccount = drop, survivingAccount = keep)
+
+            val attrs = repositories.accountAttributeRepository.getByAccount(keep).first()
+            assertEquals(2, attrs.size)
+        }
+
+    @Test
+    fun `mergeAccounts keeps both values when a group key collides with differing contents`() =
+        runTest {
+            val now = Clock.System.now()
+            val keep =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Keep", openingDate = now),
+                )
+            val drop =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Drop", openingDate = now),
+                )
+            val sortCode = repositories.attributeTypeRepository.getOrCreate("account-sort-code")
+            val accountNumber = repositories.attributeTypeRepository.getOrCreate("account-account-number")
+
+            // A stale group key: both accounts use the key "legacy" for different real identities (someone
+            // hand-edited a sort code, so the key no longer matches its contents). Neither may be lost.
+            repositories.accountAttributeRepository.insert(keep, sortCode, "040541", "legacy")
+            repositories.accountAttributeRepository.insert(keep, accountNumber, "00002490", "legacy")
+            repositories.accountAttributeRepository.insert(drop, sortCode, "040736", "legacy")
+            repositories.accountAttributeRepository.insert(drop, accountNumber, "01311504", "legacy")
+
+            repositories.accountRepository.mergeAccounts(deletedAccount = drop, survivingAccount = keep)
+
+            val attrs = repositories.accountAttributeRepository.getByAccount(keep).first()
+            assertEquals(4, attrs.size)
+            assertEquals(setOf("040541", "00002490", "040736", "01311504"), attrs.map { it.value }.toSet())
+            // The clashing group was re-keyed rather than overwritten, so the two identities stay separable.
+            assertEquals(2, attrs.map { it.groupKey }.toSet().size)
         }
 
     @Test

--- a/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/AccountRepositoryImplTest.kt
+++ b/app/db/core/src/commonTest/kotlin/com/moneymanager/database/repository/AccountRepositoryImplTest.kt
@@ -476,6 +476,36 @@ class AccountRepositoryImplTest : DbTest() {
         }
 
     @Test
+    fun `mergeAccounts dedups the same identity held under different group keys`() =
+        runTest {
+            val now = Clock.System.now()
+            val keep =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Keep", openingDate = now),
+                )
+            val drop =
+                repositories.accountRepository.createAccount(
+                    Account(id = AccountId(0), name = "Drop", openingDate = now),
+                )
+            val sortCode = repositories.attributeTypeRepository.getOrCreate("account-sort-code")
+            val accountNumber = repositories.attributeTypeRepository.getOrCreate("account-account-number")
+
+            // Same real bank account, but each was created independently so the identity sits under a
+            // DIFFERENT opaque UUID on each account (as real imports now produce). The merge must recognise
+            // them as one identity by derived value, not be fooled by the mismatched keys, and not duplicate.
+            repositories.accountAttributeRepository.insert(keep, sortCode, "040541", "11111111-1111-1111-1111-111111111111")
+            repositories.accountAttributeRepository.insert(keep, accountNumber, "00002490", "11111111-1111-1111-1111-111111111111")
+            repositories.accountAttributeRepository.insert(drop, sortCode, "040541", "22222222-2222-2222-2222-222222222222")
+            repositories.accountAttributeRepository.insert(drop, accountNumber, "00002490", "22222222-2222-2222-2222-222222222222")
+
+            repositories.accountRepository.mergeAccounts(deletedAccount = drop, survivingAccount = keep)
+
+            val attrs = repositories.accountAttributeRepository.getByAccount(keep).first()
+            assertEquals(2, attrs.size)
+            assertEquals(setOf("11111111-1111-1111-1111-111111111111"), attrs.map { it.groupKey }.toSet())
+        }
+
+    @Test
     fun `mergeAccounts keeps both values when a group key collides with differing contents`() =
         runTest {
             val now = Clock.System.now()

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/accountAttribute/AccountAttributeSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/accountAttribute/AccountAttributeSelect.sq
@@ -4,6 +4,7 @@ SELECT
     account_attribute.account_id,
     account_attribute.attribute_type_id,
     account_attribute.attribute_value,
+    account_attribute.group_key,
     attribute_type.name AS attribute_type_name
 FROM account_attribute
 JOIN attribute_type ON account_attribute.attribute_type_id = attribute_type.id
@@ -16,6 +17,7 @@ SELECT
     account_attribute.account_id,
     account_attribute.attribute_type_id,
     account_attribute.attribute_value,
+    account_attribute.group_key,
     attribute_type.name AS attribute_type_name
 FROM account_attribute
 JOIN attribute_type ON account_attribute.attribute_type_id = attribute_type.id
@@ -27,6 +29,7 @@ SELECT
     account_attribute.account_id,
     account_attribute.attribute_type_id,
     account_attribute.attribute_value,
+    account_attribute.group_key,
     attribute_type.name AS attribute_type_name
 FROM account_attribute
 JOIN attribute_type ON account_attribute.attribute_type_id = attribute_type.id
@@ -39,6 +42,7 @@ SELECT
     account_attribute.account_id,
     account_attribute.attribute_type_id,
     account_attribute.attribute_value,
+    account_attribute.group_key,
     attribute_type.name AS attribute_type_name
 FROM account_attribute
 JOIN attribute_type ON account_attribute.attribute_type_id = attribute_type.id

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/accountMerge/AccountMergeSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/accountMerge/AccountMergeSelect.sq
@@ -45,3 +45,7 @@ WHERE account_merge.deleted_account_id = ?;
 
 selectTransfersForMerge:
 SELECT transfer_id, moved_source, moved_target FROM account_merge_transfer WHERE merge_id = ?;
+
+-- The attribute rows this merge grafted onto the surviving account; unmerge deletes exactly these.
+selectAttributeIdsForMerge:
+SELECT attribute_id FROM account_merge_attribute WHERE merge_id = ?;

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/AuditSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/AuditSelect.sq
@@ -63,6 +63,7 @@ SELECT
     transfer_attribute_audit.revision_id,
     transfer_attribute_audit.attribute_type_id,
     transfer_attribute_audit.attribute_value,
+    transfer_attribute_audit.group_key,
     attribute_type.name AS attribute_type_name
 FROM transfer_attribute_audit
 JOIN audit_type ON transfer_attribute_audit.audit_type_id = audit_type.id
@@ -80,6 +81,7 @@ SELECT
     account_attribute_audit.revision_id,
     account_attribute_audit.attribute_type_id,
     account_attribute_audit.attribute_value,
+    account_attribute_audit.group_key,
     attribute_type.name AS attribute_type_name
 FROM account_attribute_audit
 JOIN audit_type ON account_attribute_audit.audit_type_id = audit_type.id
@@ -97,6 +99,7 @@ SELECT
     person_attribute_audit.revision_id,
     person_attribute_audit.attribute_type_id,
     person_attribute_audit.attribute_value,
+    person_attribute_audit.group_key,
     attribute_type.name AS attribute_type_name
 FROM person_attribute_audit
 JOIN audit_type ON person_attribute_audit.audit_type_id = audit_type.id
@@ -178,8 +181,11 @@ WHERE account_id = :accountId
 -- here using the attribute's own stamped revision_id, so it fires even after the parent account row
 -- is gone. Anchored to the account's own delete timestamp (see selectDeletedOwnershipPersonIds) so a
 -- most-recent delete with no attributes doesn't fall back to an older, unrelated delete's attributes.
+-- group_key is part of the restored tuple, not decoration: an account that owned two bank identities
+-- restored without it would collapse both pairs into the ungrouped slot and violate
+-- UNIQUE (account_id, attribute_type_id, group_key).
 selectDeletedAttributesForAccount:
-SELECT attribute_type_id, attribute_value
+SELECT attribute_type_id, attribute_value, group_key
 FROM account_attribute_audit
 WHERE account_id = :accountId
   AND audit_type_id = 3

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/personAttribute/PersonAttributeSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/personAttribute/PersonAttributeSelect.sq
@@ -4,6 +4,7 @@ SELECT
     person_attribute.person_id,
     person_attribute.attribute_type_id,
     person_attribute.attribute_value,
+    person_attribute.group_key,
     attribute_type.name AS attribute_type_name
 FROM person_attribute
 JOIN attribute_type ON person_attribute.attribute_type_id = attribute_type.id
@@ -16,6 +17,7 @@ SELECT
     person_attribute.person_id,
     person_attribute.attribute_type_id,
     person_attribute.attribute_value,
+    person_attribute.group_key,
     attribute_type.name AS attribute_type_name
 FROM person_attribute
 JOIN attribute_type ON person_attribute.attribute_type_id = attribute_type.id

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/personAttribute/PersonAttributeSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/personAttribute/PersonAttributeSelect.sq
@@ -22,3 +22,15 @@ SELECT
 FROM person_attribute
 JOIN attribute_type ON person_attribute.attribute_type_id = attribute_type.id
 WHERE person_attribute.id = ?;
+
+selectAll:
+SELECT
+    person_attribute.id,
+    person_attribute.person_id,
+    person_attribute.attribute_type_id,
+    person_attribute.attribute_value,
+    person_attribute.group_key,
+    attribute_type.name AS attribute_type_name
+FROM person_attribute
+JOIN attribute_type ON person_attribute.attribute_type_id = attribute_type.id
+ORDER BY attribute_type.name, person_attribute.person_id;

--- a/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transferAttribute/TransferAttributeSelect.sq
+++ b/app/db/read/src/commonMain/sqldelight/com/moneymanager/database/sql/transferAttribute/TransferAttributeSelect.sq
@@ -4,6 +4,7 @@ SELECT
     transfer_attribute.transaction_id,
     transfer_attribute.attribute_type_id,
     transfer_attribute.attribute_value,
+    transfer_attribute.group_key,
     attribute_type.id AS attribute_type_id,
     attribute_type.name AS attribute_type_name
 FROM transfer_attribute
@@ -17,6 +18,7 @@ SELECT
     transfer_attribute.transaction_id,
     transfer_attribute.attribute_type_id,
     transfer_attribute.attribute_value,
+    transfer_attribute.group_key,
     attribute_type.id AS attribute_type_id,
     attribute_type.name AS attribute_type_name
 FROM transfer_attribute
@@ -29,6 +31,7 @@ SELECT
     transfer_attribute.transaction_id,
     transfer_attribute.attribute_type_id,
     transfer_attribute.attribute_value,
+    transfer_attribute.group_key,
     attribute_type.id AS attribute_type_id,
     attribute_type.name AS attribute_type_name
 FROM transfer_attribute

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/AccountAttributeReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/AccountAttributeReadRepositoryImpl.kt
@@ -33,6 +33,7 @@ class AccountAttributeReadRepositoryImpl(
                                 name = row.attribute_type_name,
                             ),
                         value = row.attribute_value,
+                        groupKey = row.group_key,
                     )
                 }
             }
@@ -53,6 +54,7 @@ class AccountAttributeReadRepositoryImpl(
                                 name = row.attribute_type_name,
                             ),
                         value = row.attribute_value,
+                        groupKey = row.group_key,
                     )
                 }
             }
@@ -73,6 +75,7 @@ class AccountAttributeReadRepositoryImpl(
                                 name = row.attribute_type_name,
                             ),
                         value = row.attribute_value,
+                        groupKey = row.group_key,
                     )
                 }
             }

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/AuditReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/AuditReadRepositoryImpl.kt
@@ -200,6 +200,7 @@ class AuditReadRepositoryImpl(
                         ),
                     auditType = mapAuditType(row.audit_type),
                     value = row.attribute_value,
+                    groupKey = row.group_key,
                 )
             }
 
@@ -256,6 +257,7 @@ class AuditReadRepositoryImpl(
                             ),
                         auditType = mapAuditType(row.audit_type),
                         value = row.attribute_value,
+                        groupKey = row.group_key,
                     )
                 }
 

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/PersonAttributeReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/PersonAttributeReadRepositoryImpl.kt
@@ -37,4 +37,25 @@ class PersonAttributeReadRepositoryImpl(
                     )
                 }
             }
+
+    override fun getAll(): Flow<List<PersonAttribute>> =
+        selectQueries
+            .selectAll()
+            .asFlow()
+            .mapToList(Dispatchers.Default)
+            .map { list ->
+                list.map { row ->
+                    PersonAttribute(
+                        id = row.id,
+                        personId = PersonId(row.person_id),
+                        attributeType =
+                            AttributeType(
+                                id = AttributeTypeId(row.attribute_type_id),
+                                name = row.attribute_type_name,
+                            ),
+                        value = row.attribute_value,
+                        groupKey = row.group_key,
+                    )
+                }
+            }
 }

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/PersonAttributeReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/PersonAttributeReadRepositoryImpl.kt
@@ -33,6 +33,7 @@ class PersonAttributeReadRepositoryImpl(
                                 name = row.attribute_type_name,
                             ),
                         value = row.attribute_value,
+                        groupKey = row.group_key,
                     )
                 }
             }

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/TransactionReadRepositoryImpl.kt
@@ -56,6 +56,7 @@ class TransactionReadRepositoryImpl(
                                     name = row.attribute_type_name,
                                 ),
                             value = row.attribute_value,
+                            groupKey = row.group_key,
                         )
                     }
                 }

--- a/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/TransferAttributeReadRepositoryImpl.kt
+++ b/app/db/repository/src/commonMain/kotlin/com/moneymanager/database/repository/TransferAttributeReadRepositoryImpl.kt
@@ -33,6 +33,7 @@ class TransferAttributeReadRepositoryImpl(
                                 name = row.attribute_type_name,
                             ),
                         value = row.attribute_value,
+                        groupKey = row.group_key,
                     )
                 }
             }

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/accountAttribute/AccountAttribute.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/accountAttribute/AccountAttribute.sq
@@ -3,15 +3,31 @@ CREATE TABLE account_attribute (
     account_id INTEGER NOT NULL,
     attribute_type_id INTEGER NOT NULL,
     attribute_value TEXT NOT NULL,
+    -- Opaque grouping tag. Attributes on the same account sharing the same NON-EMPTY group_key form one
+    -- logical tuple, so an account can own several of them: a sort code + account number pair is one bank
+    -- identity, and Crypto.com moving its fiat destination to a new sort code means one account legitimately
+    -- holds two. '' means ungrouped -- the default, and the value for every scalar attribute.
+    --
+    -- READERS MUST NEVER PARSE group_key. Derive meaning from the VALUES inside a group; writers merely SEED
+    -- it with a natural key (personalCounterpartyKey: "<sortCode>|<accountNumber>") so a re-import upserts
+    -- the same group instead of minting a duplicate. Parsing it would break that guarantee, because a group
+    -- key can legitimately go stale -- a user edits a sort code in the UI, or a merge renames a colliding
+    -- key. Both must stay harmless, and they only are while the key is treated as an arbitrary token.
+    --
+    -- NOT NULL is load-bearing, not stylistic: SQLite treats every NULL as distinct in a UNIQUE index, so a
+    -- nullable group_key would make the constraint below enforce nothing for ungrouped rows and stop
+    -- ON CONFLICT from ever firing. '' is the default group, not an absent one.
+    group_key TEXT NOT NULL DEFAULT '',
     -- The account revision at which this attribute's current value became effective. Maintained by the
-    -- attribute insert/update triggers (set to the parent account's post-bump revision). Lets the DELETE
-    -- audit trigger record the correct revision even on a cascade delete, when the parent account row is
-    -- already gone (see createAccountAttributeTriggers in DatabaseConfig).
+    -- attribute insert/update triggers in AuditTriggers.sq (set to the parent account's post-bump revision).
+    -- Lets the DELETE audit trigger record the correct revision even on a cascade delete, when the parent
+    -- account row is already gone.
     revision_id INTEGER NOT NULL DEFAULT 1,
     FOREIGN KEY (account_id) REFERENCES account(id) ON DELETE CASCADE,
     FOREIGN KEY (attribute_type_id) REFERENCES attribute_type(id) ON DELETE RESTRICT,
-    UNIQUE (account_id, attribute_type_id)
+    UNIQUE (account_id, attribute_type_id, group_key)
 );
 
 CREATE INDEX idx_account_attribute_account ON account_attribute(account_id);
 CREATE INDEX idx_account_attribute_type ON account_attribute(attribute_type_id);
+CREATE INDEX idx_account_attribute_group ON account_attribute(account_id, group_key);

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/accountAttribute/AccountAttribute.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/accountAttribute/AccountAttribute.sq
@@ -8,11 +8,12 @@ CREATE TABLE account_attribute (
     -- identity, and Crypto.com moving its fiat destination to a new sort code means one account legitimately
     -- holds two. '' means ungrouped -- the default, and the value for every scalar attribute.
     --
-    -- READERS MUST NEVER PARSE group_key. Derive meaning from the VALUES inside a group; writers merely SEED
-    -- it with a natural key (personalCounterpartyKey: "<sortCode>|<accountNumber>") so a re-import upserts
-    -- the same group instead of minting a duplicate. Parsing it would break that guarantee, because a group
-    -- key can legitimately go stale -- a user edits a sort code in the UI, or a merge renames a colliding
-    -- key. Both must stay harmless, and they only are while the key is treated as an arbitrary token.
+    -- The stored value is an opaque UUID (minted by the import engine when a group is first persisted, or
+    -- by the editor when a user forms a group). READERS MUST NEVER PARSE group_key: identity is derived
+    -- from the VALUES inside a group (e.g. sort code + account number), never from the key. That is what
+    -- lets a re-import reconcile to an existing group by content, and two accounts holding the same
+    -- identity under different UUIDs be merged without duplicating it. A UUID also means a user-formed
+    -- group can never accidentally collide with an importer's key or another group's.
     --
     -- NOT NULL is load-bearing, not stylistic: SQLite treats every NULL as distinct in a UNIQUE index, so a
     -- nullable group_key would make the constraint below enforce nothing for ungrouped rows and stop

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/accountMerge/AccountMerge.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/accountMerge/AccountMerge.sq
@@ -34,9 +34,26 @@ CREATE TABLE account_merge_transfer (
 
 CREATE INDEX idx_account_merge_transfer_merge ON account_merge_transfer(merge_id);
 
--- Note: neither attributes nor ownerships are snapshotted here. The merge's cascade delete records
--- each one as a DELETE in account_attribute_audit / person_account_ownership_audit (the attribute
--- delete trigger uses the attribute's own stamped revision_id, so it fires even after the parent
+-- The attribute rows the merge GRAFTED onto the surviving account -- the deleted account's identity
+-- groups, carried across so the merge does not destroy them. Without the carry, merging away an account
+-- that held a bank identity drops that identity, and the next import sees an unknown sort code /account
+-- number pair and re-creates the very account just merged away ("merge loses identity, account
+-- resurrects"). Recorded because the survivor's own audit trail cannot distinguish "added by the merge"
+-- from "added by the user", and unmerge must remove exactly what the merge added -- no more. Rows the
+-- merge skipped (the survivor already held that identity) are deliberately not recorded.
+CREATE TABLE account_merge_attribute (
+    merge_id INTEGER NOT NULL,
+    attribute_id INTEGER NOT NULL,
+    FOREIGN KEY (merge_id) REFERENCES account_merge(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_account_merge_attribute_merge ON account_merge_attribute(merge_id);
+
+-- Note: the deleted account's attributes and ownerships are not snapshotted here. The merge's cascade
+-- delete records each one as a DELETE in account_attribute_audit / person_account_ownership_audit (the
+-- attribute delete trigger uses the attribute's own stamped revision_id, so it fires even after the parent
 -- account is gone), so unmerge reconstructs both from the audit trail (Audit.sq
 -- selectDeletedAttributesForAccount / selectDeletedOwnershipPersonIds). Only the deleted account's own
 -- core fields are snapshotted above, since the cascade delete leaves no recoverable trace of them.
+-- account_merge_attribute is the mirror image: it tracks what the merge added to the SURVIVOR, which the
+-- cascade delete knows nothing about.

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/Audit.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/Audit.sq
@@ -126,6 +126,8 @@ CREATE TABLE transfer_attribute_audit (
     revision_id INTEGER NOT NULL,
     attribute_type_id INTEGER NOT NULL,
     attribute_value TEXT NOT NULL,
+    -- Opaque grouping tag carried from the attribute row; see account_attribute.group_key.
+    group_key TEXT NOT NULL DEFAULT '',
     FOREIGN KEY (audit_type_id) REFERENCES audit_type(id),
     FOREIGN KEY (attribute_type_id) REFERENCES attribute_type(id) ON DELETE RESTRICT
 );
@@ -142,6 +144,8 @@ CREATE TABLE account_attribute_audit (
     revision_id INTEGER NOT NULL,
     attribute_type_id INTEGER NOT NULL,
     attribute_value TEXT NOT NULL,
+    -- Opaque grouping tag carried from the attribute row; see account_attribute.group_key.
+    group_key TEXT NOT NULL DEFAULT '',
     FOREIGN KEY (audit_type_id) REFERENCES audit_type(id),
     FOREIGN KEY (attribute_type_id) REFERENCES attribute_type(id) ON DELETE RESTRICT
 );
@@ -158,6 +162,8 @@ CREATE TABLE person_attribute_audit (
     revision_id INTEGER NOT NULL,
     attribute_type_id INTEGER NOT NULL,
     attribute_value TEXT NOT NULL,
+    -- Opaque grouping tag carried from the attribute row; see account_attribute.group_key.
+    group_key TEXT NOT NULL DEFAULT '',
     FOREIGN KEY (audit_type_id) REFERENCES audit_type(id),
     FOREIGN KEY (attribute_type_id) REFERENCES attribute_type(id) ON DELETE RESTRICT
 );

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/AuditTriggers.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/audit/AuditTriggers.sq
@@ -20,11 +20,11 @@ BEGIN
     -- revision_id (kept current by the insert/update triggers) when the parent revision is no
     -- longer readable. This makes merged-away attributes reconstructable from the audit (see
     -- unmergeAccount).
-    INSERT INTO account_attribute_audit (audit_timestamp, audit_type_id, account_id, revision_id, attribute_type_id, attribute_value)
+    INSERT INTO account_attribute_audit (audit_timestamp, audit_type_id, account_id, revision_id, attribute_type_id, attribute_value, group_key)
     VALUES (
         CAST(strftime('%s', 'now') AS INTEGER) * 1000, 3, old.account_id,
         COALESCE((SELECT revision_id FROM account WHERE id = old.account_id), old.revision_id),
-        old.attribute_type_id, old.attribute_value);
+        old.attribute_type_id, old.attribute_value, old.group_key);
 END;
 
 -- trigger_account_attribute_insert_audit
@@ -40,13 +40,13 @@ BEGIN
       AND NOT EXISTS (SELECT 1 FROM _creation_mode);
 
     -- Always record the addition in audit table at current revision
-    INSERT INTO account_attribute_audit (audit_timestamp, audit_type_id, account_id, revision_id, attribute_type_id, attribute_value)
-    SELECT CAST(strftime('%s', 'now') AS INTEGER) * 1000, 1, new.account_id, revision_id, new.attribute_type_id, new.attribute_value
+    INSERT INTO account_attribute_audit (audit_timestamp, audit_type_id, account_id, revision_id, attribute_type_id, attribute_value, group_key)
+    SELECT CAST(strftime('%s', 'now') AS INTEGER) * 1000, 1, new.account_id, revision_id, new.attribute_type_id, new.attribute_value, new.group_key
     FROM account WHERE id = new.account_id;
 
     -- Stamp the attribute with the (post-bump) account revision so a later cascade delete can
     -- record the exact revision. Re-fires this table's UPDATE trigger but its WHEN guard skips
-    -- it (attribute_value is unchanged), so there is no recursion or double audit.
+    -- it (neither attribute_value nor group_key changes), so there is no recursion or double audit.
     UPDATE account_attribute
     SET revision_id = (SELECT revision_id FROM account WHERE id = new.account_id)
     WHERE id = new.id;
@@ -57,7 +57,7 @@ CREATE TRIGGER trigger_account_attribute_update_audit
 AFTER UPDATE ON account_attribute
 FOR EACH ROW
 WHEN NOT EXISTS (SELECT 1 FROM _import_batch)
-  AND old.attribute_value != new.attribute_value
+  AND (old.attribute_value != new.attribute_value OR old.group_key != new.group_key)
 BEGIN
     -- Only bump revision if NOT in creation mode
     UPDATE account
@@ -66,8 +66,8 @@ BEGIN
       AND NOT EXISTS (SELECT 1 FROM _creation_mode);
 
     -- Always record the change in audit table (OLD value - what it was before)
-    INSERT INTO account_attribute_audit (audit_timestamp, audit_type_id, account_id, revision_id, attribute_type_id, attribute_value)
-    SELECT CAST(strftime('%s', 'now') AS INTEGER) * 1000, 2, new.account_id, revision_id, new.attribute_type_id, old.attribute_value
+    INSERT INTO account_attribute_audit (audit_timestamp, audit_type_id, account_id, revision_id, attribute_type_id, attribute_value, group_key)
+    SELECT CAST(strftime('%s', 'now') AS INTEGER) * 1000, 2, new.account_id, revision_id, new.attribute_type_id, old.attribute_value, old.group_key
     FROM account WHERE id = new.account_id;
 
     -- Advance the attribute's stamped revision to the new value's revision (guarded re-fire).
@@ -155,11 +155,11 @@ BEGIN
     -- gone, so a join would record nothing. The revision falls back to the attribute's own
     -- stamped revision_id (kept current by the insert/update triggers) when the parent
     -- revision is no longer readable.
-    INSERT INTO transfer_attribute_audit (audit_timestamp, audit_type_id, transfer_id, revision_id, attribute_type_id, attribute_value)
+    INSERT INTO transfer_attribute_audit (audit_timestamp, audit_type_id, transfer_id, revision_id, attribute_type_id, attribute_value, group_key)
     VALUES (
         CAST(strftime('%s', 'now') AS INTEGER) * 1000, 3, old.transaction_id,
         COALESCE((SELECT revision_id FROM transfer WHERE id = old.transaction_id), old.revision_id),
-        old.attribute_type_id, old.attribute_value);
+        old.attribute_type_id, old.attribute_value, old.group_key);
 END;
 
 -- trigger_attribute_insert_audit
@@ -175,13 +175,13 @@ BEGIN
       AND NOT EXISTS (SELECT 1 FROM _creation_mode);
 
     -- Always record the addition in audit table at current revision
-    INSERT INTO transfer_attribute_audit (audit_timestamp, audit_type_id, transfer_id, revision_id, attribute_type_id, attribute_value)
-    SELECT CAST(strftime('%s', 'now') AS INTEGER) * 1000, 1, new.transaction_id, revision_id, new.attribute_type_id, new.attribute_value
+    INSERT INTO transfer_attribute_audit (audit_timestamp, audit_type_id, transfer_id, revision_id, attribute_type_id, attribute_value, group_key)
+    SELECT CAST(strftime('%s', 'now') AS INTEGER) * 1000, 1, new.transaction_id, revision_id, new.attribute_type_id, new.attribute_value, new.group_key
     FROM transfer WHERE id = new.transaction_id;
 
     -- Stamp the attribute with the (post-bump) transfer revision so a later cascade delete can
     -- record the exact revision. Re-fires this table's UPDATE trigger but its WHEN guard skips
-    -- it (attribute_value is unchanged), so there is no recursion or double audit.
+    -- it (neither attribute_value nor group_key changes), so there is no recursion or double audit.
     UPDATE transfer_attribute
     SET revision_id = (SELECT revision_id FROM transfer WHERE id = new.transaction_id)
     WHERE id = new.id;
@@ -192,7 +192,7 @@ CREATE TRIGGER trigger_attribute_update_audit
 AFTER UPDATE ON transfer_attribute
 FOR EACH ROW
 WHEN NOT EXISTS (SELECT 1 FROM _import_batch)
-  AND old.attribute_value != new.attribute_value
+  AND (old.attribute_value != new.attribute_value OR old.group_key != new.group_key)
 BEGIN
     -- Only bump revision if NOT in creation mode
     UPDATE transfer
@@ -201,8 +201,8 @@ BEGIN
       AND NOT EXISTS (SELECT 1 FROM _creation_mode);
 
     -- Always record the change in audit table (OLD value - what it was before)
-    INSERT INTO transfer_attribute_audit (audit_timestamp, audit_type_id, transfer_id, revision_id, attribute_type_id, attribute_value)
-    SELECT CAST(strftime('%s', 'now') AS INTEGER) * 1000, 2, new.transaction_id, revision_id, new.attribute_type_id, old.attribute_value
+    INSERT INTO transfer_attribute_audit (audit_timestamp, audit_type_id, transfer_id, revision_id, attribute_type_id, attribute_value, group_key)
+    SELECT CAST(strftime('%s', 'now') AS INTEGER) * 1000, 2, new.transaction_id, revision_id, new.attribute_type_id, old.attribute_value, old.group_key
     FROM transfer WHERE id = new.transaction_id;
 
     -- Advance the attribute's stamped revision to the new value's revision (guarded re-fire).
@@ -438,11 +438,11 @@ BEGIN
     -- so a join would record nothing. The revision falls back to the attribute's own stamped
     -- revision_id (kept current by the insert/update triggers) when the parent revision is no
     -- longer readable.
-    INSERT INTO person_attribute_audit (audit_timestamp, audit_type_id, person_id, revision_id, attribute_type_id, attribute_value)
+    INSERT INTO person_attribute_audit (audit_timestamp, audit_type_id, person_id, revision_id, attribute_type_id, attribute_value, group_key)
     VALUES (
         CAST(strftime('%s', 'now') AS INTEGER) * 1000, 3, old.person_id,
         COALESCE((SELECT revision_id FROM person WHERE id = old.person_id), old.revision_id),
-        old.attribute_type_id, old.attribute_value);
+        old.attribute_type_id, old.attribute_value, old.group_key);
 END;
 
 -- trigger_person_attribute_insert_audit
@@ -455,13 +455,13 @@ BEGIN
     WHERE id = new.person_id
       AND NOT EXISTS (SELECT 1 FROM _creation_mode);
 
-    INSERT INTO person_attribute_audit (audit_timestamp, audit_type_id, person_id, revision_id, attribute_type_id, attribute_value)
-    SELECT CAST(strftime('%s', 'now') AS INTEGER) * 1000, 1, new.person_id, revision_id, new.attribute_type_id, new.attribute_value
+    INSERT INTO person_attribute_audit (audit_timestamp, audit_type_id, person_id, revision_id, attribute_type_id, attribute_value, group_key)
+    SELECT CAST(strftime('%s', 'now') AS INTEGER) * 1000, 1, new.person_id, revision_id, new.attribute_type_id, new.attribute_value, new.group_key
     FROM person WHERE id = new.person_id;
 
     -- Stamp the attribute with the (post-bump) person revision so a later cascade delete can
     -- record the exact revision. Re-fires this table's UPDATE trigger but its WHEN guard skips
-    -- it (attribute_value is unchanged), so there is no recursion or double audit.
+    -- it (neither attribute_value nor group_key changes), so there is no recursion or double audit.
     UPDATE person_attribute
     SET revision_id = (SELECT revision_id FROM person WHERE id = new.person_id)
     WHERE id = new.id;
@@ -471,15 +471,15 @@ END;
 CREATE TRIGGER trigger_person_attribute_update_audit
 AFTER UPDATE ON person_attribute
 FOR EACH ROW
-WHEN old.attribute_value != new.attribute_value
+WHEN (old.attribute_value != new.attribute_value OR old.group_key != new.group_key)
 BEGIN
     UPDATE person
     SET revision_id = revision_id + 1
     WHERE id = new.person_id
       AND NOT EXISTS (SELECT 1 FROM _creation_mode);
 
-    INSERT INTO person_attribute_audit (audit_timestamp, audit_type_id, person_id, revision_id, attribute_type_id, attribute_value)
-    SELECT CAST(strftime('%s', 'now') AS INTEGER) * 1000, 2, new.person_id, revision_id, new.attribute_type_id, old.attribute_value
+    INSERT INTO person_attribute_audit (audit_timestamp, audit_type_id, person_id, revision_id, attribute_type_id, attribute_value, group_key)
+    SELECT CAST(strftime('%s', 'now') AS INTEGER) * 1000, 2, new.person_id, revision_id, new.attribute_type_id, old.attribute_value, old.group_key
     FROM person WHERE id = new.person_id;
 
     -- Advance the attribute's stamped revision to the new value's revision (guarded re-fire).

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/personAttribute/PersonAttribute.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/personAttribute/PersonAttribute.sq
@@ -3,14 +3,19 @@ CREATE TABLE person_attribute (
     person_id INTEGER NOT NULL,
     attribute_type_id INTEGER NOT NULL,
     attribute_value TEXT NOT NULL,
+    -- Opaque grouping tag; '' means ungrouped. See account_attribute.group_key for the full contract --
+    -- readers never parse it, writers only seed it. Persons carry no grouped attributes today; the column
+    -- exists so AttributeUpdateApplier stays generic over account/person/transfer instead of branching.
+    group_key TEXT NOT NULL DEFAULT '',
     -- The person revision at which this attribute's current value became effective. Maintained by the
     -- attribute insert/update triggers; lets the DELETE audit trigger record the correct revision even
     -- on a cascade delete, when the parent person row is already gone.
     revision_id INTEGER NOT NULL DEFAULT 1,
     FOREIGN KEY (person_id) REFERENCES person(id) ON DELETE CASCADE,
     FOREIGN KEY (attribute_type_id) REFERENCES attribute_type(id) ON DELETE RESTRICT,
-    UNIQUE (person_id, attribute_type_id)
+    UNIQUE (person_id, attribute_type_id, group_key)
 );
 
 CREATE INDEX idx_person_attribute_person ON person_attribute(person_id);
 CREATE INDEX idx_person_attribute_type ON person_attribute(attribute_type_id);
+CREATE INDEX idx_person_attribute_group ON person_attribute(person_id, group_key);

--- a/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/transferAttribute/TransferAttribute.sq
+++ b/app/db/schema/src/commonMain/sqldelight/com/moneymanager/database/sql/transferAttribute/TransferAttribute.sq
@@ -3,14 +3,19 @@ CREATE TABLE transfer_attribute (
     transaction_id INTEGER NOT NULL,
     attribute_type_id INTEGER NOT NULL,
     attribute_value TEXT NOT NULL,
+    -- Opaque grouping tag; '' means ungrouped. See account_attribute.group_key for the full contract --
+    -- readers never parse it, writers only seed it. Transfers carry no grouped attributes today; the column
+    -- exists so AttributeUpdateApplier stays generic over account/person/transfer instead of branching.
+    group_key TEXT NOT NULL DEFAULT '',
     -- The transfer revision at which this attribute's current value became effective. Maintained by the
     -- attribute insert/update triggers; lets the DELETE audit trigger record the correct revision even
     -- on a cascade delete, when the parent transfer row is already gone.
     revision_id INTEGER NOT NULL DEFAULT 1,
     FOREIGN KEY (transaction_id) REFERENCES transfer(id) ON DELETE CASCADE,
     FOREIGN KEY (attribute_type_id) REFERENCES attribute_type(id) ON DELETE RESTRICT,
-    UNIQUE (transaction_id, attribute_type_id)
+    UNIQUE (transaction_id, attribute_type_id, group_key)
 );
 
 CREATE INDEX idx_transfer_attribute_transaction ON transfer_attribute(transaction_id);
 CREATE INDEX idx_transfer_attribute_type ON transfer_attribute(attribute_type_id);
+CREATE INDEX idx_transfer_attribute_group ON transfer_attribute(transaction_id, group_key);

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/AccountAttributeWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/AccountAttributeWriteRepositoryImpl.kt
@@ -20,6 +20,7 @@ class AccountAttributeWriteRepositoryImpl(
         accountId: AccountId,
         attributeTypeId: AttributeTypeId,
         value: String,
+        groupKey: String,
     ): Long =
         withContext(Dispatchers.Default) {
             writeQueries.transactionWithResult {
@@ -27,6 +28,7 @@ class AccountAttributeWriteRepositoryImpl(
                     accountId.id,
                     attributeTypeId.id,
                     value,
+                    groupKey,
                 )
                 writeQueries.selectLastInsertedId().executeAsOne()
             }
@@ -36,6 +38,7 @@ class AccountAttributeWriteRepositoryImpl(
         accountId: AccountId,
         attributeTypeId: AttributeTypeId,
         value: String,
+        groupKey: String,
     ): Long =
         withContext(Dispatchers.Default) {
             writeQueries.transactionWithResult {
@@ -45,8 +48,31 @@ class AccountAttributeWriteRepositoryImpl(
                         accountId.id,
                         attributeTypeId.id,
                         value,
+                        groupKey,
                     )
                     writeQueries.selectLastInsertedId().executeAsOne()
+                } finally {
+                    database.endCreationMode()
+                }
+            }
+        }
+
+    override suspend fun upsertInCreationMode(
+        accountId: AccountId,
+        attributeTypeId: AttributeTypeId,
+        value: String,
+        groupKey: String,
+    ): Unit =
+        withContext(Dispatchers.Default) {
+            writeQueries.transaction {
+                database.beginCreationMode()
+                try {
+                    writeQueries.upsert(
+                        accountId.id,
+                        attributeTypeId.id,
+                        value,
+                        groupKey,
+                    )
                 } finally {
                     database.endCreationMode()
                 }
@@ -64,6 +90,7 @@ class AccountAttributeWriteRepositoryImpl(
                             input.accountId.id,
                             input.attributeTypeId.id,
                             input.value,
+                            input.groupKey,
                         )
                     }
                 } finally {

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/AccountWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/AccountWriteRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.moneymanager.database.repository.write
 
 import com.moneymanager.database.mapper.TransferMapper
+import com.moneymanager.database.sql.accountAttribute.SelectByAccount
 import com.moneymanager.database.write.MoneyManagerDatabaseWrapper
 import com.moneymanager.database.write.recordSource
 import com.moneymanager.domain.model.Account
@@ -117,8 +118,10 @@ class AccountWriteRepositoryImpl(
                         },
                         bumpRevisionOnly = { writeQueries.bumpRevisionOnly(effectiveAccountId.id) },
                         selectRevision = { selectQueries.selectRevisionById(effectiveAccountId.id).executeAsOne() },
-                        selectCurrentTypeId = { id ->
-                            attributeSelectQueries.selectById(id).executeAsOneOrNull()?.attribute_type_id
+                        selectCurrentSlot = { id ->
+                            attributeSelectQueries.selectById(id).executeAsOneOrNull()?.let {
+                                it.attribute_type_id to it.group_key
+                            }
                         },
                         deleteById = { id -> attributeWriteQueries.deleteById(id) },
                         insertAttribute = { attr ->
@@ -126,6 +129,7 @@ class AccountWriteRepositoryImpl(
                                 account_id = effectiveAccountId.id,
                                 attribute_type_id = attr.typeId.id,
                                 attribute_value = attr.value,
+                                group_key = attr.groupKey,
                             )
                         },
                         updateValue = { value, id -> attributeWriteQueries.updateValue(value, id) },
@@ -215,6 +219,12 @@ class AccountWriteRepositoryImpl(
                     recordTransferMergeSource(transferId, Source.Merge)
                 }
 
+                // Carry the deleted account's attribute groups onto the survivor BEFORE the cascade delete
+                // takes them away. Without this the merge destroys the loser's bank identity, so the next
+                // import sees an unknown sort code / account number pair and re-creates the very account
+                // just merged away ("merge loses identity, account resurrects").
+                carryAttributeGroups(deletedAccount, survivingAccount, mergeId)
+
                 writeQueries.delete(deletedAccount.id)
                 // Source the deleted account's DELETE audit entry (recorded at revision_id + 1 by the
                 // custom account delete trigger) as a merge, so the trail shows where it went rather than
@@ -272,7 +282,9 @@ class AccountWriteRepositoryImpl(
 
                 // Restore attributes from the audit trail (no bump): the merge's cascade delete recorded
                 // each attribute as a DELETE in account_attribute_audit, and the latest such batch for
-                // this account is exactly the set removed by this merge.
+                // this account is exactly the set removed by this merge. group_key is restored with the
+                // value — an account that owned two bank identities would otherwise come back with both
+                // pairs collapsed into the ungrouped slot, violating the UNIQUE constraint.
                 database.beginCreationMode()
                 try {
                     auditQueries.selectDeletedAttributesForAccount(merge.deleted_account_id).executeAsList().forEach {
@@ -280,7 +292,14 @@ class AccountWriteRepositoryImpl(
                             account_id = merge.deleted_account_id,
                             attribute_type_id = it.attribute_type_id,
                             attribute_value = it.attribute_value,
+                            group_key = it.group_key,
                         )
+                    }
+                    // Remove the attributes the merge grafted onto the SURVIVOR. Leaving them would have
+                    // both accounts claiming the same bank identity, making the next import's lookup
+                    // non-deterministic (whichever account id the index happens to see first wins).
+                    mergeSelectQueries.selectAttributeIdsForMerge(mergeId.id).executeAsList().forEach { attributeId ->
+                        attributeWriteQueries.deleteById(attributeId)
                     }
                 } finally {
                     database.endCreationMode()
@@ -307,6 +326,123 @@ class AccountWriteRepositoryImpl(
                 mergeWriteQueries.markReversed(mergeId.id)
             }
         }
+
+    /**
+     * Moves [deletedAccount]'s attributes onto [survivingAccount], recording each row actually inserted in
+     * `account_merge_attribute` so [unmergeAccount] can remove exactly what was added and leave the
+     * survivor's own attributes alone.
+     *
+     * Runs in creation mode: each acquired attribute is recorded in `account_attribute_audit` at the
+     * survivor's current revision without minting one unsourced revision per attribute (the same choice
+     * unmerge already makes when restoring).
+     *
+     * Nothing is ever overwritten. A conflicting value is inserted under a fresh group instead, so merging
+     * two accounts that each carry a different `account-external-id` keeps both and the survivor stays
+     * matchable by either provider.
+     */
+    private fun carryAttributeGroups(
+        deletedAccount: AccountId,
+        survivingAccount: AccountId,
+        mergeId: Long,
+    ) {
+        val loserAttrs = attributeSelectQueries.selectByAccount(deletedAccount.id).executeAsList()
+        if (loserAttrs.isEmpty()) return
+        val survivor = SurvivorAttributes(attributeSelectQueries.selectByAccount(survivingAccount.id).executeAsList())
+
+        database.beginCreationMode()
+        try {
+            for ((groupKey, group) in loserAttrs.groupBy { it.group_key }) {
+                if (groupKey.isEmpty()) {
+                    carryUngrouped(group, survivor, survivingAccount, mergeId)
+                } else {
+                    carryGroup(groupKey, group, survivor, survivingAccount, mergeId)
+                }
+            }
+        } finally {
+            database.endCreationMode()
+        }
+    }
+
+    /**
+     * Ungrouped attributes carry one at a time: they are independent scalars, not a tuple. A conflicting
+     * value goes into a group of its own rather than overwriting, so merging two provider-created accounts
+     * keeps both external ids and the survivor stays matchable by either.
+     */
+    private fun carryUngrouped(
+        group: List<SelectByAccount>,
+        survivor: SurvivorAttributes,
+        survivingAccount: AccountId,
+        mergeId: Long,
+    ) {
+        group.forEach { attr ->
+            if (survivor.holds(attr.attribute_type_id, attr.attribute_value)) return@forEach
+            val target = if (survivor.occupiesUngrouped(attr.attribute_type_id)) "m$mergeId:${attr.id}" else ""
+            insertCarriedAttribute(survivingAccount, attr.attribute_type_id, attr.attribute_value, target, mergeId)
+        }
+    }
+
+    /**
+     * Carries one whole identity group. Skipped when the survivor already holds the same key AND the same
+     * contents, so a merge is idempotent. A same-key-different-contents clash is re-keyed rather than
+     * dropped or overwritten — rare by construction, since writers seed the key from the identity's own
+     * values, so it only arises once a key has gone stale (a hand edit, or an earlier merge's rename).
+     * Safe because matching derives the bank key from the values and never from group_key, so the next
+     * import still resolves the re-keyed group by content.
+     */
+    private fun carryGroup(
+        groupKey: String,
+        group: List<SelectByAccount>,
+        survivor: SurvivorAttributes,
+        survivingAccount: AccountId,
+        mergeId: Long,
+    ) {
+        val existing = survivor.group(groupKey)
+        if (existing != null && existing == group.associate { it.attribute_type_id to it.attribute_value }) return
+        val target = if (existing == null) groupKey else "$groupKey#m$mergeId"
+        group.forEach { attr ->
+            insertCarriedAttribute(survivingAccount, attr.attribute_type_id, attr.attribute_value, target, mergeId)
+        }
+    }
+
+    /** The surviving account's attributes, indexed for the lookups [carryAttributeGroups] needs. */
+    private class SurvivorAttributes(
+        attrs: List<SelectByAccount>,
+    ) {
+        private val groups =
+            attrs
+                .filter { it.group_key.isNotEmpty() }
+                .groupBy { it.group_key }
+                .mapValues { (_, rows) -> rows.associate { it.attribute_type_id to it.attribute_value } }
+        private val ungroupedTypes = attrs.filter { it.group_key.isEmpty() }.map { it.attribute_type_id }.toSet()
+        private val typeValues = attrs.map { it.attribute_type_id to it.attribute_value }.toSet()
+
+        fun group(key: String): Map<Long, String>? = groups[key]
+
+        fun occupiesUngrouped(typeId: Long): Boolean = typeId in ungroupedTypes
+
+        fun holds(
+            typeId: Long,
+            value: String,
+        ): Boolean = (typeId to value) in typeValues
+    }
+
+    /** Inserts one carried attribute onto the survivor and records it against [mergeId] for unmerge. */
+    private fun insertCarriedAttribute(
+        survivingAccount: AccountId,
+        attributeTypeId: Long,
+        value: String,
+        groupKey: String,
+        mergeId: Long,
+    ) {
+        attributeWriteQueries.insert(
+            account_id = survivingAccount.id,
+            attribute_type_id = attributeTypeId,
+            attribute_value = value,
+            group_key = groupKey,
+        )
+        val attributeId = attributeWriteQueries.selectLastInsertedId().executeAsOne()
+        mergeWriteQueries.insertMergeAttribute(merge_id = mergeId, attribute_id = attributeId)
+    }
 
     /** [desired] if free, else [desired] with an incrementing counter suffix until one is (always terminates). */
     private fun uniqueRestoreName(

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/AccountWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/AccountWriteRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.moneymanager.domain.model.EntityType
 import com.moneymanager.domain.model.MergeId
 import com.moneymanager.domain.model.NewAttribute
 import com.moneymanager.domain.model.Source
+import com.moneymanager.domain.model.WellKnownIds
 import com.moneymanager.domain.repository.AccountReadRepository
 import com.moneymanager.domain.repository.write.AccountWriteRepository
 import kotlinx.coroutines.Dispatchers
@@ -382,12 +383,13 @@ class AccountWriteRepositoryImpl(
     }
 
     /**
-     * Carries one whole identity group. Skipped when the survivor already holds the same key AND the same
-     * contents, so a merge is idempotent. A same-key-different-contents clash is re-keyed rather than
-     * dropped or overwritten — rare by construction, since writers seed the key from the identity's own
-     * values, so it only arises once a key has gone stale (a hand edit, or an earlier merge's rename).
-     * Safe because matching derives the bank key from the values and never from group_key, so the next
-     * import still resolves the re-keyed group by content.
+     * Carries one whole identity group onto the survivor, unless the survivor already holds that identity.
+     *
+     * Because stored group keys are opaque UUIDs, two accounts describing the same real bank account carry
+     * that identity under DIFFERENT keys, so the match must be by the identity's derived value (sort code +
+     * account number), not by the key string — otherwise every same-identity merge would duplicate it.
+     * A group with no derivable bank identity (an arbitrary user group) falls back to key-string matching,
+     * which for UUIDs effectively never collides, so it is carried across verbatim.
      */
     private fun carryGroup(
         groupKey: String,
@@ -396,16 +398,34 @@ class AccountWriteRepositoryImpl(
         survivingAccount: AccountId,
         mergeId: Long,
     ) {
+        // Same identity already on the survivor (under whatever key) -> nothing to carry.
+        bankKeyOf(group)?.let { if (survivor.hasBankKey(it)) return }
+
         val existing = survivor.group(groupKey)
         if (existing != null && existing == group.associate { it.attribute_type_id to it.attribute_value }) return
+        // A key-string collision with unrelated contents (a stale/hand-edited key) is re-keyed rather than
+        // dropped or overwritten; safe because import resolves the group by derived value, not by key.
         val target = if (existing == null) groupKey else "$groupKey#m$mergeId"
         group.forEach { attr ->
             insertCarriedAttribute(survivingAccount, attr.attribute_type_id, attr.attribute_value, target, mergeId)
         }
     }
 
+    /**
+     * The bank identity a group encodes — `"<sortCode>|<accountNumber>"` — when it holds exactly one sort
+     * code and one account number, else null. Derived from the values (never the key), mirroring the import
+     * engine's `bankKeysFrom`, so two accounts holding the same identity under different UUID keys still
+     * reconcile on merge.
+     */
+    private fun bankKeyOf(group: List<SelectByAccount>): String? {
+        val sortCode = group.singleOrNull { it.attribute_type_id == WellKnownIds.ACCOUNT_SORT_CODE_ATTR_TYPE_ID }?.attribute_value
+        val accountNumber =
+            group.singleOrNull { it.attribute_type_id == WellKnownIds.ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID }?.attribute_value
+        return if (!sortCode.isNullOrBlank() && !accountNumber.isNullOrBlank()) "$sortCode|$accountNumber" else null
+    }
+
     /** The surviving account's attributes, indexed for the lookups [carryAttributeGroups] needs. */
-    private class SurvivorAttributes(
+    private inner class SurvivorAttributes(
         attrs: List<SelectByAccount>,
     ) {
         private val groups =
@@ -416,9 +436,18 @@ class AccountWriteRepositoryImpl(
         private val ungroupedTypes = attrs.filter { it.group_key.isEmpty() }.map { it.attribute_type_id }.toSet()
         private val typeValues = attrs.map { it.attribute_type_id to it.attribute_value }.toSet()
 
+        // Bank identities the survivor already holds, one per group (grouped or, tolerating legacy data,
+        // the ungrouped slot). Lets a same-identity loser group be recognised despite a different key.
+        private val bankKeys =
+            (attrs.filter { it.group_key.isNotEmpty() }.groupBy { it.group_key }.values + listOf(attrs.filter { it.group_key.isEmpty() }))
+                .mapNotNull { bankKeyOf(it) }
+                .toSet()
+
         fun group(key: String): Map<Long, String>? = groups[key]
 
         fun occupiesUngrouped(typeId: Long): Boolean = typeId in ungroupedTypes
+
+        fun hasBankKey(key: String): Boolean = key in bankKeys
 
         fun holds(
             typeId: Long,

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/AttributeUpdateApplier.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/AttributeUpdateApplier.kt
@@ -8,7 +8,7 @@ internal fun applyAttributeChangesInCreationMode(
     deletedAttributeIds: Set<Long>,
     updatedAttributes: Map<Long, NewAttribute>,
     newAttributes: List<NewAttribute>,
-    selectCurrentTypeId: (Long) -> Long?,
+    selectCurrentSlot: (Long) -> Pair<Long, String>?,
     deleteById: (Long) -> Unit,
     insertAttribute: (NewAttribute) -> Unit,
     insertAttributeForUpdatedType: (NewAttribute) -> Unit,
@@ -21,8 +21,12 @@ internal fun applyAttributeChangesInCreationMode(
         }
 
         updatedAttributes.forEach { (id, attr) ->
-            val currentTypeId = selectCurrentTypeId(id)
-            if (currentTypeId != null && currentTypeId != attr.typeId.id) {
+            val currentSlot = selectCurrentSlot(id)
+            // The (type, group) pair is the row's UNIQUE slot. Changing either moves the row to a
+            // different slot, which an in-place UPDATE cannot express — it would keep the old group
+            // (silently un-grouping or mis-grouping the attribute) and could collide with the row
+            // already sitting in the target slot. Re-create instead.
+            if (currentSlot != null && currentSlot != (attr.typeId.id to attr.groupKey)) {
                 deleteById(id)
                 insertAttributeForUpdatedType(attr)
             } else {
@@ -47,7 +51,7 @@ internal fun updateEntityWithAttributes(
     updateEntity: () -> Unit,
     bumpRevisionOnly: () -> Unit,
     selectRevision: () -> Long,
-    selectCurrentTypeId: (Long) -> Long?,
+    selectCurrentSlot: (Long) -> Pair<Long, String>?,
     deleteById: (Long) -> Unit,
     insertAttribute: (NewAttribute) -> Unit,
     updateValue: (value: String, id: Long) -> Unit,
@@ -69,7 +73,7 @@ internal fun updateEntityWithAttributes(
             deletedAttributeIds = deletedAttributeIds,
             updatedAttributes = updatedAttributes,
             newAttributes = newAttributes,
-            selectCurrentTypeId = selectCurrentTypeId,
+            selectCurrentSlot = selectCurrentSlot,
             deleteById = deleteById,
             insertAttribute = insertAttribute,
             insertAttributeForUpdatedType = insertAttribute,

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/PersonAttributeWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/PersonAttributeWriteRepositoryImpl.kt
@@ -19,10 +19,11 @@ class PersonAttributeWriteRepositoryImpl(
         personId: PersonId,
         attributeTypeId: AttributeTypeId,
         value: String,
+        groupKey: String,
     ): Long =
         withContext(Dispatchers.Default) {
             writeQueries.transactionWithResult {
-                writeQueries.insert(personId.id, attributeTypeId.id, value)
+                writeQueries.insert(personId.id, attributeTypeId.id, value, groupKey)
                 writeQueries.selectLastInsertedId().executeAsOne()
             }
         }
@@ -31,12 +32,13 @@ class PersonAttributeWriteRepositoryImpl(
         personId: PersonId,
         attributeTypeId: AttributeTypeId,
         value: String,
+        groupKey: String,
     ): Long =
         withContext(Dispatchers.Default) {
             writeQueries.transactionWithResult {
                 database.beginCreationMode()
                 try {
-                    writeQueries.insert(personId.id, attributeTypeId.id, value)
+                    writeQueries.insert(personId.id, attributeTypeId.id, value, groupKey)
                     writeQueries.selectLastInsertedId().executeAsOne()
                 } finally {
                     database.endCreationMode()

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/PersonWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/PersonWriteRepositoryImpl.kt
@@ -90,8 +90,10 @@ class PersonWriteRepositoryImpl(
                         },
                         bumpRevisionOnly = { personWriteQueries.bumpRevisionOnly(effectivePersonId.id) },
                         selectRevision = { personSelectQueries.selectRevisionById(effectivePersonId.id).executeAsOne() },
-                        selectCurrentTypeId = { id ->
-                            attributeSelectQueries.selectById(id).executeAsOneOrNull()?.attribute_type_id
+                        selectCurrentSlot = { id ->
+                            attributeSelectQueries.selectById(id).executeAsOneOrNull()?.let {
+                                it.attribute_type_id to it.group_key
+                            }
                         },
                         deleteById = { id -> attributeWriteQueries.deleteById(id) },
                         insertAttribute = { attr ->
@@ -99,6 +101,7 @@ class PersonWriteRepositoryImpl(
                                 person_id = effectivePersonId.id,
                                 attribute_type_id = attr.typeId.id,
                                 attribute_value = attr.value,
+                                group_key = attr.groupKey,
                             )
                         },
                         updateValue = { value, id -> attributeWriteQueries.updateValue(value, id) },

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/TransactionWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/TransactionWriteRepositoryImpl.kt
@@ -116,13 +116,16 @@ class TransactionWriteRepositoryImpl(
                         updatedAttributes.forEach { (id, attr) ->
                             // Check if type changed (requires delete + insert)
                             val current = transferAttributeSelectQueries.selectById(id).executeAsOneOrNull()
-                            if (current != null && current.attribute_type_id != attr.typeId.id) {
-                                // Type changed: delete and recreate
+                            val slot = current?.let { it.attribute_type_id to it.group_key }
+                            if (slot != null && slot != (attr.typeId.id to attr.groupKey)) {
+                                // Type or group changed: the row belongs in a different UNIQUE slot, so
+                                // delete and recreate rather than UPDATE it where it sits.
                                 transferAttributeWriteQueries.deleteById(id)
                                 transferAttributeWriteQueries.insert(
                                     transaction_id = effectiveTransactionId.id,
                                     attribute_type_id = attr.typeId.id,
                                     attribute_value = attr.value,
+                                    group_key = attr.groupKey,
                                 )
                             } else {
                                 // Only value changed
@@ -136,6 +139,7 @@ class TransactionWriteRepositoryImpl(
                                 transaction_id = effectiveTransactionId.id,
                                 attribute_type_id = attr.typeId.id,
                                 attribute_value = attr.value,
+                                group_key = attr.groupKey,
                             )
                         }
                     } finally {
@@ -195,30 +199,36 @@ class TransactionWriteRepositoryImpl(
                     if (update.newAttributes.isNotEmpty()) {
                         // The existing transfer may already carry some of these attribute types (e.g. a
                         // cross-source reconciliation added one, so a re-import of an otherwise-unchanged
-                        // row is classified UPDATED). Upsert by (transaction_id, attribute_type_id) —
-                        // update a changed value, insert a genuinely new type — instead of blindly
-                        // inserting, which would violate the UNIQUE(transaction_id, attribute_type_id)
-                        // constraint on the types already present.
-                        val existingByType =
+                        // row is classified UPDATED). Upsert by (transaction_id, attribute_type_id,
+                        // group_key) — update a changed value, insert a genuinely new slot — instead of
+                        // blindly inserting, which would violate the
+                        // UNIQUE(transaction_id, attribute_type_id, group_key) constraint on the slots
+                        // already present. The group is part of the key: two attributes of the same type in
+                        // different groups are distinct rows, so keying on the type alone would make the
+                        // second one invisible here and silently drop it.
+                        val existingBySlot =
                             transferAttributeSelectQueries
-                                .selectByTransaction(updatedTransfer.id.id) { rowId, _, typeId, value, _, _ ->
-                                    typeId to (rowId to value)
+                                .selectByTransaction(updatedTransfer.id.id) { rowId, _, typeId, value, groupKey, _, _ ->
+                                    (typeId to groupKey) to (rowId to value)
                                 }.executeAsList()
                                 .toMap()
                         database.beginCreationMode()
                         try {
-                            // Deduplicate by type first: a transfer holds one value per attribute type, and
-                            // [existingByType] is a snapshot, so two incoming attributes of the same type would
-                            // both take the insert path and hit the UNIQUE(transaction_id, attribute_type_id)
-                            // constraint. Last value wins, matching how the attribute would be stored.
-                            update.newAttributes.associateBy { it.typeId.id }.forEach { (typeId, attr) ->
-                                val existing = existingByType[typeId]
+                            // Deduplicate by slot first: a transfer holds one value per (type, group), and
+                            // [existingBySlot] is a snapshot, so two incoming attributes in the same slot would
+                            // both take the insert path and hit the
+                            // UNIQUE(transaction_id, attribute_type_id, group_key) constraint. Last value wins,
+                            // matching how the attribute would be stored.
+                            update.newAttributes.associateBy { it.typeId.id to it.groupKey }.forEach { (slot, attr) ->
+                                val (typeId, groupKey) = slot
+                                val existing = existingBySlot[slot]
                                 when {
                                     existing == null ->
                                         transferAttributeWriteQueries.insert(
                                             transaction_id = updatedTransfer.id.id,
                                             attribute_type_id = typeId,
                                             attribute_value = attr.value,
+                                            group_key = groupKey,
                                         )
                                     existing.second != attr.value ->
                                         transferAttributeWriteQueries.updateValue(attr.value, existing.first)
@@ -279,6 +289,7 @@ class TransactionWriteRepositoryImpl(
                     transaction_id = generatedId,
                     attribute_type_id = attr.typeId.id,
                     attribute_value = attr.value,
+                    group_key = attr.groupKey,
                 )
             }
             database.recordSource(deviceId, EntityType.TRANSFER, realId.id, transfer.revisionId, sources[index])

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/TransferAttributeWriteRepositoryImpl.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/repository/write/TransferAttributeWriteRepositoryImpl.kt
@@ -19,6 +19,7 @@ class TransferAttributeWriteRepositoryImpl(
         transactionId: TransferId,
         attributeTypeId: AttributeTypeId,
         value: String,
+        groupKey: String,
     ): Long =
         withContext(Dispatchers.Default) {
             writeQueries.transactionWithResult {
@@ -26,6 +27,7 @@ class TransferAttributeWriteRepositoryImpl(
                     transactionId.id,
                     attributeTypeId.id,
                     value,
+                    groupKey,
                 )
                 // Get the inserted ID using last_insert_rowid()
                 writeQueries.selectLastInsertedId().executeAsOne()

--- a/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/MoneyManagerDatabaseWrapper.kt
+++ b/app/db/write/src/commonMain/kotlin/com/moneymanager/database/write/MoneyManagerDatabaseWrapper.kt
@@ -401,6 +401,7 @@ class MoneyManagerDatabaseWrapper(
             // Account-merge reversal records; they are the audit/undo data, not audited entities.
             "account_merge",
             "account_merge_transfer",
+            "account_merge_attribute",
             "settings",
             "api_credential",
             "api_session",

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/accountAttribute/AccountAttributeWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/accountAttribute/AccountAttributeWrite.sq
@@ -1,11 +1,22 @@
 insert:
 -- Seed revision_id from the parent account's current revision so it is correct even on the import path
 -- (where triggers are skipped); the insert trigger refreshes it to the post-bump revision otherwise.
-INSERT INTO account_attribute (account_id, attribute_type_id, attribute_value, revision_id)
-VALUES (:account_id, :attribute_type_id, :attribute_value, (SELECT revision_id FROM account WHERE id = :account_id));
+INSERT INTO account_attribute (account_id, attribute_type_id, attribute_value, group_key, revision_id)
+VALUES (:account_id, :attribute_type_id, :attribute_value, :group_key, (SELECT revision_id FROM account WHERE id = :account_id));
+
+upsert:
+-- Idempotent write of one attribute into one (type, group) slot: inserts when the slot is free,
+-- updates when it holds a different value, and does nothing when the value already matches. Lets a
+-- re-import of an already-known identity be a true no-op instead of a swallowed UNIQUE violation.
+INSERT INTO account_attribute (account_id, attribute_type_id, attribute_value, group_key, revision_id)
+VALUES (:account_id, :attribute_type_id, :attribute_value, :group_key, (SELECT revision_id FROM account WHERE id = :account_id))
+ON CONFLICT (account_id, attribute_type_id, group_key)
+DO UPDATE SET attribute_value = excluded.attribute_value
+WHERE attribute_value != excluded.attribute_value;
 
 selectLastInsertedId:
 SELECT last_insert_rowid();
+
 
 updateValue:
 UPDATE account_attribute

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/accountMerge/AccountMergeWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/accountMerge/AccountMergeWrite.sq
@@ -12,5 +12,11 @@ insertMergeTransfer:
 INSERT INTO account_merge_transfer(merge_id, transfer_id, moved_source, moved_target)
 VALUES (?, ?, ?, ?);
 
+insertMergeAttribute:
+-- Record an attribute row this merge grafted onto the SURVIVOR, so unmerge can remove exactly the rows
+-- the merge added and leave the survivor's own attributes alone.
+INSERT INTO account_merge_attribute(merge_id, attribute_id)
+VALUES (?, ?);
+
 markReversed:
 UPDATE account_merge SET reversed = 1 WHERE id = ?;

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/personAttribute/PersonAttributeWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/personAttribute/PersonAttributeWrite.sq
@@ -1,11 +1,22 @@
 insert:
 -- Seed revision_id from the parent person's current revision; the insert trigger refreshes it to the
 -- post-bump revision for non-import paths.
-INSERT INTO person_attribute (person_id, attribute_type_id, attribute_value, revision_id)
-VALUES (:person_id, :attribute_type_id, :attribute_value, (SELECT revision_id FROM person WHERE id = :person_id));
+INSERT INTO person_attribute (person_id, attribute_type_id, attribute_value, group_key, revision_id)
+VALUES (:person_id, :attribute_type_id, :attribute_value, :group_key, (SELECT revision_id FROM person WHERE id = :person_id));
+
+upsert:
+-- Idempotent write of one attribute into one (type, group) slot: inserts when the slot is free,
+-- updates when it holds a different value, and does nothing when the value already matches. Lets a
+-- re-import of an already-known identity be a true no-op instead of a swallowed UNIQUE violation.
+INSERT INTO person_attribute (person_id, attribute_type_id, attribute_value, group_key, revision_id)
+VALUES (:person_id, :attribute_type_id, :attribute_value, :group_key, (SELECT revision_id FROM person WHERE id = :person_id))
+ON CONFLICT (person_id, attribute_type_id, group_key)
+DO UPDATE SET attribute_value = excluded.attribute_value
+WHERE attribute_value != excluded.attribute_value;
 
 selectLastInsertedId:
 SELECT last_insert_rowid();
+
 
 updateValue:
 UPDATE person_attribute

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/personAttribute/PersonAttributeWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/personAttribute/PersonAttributeWrite.sq
@@ -4,16 +4,6 @@ insert:
 INSERT INTO person_attribute (person_id, attribute_type_id, attribute_value, group_key, revision_id)
 VALUES (:person_id, :attribute_type_id, :attribute_value, :group_key, (SELECT revision_id FROM person WHERE id = :person_id));
 
-upsert:
--- Idempotent write of one attribute into one (type, group) slot: inserts when the slot is free,
--- updates when it holds a different value, and does nothing when the value already matches. Lets a
--- re-import of an already-known identity be a true no-op instead of a swallowed UNIQUE violation.
-INSERT INTO person_attribute (person_id, attribute_type_id, attribute_value, group_key, revision_id)
-VALUES (:person_id, :attribute_type_id, :attribute_value, :group_key, (SELECT revision_id FROM person WHERE id = :person_id))
-ON CONFLICT (person_id, attribute_type_id, group_key)
-DO UPDATE SET attribute_value = excluded.attribute_value
-WHERE attribute_value != excluded.attribute_value;
-
 selectLastInsertedId:
 SELECT last_insert_rowid();
 

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/transferAttribute/TransferAttributeWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/transferAttribute/TransferAttributeWrite.sq
@@ -4,16 +4,6 @@ insert:
 INSERT INTO transfer_attribute (transaction_id, attribute_type_id, attribute_value, group_key, revision_id)
 VALUES (:transaction_id, :attribute_type_id, :attribute_value, :group_key, (SELECT revision_id FROM transfer WHERE id = :transaction_id));
 
-upsert:
--- Idempotent write of one attribute into one (type, group) slot: inserts when the slot is free,
--- updates when it holds a different value, and does nothing when the value already matches. Lets a
--- re-import of an already-known identity be a true no-op instead of a swallowed UNIQUE violation.
-INSERT INTO transfer_attribute (transaction_id, attribute_type_id, attribute_value, group_key, revision_id)
-VALUES (:transaction_id, :attribute_type_id, :attribute_value, :group_key, (SELECT revision_id FROM transfer WHERE id = :transaction_id))
-ON CONFLICT (transaction_id, attribute_type_id, group_key)
-DO UPDATE SET attribute_value = excluded.attribute_value
-WHERE attribute_value != excluded.attribute_value;
-
 selectLastInsertedId:
 SELECT last_insert_rowid();
 

--- a/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/transferAttribute/TransferAttributeWrite.sq
+++ b/app/db/write/src/commonMain/sqldelight/com/moneymanager/database/sql/transferAttribute/TransferAttributeWrite.sq
@@ -1,11 +1,22 @@
 insert:
 -- Seed revision_id from the parent transfer's current revision; the insert trigger refreshes it to the
 -- post-bump revision for non-import paths.
-INSERT INTO transfer_attribute (transaction_id, attribute_type_id, attribute_value, revision_id)
-VALUES (:transaction_id, :attribute_type_id, :attribute_value, (SELECT revision_id FROM transfer WHERE id = :transaction_id));
+INSERT INTO transfer_attribute (transaction_id, attribute_type_id, attribute_value, group_key, revision_id)
+VALUES (:transaction_id, :attribute_type_id, :attribute_value, :group_key, (SELECT revision_id FROM transfer WHERE id = :transaction_id));
+
+upsert:
+-- Idempotent write of one attribute into one (type, group) slot: inserts when the slot is free,
+-- updates when it holds a different value, and does nothing when the value already matches. Lets a
+-- re-import of an already-known identity be a true no-op instead of a swallowed UNIQUE violation.
+INSERT INTO transfer_attribute (transaction_id, attribute_type_id, attribute_value, group_key, revision_id)
+VALUES (:transaction_id, :attribute_type_id, :attribute_value, :group_key, (SELECT revision_id FROM transfer WHERE id = :transaction_id))
+ON CONFLICT (transaction_id, attribute_type_id, group_key)
+DO UPDATE SET attribute_value = excluded.attribute_value
+WHERE attribute_value != excluded.attribute_value;
 
 selectLastInsertedId:
 SELECT last_insert_rowid();
+
 
 updateValue:
 UPDATE transfer_attribute

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportKeys.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportKeys.kt
@@ -1,5 +1,8 @@
 package com.moneymanager.importengineapi
 
+import com.moneymanager.domain.model.WellKnownIds.ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID
+import com.moneymanager.domain.model.WellKnownIds.ACCOUNT_SORT_CODE_ATTR_TYPE_ID
+
 /**
  * Normalises a full name into a stable matching key (trim, collapse internal whitespace, lower-case).
  * Shared so importers that produce [PersonMatchKey.ByNameKey] derive the same key the engine uses to
@@ -12,11 +15,53 @@ fun normalizeNameKey(fullName: String): String = fullName.trim().replace(Regex("
  * the [AccountMatchKey.ByPersonalCounterparty] key. Shared so importers that emit the match key derive
  * the same string the engine uses to index existing accounts by their sort-code/account-number
  * attributes, keeping cross-provider bank reconciliation order-independent.
+ *
+ * This doubles as the **seed** for an attribute's `group_key`, which is what lets one account own several
+ * bank identities (Crypto.com moved its fiat destination to a new sort code, so payments to one account
+ * arrive under two). Seeding the group with the identity's own natural key makes a re-import upsert the
+ * same group instead of minting a duplicate.
+ *
+ * The group key is only ever a seed: readers must re-derive the key from the attribute **values** in a
+ * group and never parse `group_key` itself. A key can legitimately go stale — a user edits a sort code,
+ * or a merge re-keys a collision — and matching has to keep working when it does.
  */
 fun personalCounterpartyKey(
     sortCode: String,
     accountNumber: String,
 ): String = "$sortCode|$accountNumber"
+
+/**
+ * Every bank key derivable from [attributes], one per attribute group holding both a sort code and an
+ * account number. An account with two bank identities yields two keys, and both must be indexed or the
+ * second identity silently matches nothing.
+ *
+ * Derived from the values, never from the group key. Within the ungrouped group (`""`) a pair is only
+ * formed when there is exactly one sort code and exactly one account number, so half-grouped or
+ * partially-edited data can never mint a phantom identity by pairing one group's sort code with
+ * another's account number.
+ */
+fun bankKeysFrom(attributes: List<AttributeSlot>): List<String> =
+    attributes
+        .groupBy { it.groupKey }
+        .entries
+        .sortedBy { it.key }
+        .mapNotNull { (_, group) ->
+            val sortCodes = group.filter { it.typeId == ACCOUNT_SORT_CODE_ATTR_TYPE_ID }.map { it.value }
+            val accountNumbers = group.filter { it.typeId == ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID }.map { it.value }
+            val sortCode = sortCodes.singleOrNull()?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val accountNumber = accountNumbers.singleOrNull()?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            personalCounterpartyKey(sortCode, accountNumber)
+        }.distinct()
+
+/**
+ * One attribute reduced to what [bankKeysFrom] needs: which type it is, its value, and which group it
+ * belongs to. Lets the same pairing logic run over import intents and over persisted rows.
+ */
+data class AttributeSlot(
+    val typeId: Long,
+    val value: String,
+    val groupKey: String,
+)
 
 /**
  * Derives the [personalCounterpartyKey] from a synthetic bank external-id of the form

--- a/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportKeys.kt
+++ b/app/importengineapi/src/commonMain/kotlin/com/moneymanager/importengineapi/ImportKeys.kt
@@ -16,14 +16,12 @@ fun normalizeNameKey(fullName: String): String = fullName.trim().replace(Regex("
  * the same string the engine uses to index existing accounts by their sort-code/account-number
  * attributes, keeping cross-provider bank reconciliation order-independent.
  *
- * This doubles as the **seed** for an attribute's `group_key`, which is what lets one account own several
- * bank identities (Crypto.com moved its fiat destination to a new sort code, so payments to one account
- * arrive under two). Seeding the group with the identity's own natural key makes a re-import upsert the
- * same group instead of minting a duplicate.
- *
- * The group key is only ever a seed: readers must re-derive the key from the attribute **values** in a
- * group and never parse `group_key` itself. A key can legitimately go stale — a user edits a sort code,
- * or a merge re-keys a collision — and matching has to keep working when it does.
+ * This is also the **transient grouping tag** an importer stamps on a bank identity's attributes within a
+ * batch, so the engine knows which sort code and account number belong together (Crypto.com moved its
+ * fiat destination to a new sort code, so one account owns two identities). It is never persisted: the
+ * engine translates each tag to an opaque UUID `group_key` on write. Readers always re-derive the identity
+ * from the attribute **values** in a group and never parse `group_key` itself — so a stored key going stale
+ * (a UI edit, a merge re-key) is harmless.
  */
 fun personalCounterpartyKey(
     sortCode: String,

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -988,15 +988,16 @@ class ImportEngineImpl(
 
         val index = mutableMapOf<Pair<AttributeTypeId, String>, AccountId>()
         val claimed = mutableSetOf<AccountId>()
-        for (account in accountRepository.getAllAccounts().first()) {
-            val attrs = accountAttributeRepository.getByAccount(account.id).first()
-            for (attr in attrs) {
-                if (attr.attributeType.id in relevantTypeIds) {
-                    index.getOrPut(attr.attributeType.id to attr.value) { account.id }
-                }
-                if (attr.attributeType.id in IDENTITY_ATTR_TYPE_IDS) {
-                    claimed += account.id
-                }
+        // One query over all account attributes rather than a per-account read: this used to be an N+1
+        // over the whole account table, which dominated the "Resolving accounts" phase on a large database.
+        // getAll() is ordered by (type, account_id), so getOrPut still keeps the lowest-id account for a
+        // given (type, value) — the same winner the per-account scan produced.
+        for (attr in accountAttributeRepository.getAll().first()) {
+            if (attr.attributeType.id in relevantTypeIds) {
+                index.getOrPut(attr.attributeType.id to attr.value) { attr.accountId }
+            }
+            if (attr.attributeType.id in IDENTITY_ATTR_TYPE_IDS) {
+                claimed += attr.accountId
             }
         }
         return ExistingAccountAttrIndex(index, claimed)
@@ -1076,7 +1077,7 @@ class ImportEngineImpl(
 
         val existingPeople = personRepository.getAllPeople().first()
         val byNameKey = existingPeople.associate { normalizeNameKey(it.fullName) to it.id }.toMutableMap()
-        val byAttr = buildExistingPersonAttrIndex(batch, existingPeople)
+        val byAttr = buildExistingPersonAttrIndex(batch)
 
         val keyToId = mutableMapOf<LocalPersonKey, PersonId>()
         var created = 0
@@ -1135,10 +1136,7 @@ class ImportEngineImpl(
         return PersonResolution(keyToId, created)
     }
 
-    private suspend fun buildExistingPersonAttrIndex(
-        batch: ImportBatch,
-        existingPeople: List<Person>,
-    ): MutableMap<Pair<AttributeTypeId, String>, PersonId> {
+    private suspend fun buildExistingPersonAttrIndex(batch: ImportBatch): MutableMap<Pair<AttributeTypeId, String>, PersonId> {
         val relevantTypeIds =
             batch.peopleToCreate
                 .mapNotNull { (it.match as? PersonMatchKey.ByExternalId)?.typeId }
@@ -1146,12 +1144,11 @@ class ImportEngineImpl(
         if (relevantTypeIds.isEmpty()) return mutableMapOf()
 
         val index = mutableMapOf<Pair<AttributeTypeId, String>, PersonId>()
-        for (person in existingPeople) {
-            val attrs = personAttributeRepository.getByPerson(person.id).first()
-            for (attr in attrs) {
-                if (attr.attributeType.id in relevantTypeIds) {
-                    index.getOrPut(attr.attributeType.id to attr.value) { person.id }
-                }
+        // One query over all person attributes rather than a per-person read: this used to be an N+1
+        // over the whole person table during the "Resolving people" phase.
+        for (attr in personAttributeRepository.getAll().first()) {
+            if (attr.attributeType.id in relevantTypeIds) {
+                index.getOrPut(attr.attributeType.id to attr.value) { attr.personId }
             }
         }
         return index

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -1,6 +1,7 @@
 package com.moneymanager.importer
 
 import com.moneymanager.domain.model.Account
+import com.moneymanager.domain.model.AccountAttribute
 import com.moneymanager.domain.model.AccountId
 import com.moneymanager.domain.model.ApiCredentialId
 import com.moneymanager.domain.model.ApiImportStrategyId
@@ -58,6 +59,7 @@ import com.moneymanager.importengineapi.AccountMatchKey
 import com.moneymanager.importengineapi.AccountRef
 import com.moneymanager.importengineapi.ApiSessionMutation
 import com.moneymanager.importengineapi.ApiStrategyMutation
+import com.moneymanager.importengineapi.AttributeSlot
 import com.moneymanager.importengineapi.CsvImportMutation
 import com.moneymanager.importengineapi.CsvStrategyMutation
 import com.moneymanager.importengineapi.DedupePolicy
@@ -85,9 +87,9 @@ import com.moneymanager.importengineapi.QifImportMutation
 import com.moneymanager.importengineapi.RowOutcome
 import com.moneymanager.importengineapi.WriteIntent
 import com.moneymanager.importengineapi.bankKeyFromExternalId
+import com.moneymanager.importengineapi.bankKeysFrom
 import com.moneymanager.importengineapi.forRow
 import com.moneymanager.importengineapi.normalizeNameKey
-import com.moneymanager.importengineapi.personalCounterpartyKey
 import kotlinx.coroutines.flow.first
 import kotlin.time.Duration
 import kotlin.time.Instant
@@ -758,11 +760,12 @@ class ImportEngineImpl(
      * enough to disambiguate without making the name unreadably long).
      */
     private fun discriminatorFor(intent: ImportAccountIntent): String? {
-        val accountNumberTypeId = AttributeTypeId(WellKnownIds.ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID)
+        // Take the account number from the first group that yields a COMPLETE bank key, so an account with
+        // several identities gets a stable discriminator instead of one that depends on attribute order.
         val accountNumberDiscriminator =
-            intent.attributes
-                .firstOrNull { it.typeId == accountNumberTypeId }
-                ?.value
+            intentBankKeys(intent)
+                .firstOrNull()
+                ?.substringAfter('|')
                 ?.takeLast(4)
         if (accountNumberDiscriminator != null) return accountNumberDiscriminator
         return (intent.match as? AccountMatchKey.ByExternalId)?.value?.takeLast(6)
@@ -791,13 +794,13 @@ class ImportEngineImpl(
                 is AccountMatchKey.AlwaysCreate -> null
             }
         if (primary != null) return AccountMatch(primary, adopted = false)
-        val bankKey = intentBankKey(intent)
+        val bankKeys = intentBankKeys(intent)
         // Fallback: an intent that carries bank details (sort code + account number attributes) but didn't
         // match by its primary key adopts a pre-existing account for the same real bank account — e.g. a
         // source account adopting a counterparty another provider created, keeping imports order-independent.
         // The matched account is re-pointed (renamed + the intent's own attributes added) so this provider
         // resolves it by id next time, while its bank attributes keep the other provider matching it.
-        bankKey?.let { byPersonalKey[it] }?.let { return AccountMatch(it, adopted = true) }
+        bankKeys.firstNotNullOfOrNull { byPersonalKey[it] }?.let { return AccountMatch(it, adopted = true) }
         // An own/source account intent with no bank-identity match yet may still adopt a pre-existing
         // account of the exact same name that carries no identity attributes of its own (an "unclaimed"
         // account — e.g. one created ahead of time by hand, or by the import-directory auto-create-by-name
@@ -818,7 +821,7 @@ class ImportEngineImpl(
         // pre-existing account — so an own/source account can't merge into an unrelated account that
         // merely shares its name. Accounts that carry bank details are excluded too: two people can share
         // a name while owning different accounts.
-        if (bankKey == null && intent.match !is AccountMatchKey.AlwaysCreate) {
+        if (bankKeys.isEmpty() && intent.match !is AccountMatchKey.AlwaysCreate) {
             intent.name?.let { batchCreatedByName[it] }?.let { return AccountMatch(it, adopted = false) }
         }
         return null
@@ -846,20 +849,68 @@ class ImportEngineImpl(
         for (attr in intent.attributes) {
             val present = currentAttrs.any { it.attributeType.id == attr.typeId && it.value == attr.value }
             if (!present) {
-                runCatching { accountAttributeRepository.insertInCreationMode(id, attr.typeId, attr.value) }
+                // Upsert rather than insert-and-swallow: the (type, group) slot may already hold a
+                // different value, and dropping the write there would silently lose this provider's
+                // identity for the account.
+                accountAttributeRepository.upsertInCreationMode(
+                    id,
+                    attr.typeId,
+                    attr.value,
+                    resolveGroupKey(attr, intent.attributes, currentAttrs),
+                )
                 byAttr.getOrPut(attr.typeId to attr.value) { id }
             }
         }
     }
 
-    /** The personal-counterparty bank key from an intent's sort-code + account-number attributes, if both present. */
-    private fun intentBankKey(intent: ImportAccountIntent): String? {
-        val sortCodeTypeId = AttributeTypeId(WellKnownIds.ACCOUNT_SORT_CODE_ATTR_TYPE_ID)
-        val accountNumberTypeId = AttributeTypeId(WellKnownIds.ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID)
-        val sortCode = intent.attributes.firstOrNull { it.typeId == sortCodeTypeId }?.value
-        val accountNumber = intent.attributes.firstOrNull { it.typeId == accountNumberTypeId }?.value
-        return if (sortCode != null && accountNumber != null) personalCounterpartyKey(sortCode, accountNumber) else null
+    /**
+     * The group this incoming attribute should be written into on an existing account.
+     *
+     * For a grouped attribute, the incoming group's derived bank key is matched against the account's
+     * existing groups and the matching group's ACTUAL key is reused. That is what makes a re-import
+     * idempotent even when the stored key has drifted from the natural key (a hand edit, or an earlier
+     * merge's re-key) — matching by content rather than by key means the drifted group is updated in
+     * place instead of a near-duplicate being minted beside it.
+     *
+     * An ungrouped identity attribute whose slot already holds a different value is moved into a group of
+     * its own rather than overwriting: two providers can each know the account by a different external id,
+     * and clobbering one would stop that provider matching the account at all.
+     */
+    private fun resolveGroupKey(
+        attr: NewAttribute,
+        intentAttributes: List<NewAttribute>,
+        currentAttrs: List<AccountAttribute>,
+    ): String {
+        if (attr.groupKey.isEmpty()) {
+            val occupied =
+                currentAttrs.any {
+                    it.groupKey.isEmpty() && it.attributeType.id == attr.typeId && it.value != attr.value
+                }
+            val isIdentity = attr.typeId.id in IDENTITY_ATTR_TYPE_IDS.map { it.id }
+            return if (occupied && isIdentity) "adopted:${attr.typeId.id}:${attr.value}" else ""
+        }
+        val incomingKey =
+            bankKeysFrom(
+                intentAttributes.filter { it.groupKey == attr.groupKey }.map { AttributeSlot(it.typeId.id, it.value, it.groupKey) },
+            ).firstOrNull() ?: return attr.groupKey
+        val existingGroup =
+            currentAttrs
+                .filter { it.groupKey.isNotEmpty() }
+                .groupBy { it.groupKey }
+                .entries
+                .firstOrNull { (key, rows) ->
+                    bankKeysFrom(rows.map { AttributeSlot(it.attributeType.id.id, it.value, key) }).firstOrNull() == incomingKey
+                }?.key
+        return existingGroup ?: attr.groupKey
     }
+
+    /**
+     * Every personal-counterparty bank key this intent carries — one per attribute group holding both a
+     * sort code and an account number, so an intent describing an account with two bank identities yields
+     * both. Derived from the attribute values, never from the group key, so a stale group key is harmless.
+     */
+    private fun intentBankKeys(intent: ImportAccountIntent): List<String> =
+        bankKeysFrom(intent.attributes.map { AttributeSlot(it.typeId.id, it.value, it.groupKey) })
 
     private suspend fun createAccount(
         intent: ImportAccountIntent,
@@ -876,7 +927,7 @@ class ImportEngineImpl(
                 intent.source,
             )
         intent.attributes.forEach { attr ->
-            accountAttributeRepository.insertInCreationMode(newId, attr.typeId, attr.value)
+            accountAttributeRepository.insertInCreationMode(newId, attr.typeId, attr.value, attr.groupKey)
         }
         return newId
     }
@@ -895,9 +946,9 @@ class ImportEngineImpl(
             is AccountMatchKey.ByPersonalCounterparty -> byPersonalKey.getOrPut(match.key) { id }
             else -> Unit
         }
-        // Register the new account's bank identity (from its sort/account attributes) so a later intent in
-        // this batch sharing those details merges into it instead of creating a duplicate.
-        intentBankKey(intent)?.let { byPersonalKey.getOrPut(it) { id } }
+        // Register every bank identity the new account carries (from its sort/account attribute groups) so
+        // a later intent in this batch sharing any of them merges into it instead of creating a duplicate.
+        intentBankKeys(intent).forEach { key -> byPersonalKey.getOrPut(key) { id } }
     }
 
     /**
@@ -963,29 +1014,38 @@ class ImportEngineImpl(
         // existing account for the same real bank account.
         val hasPersonalKeys =
             intents.any { it.match is AccountMatchKey.ByPersonalCounterparty } ||
-                intents.any { intentBankKey(it) != null }
+                intents.any { intentBankKeys(it).isNotEmpty() }
         if (!hasPersonalKeys) return mutableMapOf()
 
-        val sortCodeTypeId = AttributeTypeId(WellKnownIds.ACCOUNT_SORT_CODE_ATTR_TYPE_ID)
-        val accountNumberTypeId = AttributeTypeId(WellKnownIds.ACCOUNT_ACCOUNT_NUMBER_ATTR_TYPE_ID)
-        val externalIdTypeId = AttributeTypeId(WellKnownIds.ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID)
-
         val index = mutableMapOf<String, AccountId>()
-        for (account in accountRepository.getAllAccounts().first()) {
-            val attrs = accountAttributeRepository.getByAccount(account.id).first()
-            val sortCode = attrs.firstOrNull { it.attributeType.id == sortCodeTypeId }?.value
-            val accountNumber = attrs.firstOrNull { it.attributeType.id == accountNumberTypeId }?.value
-            if (sortCode != null && accountNumber != null) {
-                index.getOrPut(personalCounterpartyKey(sortCode, accountNumber)) { account.id }
-            } else {
-                // Fallback: an account whose only bank identity is a synthetic "bank:<sort>:<account>"
-                // external-id (created before its sort/account were persisted as attributes). Don't
-                // overwrite an attribute-backed entry — those are authoritative.
-                val externalId = attrs.firstOrNull { it.attributeType.id == externalIdTypeId }?.value
-                bankKeyFromExternalId(externalId)?.let { index.getOrPut(it) { account.id } }
-            }
+        // One query for every account's attributes rather than a per-account flow read: this used to be an
+        // N+1 over the whole account table on every import carrying a bank identity.
+        for ((accountId, attrs) in accountAttributeRepository.getAll().first().groupBy { it.accountId }) {
+            // Index EVERY identity: an account that owns two bank identities must be reachable by both, or
+            // the second one silently forks a duplicate account on the next import.
+            existingBankKeys(attrs).forEach { key -> index.getOrPut(key) { accountId } }
         }
         return index
+    }
+
+    /** Every bank key an existing account's stored [attrs] resolve to, best source first. */
+    private fun existingBankKeys(attrs: List<AccountAttribute>): List<String> {
+        val slots = attrs.map { AttributeSlot(it.attributeType.id.id, it.value, it.groupKey) }
+        val grouped = bankKeysFrom(slots)
+        if (grouped.isNotEmpty()) return grouped
+        // Loose pairing: an account whose sort code and account number ended up in different groups (a
+        // half-finished hand edit) would otherwise index nothing. Only when there is exactly one of each
+        // across the whole account, so this can never invent a pair.
+        bankKeysFrom(slots.map { it.copy(groupKey = "") }).singleOrNull()?.let { return listOf(it) }
+        // Fallback: an account whose only bank identity is a synthetic "bank:<sort>:<account>" external-id
+        // (created before its sort/account were persisted as attributes).
+        val externalIdTypeId = AttributeTypeId(WellKnownIds.ACCOUNT_EXTERNAL_ID_ATTR_TYPE_ID)
+        return attrs
+            .firstOrNull { it.attributeType.id == externalIdTypeId }
+            ?.value
+            ?.let(::bankKeyFromExternalId)
+            ?.let { listOf(it) }
+            .orEmpty()
     }
 
     // endregion

--- a/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
+++ b/app/importer/src/commonMain/kotlin/com/moneymanager/importer/ImportEngineImpl.kt
@@ -93,6 +93,7 @@ import com.moneymanager.importengineapi.normalizeNameKey
 import kotlinx.coroutines.flow.first
 import kotlin.time.Duration
 import kotlin.time.Instant
+import kotlin.uuid.Uuid
 
 /**
  * Attribute types that tie an account to a specific real bank account/counterparty identity. An
@@ -846,62 +847,72 @@ class ImportEngineImpl(
             byName[resolvedName] = id
         }
         val currentAttrs = accountAttributeRepository.getByAccount(id).first()
+        val storedGroupKey = storedGroupKeyResolver(intent.attributes, currentAttrs)
         for (attr in intent.attributes) {
             val present = currentAttrs.any { it.attributeType.id == attr.typeId && it.value == attr.value }
             if (!present) {
                 // Upsert rather than insert-and-swallow: the (type, group) slot may already hold a
                 // different value, and dropping the write there would silently lose this provider's
                 // identity for the account.
-                accountAttributeRepository.upsertInCreationMode(
-                    id,
-                    attr.typeId,
-                    attr.value,
-                    resolveGroupKey(attr, intent.attributes, currentAttrs),
-                )
+                accountAttributeRepository.upsertInCreationMode(id, attr.typeId, attr.value, storedGroupKey(attr))
                 byAttr.getOrPut(attr.typeId to attr.value) { id }
             }
         }
     }
 
     /**
-     * The group this incoming attribute should be written into on an existing account.
+     * Builds the function that maps each of an intent's attributes to the `group_key` it is stored under.
      *
-     * For a grouped attribute, the incoming group's derived bank key is matched against the account's
-     * existing groups and the matching group's ACTUAL key is reused. That is what makes a re-import
-     * idempotent even when the stored key has drifted from the natural key (a hand edit, or an earlier
-     * merge's re-key) — matching by content rather than by key means the drifted group is updated in
-     * place instead of a near-duplicate being minted beside it.
+     * Stored group keys are opaque UUIDs. The intent carries a transient grouping tag (the natural
+     * `personalCounterpartyKey`) that only binds an identity's attributes together within the batch; this
+     * translates that tag to a persisted UUID, minting one for a new group and reusing an existing group's
+     * UUID when the incoming identity matches an existing one BY DERIVED VALUE. Matching by value (not by
+     * key string) is what keeps a re-import idempotent and lets two independently-created accounts be
+     * merged without duplicating a shared identity.
      *
-     * An ungrouped identity attribute whose slot already holds a different value is moved into a group of
-     * its own rather than overwriting: two providers can each know the account by a different external id,
-     * and clobbering one would stop that provider matching the account at all.
+     * Ungrouped identity attributes (e.g. a provider external id) are resolved per attribute: one whose
+     * ungrouped slot already holds a DIFFERENT value is moved into a group of its own rather than
+     * overwriting, so two providers that each know the account by a different external id both survive.
      */
-    private fun resolveGroupKey(
-        attr: NewAttribute,
+    private fun storedGroupKeyResolver(
         intentAttributes: List<NewAttribute>,
-        currentAttrs: List<AccountAttribute>,
-    ): String {
-        if (attr.groupKey.isEmpty()) {
-            val occupied =
-                currentAttrs.any {
-                    it.groupKey.isEmpty() && it.attributeType.id == attr.typeId && it.value != attr.value
-                }
-            val isIdentity = attr.typeId.id in IDENTITY_ATTR_TYPE_IDS.map { it.id }
-            return if (occupied && isIdentity) "adopted:${attr.typeId.id}:${attr.value}" else ""
-        }
-        val incomingKey =
-            bankKeysFrom(
-                intentAttributes.filter { it.groupKey == attr.groupKey }.map { AttributeSlot(it.typeId.id, it.value, it.groupKey) },
-            ).firstOrNull() ?: return attr.groupKey
-        val existingGroup =
-            currentAttrs
+        existingAttrs: List<AccountAttribute>,
+    ): (NewAttribute) -> String {
+        val existingGroups = existingAttrs.filter { it.groupKey.isNotEmpty() }.groupBy { it.groupKey }
+        val tagToStored =
+            intentAttributes
                 .filter { it.groupKey.isNotEmpty() }
                 .groupBy { it.groupKey }
-                .entries
-                .firstOrNull { (key, rows) ->
-                    bankKeysFrom(rows.map { AttributeSlot(it.attributeType.id.id, it.value, key) }).firstOrNull() == incomingKey
-                }?.key
-        return existingGroup ?: attr.groupKey
+                .keys
+                .associateWith { tag ->
+                    val incomingKey =
+                        bankKeysFrom(
+                            intentAttributes
+                                .filter { it.groupKey == tag }
+                                .map { AttributeSlot(it.typeId.id, it.value, it.groupKey) },
+                        ).firstOrNull()
+                    val reuse =
+                        incomingKey?.let {
+                            existingGroups.entries
+                                .firstOrNull { (key, rows) ->
+                                    bankKeysFrom(rows.map { AttributeSlot(it.attributeType.id.id, it.value, key) })
+                                        .firstOrNull() == incomingKey
+                                }?.key
+                        }
+                    reuse ?: Uuid.random().toString()
+                }
+        val identityTypeIds = IDENTITY_ATTR_TYPE_IDS.map { it.id }
+        return { attr ->
+            if (attr.groupKey.isNotEmpty()) {
+                tagToStored.getValue(attr.groupKey)
+            } else {
+                val occupied =
+                    existingAttrs.any {
+                        it.groupKey.isEmpty() && it.attributeType.id == attr.typeId && it.value != attr.value
+                    }
+                if (occupied && attr.typeId.id in identityTypeIds) Uuid.random().toString() else ""
+            }
+        }
     }
 
     /**
@@ -926,8 +937,9 @@ class ImportEngineImpl(
                 ),
                 intent.source,
             )
+        val storedGroupKey = storedGroupKeyResolver(intent.attributes, existingAttrs = emptyList())
         intent.attributes.forEach { attr ->
-            accountAttributeRepository.insertInCreationMode(newId, attr.typeId, attr.value, attr.groupKey)
+            accountAttributeRepository.insertInCreationMode(newId, attr.typeId, attr.value, storedGroupKey(attr))
         }
         return newId
     }

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AccountAttribute.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AccountAttribute.kt
@@ -5,4 +5,5 @@ data class AccountAttribute(
     val accountId: AccountId,
     val attributeType: AttributeType,
     val value: String,
+    val groupKey: String = "",
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AccountAttributeAuditEntry.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/AccountAttributeAuditEntry.kt
@@ -26,4 +26,5 @@ data class AccountAttributeAuditEntry(
     val attributeType: AttributeType,
     val auditType: AuditType,
     val value: String,
+    val groupKey: String = "",
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/PersonAttribute.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/PersonAttribute.kt
@@ -5,4 +5,5 @@ data class PersonAttribute(
     val personId: PersonId,
     val attributeType: AttributeType,
     val value: String,
+    val groupKey: String = "",
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/PersonAttributeAuditEntry.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/PersonAttributeAuditEntry.kt
@@ -10,4 +10,5 @@ data class PersonAttributeAuditEntry(
     val attributeType: AttributeType,
     val auditType: AuditType,
     val value: String,
+    val groupKey: String = "",
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TransferAttribute.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TransferAttribute.kt
@@ -5,13 +5,21 @@ data class TransferAttribute(
     val transactionId: TransferId,
     val attributeType: AttributeType,
     val value: String,
+    val groupKey: String = "",
 )
 
 /**
  * An attribute value to be created (before it has an ID).
- * Used when creating new attributes for a transfer.
+ * Used when creating new attributes for a transfer, an account or a person.
+ *
+ * [groupKey] ties this attribute to the others in the same logical tuple on the same entity — a sort code
+ * and an account number sharing a group key are one bank identity, and an account may hold several. `""`
+ * (the default) means ungrouped, which is what every scalar attribute uses. The key is opaque: never parse
+ * it, derive meaning from the values inside a group. See `account_attribute.group_key` for the full
+ * contract and `ImportKeys.personalCounterpartyKey` for the natural key writers seed it with.
  */
 data class NewAttribute(
     val typeId: AttributeTypeId,
     val value: String,
+    val groupKey: String = "",
 )

--- a/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TransferAttributeAuditEntry.kt
+++ b/app/model/core/src/commonMain/kotlin/com/moneymanager/domain/model/TransferAttributeAuditEntry.kt
@@ -23,4 +23,5 @@ data class TransferAttributeAuditEntry(
     val attributeType: AttributeType,
     val auditType: AuditType,
     val value: String,
+    val groupKey: String = "",
 )

--- a/app/model/repository/read/src/commonMain/kotlin/com/moneymanager/domain/repository/PersonAttributeReadRepository.kt
+++ b/app/model/repository/read/src/commonMain/kotlin/com/moneymanager/domain/repository/PersonAttributeReadRepository.kt
@@ -6,4 +6,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface PersonAttributeReadRepository {
     fun getByPerson(personId: PersonId): Flow<List<PersonAttribute>>
+
+    /** Every person attribute in one query — lets callers build an index without an N+1 per person. */
+    fun getAll(): Flow<List<PersonAttribute>>
 }

--- a/app/model/repository/write/src/commonMain/kotlin/com/moneymanager/domain/repository/write/AccountAttributeWriteRepository.kt
+++ b/app/model/repository/write/src/commonMain/kotlin/com/moneymanager/domain/repository/write/AccountAttributeWriteRepository.kt
@@ -13,6 +13,7 @@ interface AccountAttributeWriteRepository : AccountAttributeReadRepository {
         accountId: AccountId,
         attributeTypeId: AttributeTypeId,
         value: String,
+        groupKey: String = "",
     ): Long
 
     /**
@@ -24,7 +25,21 @@ interface AccountAttributeWriteRepository : AccountAttributeReadRepository {
         accountId: AccountId,
         attributeTypeId: AttributeTypeId,
         value: String,
+        groupKey: String = "",
     ): Long
+
+    /**
+     * Writes one attribute into one (type, group) slot, inserting or updating as needed and doing nothing
+     * when the value already matches. Unlike [insertInCreationMode] this never throws on a slot that is
+     * already occupied, so a re-import of an already-known bank identity is a true no-op rather than a
+     * swallowed UNIQUE violation.
+     */
+    suspend fun upsertInCreationMode(
+        accountId: AccountId,
+        attributeTypeId: AttributeTypeId,
+        value: String,
+        groupKey: String = "",
+    )
 
     /**
      * Inserts many attributes in creation mode.
@@ -36,6 +51,7 @@ interface AccountAttributeWriteRepository : AccountAttributeReadRepository {
                 accountId = input.accountId,
                 attributeTypeId = input.attributeTypeId,
                 value = input.value,
+                groupKey = input.groupKey,
             )
         }
     }
@@ -60,4 +76,5 @@ data class AccountAttributeCreateInput(
     val accountId: AccountId,
     val attributeTypeId: AttributeTypeId,
     val value: String,
+    val groupKey: String = "",
 )

--- a/app/model/repository/write/src/commonMain/kotlin/com/moneymanager/domain/repository/write/PersonAttributeWriteRepository.kt
+++ b/app/model/repository/write/src/commonMain/kotlin/com/moneymanager/domain/repository/write/PersonAttributeWriteRepository.kt
@@ -9,12 +9,14 @@ interface PersonAttributeWriteRepository : PersonAttributeReadRepository {
         personId: PersonId,
         attributeTypeId: AttributeTypeId,
         value: String,
+        groupKey: String = "",
     ): Long
 
     suspend fun insertInCreationMode(
         personId: PersonId,
         attributeTypeId: AttributeTypeId,
         value: String,
+        groupKey: String = "",
     ): Long
 
     suspend fun updateValue(

--- a/app/model/repository/write/src/commonMain/kotlin/com/moneymanager/domain/repository/write/TransferAttributeWriteRepository.kt
+++ b/app/model/repository/write/src/commonMain/kotlin/com/moneymanager/domain/repository/write/TransferAttributeWriteRepository.kt
@@ -13,6 +13,7 @@ interface TransferAttributeWriteRepository : TransferAttributeReadRepository {
         transactionId: TransferId,
         attributeTypeId: AttributeTypeId,
         value: String,
+        groupKey: String = "",
     ): Long
 
     /**

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
@@ -36,6 +36,7 @@ import com.moneymanager.importengineapi.ImportOperation
 import com.moneymanager.importengineapi.ImportOwnershipIntent
 import com.moneymanager.importengineapi.LocalAccountKey
 import com.moneymanager.importengineapi.getOrCreateAttributeType
+import com.moneymanager.ui.components.transactions.EditableAttribute
 import com.moneymanager.ui.components.transactions.EditableAttributesSection
 import com.moneymanager.ui.error.rememberFlowAsStateWithSchemaErrorHandling
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
@@ -82,7 +83,7 @@ fun EditAccountDialog(
 
     // Attribute state
     var existingAttributeTypes by remember { mutableStateOf<List<AttributeType>>(emptyList()) }
-    var editableAttributes by remember { mutableStateOf<Map<Long, Pair<String, String>>>(emptyMap()) }
+    var editableAttributes by remember { mutableStateOf<Map<Long, EditableAttribute>>(emptyMap()) }
     var originalAttributeList by remember { mutableStateOf<List<com.moneymanager.domain.model.AccountAttribute>>(emptyList()) }
     var nextTempId by remember { mutableStateOf(-1L) }
     var attributesLoaded by remember { mutableStateOf(false) }
@@ -101,7 +102,7 @@ fun EditAccountDialog(
                 originalAttributeList = attrs
                 editableAttributes =
                     attrs.associate { attr ->
-                        attr.id to Pair(attr.attributeType.name, attr.value)
+                        attr.id to EditableAttribute(attr.attributeType.name, attr.value, attr.groupKey)
                     }
                 attributesLoaded = true
             }
@@ -152,25 +153,27 @@ fun EditAccountDialog(
                     val deletedAttributeIds = originalIds - editableIds
 
                     val updatedAttributes = mutableMapOf<Long, NewAttribute>()
-                    editableAttributes.filter { (id, _) -> id > 0 }.forEach { (id, pair) ->
-                        val (typeName, value) = pair
+                    editableAttributes.filter { (id, _) -> id > 0 }.forEach { (id, attribute) ->
+                        val (typeName, value, groupKey) = attribute
                         val original = originalAttributeList.find { it.id == id }
                         if (original != null) {
                             val typeChanged = original.attributeType.name != typeName
                             val valueChanged = original.value != value
                             if (typeChanged || valueChanged) {
                                 val typeId = importEngine.getOrCreateAttributeType(typeName.trim())
-                                updatedAttributes[id] = NewAttribute(typeId, value.trim())
+                                // Carry the row's original group through: editing a sort code must keep the
+                                // attribute bound to its own bank identity, not move it into the ungrouped slot.
+                                updatedAttributes[id] = NewAttribute(typeId, value.trim(), groupKey)
                             }
                         }
                     }
 
                     val newAttributes = mutableListOf<NewAttribute>()
-                    editableAttributes.filter { (id, _) -> id < 0 }.forEach { (_, pair) ->
-                        val (typeName, value) = pair
+                    editableAttributes.filter { (id, _) -> id < 0 }.forEach { (_, attribute) ->
+                        val (typeName, value, groupKey) = attribute
                         if (typeName.isNotBlank() && value.isNotBlank()) {
                             val typeId = importEngine.getOrCreateAttributeType(typeName.trim())
-                            newAttributes.add(NewAttribute(typeId, value.trim()))
+                            newAttributes.add(NewAttribute(typeId, value.trim(), groupKey))
                         }
                     }
 
@@ -279,7 +282,7 @@ fun EditAccountDialog(
                     isSaving = accountState.isSaving,
                     onAttributesChange = { editableAttributes = it },
                     onAddAttribute = {
-                        editableAttributes = editableAttributes + (nextTempId to Pair("", ""))
+                        editableAttributes = editableAttributes + (nextTempId to EditableAttribute("", ""))
                         nextTempId--
                     },
                 )

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
@@ -281,10 +281,11 @@ fun EditAccountDialog(
                     existingAttributeTypes = existingAttributeTypes,
                     isSaving = accountState.isSaving,
                     onAttributesChange = { editableAttributes = it },
-                    onAddAttribute = {
-                        editableAttributes = editableAttributes + (nextTempId to EditableAttribute("", ""))
+                    onAddAttribute = { groupKey ->
+                        editableAttributes = editableAttributes + (nextTempId to EditableAttribute("", "", groupKey))
                         nextTempId--
                     },
+                    grouping = true,
                 )
 
                 accountState.errorMessage?.let { error -> ErrorMessageText(error) }

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/EditAccountDialog.kt
@@ -159,7 +159,8 @@ fun EditAccountDialog(
                         if (original != null) {
                             val typeChanged = original.attributeType.name != typeName
                             val valueChanged = original.value != value
-                            if (typeChanged || valueChanged) {
+                            val groupChanged = original.groupKey != groupKey
+                            if (typeChanged || valueChanged || groupChanged) {
                                 val typeId = importEngine.getOrCreateAttributeType(typeName.trim())
                                 // Carry the row's original group through: editing a sort code must keep the
                                 // attribute bound to its own bank identity, not move it into the ungrouped slot.

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
@@ -36,6 +36,7 @@ import com.moneymanager.importengineapi.ImportOperation
 import com.moneymanager.importengineapi.ImportPersonIntent
 import com.moneymanager.importengineapi.LocalPersonKey
 import com.moneymanager.importengineapi.getOrCreateAttributeType
+import com.moneymanager.ui.components.transactions.EditableAttribute
 import com.moneymanager.ui.components.transactions.EditableAttributesSection
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.foundation.LocalImportEngine
@@ -62,7 +63,7 @@ fun EditPersonDialog(
     // Attribute editing (e.g. provider external ids) is available when both repositories are provided.
     val attributesEditable = personAttributeRepository != null && attributeTypeRepository != null
     var existingAttributeTypes by remember { mutableStateOf<List<AttributeType>>(emptyList()) }
-    var editableAttributes by remember { mutableStateOf<Map<Long, Pair<String, String>>>(emptyMap()) }
+    var editableAttributes by remember { mutableStateOf<Map<Long, EditableAttribute>>(emptyMap()) }
     var originalAttributeList by remember { mutableStateOf<List<PersonAttribute>>(emptyList()) }
     var nextTempId by remember { mutableStateOf(-1L) }
     var attributesLoaded by remember { mutableStateOf(false) }
@@ -78,7 +79,7 @@ fun EditPersonDialog(
         if (personAttributeRepository != null && personToEdit != null && !attributesLoaded) {
             val attrs = personAttributeRepository.getByPerson(personToEdit.id).first()
             originalAttributeList = attrs
-            editableAttributes = attrs.associate { it.id to Pair(it.attributeType.name, it.value) }
+            editableAttributes = attrs.associate { it.id to EditableAttribute(it.attributeType.name, it.value, it.groupKey) }
             attributesLoaded = true
         }
     }
@@ -113,21 +114,32 @@ fun EditPersonDialog(
                             .toSet()
                             .minus(keptIds)
                             .forEach { deletedAttributeIds.add(it) }
-                        editableAttributes.filterKeys { it > 0 }.forEach { (id, pair) ->
-                            val typeName = pair.first.trim()
-                            val value = pair.second.trim()
+                        editableAttributes.filterKeys { it > 0 }.forEach { (id, attribute) ->
+                            val typeName = attribute.typeName.trim()
+                            val value = attribute.value.trim()
                             val original = originalAttributeList.find { it.id == id } ?: return@forEach
                             when {
                                 typeName.isBlank() || value.isBlank() -> deletedAttributeIds.add(id)
                                 original.attributeType.name != typeName || original.value != value ->
-                                    updatedAttributes[id] = NewAttribute(importEngine.getOrCreateAttributeType(typeName), value)
+                                    updatedAttributes[id] =
+                                        NewAttribute(
+                                            importEngine.getOrCreateAttributeType(typeName),
+                                            value,
+                                            attribute.groupKey,
+                                        )
                             }
                         }
-                        editableAttributes.filterKeys { it < 0 }.forEach { (_, pair) ->
-                            val typeName = pair.first.trim()
-                            val value = pair.second.trim()
+                        editableAttributes.filterKeys { it < 0 }.forEach { (_, attribute) ->
+                            val typeName = attribute.typeName.trim()
+                            val value = attribute.value.trim()
                             if (typeName.isNotEmpty() && value.isNotEmpty()) {
-                                newAttributes.add(NewAttribute(importEngine.getOrCreateAttributeType(typeName), value))
+                                newAttributes.add(
+                                    NewAttribute(
+                                        importEngine.getOrCreateAttributeType(typeName),
+                                        value,
+                                        attribute.groupKey,
+                                    ),
+                                )
                             }
                         }
                     }
@@ -248,7 +260,7 @@ fun EditPersonDialog(
                         isSaving = saveState.isSaving,
                         onAttributesChange = { editableAttributes = it },
                         onAddAttribute = {
-                            editableAttributes = editableAttributes + (nextTempId to Pair("", ""))
+                            editableAttributes = editableAttributes + (nextTempId to EditableAttribute("", ""))
                             nextTempId--
                         },
                     )

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/EditPersonDialog.kt
@@ -260,7 +260,7 @@ fun EditPersonDialog(
                         isSaving = saveState.isSaving,
                         onAttributesChange = { editableAttributes = it },
                         onAddAttribute = {
-                            editableAttributes = editableAttributes + (nextTempId to EditableAttribute("", ""))
+                            editableAttributes = editableAttributes + (nextTempId to EditableAttribute("", "", it))
                             nextTempId--
                         },
                     )

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/transactions/AttributeFields.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/transactions/AttributeFields.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
@@ -13,6 +15,7 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -25,14 +28,29 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.moneymanager.domain.model.AttributeType
+import kotlin.uuid.Uuid
 
+/**
+ * Editor for an entity's attributes.
+ *
+ * When [grouping] is on (account editor), attributes sharing a non-empty [EditableAttribute.groupKey]
+ * render together in a card and can be dissolved with Ungroup; ungrouped attributes gain a checkbox so
+ * two or more can be bound into a new group. A group key is a freshly-minted opaque [Uuid], so a
+ * user-formed group can never collide with an importer's key. When [grouping] is off (person/transfer
+ * editors) the rendering is a flat list exactly as before, and any loaded group keys are carried through
+ * untouched.
+ *
+ * [onAddAttribute] receives the group key the new (blank) row should belong to — `""` for an ungrouped
+ * row, or an existing group's key for "+ Add to group".
+ */
 @Composable
 fun EditableAttributesSection(
     editableAttributes: Map<Long, EditableAttribute>,
     existingAttributeTypes: List<AttributeType>,
     isSaving: Boolean,
     onAttributesChange: (Map<Long, EditableAttribute>) -> Unit,
-    onAddAttribute: () -> Unit,
+    onAddAttribute: (groupKey: String) -> Unit,
+    grouping: Boolean = false,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -44,50 +62,160 @@ fun EditableAttributesSection(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
-        editableAttributes.forEach { (id, attribute) ->
-            val (typeName, value) = attribute
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                AttributeTypeField(
-                    value = typeName,
-                    onValueChange = { newTypeName ->
-                        onAttributesChange(editableAttributes + (id to attribute.copy(typeName = newTypeName)))
-                    },
-                    existingTypes = existingAttributeTypes,
-                    enabled = !isSaving,
-                    modifier = Modifier.weight(0.4f),
-                )
-                OutlinedTextField(
-                    value = value,
-                    onValueChange = { newValue ->
-                        onAttributesChange(editableAttributes + (id to attribute.copy(value = newValue)))
-                    },
-                    label = { Text("Value") },
-                    modifier = Modifier.weight(0.5f),
-                    singleLine = true,
-                    enabled = !isSaving,
-                )
-                IconButton(
-                    onClick = { onAttributesChange(editableAttributes - id) },
-                    enabled = !isSaving,
-                ) {
-                    Text(
-                        text = "X",
-                        color = MaterialTheme.colorScheme.error,
-                        style = MaterialTheme.typography.bodyLarge,
+        if (!grouping) {
+            editableAttributes.forEach { (id, attribute) ->
+                AttributeRow(id, attribute, existingAttributeTypes, isSaving, editableAttributes, onAttributesChange)
+            }
+            TextButton(onClick = { onAddAttribute("") }, enabled = !isSaving) {
+                Text("+ Add Attribute")
+            }
+            return@Column
+        }
+
+        // Selection is transient view state, owned here like the type field's own dropdown state.
+        var selectedIds by remember { mutableStateOf(emptySet<Long>()) }
+        val ungrouped = editableAttributes.filterValues { it.groupKey.isEmpty() }
+        val groups = editableAttributes.entries.filter { it.value.groupKey.isNotEmpty() }.groupBy { it.value.groupKey }
+
+        ungrouped.forEach { (id, attribute) ->
+            AttributeRow(
+                id,
+                attribute,
+                existingAttributeTypes,
+                isSaving,
+                editableAttributes,
+                onAttributesChange,
+                selected = id in selectedIds,
+                onSelectedChange = { checked -> selectedIds = if (checked) selectedIds + id else selectedIds - id },
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            TextButton(
+                onClick = {
+                    val newKey = Uuid.random().toString()
+                    onAttributesChange(
+                        editableAttributes.mapValues { (id, a) -> if (id in selectedIds) a.copy(groupKey = newKey) else a },
                     )
-                }
+                    selectedIds = emptySet()
+                },
+                // Grouping one attribute is meaningless; require at least two.
+                enabled = !isSaving && selectedIds.size >= 2,
+            ) {
+                Text("Group selected")
+            }
+            TextButton(onClick = { onAddAttribute("") }, enabled = !isSaving) {
+                Text("+ Add Attribute")
             }
         }
 
-        TextButton(
-            onClick = onAddAttribute,
+        groups.forEach { (groupKey, members) ->
+            AttributeGroupCard(
+                groupKey = groupKey,
+                members = members.map { it.key to it.value },
+                existingAttributeTypes = existingAttributeTypes,
+                isSaving = isSaving,
+                editableAttributes = editableAttributes,
+                onAttributesChange = onAttributesChange,
+                onAddAttribute = onAddAttribute,
+            )
+        }
+    }
+}
+
+/** One attribute editor row: an optional leading checkbox, a type field, a value field, and a delete button. */
+@Composable
+private fun AttributeRow(
+    id: Long,
+    attribute: EditableAttribute,
+    existingAttributeTypes: List<AttributeType>,
+    isSaving: Boolean,
+    editableAttributes: Map<Long, EditableAttribute>,
+    onAttributesChange: (Map<Long, EditableAttribute>) -> Unit,
+    selected: Boolean? = null,
+    onSelectedChange: (Boolean) -> Unit = {},
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (selected != null) {
+            Checkbox(checked = selected, onCheckedChange = onSelectedChange, enabled = !isSaving)
+        }
+        AttributeTypeField(
+            value = attribute.typeName,
+            onValueChange = { newTypeName ->
+                onAttributesChange(editableAttributes + (id to attribute.copy(typeName = newTypeName)))
+            },
+            existingTypes = existingAttributeTypes,
             enabled = !isSaving,
+            modifier = Modifier.weight(0.4f),
+        )
+        OutlinedTextField(
+            value = attribute.value,
+            onValueChange = { newValue ->
+                onAttributesChange(editableAttributes + (id to attribute.copy(value = newValue)))
+            },
+            label = { Text("Value") },
+            modifier = Modifier.weight(0.5f),
+            singleLine = true,
+            enabled = !isSaving,
+        )
+        IconButton(onClick = { onAttributesChange(editableAttributes - id) }, enabled = !isSaving) {
+            Text(
+                text = "X",
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+        }
+    }
+}
+
+/** A bordered card holding one group's attributes, with Ungroup and "+ Add to group" actions. */
+@Composable
+private fun AttributeGroupCard(
+    groupKey: String,
+    members: List<Pair<Long, EditableAttribute>>,
+    existingAttributeTypes: List<AttributeType>,
+    isSaving: Boolean,
+    editableAttributes: Map<Long, EditableAttribute>,
+    onAttributesChange: (Map<Long, EditableAttribute>) -> Unit,
+    onAddAttribute: (groupKey: String) -> Unit,
+) {
+    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Text("+ Add Attribute")
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Grouped",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                // Ungroup is a deliberate action: for a two-identity account, ungrouping both identities
+                // leaves their sort/account numbers unpairable and the account no longer matches on import.
+                TextButton(
+                    onClick = {
+                        onAttributesChange(
+                            editableAttributes.mapValues { (_, a) -> if (a.groupKey == groupKey) a.copy(groupKey = "") else a },
+                        )
+                    },
+                    enabled = !isSaving,
+                ) {
+                    Text("Ungroup")
+                }
+            }
+            members.forEach { (id, attribute) ->
+                AttributeRow(id, attribute, existingAttributeTypes, isSaving, editableAttributes, onAttributesChange)
+            }
+            TextButton(onClick = { onAddAttribute(groupKey) }, enabled = !isSaving) {
+                Text("+ Add to group")
+            }
         }
     }
 }

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/transactions/AttributeFields.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/transactions/AttributeFields.kt
@@ -28,10 +28,10 @@ import com.moneymanager.domain.model.AttributeType
 
 @Composable
 fun EditableAttributesSection(
-    editableAttributes: Map<Long, Pair<String, String>>,
+    editableAttributes: Map<Long, EditableAttribute>,
     existingAttributeTypes: List<AttributeType>,
     isSaving: Boolean,
-    onAttributesChange: (Map<Long, Pair<String, String>>) -> Unit,
+    onAttributesChange: (Map<Long, EditableAttribute>) -> Unit,
     onAddAttribute: () -> Unit,
 ) {
     Column(
@@ -44,8 +44,8 @@ fun EditableAttributesSection(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
-        editableAttributes.forEach { (id, pair) ->
-            val (typeName, value) = pair
+        editableAttributes.forEach { (id, attribute) ->
+            val (typeName, value) = attribute
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -54,7 +54,7 @@ fun EditableAttributesSection(
                 AttributeTypeField(
                     value = typeName,
                     onValueChange = { newTypeName ->
-                        onAttributesChange(editableAttributes + (id to Pair(newTypeName, value)))
+                        onAttributesChange(editableAttributes + (id to attribute.copy(typeName = newTypeName)))
                     },
                     existingTypes = existingAttributeTypes,
                     enabled = !isSaving,
@@ -63,7 +63,7 @@ fun EditableAttributesSection(
                 OutlinedTextField(
                     value = value,
                     onValueChange = { newValue ->
-                        onAttributesChange(editableAttributes + (id to Pair(typeName, newValue)))
+                        onAttributesChange(editableAttributes + (id to attribute.copy(value = newValue)))
                     },
                     label = { Text("Value") },
                     modifier = Modifier.weight(0.5f),

--- a/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/transactions/EditableAttribute.kt
+++ b/app/ui/components/src/commonMain/kotlin/com/moneymanager/ui/components/transactions/EditableAttribute.kt
@@ -1,0 +1,16 @@
+package com.moneymanager.ui.components.transactions
+
+/**
+ * One row in the attribute editor.
+ *
+ * [groupKey] is carried through the editor untouched. It ties this attribute to the others in the same
+ * logical tuple (a sort code and an account number sharing a group key are one bank identity, and an
+ * account may own several). The editor never shows or changes it, but it must survive the round trip:
+ * rebuilding a row without its group would rewrite every identity into the ungrouped slot on save,
+ * collapsing them into one and destroying all but the first.
+ */
+data class EditableAttribute(
+    val typeName: String,
+    val value: String,
+    val groupKey: String = "",
+)

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/monzo/MonzoImportE2ETest.kt
@@ -1569,7 +1569,6 @@ class MonzoImportE2ETest : DbTest() {
             val suggestions =
                 discoverApiCounterpartiesToCreate(
                     apiSessionRepository = repositories.apiSessionRepository,
-                    accountRepository = repositories.accountRepository,
                     accountAttributeRepository = repositories.accountAttributeRepository,
                     sessionId = sessionId,
                     strategy = strategy,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/starling/StarlingImportE2ETest.kt
@@ -820,7 +820,6 @@ class StarlingImportE2ETest : DbTest() {
             )
             importApiSessionPeople(
                 apiSessionRepository = repositories.apiSessionRepository,
-                accountRepository = repositories.accountRepository,
                 accountAttributeRepository = repositories.accountAttributeRepository,
                 importEngine = repositories.importEngine,
                 sessionId = sessionId,
@@ -887,7 +886,6 @@ class StarlingImportE2ETest : DbTest() {
             // 1) People FIRST, before any accounts exist — the holder is created but can link to nothing.
             importApiSessionPeople(
                 apiSessionRepository = repositories.apiSessionRepository,
-                accountRepository = repositories.accountRepository,
                 accountAttributeRepository = repositories.accountAttributeRepository,
                 importEngine = repositories.importEngine,
                 sessionId = sessionId,
@@ -948,7 +946,6 @@ class StarlingImportE2ETest : DbTest() {
             )
             importApiSessionPeople(
                 apiSessionRepository = repositories.apiSessionRepository,
-                accountRepository = repositories.accountRepository,
                 accountAttributeRepository = repositories.accountAttributeRepository,
                 importEngine = repositories.importEngine,
                 sessionId = peopleSessionId,

--- a/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
+++ b/app/ui/core/src/commonTest/kotlin/com/moneymanager/ui/wise/WiseImportE2ETest.kt
@@ -319,7 +319,6 @@ class WiseImportE2ETest : DbTest() {
             val importResult =
                 importApiSessionPeople(
                     apiSessionRepository = repositories.apiSessionRepository,
-                    accountRepository = repositories.accountRepository,
                     accountAttributeRepository = repositories.accountAttributeRepository,
                     importEngine = repositories.importEngine,
                     sessionId = peopleSessionId,
@@ -379,7 +378,6 @@ class WiseImportE2ETest : DbTest() {
             downloadApiSessionPeople("test-wise-token", client, repositories.apiSessionRepository, peopleSessionId, strategy)
             importApiSessionPeople(
                 apiSessionRepository = repositories.apiSessionRepository,
-                accountRepository = repositories.accountRepository,
                 accountAttributeRepository = repositories.accountAttributeRepository,
                 importEngine = repositories.importEngine,
                 sessionId = peopleSessionId,

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiSessionsScreen.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiSessionsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -178,6 +179,11 @@ fun ApiSessionsScreen(
     var importResultBySession by remember { mutableStateOf<Map<ApiSessionId, ApiSessionImportResult>>(emptyMap()) }
     var importErrorBySession by remember { mutableStateOf<Map<ApiSessionId, String>>(emptyMap()) }
     var importProgressBySession by remember { mutableStateOf<Map<ApiSessionId, ApiSessionImportProgress>>(emptyMap()) }
+    // Sessions whose import was clicked but whose background task has not yet registered — the gap covers
+    // the counterparty-discovery scan and the engine's initial index build, both of which can run for
+    // seconds on a large database with no progress callback. Tracking it here lets the button grey out and
+    // a progress indicator appear the instant Import is pressed, rather than only once real progress arrives.
+    var preparingImportSessions by remember { mutableStateOf<Set<ApiSessionId>>(emptySet()) }
 
     // Per-credential download result state (cleared when a new download starts)
     var downloadResultByCredential by remember { mutableStateOf<Map<ApiCredentialId, ApiSessionDownloadResult>>(emptyMap()) }
@@ -498,7 +504,9 @@ fun ApiSessionsScreen(
                                 importProgressBySession = importProgressBySession,
                                 importedSessionRevisions = importedSessionRevisions,
                                 selectedStrategyRevision = currentStrategyRevisionByCredential[credential.id],
-                                isImportingSession = { sessionId -> backgroundTasks.isRunning(apiImportTaskKey(sessionId)) },
+                                isImportingSession = { sessionId ->
+                                    backgroundTasks.isRunning(apiImportTaskKey(sessionId)) || sessionId in preparingImportSessions
+                                },
                                 hasEverBeenImported = { sessionId -> importedSessionRevisions.any { it.sessionId == sessionId } },
                                 importedSessionCount =
                                     sessionsByCredential[credential.id].orEmpty().count { session ->
@@ -506,7 +514,7 @@ fun ApiSessionsScreen(
                                     },
                                 isAnySessionImporting =
                                     sessionsByCredential[credential.id].orEmpty().any {
-                                        backgroundTasks.isRunning(apiImportTaskKey(it.id))
+                                        backgroundTasks.isRunning(apiImportTaskKey(it.id)) || it.id in preparingImportSessions
                                     },
                                 onDownload = {
                                     downloadResultByCredential = downloadResultByCredential - credential.id
@@ -655,32 +663,41 @@ fun ApiSessionsScreen(
                                 onImport = { session ->
                                     importResultBySession = importResultBySession - session.id
                                     importErrorBySession = importErrorBySession - session.id
+                                    // Mark it importing synchronously so the button greys and a progress
+                                    // indicator appears immediately, before the discovery scan below runs.
+                                    preparingImportSessions = preparingImportSessions + session.id
                                     scope.launch {
-                                        val strategy =
-                                            resolveStrategy(credential) ?: run {
-                                                importErrorBySession =
-                                                    importErrorBySession + (session.id to "No import strategy configured")
-                                                return@launch
-                                            }
-                                        // Safe for all providers: returns empty when the strategy has no
-                                        // counterparty field, skipping the confirmation dialog.
-                                        val suggestions =
-                                            discoverApiCounterpartiesToCreate(
-                                                apiSessionRepository = apiSessionRepository,
-                                                accountRepository = accountRepository,
-                                                accountAttributeRepository = accountAttributeRepository,
-                                                sessionId = session.id,
-                                                strategy = strategy,
-                                            )
-                                        if (suggestions.isEmpty()) {
-                                            startImport(session, strategy, emptyMap())
-                                        } else {
-                                            pendingImport =
-                                                PendingApiImport(
-                                                    session = session,
+                                        try {
+                                            val strategy =
+                                                resolveStrategy(credential) ?: run {
+                                                    importErrorBySession =
+                                                        importErrorBySession + (session.id to "No import strategy configured")
+                                                    return@launch
+                                                }
+                                            // Safe for all providers: returns empty when the strategy has no
+                                            // counterparty field, skipping the confirmation dialog.
+                                            val suggestions =
+                                                discoverApiCounterpartiesToCreate(
+                                                    apiSessionRepository = apiSessionRepository,
+                                                    accountRepository = accountRepository,
+                                                    accountAttributeRepository = accountAttributeRepository,
+                                                    sessionId = session.id,
                                                     strategy = strategy,
-                                                    counterparties = suggestions,
                                                 )
+                                            if (suggestions.isEmpty()) {
+                                                // startImport registers the background task synchronously, so
+                                                // isImportingSession stays true across the handoff below.
+                                                startImport(session, strategy, emptyMap())
+                                            } else {
+                                                pendingImport =
+                                                    PendingApiImport(
+                                                        session = session,
+                                                        strategy = strategy,
+                                                        counterparties = suggestions,
+                                                    )
+                                            }
+                                        } finally {
+                                            preparingImportSessions = preparingImportSessions - session.id
                                         }
                                     }
                                 },
@@ -1086,6 +1103,14 @@ private fun SessionRow(
 
         if (isImporting) {
             Text(text = "Importing...", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
+            // Indeterminate until the first progress fraction arrives, so the bar is visible during the
+            // discovery scan and the engine's initial index build; determinate thereafter.
+            val fraction = importProgress?.progress
+            if (fraction == null) {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            } else {
+                LinearProgressIndicator(progress = { fraction.coerceIn(0f, 1f) }, modifier = Modifier.fillMaxWidth())
+            }
             importProgress?.let {
                 val percent = it.progress?.let { p -> " (${(p * 100).toInt().coerceIn(0, 100)}%)" }.orEmpty()
                 Text(

--- a/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiSessionsScreen.kt
+++ b/app/ui/imports/api/src/commonMain/kotlin/com/moneymanager/ui/screens/apistrategy/ApiSessionsScreen.kt
@@ -341,7 +341,6 @@ fun ApiSessionsScreen(
                 if (strategy.peopleDownload != null) {
                     importApiSessionPeople(
                         apiSessionRepository = apiSessionRepository,
-                        accountRepository = accountRepository,
                         accountAttributeRepository = accountAttributeRepository,
                         importEngine = importEngine,
                         sessionId = session.id,
@@ -667,6 +666,10 @@ fun ApiSessionsScreen(
                                     // indicator appears immediately, before the discovery scan below runs.
                                     preparingImportSessions = preparingImportSessions + session.id
                                     scope.launch {
+                                        // Cleared in the finally UNLESS we hand off to startImport, which then
+                                        // owns the progress state — clearing it there would race the engine's
+                                        // first progress callback.
+                                        var handedOffToImport = false
                                         try {
                                             val strategy =
                                                 resolveStrategy(credential) ?: run {
@@ -675,18 +678,22 @@ fun ApiSessionsScreen(
                                                     return@launch
                                                 }
                                             // Safe for all providers: returns empty when the strategy has no
-                                            // counterparty field, skipping the confirmation dialog.
+                                            // counterparty field, skipping the confirmation dialog. Its
+                                            // sub-step progress surfaces on the same bar as the import phases.
                                             val suggestions =
                                                 discoverApiCounterpartiesToCreate(
                                                     apiSessionRepository = apiSessionRepository,
-                                                    accountRepository = accountRepository,
                                                     accountAttributeRepository = accountAttributeRepository,
                                                     sessionId = session.id,
                                                     strategy = strategy,
+                                                    onProgress = { progress ->
+                                                        importProgressBySession = importProgressBySession + (session.id to progress)
+                                                    },
                                                 )
                                             if (suggestions.isEmpty()) {
                                                 // startImport registers the background task synchronously, so
                                                 // isImportingSession stays true across the handoff below.
+                                                handedOffToImport = true
                                                 startImport(session, strategy, emptyMap())
                                             } else {
                                                 pendingImport =
@@ -698,6 +705,9 @@ fun ApiSessionsScreen(
                                             }
                                         } finally {
                                             preparingImportSessions = preparingImportSessions - session.id
+                                            if (!handedOffToImport) {
+                                                importProgressBySession = importProgressBySession - session.id
+                                            }
                                         }
                                     }
                                 },
@@ -1102,22 +1112,20 @@ private fun SessionRow(
         }
 
         if (isImporting) {
-            Text(text = "Importing...", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
-            // Indeterminate until the first progress fraction arrives, so the bar is visible during the
-            // discovery scan and the engine's initial index build; determinate thereafter.
             val fraction = importProgress?.progress
+            // Before the first engine progress arrives, the import is still in the UI-side preparation
+            // phase (resolving the strategy, scanning for counterparties, loading the session) — so label
+            // it accurately as "Preparing import…" rather than the misleading "Importing…". Once progress
+            // flows, each phase reports its own detail ("Counterparties prepared.", "Resolving accounts",
+            // "Importing transactions", "Import finalized.", …), which we surface as the label.
+            val percent = fraction?.let { " (${(it * 100).toInt().coerceIn(0, 100)}%)" }.orEmpty()
+            val label = importProgress?.let { it.detail + percent } ?: "Preparing import…"
+            Text(text = label, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
+            // Indeterminate during preparation (no fraction yet), determinate once a phase reports one.
             if (fraction == null) {
                 LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
             } else {
                 LinearProgressIndicator(progress = { fraction.coerceIn(0f, 1f) }, modifier = Modifier.fillMaxWidth())
-            }
-            importProgress?.let {
-                val percent = it.progress?.let { p -> " (${(p * 100).toInt().coerceIn(0, 100)}%)" }.orEmpty()
-                Text(
-                    text = it.detail + percent,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.bodySmall,
-                )
             }
         }
 

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
@@ -582,7 +582,7 @@ fun TransactionEditDialog(
                     isSaving = isSaving,
                     onAttributesChange = { editableAttributes = it },
                     onAddAttribute = {
-                        editableAttributes = editableAttributes + (nextTempId to EditableAttribute("", ""))
+                        editableAttributes = editableAttributes + (nextTempId to EditableAttribute("", "", it))
                         nextTempId--
                     },
                 )

--- a/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
+++ b/app/ui/transactions/src/commonMain/kotlin/com/moneymanager/ui/screens/transactions/TransactionEditDialog.kt
@@ -60,6 +60,7 @@ import com.moneymanager.importengineapi.getOrCreateAttributeType
 import com.moneymanager.ui.components.AccountPicker
 import com.moneymanager.ui.components.CurrencyPicker
 import com.moneymanager.ui.components.LoadingTextButton
+import com.moneymanager.ui.components.transactions.EditableAttribute
 import com.moneymanager.ui.components.transactions.EditableAttributesSection
 import com.moneymanager.ui.error.rememberSchemaAwareCoroutineScope
 import com.moneymanager.ui.foundation.LocalImportEngine
@@ -142,11 +143,10 @@ fun TransactionEditDialog(
 
     // EditableAttribute represents the current state of each attribute in the UI
     // key: a stable identifier (original attribute id or a negative temp id for new ones)
-    // value: Pair(attributeTypeName, value)
     var editableAttributes by remember {
         mutableStateOf(
             originalAttributes.associate { attr ->
-                attr.id to Pair(attr.attributeType.name, attr.value)
+                attr.id to EditableAttribute(attr.attributeType.name, attr.value, attr.groupKey)
             },
         )
     }
@@ -161,15 +161,16 @@ fun TransactionEditDialog(
 
     // Helper to check if attributes have changed
     fun hasAttributeChanges(): Boolean {
-        val originalMap = originalAttributes.associate { it.id to Pair(it.attributeType.name, it.value) }
+        val originalMap =
+            originalAttributes.associate { it.id to EditableAttribute(it.attributeType.name, it.value, it.groupKey) }
         // Check if any new attributes were added (negative IDs)
         if (editableAttributes.keys.any { it < 0 }) return true
         // Check if any original attributes were removed
         if (originalMap.keys.any { it !in editableAttributes.keys }) return true
         // Check if any attribute values changed
-        return editableAttributes.any { (id, pair) ->
+        return editableAttributes.any { (id, attribute) ->
             val original = originalMap[id]
-            original == null || original != pair
+            original == null || original != attribute
         }
     }
 
@@ -315,26 +316,26 @@ fun TransactionEditDialog(
 
                             // Build updated attributes map (id -> NewAttribute)
                             val updatedAttributes = mutableMapOf<Long, NewAttribute>()
-                            editableAttributes.filter { (id, _) -> id > 0 }.forEach { (id, pair) ->
-                                val (typeName, value) = pair
+                            editableAttributes.filter { (id, _) -> id > 0 }.forEach { (id, attribute) ->
+                                val (typeName, value, groupKey) = attribute
                                 val original = originalAttributes.find { it.id == id }
                                 if (original != null) {
                                     val typeChanged = original.attributeType.name != typeName
                                     val valueChanged = original.value != value
                                     if (typeChanged || valueChanged) {
                                         val typeId = importEngine.getOrCreateAttributeType(typeName)
-                                        updatedAttributes[id] = NewAttribute(typeId, value)
+                                        updatedAttributes[id] = NewAttribute(typeId, value, groupKey)
                                     }
                                 }
                             }
 
                             // Build new attributes list
                             val newAttributes = mutableListOf<NewAttribute>()
-                            editableAttributes.filter { (id, _) -> id < 0 }.forEach { (_, pair) ->
-                                val (typeName, value) = pair
+                            editableAttributes.filter { (id, _) -> id < 0 }.forEach { (_, attribute) ->
+                                val (typeName, value, groupKey) = attribute
                                 if (typeName.isNotBlank() && value.isNotBlank()) {
                                     val typeId = importEngine.getOrCreateAttributeType(typeName)
-                                    newAttributes.add(NewAttribute(typeId, value))
+                                    newAttributes.add(NewAttribute(typeId, value, groupKey))
                                 }
                             }
 
@@ -380,10 +381,10 @@ fun TransactionEditDialog(
                             // CREATE MODE: build attributes to save (only non-blank ones).
                             val attributesToSave =
                                 editableAttributes
-                                    .filter { (_, pair) -> pair.first.isNotBlank() && pair.second.isNotBlank() }
-                                    .map { (_, pair) ->
-                                        val typeId = importEngine.getOrCreateAttributeType(pair.first.trim())
-                                        NewAttribute(typeId, pair.second.trim())
+                                    .filter { (_, attr) -> attr.typeName.isNotBlank() && attr.value.isNotBlank() }
+                                    .map { (_, attr) ->
+                                        val typeId = importEngine.getOrCreateAttributeType(attr.typeName.trim())
+                                        NewAttribute(typeId, attr.value.trim(), attr.groupKey)
                                     }.toMutableList()
 
                             if (isExcluded) {
@@ -581,7 +582,7 @@ fun TransactionEditDialog(
                     isSaving = isSaving,
                     onAttributesChange = { editableAttributes = it },
                     onAddAttribute = {
-                        editableAttributes = editableAttributes + (nextTempId to Pair("", ""))
+                        editableAttributes = editableAttributes + (nextTempId to EditableAttribute("", ""))
                         nextTempId--
                     },
                 )


### PR DESCRIPTION
## What

- Adds a `group_key` column to `account_attribute`/`person_attribute`/`transfer_attribute` so a single account can own **multiple bank identities** (e.g. two different sort code + account number pairs), fixing Monzo→Crypto.com transfers routing to the wrong account after Crypto.com changed its bank identity.
- Stores every group key as an opaque **UUID**, minted by the `ImportEngine` and reused across re-imports by matching on the derived bank value (not the key string), so imports stay idempotent.
- Account merge/unmerge now carries attribute groups correctly, deduplicating identities that share a derived bank key even when stored under different UUIDs.
- Adds a grouping editor to the account attributes UI: select ungrouped rows → "Group selected"; grouped attributes render as a bordered card with "Ungroup" / "+ Add to group".
- Fixes the API import "Import" button appearing to do nothing on large databases: the button now disables and shows progress immediately, with phase-level detail ("Scanning existing accounts…", "Resolving accounts", "Saving to database…", etc.) instead of a static "Importing…" label.
- Fixes N+1 query patterns in `ImportEngineImpl`/`ApiSessionImportService` that dominated the "Resolving accounts"/"Resolving people" import phases on large databases (per-row repository calls replaced with a single bulk `getAll()` query each).

## Why

Crypto.com rotated its bank sort code/account number, and the schema only allowed one bank identity per account, so imports silently created a duplicate account and reconciliation broke. The general fix (multi-identity accounts via grouped attributes) needed a proper editor UI and collision-proof keys, and while investigating the API import UX we found the "does nothing" bug plus the underlying N+1 performance issue in the same import path.

## Test plan

- [x] `./gradlew build buildHealth --console=plain` (includes Wise/Starling/Monzo API import E2E tests)
- [ ] Manual: group/ungroup attributes in the account editor, confirm round-trip after save/reopen
- [ ] Manual: run an API import on a large database, confirm the button disables immediately and phase labels update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Group account, person, and transaction attributes in the editing interface.
  - Add attributes to groups, remove them from groups, and add new attributes directly to an existing group.
  - Show “Preparing import…” status and progress during imports.

- **Bug Fixes**
  - Improved bank identity matching to prevent duplicate accounts during imports.
  - Preserved grouped attributes when merging and unmerging accounts.
  - Improved re-import reliability and prevented previously merged accounts from being recreated.
  - Made import progress reporting clearer during data saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->