### PR TITLE
Match non-regex account attribute values literally

### DIFF
--- a/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/AttributeAccountMatcher.kt
+++ b/app/csvimporter/src/commonMain/kotlin/com/moneymanager/csvimporter/AttributeAccountMatcher.kt
@@ -14,6 +14,10 @@ import com.moneymanager.domain.model.AccountId
  *
  * A last-4 like "7721" is just a trivial regex, so existing `card-last4` attributes keep working; use
  * `\s` for a literal space in a pattern, since spaces separate tokens.
+ *
+ * Attribute values are free text a user or an importer may have written without regex intent (a raw
+ * card descriptor like `crv*revolut**4647*`), so a token that isn't a valid regex is matched
+ * literally rather than failing the whole import.
  */
 class AttributeAccountMatcher private constructor(
     private val patterns: List<Pair<Regex, AccountId>>,
@@ -35,9 +39,14 @@ class AttributeAccountMatcher private constructor(
                         .split(TOKEN_DELIMITER)
                         .map { it.trim() }
                         .filter { it.isNotEmpty() }
-                        .map { Regex(it, RegexOption.IGNORE_CASE) to attribute.accountId }
+                        .map { compileToken(it) to attribute.accountId }
                 },
             )
+
+        /** Compiles a token as a regex, falling back to a literal match when it isn't valid regex syntax. */
+        private fun compileToken(token: String): Regex =
+            runCatching { Regex(token, RegexOption.IGNORE_CASE) }
+                .getOrElse { Regex(Regex.escape(token), RegexOption.IGNORE_CASE) }
 
         /** Builds a registry keyed by attribute-type name from a mixed list of account attributes. */
         fun registry(attributes: List<AccountAttribute>): Map<String, AttributeAccountMatcher> =

--- a/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/AttributeAccountMatcherTest.kt
+++ b/app/csvimporter/src/commonTest/kotlin/com/moneymanager/csvimporter/AttributeAccountMatcherTest.kt
@@ -69,6 +69,14 @@ class AttributeAccountMatcherTest {
     }
 
     @Test
+    fun `a token that is not valid regex syntax matches literally instead of throwing`() {
+        val matcher = AttributeAccountMatcher.from(listOf(attribute(accountId = 55, value = "crv*revolut**4647*")))
+
+        assertEquals(AccountId(55), matcher.match("CRV*REVOLUT**4647* LONDON"))
+        assertNull(matcher.match("crv revolut 4647"))
+    }
+
+    @Test
     fun `registry groups matchers by attribute type name`() {
         val registry =
             AttributeAccountMatcher.registry(


### PR DESCRIPTION
## What

`AttributeAccountMatcher` compiled every account-attribute token as a `Regex`. Account attribute
values are free text, so a raw card descriptor such as `crv*revolut**4647*` is not valid regex
syntax and threw `PatternSyntaxException` ("Dangling meta character '*'"), failing the entire
re-import preview:

```
ERROR ... Re-import preview failed: Dangling meta character '*' near index 12
crv*revolut**4647*
    at com.moneymanager.csvimporter.AttributeAccountMatcher$Companion.from(AttributeAccountMatcher.kt:38)
    at com.moneymanager.ui.screens.csv.ReimportDialogKt$ReimportDialog$2$1...
```

## Why

One un-regex-like identity on one account took down every re-import preview, not just the match for
that account. A literal substring match is what such a value means anyway — the regex support exists
for attributes deliberately authored as patterns (`ACME.*LTD`).

## How

A token that fails to compile falls back to `Regex(Regex.escape(token), IGNORE_CASE)`. Valid regex
attributes keep their current behaviour. Added a regression test using the exact failing value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV imports now handle attribute tokens containing invalid regular-expression syntax by matching them as literal text instead of failing.
  * Matching remains case-insensitive, including for literal special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->