### PR TITLE
Adopt Gradle 9.7 stable Isolated Projects property names

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -58,7 +58,7 @@ jobs:
         # for this single reporting task. It writes webpage/modules-graph.md.
         uses: ./.github/actions/gradle-run
         with:
-          command: 'createModuleGraph -Dorg.gradle.unsafe.isolated-projects=false --no-configuration-cache --stacktrace'
+          command: 'createModuleGraph -Dorg.gradle.isolated-projects=false --no-configuration-cache --stacktrace'
           cache-read-only: true
       - name: Generate strategy catalog
         # Renders the Kotlin built-in strategy definitions (app/strategies) into

--- a/app/db/read/build.gradle.kts
+++ b/app/db/read/build.gradle.kts
@@ -65,7 +65,7 @@ sqldelight {
             packageName.set("com.moneymanager.database.sql.read")
             verifyMigrations.set(false)
             dialect(libs.sqldelight.dialect.sqlite)
-            dependency(project(":app:db:schema"))
+            dependency(projects.app.db.schema)
         }
     }
 }

--- a/app/db/seed/build.gradle.kts
+++ b/app/db/seed/build.gradle.kts
@@ -31,7 +31,7 @@ sqldelight {
             packageName.set("com.moneymanager.database.sql.seed")
             verifyMigrations.set(false)
             dialect(libs.sqldelight.dialect.sqlite)
-            dependency(project(":app:db:schema"))
+            dependency(projects.app.db.schema)
             srcDirs("src/commonMain/sqldelight")
         }
     }

