### PR TITLE
deps(deps): bump gradle from 9.7.0 to 9.7.1 and java toolchain to 25.0.4+7

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java temurin-25.0.1+8.0.LTS
+java temurin-25.0.4+7.0.LTS

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
## Gradle 9.7.0 → 9.7.1

Wrapper bumped via `./gradlew wrapper --gradle-version 9.7.1` (run twice). `gradle/wrapper/gradle-wrapper.properties` was the only file pinning the version.

A patch release — six regression fixes over 9.7.0, none of which require a change here:

| Fix | Relevance |
|---|---|
| `BaseExecSpec` streams API conformance | not used in our build logic |
| "Click to see difference" restored in failed unit test reports | free win for test report readability |
| Bundled ANTLR leaking into the kapt classpath | n/a — we use KSP / compiler plugins, no kapt |
| Custom `Transformer` implementation compatibility | not used |
| Ant `taskdef` classpath isolation from Gradle's bundled jars | not used |
| `@Option` annotation parameter ordering in the Kotlin DSL | not used |

The headline 9.7.0 features are already in use here — `org.gradle.isolated-projects=true` is set. The pre-existing "Deprecated Gradle features were used" warning is unchanged; that's the SQLDelight/KGP internals already documented in `gradle.properties`, still blocking `org.gradle.warning.mode=fail`.

## Java toolchain temurin-25.0.1+8 → 25.0.4+7

`.tool-versions` only. No other file pins a JDK version.

## Verification

`./gradlew build buildHealth` — BUILD SUCCESSFUL, 9311 tasks, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)