--- a/app/db/write/build.gradle.kts
+++ b/app/db/write/build.gradle.kts
@@ -73,7 +73,7 @@ sqldelight {
             packageName.set("com.moneymanager.database.sql.write")
             verifyMigrations.set(false)
             dialect(libs.sqldelight.dialect.sqlite)
-            dependency(project(":app:db:schema"))
+            dependency(projects.app.db.schema)
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ version = projectVersion
 
 // gradle-doctor configures tasks/plugins across subprojects from the root project,
 // which violates project isolation — keep it off while isolation is enabled.
-if (providers.gradleProperty("org.gradle.unsafe.isolated-projects").orNull != "true") {
+if (providers.gradleProperty("org.gradle.isolated-projects").orNull != "true") {
     pluginManager.apply("com.osacky.doctor")
 }
 

--- a/docs/gradle-project-isolation.md
+++ b/docs/gradle-project-isolation.md
@@ -4,7 +4,9 @@ Date tested: 2026-06-06 (previous attempt: 2026-05-24)
 
 ## Result
 
-Project isolation (`org.gradle.unsafe.isolated-projects=true`) is **enabled** in `gradle.properties`.
+Project isolation (`org.gradle.isolated-projects=true`) is **enabled** in `gradle.properties`. Gradle
+9.7 promoted the feature to *incubating* and stabilised the property name — the old
+`org.gradle.unsafe.isolated-projects` spelling is a deprecated alias.
 
 `./gradlew build` (tests, kover, buildHealth, detekt, ktlint, Android lint) passes with the flag
 on, and the configuration cache entry is stored without isolation violations.

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,9 +11,11 @@ kotlin.suppressGradlePluginWarnings=KotlinDefaultHierarchyFallbackDependsOnUsage
 #
 # It cannot be switched on yet: two Gradle deprecations fire from *plugin internals*, not from this
 # build, and would fail every invocation regardless of our code —
-#   * Kover  — Project-as-dependency-notation (KoverGradlePlugin.apply -> PrepareKover.kt:29)
-#   * KGP    — Configuration.getTaskDependencyFromProjectDependency (ConfigureBuildSideEffect.kt:35)
-# Re-try `org.gradle.warning.mode=fail` after a Kover/KGP bump; the build is otherwise clean under it.
+#   * SQLDelight — Project-as-dependency-notation. Every `SqlDelightDatabase.dependency(...)`
+#     overload funnels into `dependency(Project)`, which calls `dependencies.create(project)`
+#     (SqlDelightDatabase.kt:177-181). Nothing at our call sites can avoid it.
+#   * KGP        — Configuration.getTaskDependencyFromProjectDependency (ConfigureBuildSideEffect.kt:35)
+# Re-try `org.gradle.warning.mode=fail` after a SQLDelight/KGP bump; the build is otherwise clean.
 
 android.useAndroidX=true
 android.nonTransitiveRClass=true
@@ -27,8 +29,9 @@ kotlin.daemon.jvmargs=-Xmx3g
 # Configuration cache for faster builds
 org.gradle.configuration-cache=true
 
-# Project isolation (implies configuration cache)
-org.gradle.unsafe.isolated-projects=true
+# Project isolation (implies configuration cache). Gradle 9.7 stabilised the property name; the
+# `org.gradle.unsafe.` spelling still works as an alias but is deprecated for removal.
+org.gradle.isolated-projects=true
 
 # Mokkery looks this up via Project.findProperty, which walks up to the parent
 # project when undefined — a project-isolation violation. Defining it here makes


### PR DESCRIPTION
## What

Post-9.7.0 cleanup pass over the build after the Gradle wrapper bump.

- **Isolated Projects property rename.** 9.7 promoted Isolated Projects from *experimental* to *incubating* and stabilised the property names; `org.gradle.unsafe.isolated-projects` is now a deprecated alias scheduled for removal. Moved all four references to `org.gradle.isolated-projects`: `gradle.properties`, the gradle-doctor guard in the root `build.gradle.kts`, the `createModuleGraph` step in `.github/workflows/static.yml`, and `docs/gradle-project-isolation.md`.
- **Typesafe project accessor in the SQLDelight blocks.** `dependency(project(":app:db:schema"))` → `dependency(projects.app.db.schema)` in `app/db/{read,write,seed}`, per the `projects.*` rule in CLAUDE.md.
- **Corrected the `warning.mode=fail` blocker list** in `gradle.properties`.

## Why

A full `./gradlew build --warning-mode=all` on 9.7.0 surfaces exactly two Gradle deprecations, both from plugin internals:

1. **Project-as-dependency-notation** ("will fail with an error in Gradle 10") — the stack trace points at our SQLDelight `dependency(...)` call sites, but it is not fixable there: all three `SqlDelightDatabase.dependency(...)` overloads delegate to `dependency(Project)`, which calls `dependencies.create(dependencyProject)` (`SqlDelightDatabase.kt:177-181`). The accessor change here is style-only; the warning needs an upstream fix.
2. **KGP's `Configuration.getTaskDependencyFromProjectDependency`** — unchanged.

The existing comment in `gradle.properties` attributed (1) to Kover's `PrepareKover.kt:29`. Kover no longer fires it, so the note is corrected to SQLDelight + KGP with the exact internal call site. `org.gradle.warning.mode=fail` therefore stays off, but the reason recorded is now accurate.

Everything else new in 9.7 is either automatic (test-framework startup failures now surfacing in the console, Kotlin DSL accessors no longer round-tripping the build cache, the IDEA config-cache invalidation fix) or not applicable to this build (reproducible archive timestamps, lazy `Javadoc`/`War`/`Groovydoc` file properties, `ResolutionResult` as task input, `--project-cache-dir` + FS watching).

## Testing

`./gradlew --console=plain build` — BUILD SUCCESSFUL (3515 actionable tasks). Isolated Projects remains active under the new property name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project-isolation guidance to use Gradle’s current property name.
  * Clarified the feature’s incubating status and deprecated alias.

* **Chores**
  * Modernized build configuration for improved Gradle compatibility.
  * Updated build warning documentation to reflect current remaining issues.
  * Replaced string-based module references with type-safe project accessors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->